### PR TITLE
feat(orchestrate): e2e pre-flight + REPORT generation + tier-3 worker guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### `/orchestrate --e2e` v4 integration — pre-flight + REPORT + Tier-3 guard (2026-05-01)
+
+Folds the delegated-mode plan v4 into `skills/orchestrate/` so `/orchestrate --e2e` becomes a "single-researcher" mode: one delegation, no per-phase confirmations except the PHI gate, and a single REPORT.md the user reviews at the end. Replaces the earlier scheme that put the report template and the usage rule under `~/.claude/templates/` + `~/.claude/rules/` (both deleted) — the repo is now the only source of truth.
+
+- **Added** — `skills/orchestrate/references/report_template.md`. Canonical 11-section REPORT layout written to `manuscript/<id>/REPORT.md` at every `--e2e` termination (success or halt). Sections: 한 줄 요약, Frozen / Version status, Source artifacts checked, 변경 파일, Changed claims, 검토 포인트, 환각 게이트 결과, QC artifact links, Human-only missing fields, Tier-3 차단 항목, 다음 액션 + Next safe command + Pipeline log. The Tier-3 section is split into hook-confirmed (`tier3-confirm.sh`) vs prompt/skill-guard-only blocks so a future hook regression cannot silently re-open a prompt-only block.
+
+- **Changed** — `skills/orchestrate/SKILL.md` `### --e2e Flag` now opens with a Pre-flight Validation block (4 checks): STATUS / project_state, frozen artifact (v_N `_FROZEN` marker → v_(N+1) branch only), required inputs, dependency miss. Default on dependency miss is halt; `--auto-extend` is the only opt-in that prepends missing phases. PHI Safety Gate remains the only legitimate interrupt after pre-flight passes.
+
+- **Added** — `skills/orchestrate/SKILL.md` `### REPORT.md Generation` section after Post-Skill Validation. Worker MUST write `manuscript/<id>/REPORT.md` from the new template at every `--e2e` termination. Empty fields render as `(none)` / `(unknown)` — never omitted. The §"Pipeline log" entry is a 5-line summary, not the full log.
+
+- **Added** — `skills/orchestrate/SKILL.md` `### Tier-3 Worker Guard` section. Permanently forbids `--e2e` auto-entry into `git push`, `gh pr create`, MCP Gmail/Calendar send, MCP GitHub create-pr, `/sync-submission build` external publication paths, Phase 8 submission DOCX auto-build, and senior-mentor automatic email reply. `git commit` is allowed; subsequent `git push` halts. Reinforces the existing `### Post-E2E` boundary (Phase 8 already required explicit user invocation).
+
+- **Changed** — `skills/orchestrate/SKILL.md` `check-reporting` row in the Available Skills table now reads "33 reporting guidelines and risk-of-bias tools" to match README and the skill's own SKILL.md (was stale at 22).
+
+#### Follow-up (deferred, not in this PR)
+
+- Release ZIP refresh — `dist/medsci-skills-classroom-*.zip` is stale at v2.1.1 / 37 skills (current 39, including `/manage-refs`, `/render-pdf-doc`, and the e2e+REPORT contract).
+- skill.yml v1 → v2 contract migration — 15 skill.yml files still v1; v2 schema not yet adopted across the bundle.
+- Mock test for frozen-artifact halt under `--e2e` (Plan v4 Verification §3) — current PR ships docs/contract only.
+
 ### Integration cleanup — orchestrator hardening + `/render-pdf-doc` adoption (2026-05-01)
 
 End-to-end integration sweep after the parallel-session conflict around the manage-refs split. Three sessions had been editing the repo simultaneously (`/render-pdf-doc` spinoff, `/write-paper` backbone Phase 0, manage-refs split + circulation memo). This cleanup folds the surviving artifacts together, fixes the runtime breakage left in `/write-paper` Phase 7.6, registers the four previously-unrouted skills with `/orchestrate`, and standardizes per-skill `## Gates` sections.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -48,7 +48,7 @@ You do NOT do the work yourself. You classify, plan, and delegate.
 | **meta-analysis** | Systematic review | Full MA pipeline: protocol, search, screening, extraction, synthesis, PRISMA-DTA |
 | **write-paper** | Writing | IMRAD manuscript drafting (8-phase pipeline), any section writing |
 | **self-review** | Quality | Pre-submission self-check from reviewer perspective (10 categories) |
