### PR TITLE
chore(validator): extend precedent blocklist + generalize artifact filenames

### DIFF
--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -165,7 +165,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # historical prefix patterns (Paper ①②③). Keep additions in alphabetical
   # blocks so future maintainers can spot what is being filtered.
   precedent_hits=0
-  precedent_patterns='\bCK-[0-9]+\b|\bMA-[0-9]+\b|\b0_MI2RL\b|\b1_Samsung_Changwon\b|\b5_Personal_Research\b|\b6_Aperivue\b|\b10_Meta_Analysis\b|\b11_CheckUP\b|\b21_Aneurysm\b|01_RFA_Adjunct|02_CBCT_Biopsy|03_CBCT_Ablation|RFA-Adjunct|RFA_Adjunct|CBCT Ablation MA|CBCT Biopsy MA|Du 2023|FD Occlusion AI SR|FD Occlusion|Paper ①|Paper ②|Paper ③|MeducAI|CXRscoliosis|SkullFx|Samsung Changwon|삼성서울|삼성창원|서울아산|Asan/UoU|\bKKW\b|\bLHC\b|\bKDY\b|\bLWJ\b|\bHRP_Rhim\b|김경원|이덕희|김남국|임현철|임해진|남유진|Hyunchul Rhim|Pa Hong|Taein An|Hye Ree Cho|Yoojin Nam|Dong Yeong Kim|Kyung Won Kim|Jeong Min Song|Jaeyoon Kim|[가-힣]{2,4}[[:space:]]*(교수님|선생님)'
+  precedent_patterns='\bCK-[0-9]+\b|\bMA-[0-9]+\b|\b0_MI2RL\b|\b1_Samsung_Changwon\b|\b5_Personal_Research\b|\b6_Aperivue\b|\b10_Meta_Analysis\b|\b11_CheckUP\b|\b21_Aneurysm\b|01_RFA_Adjunct|02_CBCT_Biopsy|03_CBCT_Ablation|RFA-Adjunct|RFA_Adjunct|CBCT Ablation MA|CBCT Biopsy MA|Du 2023|FD Occlusion AI SR|FD Occlusion|Paper ①|Paper ②|Paper ③|MeducAI|CXRscoliosis|SkullFx|Samsung Changwon|삼성서울|삼성창원|서울아산|Asan/UoU|\bKKW\b|\bLHC\b|\bKDY\b|\bLWJ\b|\bHRP_Rhim\b|김경원|이덕희|김남국|임현철|임해진|남유진|Hyunchul Rhim|Pa Hong|Taein An|Hye Ree Cho|Yoojin Nam|Dong Yeong Kim|Kyung Won Kim|Jeong Min Song|Jaeyoon Kim|[가-힣]{2,4}[[:space:]]*(교수님|선생님)|CAC>[0-9]+|VIF[[:space:]]+Diag|[A-Z]+[0-9]+_Consensus_Sheet|v[0-9]+_edit_plan\.md|screening_consensus_final\.md|fulltext_screening_final\.tsv'
   for f in "${integrity_files[@]}"; do
     if grep -qE "$precedent_patterns" "$f"; then
       hit=$(grep -nE "$precedent_patterns" "$f" | head -1)

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -168,19 +168,19 @@ Use `/make-figures` to generate PRISMA flow diagram when numbers are finalized.
 
 #### 3f. Post-Consensus Count Reconciliation Gate (MANDATORY before Phase 5 write-up)
 
-Before handing the screening artifacts to Phase 5 (statistical synthesis) or to `/write-paper` / `/self-review`, run an explicit ID-set reconciliation and record the canonical totals in a single source-of-truth file (typically `2_Screening/screening_consensus_final.md` §Net Impact or equivalent):
+Before handing the screening artifacts to Phase 5 (statistical synthesis) or to `/write-paper` / `/self-review`, run an explicit ID-set reconciliation and record the canonical totals in a single source-of-truth file (typically `2_Screening/screening_consensus.md` §Net Impact or equivalent):
 
 Use the deterministic helper when TSV/CSV artifacts are available:
 
 ```bash
 python "${CLAUDE_SKILL_DIR}/scripts/screening_reconcile.py" \
-  --screening 2_Screening/fulltext_screening_final.tsv \
+  --screening 2_Screening/fulltext_screening.tsv \
   --consensus 2_Screening/consensus_decisions.tsv \
   --table1 6_Tables/table1_studies.csv \
-  --output 2_Screening/screening_consensus_final.json
+  --output 2_Screening/screening_consensus.json
 ```
 
-Downstream stages should consume `screening_consensus_final.json` for counts and
+Downstream stages should consume `screening_consensus.json` for counts and
 ID sets. The Markdown consensus document remains the human explanation.
 
 1. **Enumerate ID sets from raw artifacts (not from prose summaries):**

--- a/skills/meta-analysis/scripts/screening_reconcile.py
+++ b/skills/meta-analysis/scripts/screening_reconcile.py
@@ -82,7 +82,7 @@ def main() -> int:
     parser.add_argument("--screening", required=True, help="TSV/CSV with screening decisions")
     parser.add_argument("--consensus", help="TSV/CSV with final consensus decisions")
     parser.add_argument("--table1", help="TSV/CSV containing bivariate/Table 1 study IDs")
-    parser.add_argument("--output", default="2_Screening/screening_consensus_final.json")
+    parser.add_argument("--output", default="2_Screening/screening_consensus.json")
     parser.add_argument("--screening-id-col")
     parser.add_argument("--screening-decision-col")
     parser.add_argument("--consensus-id-col")

--- a/skills/meta-analysis/skill.yml
+++ b/skills/meta-analysis/skill.yml
@@ -18,7 +18,7 @@ inputs:
   - screening/*.tsv
   - extraction/*.csv
 outputs:
-  - 2_Screening/screening_consensus_final.json
+  - 2_Screening/screening_consensus.json
   - analysis/meta_analysis_outputs.json
   - manuscript/manuscript.md
 deterministic_scripts:


### PR DESCRIPTION
## Summary
- Extend `scripts/validate_skills.sh` precedent blocklist with 6 additional patterns covering project-specific artifact names and threshold idioms that have appeared in private skill drafts.
- The new patterns immediately surfaced one historical leak in `skills/meta-analysis/SKILL.md`: project-specific filenames embedded in the screening reconciliation gate. Renamed those paths to generic forms.
- Updated `skills/meta-analysis/skill.yml` (`outputs:` declaration) and `skills/meta-analysis/scripts/screening_reconcile.py` (`--output` default) to match.

## New blocklist patterns
- `CAC>[0-9]+` — clinical threshold notations
- `VIF[[:space:]]+Diag` — statistical artifact label
- `[A-Z]+[0-9]+_Consensus_Sheet` — internal consensus spreadsheet naming
- `v[0-9]+_edit_plan\.md` — versioned edit-plan docs
- `screening_consensus_final\.md` — internal SR consensus file naming
- `fulltext_screening_final\.tsv` — internal SR screening file naming

## Filename generalization (meta-analysis skill)
- `screening_consensus_final.md` → `screening_consensus.md`
- `screening_consensus_final.json` → `screening_consensus.json`
- `fulltext_screening_final.tsv` → `fulltext_screening.tsv`

## Test plan
- [x] `bash scripts/validate_skills.sh` — ALL CHECKS PASSED (0 failures)
- [x] Verified the new patterns catch the historical leak before generalization
- [x] Verified all skill prose / yaml / scripts reference the new generic filenames consistently