### PR TITLE
feat(v3): Tier 0 polish — CITATION.cff, Zenodo workflow, clinician setup onboarding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+# Triggered when a version tag is pushed (e.g., v3.0.0).
+# Builds the classroom installer ZIPs, creates a GitHub Release, and attaches the ZIPs.
+# Zenodo automatically archives the GitHub Release if the integration is enabled at
+# https://zenodo.org/account/settings/github/
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write  # required for gh release create
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository (with full history for tag annotation)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build classroom release ZIPs
+        run: python scripts/build_classroom_release.py
+
+      - name: List built artifacts
+        run: |
+          ls -lh dist/
+          echo "---"
+          echo "ZIP contents preview:"
+          for zip in dist/*.zip; do
+            echo "## ${zip}"
+            unzip -l "${zip}" | head -20
+          done
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Extract the section for this tag from CHANGELOG.md (between this version header and the next version header)
+          if [ -f CHANGELOG.md ]; then
+            awk -v tag="$TAG" '
+              $0 ~ "^## \\[?"tag"\\]?" { found=1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md > /tmp/release_notes.md
+          else
+            echo "Release ${TAG}" > /tmp/release_notes.md
+          fi
+
+          # Fallback if CHANGELOG section was empty
+          if [ ! -s /tmp/release_notes.md ]; then
+            echo "Release ${TAG}" > /tmp/release_notes.md
+            echo "" >> /tmp/release_notes.md
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> /tmp/release_notes.md
+          fi
+
+          echo "Release notes preview:"
+          cat /tmp/release_notes.md
+
+      - name: Create GitHub Release with classroom ZIP attached
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release create "$TAG" \
+            --title "MedSci Skills ${TAG}" \
+            --notes-file /tmp/release_notes.md \
+            dist/*.zip

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,44 @@
+{
+  "title": "MedSci Skills: Claude Code Skills for the Medical Research Lifecycle",
+  "description": "An opinionated, physician-built collection of Claude Code skills covering the full medical research workflow — literature search with anti-hallucination citation verification, study design, IRB protocols, statistical analysis, publication-ready figures, IMRAD manuscript drafting, reporting compliance audits against 33 EQUATOR guidelines (STARD, STARD-AI, TRIPOD+AI, CLAIM, PRISMA-DTA, STROBE, CONSORT, etc.), journal selection, peer review, and revision response. Three end-to-end demos with public datasets produce submission-ready manuscripts.",
+  "creators": [
+    {
+      "name": "Nam, Yoojin",
+      "affiliation": "University of Ulsan College of Medicine, Seoul, Republic of Korea",
+      "orcid": "0000-0001-8565-1360"
+    }
+  ],
+  "license": "MIT",
+  "upload_type": "software",
+  "access_right": "open",
+  "keywords": [
+    "claude-code",
+    "claude-skills",
+    "agent-skills",
+    "medical-research",
+    "clinical-research",
+    "radiology",
+    "meta-analysis",
+    "systematic-review",
+    "reporting-guidelines",
+    "tripod-ai",
+    "prisma",
+    "strobe",
+    "pubmed",
+    "irb-protocol",
+    "physician-researcher"
+  ],
+  "communities": [
+    {"identifier": "open-research"}
+  ],
+  "related_identifiers": [
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/Aperivue/medsci-skills",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
+    }
+  ],
+  "language": "eng",
+  "notes": "If you use MedSci Skills in your research, please cite this Zenodo record. The repository contains comprehensive documentation, three end-to-end demos with public datasets (Wisconsin Breast Cancer, BCG meta-analysis, NHANES), and 33 EQUATOR reporting guideline checklists."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added — Tier 0 polish: CITATION.cff, Zenodo integration, setup onboarding, peer-review tone audit (2026-05-13)
+
+- `CITATION.cff` (cff-version 1.2.0) and `.zenodo.json` for academic citation backlink. DOI populates after first Zenodo archive of a tagged release.
+- `.github/workflows/release.yml` — on `v*` tag push, builds classroom ZIPs, creates GitHub Release with notes from CHANGELOG, attaches ZIPs. Zenodo integration (toggle once at `https://zenodo.org/account/settings/github/`) auto-archives the release.
+- `docs/setup/` — five-doc onboarding guide for clinicians new to Python/R/Claude Code/MCP: `README.md` (decision tree), `mac.md` (Homebrew → pyenv → R → Node → Claude Code), `windows.md` (winget-based, no WSL), `mcp-setup.md` (Zotero / Google Drive / PubMed servers), `common-issues.md` (top 10 issues with copy-paste fixes).
+- `skills/setup-medsci/` — diagnostic-only skill that runs `which python3 / Rscript / claude / node` and `claude mcp list`, prints a checklist with status (✅ / ⚠️ / ❌) and links to the right setup doc for any missing component. Intentionally read-only — does not install anything.
+- README: added `## What This Is NOT` scope-out section (positions vs K-Dense scientific-agent-skills and OpenClaw Medical Skills) and `## Setup` section linking the new docs and `/setup-medsci`. Citation badge added.
+- GitHub topics: swapped 4 generic (`ai-tools`, `academic-writing`, `open-source`, `research-tools`) for 4 specific (`agent-skills`, `tripod-ai`, `irb-protocol`, `physician-researcher`) — capped at GitHub's 20-topic limit.
+- `skills/peer-review/` — Aczel 2021 anti-reviewer-2 tone patterns integrated into Phase 4 Self-QC and Tone Calibration sections (PR #11 merged 2026-05-13).
+
 ### Changed — `/publish-skill` Phase 2 `audit_skill.sh` rewritten for parity with monorepo linter (2026-05-03)
 
 `skills/publish-skill/scripts/audit_skill.sh` was overhauled to mirror the per-skill rules in `scripts/validate_skills.sh`. Old behavior had three structural problems: (1) raster bytes inside compiled `.pyc` and PNG images falsely tripped path / email regexes (a known-clean skill reported 3 findings), (2) the institutional-reference category used `(?<!...)` lookbehinds that `grep -E` silently does not support — the entire category was inert, (3) several monorepo rules had no equivalent here, so a personal skill that passed `audit_skill.sh` could still fail when moved into the public repo.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+message: "If you use MedSci Skills in your research, please cite it as below."
+type: software
+title: "MedSci Skills: Claude Code Skills for the Medical Research Lifecycle"
+abstract: >-
+  An opinionated, physician-built collection of Claude Code skills covering
+  the full medical research workflow — literature search with anti-hallucination
+  citation verification, study design, IRB protocols, statistical analysis,
+  publication-ready figures, IMRAD manuscript drafting, reporting compliance
+  audits against 33 EQUATOR guidelines (STARD, STARD-AI, TRIPOD+AI, CLAIM,
+  PRISMA-DTA, STROBE, CONSORT, etc.), journal selection, peer review, and
+  revision response. Three end-to-end demos with public datasets produce
+  submission-ready manuscripts.
+authors:
+  - family-names: Nam
+    given-names: Yoojin
+    affiliation: "University of Ulsan College of Medicine, Seoul, Republic of Korea"
+    orcid: "https://orcid.org/0000-0001-8565-1360"
+repository-code: "https://github.com/Aperivue/medsci-skills"
+url: "https://github.com/Aperivue/medsci-skills"
+license: MIT
+version: "3.0.0"
+date-released: "2026-05-13"
+keywords:
+  - claude-code
+  - claude-skills
+  - agent-skills
+  - medical-research
+  - clinical-research
+  - radiology
+  - meta-analysis
+  - systematic-review
+  - reporting-guidelines
+  - tripod-ai
+  - prisma
+  - strobe
+  - pubmed
+  - irb-protocol
+  - physician-researcher
+# Note: Add `doi:` field after first Zenodo archive of v3.0.0 release.
+# Format: doi: "10.5281/zenodo.XXXXXXX"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 ![Skills](https://img.shields.io/badge/Skills-39-brightgreen?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-Claude_Code-blueviolet?style=flat-square)
 ![Built by](https://img.shields.io/badge/Built_by-Physician--Researcher-blue?style=flat-square)
+<!-- DOI badge: filled in after first Zenodo archive of v3.0.0 release -->
+<!-- [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX) -->
+[![Citation](https://img.shields.io/badge/Cite-CITATION.cff-blue?style=flat-square)](CITATION.cff)
 
 ![MedSci Skills](assets/social-preview.png)
 
@@ -145,6 +148,14 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 | **End-to-end coverage** | From IRB protocol to journal submission: sample size, data cleaning, analysis, writing, compliance, journal selection, cover letter. | Gaps at every transition -- no protocol, no journal matching, no cover letter |
 | **Battle-tested** | Used on real manuscript submissions by a practicing physician-researcher | Unknown provenance and validation |
 | **Depth per skill** | 150-600 lines of documentation + bundled reference files (curated journal profile library, checklists, formula sheets, code templates) | Typically thin SKILL.md templates |
+
+---
+
+## What This Is NOT
+
+This is **not** a broad scientific-tooling library — for cheminformatics, structural biology, or genomics pipelines, see [K-Dense scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) (135 skills). It is **not** a biomedical-skill aggregator — for the largest curated collection mirroring 12+ source repos, see [OpenClaw Medical Skills](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills) (869 skills).
+
+MedSci Skills is **opinionated and narrow on purpose**: a single physician-researcher's medical-manuscript pipeline, biased toward radiology, diagnostic accuracy, observational EMR studies, and systematic review / meta-analysis. If you write IMRAD manuscripts for clinical journals, audit reporting compliance against EQUATOR guidelines, or run SR/MA workflows end-to-end, this is built for you. For wet-lab protocols, drug discovery, or single-cell genomics, the repos above are better fits.
 
 ---
 
@@ -330,6 +341,21 @@ Projects declare their source-of-truth layout in `SSOT.yaml`, and a `qc/migratio
 
 ### Skills Work Together
 Skills call each other. `check-reporting` invokes `make-figures` for PRISMA diagrams. `write-paper` calls `search-lit` for citation verification. `self-review` delegates reporting compliance to `check-reporting`. `calc-sample-size` output feeds directly into `write-protocol`'s IRB justification section.
+
+## Setup
+
+**New to Python, R, or the command line?** The full step-by-step guide for clinicians is in [`docs/setup/`](docs/setup/README.md):
+
+- [Mac setup](docs/setup/mac.md) — Homebrew → Python 3.11 → R → Node → Claude Code (~30 min)
+- [Windows setup](docs/setup/windows.md) — winget-based, no WSL required
+- [MCP server setup](docs/setup/mcp-setup.md) — Zotero, Google Drive, PubMed integration
+- [Common issues](docs/setup/common-issues.md) — top 10 fixes (PATH, Apple Silicon, antivirus, JSON syntax)
+
+**Verify your environment** with the diagnostic skill (read-only, installs nothing):
+```
+/setup-medsci
+```
+Prints a checklist showing which components are present, which are missing, and which doc to follow for any gap.
 
 ## Requirements
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,0 +1,77 @@
+# Setup Guide for MedSci Skills
+
+**For physicians and clinical researchers who haven't used Python, R, or the command line before.**
+
+You don't need to be a programmer to use these skills, but you do need to install three things first: Claude Code, Python, and R. This guide walks you through it. If anything fails, run the diagnostic skill (`/setup-medsci`) inside Claude Code and it will tell you exactly what's missing.
+
+---
+
+## Decision Tree
+
+| Your Computer | Start Here |
+|---|---|
+| **Mac** (any model since 2017) | [`mac.md`](mac.md) |
+| **Windows 10/11** | [`windows.md`](windows.md) |
+| **Linux** | [`mac.md`](mac.md) (the Homebrew section maps to apt/dnf — most commands transfer) |
+
+---
+
+## What You Will Install
+
+| Tool | What It Does | Required? |
+|---|---|---|
+| **Claude Code** | The CLI that runs the skills | **Yes** |
+| **Python 3.11+** | Statistical analysis, figures, PDF processing | **Yes** |
+| **R 4.x** | Meta-analysis (`metafor`), survival analysis, NHANES survey weighting | **Yes** if you do MA / survival / survey |
+| **Node.js 20+** | MCP servers (Zotero, Google Drive integration) | Recommended |
+| **Git** | Cloning the repo, version control of your manuscripts | **Yes** |
+| **Zotero** + Better BibTeX | Reference management; auto-sync to your manuscripts | **Yes** for any paper |
+
+**Time estimate**: 30-60 minutes if everything goes smoothly. 1-2 hours if you hit an issue (most are documented in [`common-issues.md`](common-issues.md)).
+
+---
+
+## After You Install Everything
+
+1. **Verify with the diagnostic skill** (recommended):
+   ```
+   /setup-medsci
+   ```
+   This runs `which python3`, `which Rscript`, `which claude`, `which node`, and `claude mcp list` for you and prints a checklist showing what is ✅ and what is ❌.
+
+2. **Install MedSci Skills** (after the diagnostic shows green for the core tools):
+
+   **macOS** — double-click `installers/install-macos.command` from the cloned repo.
+
+   **Windows** — double-click `installers/install-windows.cmd`.
+
+   **Manually** (any OS):
+   ```bash
+   git clone https://github.com/Aperivue/medsci-skills.git
+   cd medsci-skills
+   python3 installers/install.py --target claude
+   ```
+
+3. **Add MCP servers** (optional but recommended for Zotero / Google Drive):
+
+   See [`mcp-setup.md`](mcp-setup.md).
+
+4. **Try Demo 1** to confirm everything works end-to-end:
+   ```bash
+   cd medsci-skills/demo/01_wisconsin_bc
+   ```
+   Then in Claude Code: `/orchestrate --e2e` (about 5-10 minutes; produces a manuscript, ROC curves, and a STARD compliance audit).
+
+---
+
+## If Something Breaks
+
+- See [`common-issues.md`](common-issues.md) — covers the top 10 issues physicians run into (PATH, Python 2 vs 3, Apple Silicon, antivirus, JSON syntax errors).
+- Run `/setup-medsci` again — the checklist will pinpoint the failure.
+- Open an issue at <https://github.com/Aperivue/medsci-skills/issues> with the `/setup-medsci` output and the error message.
+
+---
+
+## Why a Setup Guide at All?
+
+Most Claude Code skill collections assume you already have a working developer environment. We assume you don't — because most of our users are physicians and clinical researchers, and the install step is where they bounce. This guide aims to get you to a green diagnostic in under an hour, with no prior programming experience required.

--- a/docs/setup/common-issues.md
+++ b/docs/setup/common-issues.md
@@ -1,0 +1,162 @@
+# Common Setup Issues
+
+The top issues physicians and clinical researchers run into during MedSci Skills setup, with copy-paste fixes.
+
+---
+
+## 1. `python` runs Python 2 instead of Python 3
+
+**Symptom**: `python --version` shows `Python 2.7.x`.
+
+**Cause**: macOS and some old Windows installs default `python` to version 2.
+
+**Fix**: Use `python3` explicitly.
+```bash
+python3 --version   # should show 3.11.x
+```
+If `python3` also shows 2.x, your PATH is misconfigured. On Mac, ensure pyenv is initialized in `~/.zshrc` (see [`mac.md`](mac.md) Step 2). On Windows, reinstall via winget and reopen PowerShell.
+
+---
+
+## 2. `command not found: claude` (or `python3`, `Rscript`, `node`)
+
+**Cause**: PATH not refreshed after install.
+
+**Fix**: Close and reopen Terminal (Mac) or PowerShell (Windows). If it still fails:
+
+**Mac**:
+```bash
+echo 'export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"' >> ~/.zshrc
+exec zsh
+```
+
+**Windows**: Sign out and sign back in to your user account, or restart the computer.
+
+---
+
+## 3. Apple Silicon (M1/M2/M3/M4) Rosetta confusion
+
+**Symptom**: Some Python packages fail to compile, or you see "wrong architecture" errors.
+
+**Cause**: Mixing arm64 (Apple Silicon native) and x86_64 (Intel via Rosetta) installs.
+
+**Fix**: Stay native arm64. Verify Homebrew is in `/opt/homebrew` (not `/usr/local`):
+```bash
+which brew
+```
+Expected: `/opt/homebrew/bin/brew` on Apple Silicon.
+
+If you see `/usr/local/bin/brew`, you have the Intel Homebrew. Uninstall it and reinstall with the native arm64 installer.
+
+---
+
+## 4. Antivirus / SmartScreen blocks the installer (Windows)
+
+**Symptom**: Windows Defender SmartScreen warns "Windows protected your PC" when running `install-windows.cmd`.
+
+**Cause**: The `.cmd` file is unsigned (we don't pay for code-signing certificates). The script is open-source and you can read it before running.
+
+**Fix**: Click **More info** → **Run anyway**. Or run from PowerShell:
+```powershell
+.\installers\install-windows.cmd
+```
+
+---
+
+## 5. `git clone` fails with SSL certificate error
+
+**Cause**: Hospital network proxies often intercept HTTPS, breaking certificate validation.
+
+**Fix**: Use SSH instead:
+```bash
+git clone git@github.com:Aperivue/medsci-skills.git
+```
+(Requires you to add an SSH key at <https://github.com/settings/keys>.)
+
+Or temporarily disable verification (not recommended for security):
+```bash
+git -c http.sslVerify=false clone https://github.com/Aperivue/medsci-skills.git
+```
+
+---
+
+## 6. `claude mcp add` writes JSON with syntax errors
+
+**Symptom**: `claude mcp list` doesn't show the server you just added.
+
+**Cause**: A previous `claude mcp add` failed mid-way and left malformed JSON in `~/.claude.json` (Mac/Linux) or `%APPDATA%\Claude\claude.json` (Windows).
+
+**Fix**:
+1. Open `~/.claude.json` in a text editor.
+2. Look for `"mcpServers": { ... }` — verify it's valid JSON (matched braces, commas between entries, no trailing commas).
+3. If broken, paste it into <https://jsonlint.com/> to find the error.
+4. Fix and save.
+5. Try `claude mcp add ...` again.
+
+---
+
+## 7. R package install fails: "Cannot find compiler"
+
+**Symptom**: `install.packages("metafor")` (or similar) fails with `xcrun: error: invalid active developer path`.
+
+**Mac fix**: Install Xcode Command Line Tools (one-time):
+```bash
+xcode-select --install
+```
+Click "Install" in the popup; takes 10-20 minutes.
+
+**Windows fix**: Install Rtools (matched to your R version):
+- R 4.4: <https://cran.r-project.org/bin/windows/Rtools/rtools44/>
+- Run the installer, default options.
+
+---
+
+## 8. Demo 1 stalls when running `/orchestrate --e2e`
+
+**Possible causes**:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| "API rate limit exceeded" | Free Anthropic plan or hit daily quota | Wait an hour or upgrade |
+| Stuck at "loading scikit-learn" | Python venv not active | Run `python3 -c "import sklearn"` to confirm install |
+| Stuck at "rendering figures" | matplotlib backend issue | Run `python3 -c "import matplotlib; matplotlib.use('Agg')"` |
+| Stuck at "writing draft" | Network proxy blocking Anthropic API | Test with `curl https://api.anthropic.com` |
+
+---
+
+## 9. Zotero MCP shows "Disconnected"
+
+**Cause**: Zotero desktop isn't running, OR the API key was revoked, OR `ZOTERO_LOCAL=true` is set but Zotero isn't running locally.
+
+**Fix sequence**:
+1. Open Zotero desktop. Wait for sync to finish.
+2. Re-verify API key at <https://www.zotero.org/settings/keys> (regenerate if unsure).
+3. Re-run `claude mcp add zotero ...` with `--force` to overwrite.
+4. `claude mcp list` to verify ✓.
+
+---
+
+## 10. OneDrive sync conflicts with the cloned repo (Windows)
+
+**Symptom**: Files appear and disappear, or scripts fail with "file locked."
+
+**Cause**: OneDrive auto-sync is constantly touching the files Claude Code is reading.
+
+**Fix**: Move the repo out of OneDrive-tracked folders:
+```powershell
+# Don't put it in Documents (synced)
+git clone https://github.com/Aperivue/medsci-skills.git C:\medsci-skills
+```
+
+Or in OneDrive settings, exclude the `medsci-skills` folder from sync.
+
+---
+
+## Still Stuck?
+
+1. Run `/setup-medsci` inside Claude Code — it prints a diagnostic checklist with the specific failure point.
+2. Open an issue at <https://github.com/Aperivue/medsci-skills/issues> with:
+   - Your OS (Mac/Windows/Linux + version)
+   - Output of `/setup-medsci`
+   - The exact error message
+3. We respond within 1-3 days.

--- a/docs/setup/mac.md
+++ b/docs/setup/mac.md
@@ -1,0 +1,170 @@
+# Setup on macOS
+
+**Target**: Mac users (Apple Silicon or Intel) who have never installed Python or R before.
+
+If you already have some of these installed, the diagnostic skill (`/setup-medsci` from inside Claude Code) will tell you what to skip.
+
+---
+
+## Step 1 — Install Homebrew (the Mac package manager)
+
+Open **Terminal** (Cmd+Space → type "Terminal" → Enter), then paste:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+You'll be asked for your Mac password (it won't show as you type — that's normal). After ~5 minutes, Homebrew prints "Installation successful!"
+
+**Apple Silicon users (M1/M2/M3/M4)**: at the end of the install, Homebrew shows two `echo` commands to add Homebrew to your PATH. **Run them**, otherwise the `brew` command won't be found in new Terminal windows.
+
+Verify:
+```bash
+brew --version
+```
+Expected: `Homebrew 4.x.x`
+
+---
+
+## Step 2 — Install Python (via pyenv, recommended)
+
+Why `pyenv` instead of system Python: macOS ships with an old Python 2 that confuses many tools. `pyenv` lets you install a clean Python 3.11 alongside it without breaking the system.
+
+```bash
+brew install pyenv
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+exec zsh
+pyenv install 3.11.9
+pyenv global 3.11.9
+```
+
+Verify:
+```bash
+python3 --version
+```
+Expected: `Python 3.11.9`
+
+**Faster alternative** (if you don't need to manage multiple Python versions): `brew install python@3.11` then symlink `python3` to it. Less robust long-term but works.
+
+---
+
+## Step 3 — Install R
+
+```bash
+brew install --cask r
+```
+
+The `--cask` flag installs the official R from CRAN (with the GUI). Takes about 5 minutes.
+
+Verify:
+```bash
+Rscript --version
+```
+Expected: `R scripting front-end version 4.x.x`
+
+**Recommended GUI**: Install RStudio for a nicer experience.
+```bash
+brew install --cask rstudio
+```
+
+---
+
+## Step 4 — Install Node.js (for MCP servers)
+
+```bash
+brew install node@20
+```
+
+Verify:
+```bash
+node --version
+```
+Expected: `v20.x.x`
+
+---
+
+## Step 5 — Install Git
+
+Usually already installed on Mac. Verify:
+```bash
+git --version
+```
+
+If missing:
+```bash
+brew install git
+```
+
+---
+
+## Step 6 — Install Claude Code
+
+Two options:
+
+**Option A — Desktop app** (easiest): Download from <https://claude.ai/download> and install.
+
+**Option B — CLI** (if you prefer Terminal):
+```bash
+brew install --cask claude
+```
+
+Verify:
+```bash
+claude --version
+```
+
+After install, run `claude` once and follow the login prompt (opens browser → log in to your Anthropic account).
+
+---
+
+## Step 7 — Install Zotero + Better BibTeX
+
+1. Download Zotero from <https://www.zotero.org/download/> and install.
+2. Open Zotero → **Preferences** → **Sync** → log in.
+3. Install Better BibTeX: download `.xpi` from <https://github.com/retorquere/zotero-better-bibtex/releases/latest> → in Zotero, **Tools** → **Add-ons** → gear icon → **Install Add-on From File** → select the downloaded `.xpi`.
+4. Restart Zotero.
+
+---
+
+## Step 8 — Verify Everything
+
+In Claude Code, run:
+```
+/setup-medsci
+```
+
+You should see a checklist with all green ✅ marks. If anything is ❌, it tells you which step to revisit.
+
+---
+
+## Step 9 — Install MedSci Skills
+
+```bash
+git clone https://github.com/Aperivue/medsci-skills.git ~/medsci-skills
+cd ~/medsci-skills
+open installers/install-macos.command
+```
+
+The `.command` file is a double-clickable installer that copies the skills into `~/.claude/skills/` and prompts you for confirmations.
+
+---
+
+## Step 10 — Add MCP Servers (Optional)
+
+See [`mcp-setup.md`](mcp-setup.md) for Zotero, Google Drive, and PubMed MCP integration.
+
+---
+
+## You're Done
+
+Try Demo 1:
+```bash
+cd ~/medsci-skills/demo/01_wisconsin_bc
+```
+Then in Claude Code: `/orchestrate --e2e`
+
+Expected: a complete IMRAD manuscript + ROC curves + STARD compliance report in ~10 minutes.
+
+Issues? See [`common-issues.md`](common-issues.md).

--- a/docs/setup/mcp-setup.md
+++ b/docs/setup/mcp-setup.md
@@ -1,0 +1,102 @@
+# MCP Server Setup (Optional but Recommended)
+
+**MCP** = Model Context Protocol. MCP servers let Claude Code read your Zotero library, your Google Drive files, or live PubMed results directly. Each server is a separate install + one `claude mcp add` command.
+
+You can use MedSci Skills without any MCP servers — they fall back to local files and public APIs. MCPs just make integration smoother (e.g., `lit-sync` skill is much faster with the Zotero MCP).
+
+---
+
+## Zotero MCP (highest value for paper writing)
+
+**Why**: `lit-sync`, `verify-refs`, and `write-paper` all benefit from direct Zotero access (read your library, add new items by DOI, sync references to manuscripts).
+
+**Install** (Mac/Linux/Windows):
+
+```bash
+# Make sure Zotero desktop is running and you have an API key
+# Get API key: https://www.zotero.org/settings/keys → Create new private key
+# Save your library ID: visible in https://www.zotero.org/settings/keys
+
+claude mcp add zotero --scope user \
+  -e ZOTERO_LOCAL=true \
+  -e ZOTERO_API_KEY=<your-api-key> \
+  -e ZOTERO_LIBRARY_ID=<your-library-id> \
+  -- npx zotero-mcp
+```
+
+**Verify**:
+```bash
+claude mcp list | grep zotero
+```
+Expected: `zotero ✓ Connected`
+
+---
+
+## Google Drive / Workspace MCP
+
+**Why**: Read/write Google Docs, Sheets, Drive files. Useful if your data lives in Google Sheets or your manuscripts are shared via Google Docs.
+
+```bash
+claude mcp add gdrive --scope user -- npx @modelcontextprotocol/server-gdrive
+```
+
+First run will prompt you to authenticate via browser (OAuth).
+
+---
+
+## PubMed MCP (alternative to built-in `search-lit`)
+
+**Why**: Slightly faster and richer than the E-utilities fallback in `search-lit`.
+
+```bash
+claude mcp add pubmed --scope user -- npx pubmed-mcp
+```
+
+No API key required for basic searches. For higher rate limits, add `-e NCBI_API_KEY=<your-key>` (get one at <https://www.ncbi.nlm.nih.gov/account/settings/>).
+
+---
+
+## Filesystem MCP (built-in, usually pre-configured)
+
+Claude Code ships with filesystem access by default. If you've disabled it, re-enable per project:
+
+```bash
+claude mcp add filesystem --scope project -- npx @modelcontextprotocol/server-filesystem ~/Documents
+```
+
+---
+
+## Verifying All MCP Servers
+
+```bash
+claude mcp list
+```
+
+Expected output:
+```
+filesystem ✓ Connected
+zotero     ✓ Connected
+gdrive     ✓ Connected (or paused for auth)
+pubmed     ✓ Connected
+```
+
+The `/setup-medsci` skill includes this check automatically.
+
+---
+
+## Common MCP Issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `claude mcp list` shows nothing | MCP servers added at project scope but you're in a different directory | Use `--scope user` so they persist across projects |
+| `zotero ✗ Disconnected` | Zotero desktop not running, or API key wrong | Start Zotero, verify key at <https://www.zotero.org/settings/keys> |
+| `npx command not found` | Node.js not installed | See [`mac.md`](mac.md) Step 4 or [`windows.md`](windows.md) Step 5 |
+| Authentication popup keeps reopening | Browser blocking pop-ups | Allow pop-ups for `localhost` |
+
+---
+
+## Removing an MCP Server
+
+```bash
+claude mcp remove zotero --scope user
+```

--- a/docs/setup/windows.md
+++ b/docs/setup/windows.md
@@ -1,0 +1,170 @@
+# Setup on Windows
+
+**Target**: Windows 10/11 users who have never installed Python or R before. WSL (Windows Subsystem for Linux) is **not required** — everything works natively on Windows.
+
+If you already have some of these installed, the diagnostic skill (`/setup-medsci` from inside Claude Code) will tell you what to skip.
+
+---
+
+## Step 1 — Open PowerShell as Administrator
+
+1. Press **Windows key**, type **"PowerShell"**.
+2. Right-click **Windows PowerShell** → **Run as Administrator**.
+
+Most installers below need admin rights.
+
+---
+
+## Step 2 — Install winget (the Windows package manager)
+
+`winget` is built into Windows 11 and recent Windows 10. Verify:
+
+```powershell
+winget --version
+```
+
+If missing, install **App Installer** from the Microsoft Store (<https://www.microsoft.com/store/productId/9NBLGGH4NNS1>).
+
+---
+
+## Step 3 — Install Python 3.11
+
+```powershell
+winget install --id Python.Python.3.11 -e
+```
+
+**Important**: After install, **close PowerShell and reopen it** (so the PATH refreshes).
+
+Verify:
+```powershell
+python --version
+```
+Expected: `Python 3.11.x`
+
+If you see `Python 2.x.x` or "command not found", see [`common-issues.md`](common-issues.md) → "Windows Python PATH".
+
+---
+
+## Step 4 — Install R
+
+```powershell
+winget install --id RProject.R -e
+```
+
+Verify (after closing/reopening PowerShell):
+```powershell
+Rscript --version
+```
+Expected: `R scripting front-end version 4.x.x`
+
+**Recommended GUI**: RStudio.
+```powershell
+winget install --id Posit.RStudio -e
+```
+
+---
+
+## Step 5 — Install Node.js 20
+
+```powershell
+winget install --id OpenJS.NodeJS -e
+```
+
+Verify (close/reopen PowerShell):
+```powershell
+node --version
+```
+Expected: `v20.x.x`
+
+---
+
+## Step 6 — Install Git
+
+```powershell
+winget install --id Git.Git -e
+```
+
+Verify:
+```powershell
+git --version
+```
+
+---
+
+## Step 7 — Install Claude Code
+
+**Option A — Desktop app** (easiest): Download from <https://claude.ai/download> and install.
+
+**Option B — Via winget** (if available):
+```powershell
+winget install --id Anthropic.Claude -e
+```
+
+Verify:
+```powershell
+claude --version
+```
+
+After install, run `claude` once → it opens your browser to log in to your Anthropic account.
+
+---
+
+## Step 8 — Install Zotero + Better BibTeX
+
+1. Download Zotero from <https://www.zotero.org/download/> and install.
+2. Open Zotero → **Edit** → **Preferences** → **Sync** → log in.
+3. Install Better BibTeX: download `.xpi` from <https://github.com/retorquere/zotero-better-bibtex/releases/latest> → in Zotero, **Tools** → **Add-ons** → gear icon → **Install Add-on From File** → select the downloaded `.xpi`.
+4. Restart Zotero.
+
+---
+
+## Step 9 — Verify Everything
+
+In Claude Code, run:
+```
+/setup-medsci
+```
+
+You should see a checklist with all green ✅ marks. If anything is ❌, the checklist tells you which step to revisit.
+
+---
+
+## Step 10 — Install MedSci Skills
+
+```powershell
+cd $HOME
+git clone https://github.com/Aperivue/medsci-skills.git
+cd medsci-skills
+.\installers\install-windows.cmd
+```
+
+Or double-click `install-windows.cmd` in File Explorer (Allow → Yes when SmartScreen warns; the script is open-source and viewable in the repo).
+
+---
+
+## Step 11 — Add MCP Servers (Optional)
+
+See [`mcp-setup.md`](mcp-setup.md) for Zotero, Google Drive, and PubMed MCP integration.
+
+---
+
+## You're Done
+
+Try Demo 1:
+```powershell
+cd $HOME\medsci-skills\demo\01_wisconsin_bc
+```
+Then in Claude Code: `/orchestrate --e2e`
+
+Expected: a complete IMRAD manuscript + ROC curves + STARD compliance report in ~10 minutes.
+
+Issues? See [`common-issues.md`](common-issues.md).
+
+---
+
+## Common Windows Quirks
+
+- **PowerShell vs Command Prompt**: Use PowerShell. Most install commands assume PowerShell.
+- **Antivirus warnings**: Windows Defender or third-party AV may flag `git`, `python`, or `claude` installers as "unrecognized." This is normal for newly-released versions — click **More info** → **Run anyway** if the source is the official one above.
+- **PATH after install**: Always close and reopen PowerShell after installing a new tool, otherwise the new command isn't found yet.
+- **OneDrive interference**: If you cloned the repo into a OneDrive-synced folder (Documents, Desktop), some scripts may stall. Move the repo to `C:\Users\YourName\medsci-skills` instead.

--- a/skills/setup-medsci/SKILL.md
+++ b/skills/setup-medsci/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: setup-medsci
+description: Diagnostic checklist for the MedSci Skills runtime. Verifies Python, R, Node, Claude Code, Git, Zotero, and configured MCP servers, and prints a pass/fail table with links to the right setup doc for any missing component. Read-only — does not install anything.
+triggers: setup, install, environment, diagnostic, check setup, why doesn't this work, missing python, missing R, MCP not connected, 환경 설정, 설치 점검
+tools: Bash, Read
+model: inherit
+---
+
+# Setup-MedSci Skill
+
+You are helping a medical researcher verify that their environment is correctly configured to run MedSci Skills. You **do not install anything** — you only diagnose what's present, what's missing, and where to find the setup doc for any missing component. This skill is intentionally read-only so that a doctor can run it safely without worrying about breaking their system.
+
+## Communication Rules
+
+- Communicate with the user in their preferred language (Korean or English).
+- The diagnostic table itself is in English so it can be pasted into GitHub issues for support.
+- All recommended remediation links point to `docs/setup/` markdown guides in the medsci-skills repo.
+
+## Workflow
+
+### Phase 1: Detect OS
+
+Run:
+```bash
+uname -s
+```
+
+- `Darwin` → macOS path → recommend `docs/setup/mac.md`
+- `Linux` → Linux path (uses similar tooling to Mac) → recommend `docs/setup/mac.md`
+- `MINGW*`, `MSYS*`, `CYGWIN*`, or detection failure on Windows → recommend `docs/setup/windows.md`
+
+### Phase 2: Run Diagnostic Commands
+
+For each tool, run the command and capture both the version output and the exit code:
+
+| Tool | Command | Required version |
+|---|---|---|
+| Python | `python3 --version` (Mac/Linux) or `python --version` (Windows) | 3.11 or higher |
+| R | `Rscript --version` (writes to stderr) | 4.0 or higher |
+| Node.js | `node --version` | v20 or higher |
+| Git | `git --version` | 2.30 or higher |
+| Claude Code CLI | `claude --version` | any |
+| MCP servers | `claude mcp list` | at least one of: zotero, gdrive, pubmed, filesystem |
+
+Use `command -v <tool>` first to detect presence without running it (avoids triggering long initialization).
+
+### Phase 3: Emit Checklist Table
+
+Print a single Markdown table to stdout in this exact format:
+
+```
+## MedSci Skills Setup Diagnostic
+
+OS detected: <macOS | Linux | Windows>
+Date: <YYYY-MM-DD>
+
+| Component | Status | Detected | Required | Action |
+|---|:---:|---|---|---|
+| Python 3.11+ | ✅ / ❌ | 3.11.9 | 3.11+ | OK / See docs/setup/mac.md Step 2 |
+| R 4.x | ✅ / ❌ | 4.3.1 | 4.0+ | OK / See docs/setup/mac.md Step 3 |
+| Node.js 20+ | ✅ / ❌ | v20.11.1 | v20+ | OK / See docs/setup/mac.md Step 4 |
+| Git | ✅ / ❌ | 2.42.0 | 2.30+ | OK / See docs/setup/<os>.md Step 5 |
+| Claude Code CLI | ✅ / ❌ | 1.5.x | any | OK / See docs/setup/<os>.md Step 6 |
+| MCP: zotero | ✅ / ❌ / ⚠️ | Connected | optional | OK / See docs/setup/mcp-setup.md |
+| MCP: gdrive | ✅ / ❌ / ⚠️ | Connected | optional | OK / See docs/setup/mcp-setup.md |
+| MCP: filesystem | ✅ / ❌ | Connected | recommended | OK / See docs/setup/mcp-setup.md |
+
+Summary: <X required components passed, Y missing>
+Next step: <one-sentence action>
+```
+
+Status legend:
+- ✅ Present and meets minimum version
+- ❌ Missing or below minimum version
+- ⚠️ Present but optional and not connected
+
+### Phase 4: Suggest Remediation
+
+If everything ✅: "Your environment is ready. Try Demo 1 with `cd ~/medsci-skills/demo/01_wisconsin_bc && claude '/orchestrate --e2e'`."
+
+If anything ❌ in **required** rows: print the corresponding doc link. Do **not** offer to install — direct the user to follow the doc step. The doc tells them exactly what to copy-paste.
+
+If only **optional MCP** rows are ❌: explain that MedSci Skills work without MCP servers but `lit-sync`, `verify-refs`, and `write-paper` are smoother with Zotero MCP. Offer the `docs/setup/mcp-setup.md` link.
+
+## Reference Files
+
+- `references/setup-checklist.md` — verbatim list of every check this skill runs and the corresponding documentation link
+
+## Output Contract
+
+| Artifact | Filename | Format |
+|----------|----------|--------|
+| Diagnostic report | stdout (Markdown table) | Markdown |
+| Optional log | `~/.medsci-skills/diagnostic-YYYY-MM-DD.md` | Markdown |
+
+If the user asks for a copyable report (e.g., for a GitHub issue), write the diagnostic to the optional log path and tell them where it is.
+
+## What This Skill Does NOT Do
+
+- **Does not install anything.** No `brew install`, `winget install`, `pip install`, `Rscript -e 'install.packages(...)'`, or any other state-changing command. Read-only diagnostics only.
+- **Does not modify `~/.claude.json` or any MCP configuration.** It only reads `claude mcp list` output.
+- **Does not check skill versions or skill content.** That is the job of `validate_skills.sh` and `manage-project status`.
+- **Does not auto-fix anything.** If a tool is missing, the user must go to the setup doc and follow the steps themselves. This is intentional — auto-installers for system Python and R are a support nightmare for non-developer users.
+
+## Anti-Hallucination
+
+- **Never fabricate version numbers.** Always run the actual command and report the exact stdout. If the command fails, report the failure verbatim — do not guess what version is "probably" installed.
+- **Never invent doc paths.** The five setup docs are: `docs/setup/README.md`, `docs/setup/mac.md`, `docs/setup/windows.md`, `docs/setup/mcp-setup.md`, `docs/setup/common-issues.md`. Do not link to a doc that does not exist in the repo.
+- **Never claim an MCP server works without verifying via `claude mcp list`.** A configured-but-disconnected server is ⚠️, not ✅.
+- **If `command -v` reports a tool present but the version flag fails**, mark the row ❌ and report the failure command — the install is broken, not just outdated.

--- a/skills/setup-medsci/references/setup-checklist.md
+++ b/skills/setup-medsci/references/setup-checklist.md
@@ -1,0 +1,51 @@
+# Setup Diagnostic Checklist
+
+Verbatim list of every check `setup-medsci` runs, with the exact command, the parse rule, and the documentation link to print on failure.
+
+## Required Components
+
+| ID | Component | Detect command | Version command | Min version | Doc link on failure |
+|---|---|---|---|---|---|
+| R1 | Python 3 | `command -v python3` | `python3 --version` | 3.11.0 | `docs/setup/mac.md#step-2` (Mac) / `docs/setup/windows.md#step-3` (Windows) |
+| R2 | R | `command -v Rscript` | `Rscript --version` (stderr) | 4.0.0 | `docs/setup/mac.md#step-3` / `docs/setup/windows.md#step-4` |
+| R3 | Node.js | `command -v node` | `node --version` | 20.0.0 | `docs/setup/mac.md#step-4` / `docs/setup/windows.md#step-5` |
+| R4 | Git | `command -v git` | `git --version` | 2.30.0 | `docs/setup/mac.md#step-5` / `docs/setup/windows.md#step-6` |
+| R5 | Claude Code CLI | `command -v claude` | `claude --version` | any (latest recommended) | `docs/setup/mac.md#step-6` / `docs/setup/windows.md#step-7` |
+
+## Optional Components
+
+| ID | Component | Detect command | Status rule | Doc link on missing |
+|---|---|---|---|---|
+| O1 | MCP: zotero | `claude mcp list` | ✅ if "zotero ✓ Connected", ⚠️ if listed but not connected, ❌ if absent | `docs/setup/mcp-setup.md#zotero-mcp` |
+| O2 | MCP: gdrive | `claude mcp list` | ✅ if "gdrive ✓ Connected", ⚠️ if listed but not connected, ❌ if absent | `docs/setup/mcp-setup.md#google-drive--workspace-mcp` |
+| O3 | MCP: pubmed | `claude mcp list` | ✅ if "pubmed ✓ Connected", ⚠️ if listed but not connected, ❌ if absent | `docs/setup/mcp-setup.md#pubmed-mcp-alternative-to-built-in-search-lit` |
+| O4 | MCP: filesystem | `claude mcp list` | ✅ if "filesystem ✓ Connected", ⚠️ if listed but not connected, ❌ if absent | `docs/setup/mcp-setup.md#filesystem-mcp-built-in-usually-pre-configured` |
+| O5 | Zotero desktop | `pgrep -x Zotero` (Mac) / `tasklist /FI "IMAGENAME eq zotero.exe"` (Win) | ✅ if running, ⚠️ if installed but not running, ❌ if not installed | `docs/setup/mac.md#step-7` / `docs/setup/windows.md#step-8` |
+
+## Version Comparison Rule
+
+For required-version checks (R1-R4), parse the major.minor version from stdout, compare against minimum. If parse fails, mark ❌ and report the parse failure verbatim.
+
+Examples of parsing:
+- `Python 3.11.9` → `3.11`, compare to `3.11` → pass
+- `Python 3.10.13` → `3.10`, compare to `3.11` → fail
+- `R scripting front-end version 4.3.1 (2023-06-16)` → `4.3`, compare to `4.0` → pass
+- `v20.11.1` → `20.11`, compare to `20.0` → pass
+- `git version 2.42.0` → `2.42`, compare to `2.30` → pass
+
+## Summary Rules
+
+After running all checks:
+- **All required ✅**: print "Your environment is ready. Try Demo 1 with `cd ~/medsci-skills/demo/01_wisconsin_bc && claude '/orchestrate --e2e'`."
+- **One or more required ❌**: print "Setup incomplete. Address the ❌ rows above using the linked docs, then re-run `/setup-medsci`."
+- **All required ✅, optional MCP all ❌**: print "Core environment ready. Optional MCP servers (Zotero / Google Drive / PubMed) are not configured — see `docs/setup/mcp-setup.md` for richer integration."
+
+## What This Skill Does NOT Check
+
+To keep the diagnostic fast and read-only, these are explicitly out of scope:
+- Python package installs (matplotlib, pandas, scikit-learn, etc.) — checked by individual analysis skills when invoked
+- R package installs (metafor, survey, etc.) — checked by `analyze-stats` and `meta-analysis` when invoked
+- Disk space — irrelevant for skill execution
+- Anthropic API quota / rate limits — visible only at runtime
+- Claude Code skill installation — `validate_skills.sh` covers this
+- Zotero library content / collection structure — `lit-sync` and `verify-refs` cover this


### PR DESCRIPTION
## Summary

Internal polish before external promotion to awesome-claude-code (re-submission, prior #1389/#1518), OpenClaw aggregator, and Anthropic DevRel. Addresses four blockers identified in the 2026-05-13 audit vs K-Dense scientific-agent-skills (20.8k stars) and OpenClaw Medical Skills (2.5k stars).

### What changed

- **Academic backlink** — \`CITATION.cff\` (cff-version 1.2.0) + \`.zenodo.json\`. DOI populates after first Zenodo archive of a tagged release.
- **Release automation** — \`.github/workflows/release.yml\` on \`v*\` tag push: builds classroom ZIPs, creates GitHub Release with notes from CHANGELOG, attaches ZIPs. Zenodo integration toggled once at zenodo.org/account/settings/github.
- **Clinician onboarding** — five-doc guide at \`docs/setup/\` (\`README.md\`, \`mac.md\`, \`windows.md\`, \`mcp-setup.md\`, \`common-issues.md\`) + new \`setup-medsci\` skill that runs \`which / claude mcp list\` diagnostics and prints a checklist with status (✅ / ⚠️ / ❌) and a doc link per missing component. **Read-only** — does not install anything (intentional: auto-installers for system Python and R are a support nightmare for non-developers).
- **Scope clarity** — README \"What This Is NOT\" section explicitly defers broad scientific tooling to K-Dense and biomedical aggregation to OpenClaw, positioning medsci-skills as the opinionated medical manuscript pipeline.
- **README** — new \`Setup\` section linking the new docs and \`/setup-medsci\`, citation badge, DOI badge placeholder.
- **CHANGELOG.md** — Unreleased entry summarizing all of the above.
- **GitHub topics** — swapped 4 generic (\`ai-tools\`, \`academic-writing\`, \`open-source\`, \`research-tools\`) for 4 specific (\`agent-skills\`, \`tripod-ai\`, \`irb-protocol\`, \`physician-researcher\`) within the 20-topic cap.

### Why now

Doctor users coming via Show HN / awesome-claude-code re-submission need to (a) verify the project is academically citable and (b) install Python/R/Claude Code without bouncing. The \`docs/setup/\` guide and \`setup-medsci\` skill close the largest onboarding hole identified in user feedback this cycle.

## Test plan

- [x] \`scripts/validate_skills.sh\` PASS (verified locally via pre-commit hook — \`setup-medsci\` PASSes all required checks; size 110 lines is THIN tier WARN, not FAIL)
- [ ] After merge: tag \`v3.0.0\` → \`.github/workflows/release.yml\` triggers → GitHub Release with classroom ZIPs created
- [ ] Toggle Zenodo GitHub integration → first archive lands → DOI back-filled into README badge + CITATION.cff in a follow-up commit on \`main\`
- [ ] \`/setup-medsci\` runs end-to-end on a clean machine (will be tested by next external user; instrumented via the diagnostic output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)