-| **check-reporting** | Compliance | Audit against 22 reporting guidelines and risk-of-bias tools |
+| **check-reporting** | Compliance | Audit against 33 reporting guidelines and risk-of-bias tools |
 | **revise** | Revision | Parse reviewer comments, generate point-by-point response, track changes |
 | **grant-builder** | Funding | Structure grant proposals: significance, innovation, approach, milestones |
 | **present-paper** | Presentation | Prepare academic talks: analyze paper, draft scripts, inject slide notes, Q&A prep |
@@ -206,6 +206,35 @@ When the user requests "run the full pipeline," "end-to-end," or similar, execut
 
 ### `--e2e` Flag
 
+#### Pre-flight Validation (run once at `--e2e` entry)
+
+Before invoking any downstream skill in `--e2e` mode, run the following 4 checks.
+A failure on any one halts the pipeline and is recorded to
+`manuscript/<id>/REPORT.md` (see §"REPORT.md Generation") under
+`Frozen / Version status` + `Source artifacts checked`.
+
+1. **STATUS / project_state**: read `STATUS.md` or `project_state.json` in the
+   working directory and confirm the current phase. If neither exists, halt with
+   `STATUS_MISSING` unless the user passes `--no-status`.
+2. **Frozen artifact**: scan `manuscript/<id>/v_*_package/`. If the latest `v_N`
+   carries a `_FROZEN` marker file or `INDEX.md::frozen=true`, this run is
+   restricted to a `v_(N+1)_package/` branch. Any attempt to write directly into
+   `v_N` halts with `FROZEN_VIOLATION` (see `~/.claude/rules/manuscript-versioning.md`).
+3. **Required inputs**: confirm input artifacts for the requested phase exist.
+   Examples: Phase 4 figure requires `analysis/_analysis_outputs.md`; Phase 7
+   self-review requires `manuscript/manuscript.md`. Missing → halt with
+   `REQUIRED_INPUT_MISSING: <path>`.
+4. **Dependency miss**: if the user requested phase `k` but a prior phase is
+   incomplete, halt with `DEPENDENCY_MISS: [Phase i, Phase j]` by default. Only
+   when the user explicitly passes `--auto-extend` may the orchestrator prepend
+   the missing phases and continue.
+
+PHI Safety Gate (node N6) remains the only legitimate interrupt of an autonomous
+run after pre-flight passes. All four pre-flight outcomes are written to REPORT
+verbatim.
+
+#### `--e2e` Pipeline Behavior
+
 When `--e2e` is passed (or the user says "end-to-end", "Arm A", or "fully autonomous"):
 1. Set `--e2e` mode ON.
 2. Pass `--autonomous` to `/write-paper` when invoking it.
@@ -264,6 +293,54 @@ After each skill completes, verify that expected output files exist. If validati
 - Log the failure: which skill, which output was missing, any error messages.
 - In `--e2e` mode: report the error in `qc/_pipeline_log.md` and STOP. Do not proceed to the next skill. Output: "Pipeline halted at {skill}: {missing output}. Check the skill's output and re-run."
 - In interactive mode: report the error and ask the user how to proceed.
+
+### REPORT.md Generation
+
+At the termination of every `--e2e` invocation — whether the pipeline completed,
+halted at pre-flight, or halted on post-skill validation — the Worker MUST write
+`manuscript/<id>/REPORT.md` using the template at
+`${SKILL_DIR}/references/report_template.md`.
+
+Rules:
+
+- Copy all 11 sections from the template verbatim. Never delete a section. Empty
+  fields are filled with `(none)` or `(unknown)` — never omitted, never collapsed.
+- The §"Pipeline log" entry is a 5-line summary of `qc/_pipeline_log.md` (Dialogue
+  node defaults applied, skill invocations, halt reason if any) — not a paste of
+  the full log.
+- The §"Tier-3 차단 항목" hook-vs-prompt-guard split is mandatory — see
+  §"Tier-3 Worker Guard" below.
+- The §"Next safe command" line is the literal command the user can copy to
+  resume the next phase. Do not editorialize.
+- REPORT.md is the single artifact the user reviews; every other QC output is
+  linked from it.
+
+### Tier-3 Worker Guard
+
+The following actions are permanently forbidden inside `--e2e` autonomous flow.
+On detection, the Worker halts the pipeline and records the attempt under
+REPORT.md §"Tier-3 차단 항목" as `tier3_pending: <command>`. Hook-confirmed
+blocks and prompt-only blocks are listed separately so a future hook regression
+cannot silently re-open a prompt-only block.
+
+**Hook-confirmed (`~/.claude/hooks/tier3-confirm.sh` enforces)**:
+- `gws gmail +send` / `+reply`
+- YouTube upload
+
+**Prompt / skill guard only (no hook coverage — Worker prompt enforces)**:
+- `git push`, `gh pr create`
+- MCP Gmail send, MCP Calendar send
+- MCP GitHub create-pr
+- `/sync-submission build` external publication paths
+- Phase 8 submission DOCX auto-build / journal submission
+- Senior mentor automatic email reply
+
+`git commit` is allowed; a subsequent `git push` attempt halts. Circulation
+emails are written via `gws-draft.py` to a Gmail Draft only — never sent.
+
+Phase 8 (Post-E2E Journal Selection & Submission Prep, see §"Post-E2E" below)
+is explicitly outside `--e2e` and requires explicit user invocation. The Tier-3
+guard reinforces that boundary.
 
 ### Data Flow Contract
 

--- a/skills/orchestrate/references/report_template.md
+++ b/skills/orchestrate/references/report_template.md
@@ -1,0 +1,107 @@
+# `/orchestrate --e2e` REPORT Template
+
+This is the canonical end-of-run report written to `manuscript/<id>/REPORT.md` at the
+termination of every `--e2e` invocation (whether the pipeline completed, halted at
+pre-flight, or halted on validation failure). It is the single artifact the user
+reviews — every other QC output is referenced from here.
+
+The Worker fills every section. Missing or non-applicable information is recorded
+explicitly as `(none)`, `(unknown)`, or `N/A` — never omitted.
+
+---
+
+```markdown
+# {project_id} Phase {N} 완료 보고
+
+## 한 줄 요약
+{무엇을 했고 결과 어땠는지 1문장}
+
+## Frozen / Version status
+- Source artifact: {manuscript/<id>/v_N_package/draft.md, mtime, sha256}
+- Frozen version: v_{N} (freeze date YYYY-MM-DD, 회람 발송 시점)
+- This run wrote to: v_{N+1}_package/ (분기 OK) | OR v_{N} 직접 (**violation — halt**)
+- `manuscript-versioning.md` 룰 준수: ✅ / ❌
+
+## Source artifacts checked
+- {path1} — read at {timestamp}, sha256 {hash}
+- {path2} — ...
+- 누락된 expected input: {list, or "(none)"}
+- Pre-flight result: PASS | HALT (reason: STATUS_MISSING / FROZEN_VIOLATION / REQUIRED_INPUT_MISSING / DEPENDENCY_MISS)
+
+## 변경 파일 (priority 순)
+- {path} — {1줄 변경 요약}
+- ...
+- (없으면 "(none)")
+
+## Changed claims
+- {Methods §X에서 sample size N=68 → N=70 (CSV row count 재집계)}
+- {Discussion에서 "primary outcome" → "co-primary outcome" 표현}
+- (없으면 "no claim-level changes")
+
+## 검토 포인트 (사용자 우선순위 순)
+1. {가장 중요 — 보통 수치·인용·논리 검증 포인트}
+2. {차순위}
+3. {그 다음}
+
+## 환각 게이트 결과
+- citation_safety: PASS / FAIL ({n} refs verified, first-author cross-check applied)
+- numerical_safety: PASS / FAIL ([VERIFY-CSV] 잔존 {n}건)
+- dictionary_first: PASS / N/A (observational/cohort 컨텍스트만 적용)
+- reporting_compliance: PASS / PARTIAL / FAIL ({guideline})
+
+## QC artifact links
+- `qc/reference_audit.json` — verify-refs 결과
+- `qc/self_review.md` — self-review JSON 블록
+- `qc/reporting_checklist.md` — check-reporting 결과
+- `qc/xref_audit.json` — manage-refs cross-reference QC
+- `qc/_pipeline_log.md` — Dialogue node defaults + halt reasons
+
+## Human-only missing fields
+이 항목은 사용자가 직접 채워야 함 (자율 작성 영구 금지):
+- Funding grant IDs: ___
+- Senior mentor 회람 답신 반영: ___
+- Recommended reviewers (또는 "없음"): ___
+- Cover letter 인사말 / corresponding 서명: ___
+- (해당 없으면 "(none)")
+
+## Tier-3 차단 항목
+이 작업들은 `--e2e` 자동 진입 영구 금지. 시도 발생 시 halt + 아래 기록.
+
+**Hook으로 차단 확인 (`~/.claude/hooks/tier3-confirm.sh`)**:
+- `gws gmail +send/+reply`
+- YouTube upload
+
+**Prompt / skill guard만 (hook 미적용 — Worker prompt가 막음)**:
+- `git push`, `gh pr create`
+- MCP Gmail send, MCP Calendar send
+- MCP GitHub create-pr
+- `/sync-submission build` 외부 발행 path
+- Phase 8 (submission docx 자동 빌드 / 투고)
+- senior mentor 자동 회신
+
+이번 run에서 시도 감지: `tier3_pending: <command or "(none)">`
+
+## 다음 액션
+- [ ] APPROVE → 다음 phase 진행
+- [ ] REJECT (사유: ___)
+- [ ] PARTIAL (수정사항: ___)
+
+## Next safe command
+다음 phase 위임 명령 (사용자가 그대로 복사):
+`/orchestrate "<id> Phase {N+1} 끝까지" --e2e`
+
+## Pipeline log
+{qc/_pipeline_log.md 핵심 5줄 요약 — Dialogue node defaults, skill invocations, halt 사유}
+```
+
+---
+
+## Notes for the Worker
+
+- The fenced block above is the literal template. Copy it verbatim into
+  `manuscript/<id>/REPORT.md` and replace `{...}` placeholders.
+- Never delete a section. If empty, write `(none)`.
+- The "Tier-3 차단 항목" hook vs prompt-guard split is mandatory — collapsing them
+  hides which blocks survive prompt regression. See SKILL.md §"Tier-3 Worker Guard".
+- "Pipeline log" is a 5-line summary, not a paste of the full
+  `qc/_pipeline_log.md`.


### PR DESCRIPTION
## Summary

Folds delegated-mode plan v4 into `skills/orchestrate/` so `/orchestrate --e2e` becomes a "single-researcher" mode: one delegation, no per-phase confirmations except the PHI gate, and a single `manuscript/<id>/REPORT.md` the user reviews at the end. The earlier scheme that put the report template and the usage rule under `~/.claude/templates/` + `~/.claude/rules/` is replaced — the repo is now the only source of truth.

- **Pre-flight Validation** at `--e2e` entry: STATUS / project_state, frozen artifact (v_N `_FROZEN` → v_(N+1) branch only), required inputs, dependency miss. Default on dependency miss is halt; `--auto-extend` is the only opt-in that prepends missing phases.
- **REPORT.md Generation** contract: Worker writes the 11-section report at every `--e2e` termination (success or halt) using `skills/orchestrate/references/report_template.md`. Empty fields render as `(none)` / `(unknown)` — never omitted.
- **Tier-3 Worker Guard**: `git push`, `gh pr create`, MCP Gmail/Calendar send, MCP GitHub create-pr, `/sync-submission build` external paths, Phase 8 submission DOCX auto-build, and senior-mentor automatic email reply are forbidden under `--e2e`. The REPORT template splits hook-confirmed blocks (`tier3-confirm.sh`) from prompt/skill-guard-only blocks so a future hook regression cannot silently re-open a prompt-only block.
- Drift fix: `check-reporting` row now reads "33 reporting guidelines and risk-of-bias tools" (was stale at 22; README is SSOT).

## Test plan

- [x] `bash scripts/validate_skills.sh` — 39 skills, 313 PASS / 38 WARN / 0 FAIL.
- [x] `python3 scripts/validate_skill_contracts.py` — 0 failures (39 v1 warnings pre-existing).
- [x] `grep "22 reporting" skills/orchestrate/SKILL.md` → 0 hits.
- [x] `grep "report_template.md" skills/orchestrate/SKILL.md` → 1 hit.
- [ ] First live `--e2e` smoke run (deferred to a later figure phase).

## Follow-ups (not in this PR)

- Release ZIP refresh — `dist/medsci-skills-classroom-*.zip` stale at v2.1.1 / 37 skills (current 39).
- skill.yml v1 → v2 contract migration (15 v1 / 0 v2; sunset 2026-07-24).
- Mock test for frozen-artifact halt under `--e2e` (Plan v4 Verification §3).
- Optional: opt-in env var to relax the Tier-3 guard for feature-branch (non-main) `git push` only — keeps default conservative for OSS users with unknown workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

