### PR TITLE
feat(journal-profiles): retrofit KJR + add 5 Korean/UK profiles + fix check_xref regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ skills/**/HANDOFF_*.md
 # Note: skills/*/TODO_*.md are intentionally TRACKED (sanitized before commit)
 # so that downstream users can see what's planned. They are scanned by
 # validate_skills.sh just like SKILL.md/references.
+
+# Gemini/Antigravity AI assistant scratchpad (per-session, not for repo)
+.gemini/

--- a/INTAKE/from_CK07_session_2026-05-20_to_21.md
+++ b/INTAKE/from_CK07_session_2026-05-20_to_21.md
@@ -1,0 +1,189 @@
+# Update intake — from CK-07 e2e session (2026-05-20 → 2026-05-21)
+
+**Source session**: CK-07 CKM Syndrome Mortality manuscript v1.0 → v1.5 (JACC: Advances submission format)
+**Triage status**: ✅ harvested 2026-05-21 (this intake plus session 1 + session 3 feedback consolidated into plan `~/.claude/plans/e2e-dapper-cerf.md`)
+**OSS PII guard applied**: yes — no manuscript IDs, no mentor names, no project-internal codes leaked in this file
+
+This file lists candidate updates discovered during a single end-to-end manuscript build cycle.
+
+## Absorption status (2026-05-21 harvesting session)
+
+- [x] §1 Profile promotions (JACC_Advances / EJPC / NMCD / JCEM / Korean_Circulation_Journal) — harvested from `~/.claude/private-journal-profiles/` and written to public `skills/{find-journal,write-paper}/references/journal_profiles/` (Phase 3)
+- [x] §2 `lit-sync` DOI-dedup (already implemented at SKILL.md line 109–116, verified)
+- [x] §3 `journal-profile-creation.md` global rule — created at `~/.claude/rules/` (Phase 5A)
+- [x] §3 `numerical-safety.md` prose-level recompute — boost added (Phase 5B)
+- [DEFERRED] §2 `write-paper` journal-format automation, `sync-submission` v_N branching, `check-reporting` regenerate — recorded as Phase 4 deferred PR candidates
+- [DEFERRED] §4 `manuscript-version-bump-guard.sh` hook — defer until incident
+- [PENDING USER] §5 Cardiovascular Diabetology + Circulation: Cardiovascular Quality and Outcomes — user fallback data needed
+
+---
+
+## 1. Journal profiles added (private tier)
+
+8 files newly created under `~/.claude/private-journal-profiles/`. POLICY (private→public) requires user verification before promotion. Recommended promotion candidates marked ★.
+
+### Compact profiles — `~/.claude/private-journal-profiles/find-journal/`
+
+| File | Promotion candidate | Verification needed |
+|------|---------------------|---------------------|
+| `JACC_Advances.md` (33 lines) | ★ public (high — JACC family) | Homepage + GfA fetched OK; AI policy = Elsevier publisher-level (transcribed from publisher policy page, not journal page) |
+| `EJPC.md` (31 lines) | ★ public (high — ESC/EAPC flagship; AI policy verbatim from journal Author Guidelines) | OUP GfA fetched OK; verbatim AI policy quoted |
+| `NMCD.md` (31 lines) | ★ public (Elsevier, cardio-metabolic) | ScienceDirect GfA fetched OK |
+| `JCEM.md` (32 lines) | public candidate (OUP/Endocrine Society) | OUP Author Guidelines fetched OK; AI policy verbatim |
+| `Korean_Circulation_Journal.md` (30 lines) | public candidate (KSC flagship) | e-kcj.org fetched OK; AI policy not on instructions page (refer to journal editorial office) |
+| `Korean_Journal_of_Internal_Medicine.md` (29 lines) | public candidate (KAIM, IF 2.4) | kjim.org Authors page fetched OK; AI policy verbatim |
+
+### Detailed profiles — `~/.claude/private-journal-profiles/write-paper/`
+
+| File | Promotion candidate |
+|------|---------------------|
+| `JACC_Advances.md` (197 lines) | ★ public — full positioning table vs JACC main / JACC Asia / EJPC; submission portal verified |
+| `EJPC.md` (192 lines) | ★ public — full positioning table vs JACC: Advances / JAHA / NMCD |
+
+### Two journals deferred (auth-gated; user fallback needed)
+
+- **Cardiovascular Diabetology** (Springer auth-gate `idp.springer.com`) — needs user-supplied submission guidelines text
+- **Circulation: Cardiovascular Quality and Outcomes** (AHA Journals 403) — AHA family-wide WebFetch failure; user-supplied scope + Author Instructions needed
+
+### Already-registered journals (work not needed; reuse existing)
+
+- `Atherosclerosis.md` (private find-journal) — high-quality profile already exists
+- `JAHA.md` (private find-journal) — full populated profile already exists
+- AHA family (Circulation main, JAMA Cardiology, JACC main, JACC: CV Imaging, European Heart Journal) — already in private library
+
+### Promotion checklist before public push
+
+Per `skills/find-journal/POLICY.md`, before `git mv private → public`, the next session should:
+
+- [ ] User opens each journal homepage + author guidelines and attests
+- [ ] ISSN cross-checked against portal.issn.org for the exact journal name (currently transcribed from journal's own masthead/about pages)
+- [ ] AI policy wording double-checked against the journal's or publisher's own policy page (for JACC: Advances specifically — confirm Elsevier publisher-level policy applies, since the JACC: Advances GfA page does not show a journal-specific AI policy)
+- [ ] Commit message records which pages were opened and on what date
+
+---
+
+## 2. Skill improvement candidates
+
+### `/verify-refs` — works as designed; one usability note
+
+**Validated**: this session reproduced the v1.1.2 first-author cross-check value. A bib entry with correct DOI but wrong first author (CK-07 case: `Lee, Seon Mee` vs actual `Kim, Mee Kyoung`, DOI `10.3803/EnM.2014.29.4.405`) was caught as MISMATCH with `note: "first-author hallucination suspected"`. The rule pays off — no change needed to the detection.
+
+**Usability nit**: when verify-refs flags a MISMATCH, the report does not trace which manuscript paragraph cites the offending bibkey. A future enhancement could add a "cited from manuscript.md line N" pointer for faster remediation. Defer until 2+ similar cases recur.
+
+### `/lit-sync` — three improvement candidates
+
+**a) Collection auto-create on first sync.** This session found that for a project with no `references/` folder, lit-sync needed manual prep (Zotero collection creation, `references/zotero_collection.json` scaffolding). Recommended: lit-sync detects missing collection by project_id and auto-creates `<ProjectID>` Zotero collection on Phase 1.
+
+**b) DOI-based dedup before add.** `zotero_add_by_doi` does not check if the DOI is already in the library. This session triggered Inker 2021 → 4 duplicates (one new add + 3 prior from CK-01/08/13). Recommended: lit-sync should search by DOI first, and only call `add_by_doi` when no existing item matches. Then assign existing item to the new collection rather than re-adding.
+
+**c) After-sync cleanup: report duplicates within current collection only.** Current `zotero_find_duplicates` returns all library-wide duplicates (11 groups in this session, only 1 actually CK-07-related). Recommended: lit-sync filters duplicates to those whose any-member is in the just-synced collection.
+
+### `/write-paper` — journal-format automation candidate
+
+**Observation**: this session manually adjusted v1.4 → v1.5 for JACC: Advances format:
+- Abstract 4-heading → 5-heading (Background / Objectives / Methods / Results / Conclusions)
+- Highlights 3-5 bullets added
+- Central Illustration legend added
+- AI Declaration section moved to immediately above references (Elsevier publisher policy)
+- 5,000-word cap aggressive trim (text + refs + figure legends combined)
+
+**Recommended enhancement**: write-paper Phase 7 (journal-format adjustment) reads the find-journal compact profile's "Special Notes" + "Article Types Accepted" + detailed profile's "Required Journal-Specific Elements", and proposes format transformations as a checklist. Currently this step is implicit; making it explicit would shorten the v_N → v_(N+1) cascade when switching journals.
+
+### `/sync-submission` — v_N → v_(N+1) branching automation
+
+**Pattern observed**: this session executed 6 versions (v1 → v1.1 → v1.2 → v1.3 → v1.4 → v1.5), each triggered by audit results. Each branch followed:
+
+1. Freeze v_N (`manuscript/archive/v{N}_frozen/`)
+2. Update SSOT (`manuscript.md` in place with `manuscript_version` bumped)
+3. Rebuild DOCX (`submission/<journal>/v{N+1}/manuscript_v{N+1}.docx`)
+4. Re-run QC gates (`xref_audit_v{N+1}.json`, `reference_audit.json`)
+5. Update `STATUS.md` Stream table
+6. Sync into `reviews/circulation_R1/` if circulating
+
+**Recommended**: sync-submission could add a `branch v{N+1}` subcommand that automates steps 1-5 given a trigger ("Codex audit yielded N items", "critic R0 cycle 2", "senior PI revision", "cascade to new journal"). Currently this is manual cp + Edit + bash, error-prone for the version-counting.
+
+### `/check-reporting` — usability nit (no functional change)
+
+Manuscript v1.5 was prepared without re-running check-reporting on STROBE checklist. The skill is solid but its output (`qc/reporting_checklist.md`) ages quickly as the manuscript changes. Recommended: add a "regenerate if manuscript.md mtime > checklist mtime" automation pattern in the skill's preamble.
+
+---
+
+## 3. Cross-cutting global-rule candidates
+
+### Candidate new rule: `journal-profile-creation.md`
+
+Pattern observed this session for adding 10 candidate journals to medsci-skills:
+
+1. **WebFetch attempt first** — Elsevier ScienceDirect, OUP, Wiley typically OK
+2. **403 / auth-gate detection** — AHA Journals family (Circulation, JAHA, Hypertension), Springer journals (BMC Cardiovascular Diabetology) typically blocked
+3. **User-fallback request** — paste page text or PDF path; do not infer
+4. **Private tier default** — POLICY's verification bar is strict; promote later
+
+This pattern is documented inline in `find-journal/POLICY.md` but a separate global rule (`~/.claude/rules/journal-profile-creation.md`) would make it discoverable from outside the skill. Defer until 2-3 sessions repeat the pattern.
+
+### Existing rules validated (no change needed)
+
+- `~/.claude/rules/manuscript-style-classical.md` — § = 0, em-dash < 25, classical heading style; all enforced cleanly
+- `~/.claude/rules/citation-safety.md` v1.1.2 — first-author cross-check caught the Lee→Kim KSSO case
+- `~/.claude/rules/manuscript-references.md` — Phase 1 (pandoc citeproc) + Phase 2 (Zotero CWYW preparation) hybrid worked
+- `~/.claude/rules/manuscript-versioning.md` — v_N freeze + v_(N+1) branch pattern executed 6 times this session without drift
+- `~/.claude/rules/senior-mentor-circulation.md` — circulation_R1/ folder structure preserved through 6 version bumps
+- `~/.claude/rules/zotero-workflow.md` — MCP user-scope + BBT auto-export pattern (auto-export still requires user GUI step)
+- `~/.claude/rules/oss-publication-pii-guard.md` — applied to this intake file itself
+
+### Existing rule that needs a small clarification: `numerical-safety.md`
+
+This session caught a stale hand-typed number in Limitations §7 ("21,679 single-visit subjects" from v1.1 cohort 30,700) that survived v1.2 → v1.3 because the cohort denominator changed under it. Current `numerical-safety.md` says "never hand-type CSV data into scripts." Recommended: add a parallel rule "never hand-type aggregate counts into manuscript prose; recompute from parquet/CSV on every revision." Currently this is implicit in the skill's audit checklist, not in the global rule.
+
+---
+
+## 4. Harness setting candidates
+
+### No `settings.json` changes proposed
+
+The harness already permits the tools used in this session (Bash, WebFetch, Zotero MCP, Skill tool). No `update-config` changes needed.
+
+### Hook candidate (low priority): `manuscript-version-bump-guard.sh`
+
+Triggered on `Edit` to any `manuscript/manuscript.md` whose YAML front-matter `manuscript_version` field changes — automatically `cp` to `manuscript/archive/v{old}_frozen/` before allowing the edit. This would enforce `manuscript-versioning.md` mechanically. Defer until a v_N drift incident occurs.
+
+---
+
+## 5. Two journal profiles still owed (user-supplied data needed)
+
+Tracked separately so another session can pick up when user provides the data:
+
+### Cardiovascular Diabetology
+- Springer auth-gate blocked WebFetch on both homepage and submission-guidelines
+- Need from user: (1) journal scope statement, (2) submission guidelines body (article types, word limits, abstract structure, references, AI policy), (3) APC amount
+- Filename target: `~/.claude/private-journal-profiles/find-journal/Cardiovascular_Diabetology.md`
+
+### Circulation: Cardiovascular Quality and Outcomes
+- AHA Journals 403 (family-wide block)
+- Need from user: (1) journal scope statement, (2) Author Instructions body — article types and word limits + abstract structure (typically 4-heading)
+- AI policy can inherit from existing `JAHA.md` profile (AHA family-wide AI policy)
+- Filename target: `~/.claude/private-journal-profiles/find-journal/Circulation_Cardiovascular_Quality_and_Outcomes.md`
+
+---
+
+## 6. Verification artifacts (for reproducibility)
+
+Intake claims here are anchored to source files in the originating project workspace (paths redacted to OSS-safe placeholders per `oss-publication-pii-guard.md`):
+
+- v1.4 → v1.5 word count + Highlights / 5-heading abstract changes: `<project>/submission/jacc_advances/v1.5/manifest.md`
+- 6-version cascade log: `<project>/STATUS.md` (Stream table)
+- Zotero collection map: `<project>/references/zotero_collection.json` (19 items, 1:1 mapped)
+- First-author hallucination case (cross-cohort surname swap): `<project>/qc/reference_audit.json` (counter-validated by re-run after fix)
+- Stale-number P1-a discovery + fix: `<project>/qc/critic_review_R0_v1.2.md` (item P1-a)
+- POSIXct/Date mismatch W-1 case: `<project>/qc/audit_R0_cycle3_v1.4.md` (item W-1)
+
+---
+
+## Suggested processing order for the harvesting session
+
+1. **Profile promotions** (lowest risk, immediate value): JACC: Advances + EJPC compact + detailed → public (after POLICY checklist). NMCD + JCEM + KCJ + KJIM compact → public consideration.
+2. **lit-sync DOI-dedup enhancement** (small, high-value): prevents future Inker-like 4-duplicate incidents across CK projects.
+3. **journal-profile-creation.md global rule** (defer until 2-3 more sessions repeat the WebFetch → user-fallback pattern).
+4. **write-paper journal-format automation** (medium, defer — current manual process worked).
+5. **sync-submission v_N branching automation** (medium, defer — current manual cascade worked, 6 versions in 2 days).
+6. **manuscript-version-bump-guard.sh hook** (low priority; defer until incident).

--- a/skills/find-journal/references/journal_profiles/British_Journal_of_Radiology.md
+++ b/skills/find-journal/references/journal_profiles/British_Journal_of_Radiology.md
@@ -1,0 +1,39 @@
+# British Journal of Radiology
+
+## Identity
+- **Abbreviation:** BJR
+- **Publisher:** Oxford University Press (British Institute of Radiology)
+- **ISSN:** 0007-1285 / 1748-880X
+- **Homepage:** https://academic.oup.com/bjr
+- **Author guidelines:** https://academic.oup.com/bjr/pages/author-guidelines
+
+## Scope
+BJR publishes original research, reviews, and pictorial reviews across all subspecialties of diagnostic radiology, interventional radiology, nuclear medicine, radiation oncology, and radiation physics, with emphasis on clinical research, methodology, and translational radiology and an explicit "Advances in knowledge" novelty framing.
+
+## Scope Keywords
+diagnostic radiology, interventional radiology, nuclear medicine, radiation oncology, radiation physics, CT, MRI, ultrasound, PET, clinical radiology, translational imaging, advances in knowledge, methodology, multi-center radiology
+
+## Article Types Accepted
+- Research Article
+- Review
+- Systematic Review
+- Pictorial Review
+- Guidelines
+- Short Communication
+- Commentary
+- Letter to the Editor
+
+## Classification
+- **Tier:** Q2 (general radiology; verify current JCR rank)
+- **Open Access:** Hybrid (optional CC BY / CC BY-NC; APC ~£2,393)
+- **Field:** Radiology (general; includes physics + radiation oncology)
+
+## Special Notes
+British Institute of Radiology flagship; UK/European general-radiology readership; double-anonymized peer review (blind all upload files except title page); structured abstract requires the BJR-specific "Advances in knowledge" heading. AI policy: mandatory disclosure in both cover letter AND Methods/Acknowledgements; AI tools cannot be listed as authors; AI image generation must be disclosed.
+
+
+---
+
+## Verification
+- **Source:** https://academic.oup.com/bjr/pages/author-guidelines
+- **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/Diabetes_Metabolism_Journal.md
+++ b/skills/find-journal/references/journal_profiles/Diabetes_Metabolism_Journal.md
@@ -1,0 +1,36 @@
+# Diabetes & Metabolism Journal
+
+## Identity
+- **Abbreviation:** Diabetes Metab J
+- **Publisher:** Korean Diabetes Association (KDA)
+- **ISSN:** [TODO: verify at e-dmj.org]
+- **Homepage:** https://e-dmj.org
+- **Author guidelines:** https://e-dmj.org/authors/authors.php
+
+## Scope
+Diabetes & Metabolism Journal is the official English-language journal of the Korean Diabetes Association covering diabetes mellitus, metabolic disorders, and endocrinology — clinical, epidemiological, and basic-science research. The journal is particularly receptive to Korean and East Asian population studies addressing diabetes epidemiology, prevention, treatment, complications, body composition, metabolic syndrome, and related cohort outcomes.
+
+## Scope Keywords
+diabetes mellitus, type 2 diabetes, metabolic syndrome, body composition, sarcopenia, sarcopenic obesity, hepatic steatosis, MASLD, insulin resistance, HOMA-IR, glycaemic control, prediabetes, Korean cohort, East Asian population, KDA, diabetes prevention, diabetes complications, endocrinology, lipid disorders
+
+## Article Types Accepted
+- Original Article (4,000 words, abstract <250, refs ≤50, ≤6 figures/tables)
+- Review Article (abstract <200, refs ≤150)
+- Brief Report (1,500 words, abstract <180, refs ≤20, ≤2 figures)
+- Editorial (refs ≤20)
+- Letter to the Editor (1,000 words, refs ≤10, 1 figure or 1 table)
+
+## Classification
+- **Tier:** Q2 (specialty diabetes/endocrinology journal)
+- **Open Access:** Full OA, Creative Commons Attribution Non-Commercial License (CC BY-NC)
+- **Field:** Diabetes / Endocrinology / Metabolic Disease
+
+## Special Notes
+Diabetes & Metabolism Journal is the KDA flagship English-language journal, bimonthly (Jan/Mar/May/Jul/Sep/Nov). Double-blind peer review ensuring both authors and reviewers remain anonymous. Strict 4,000-word body limit for Original Article (excluding abstract, references, legends); structured abstract (Background-Methods-Results-Conclusion) ≤250 words; 3–10 MeSH keywords. Reporting guidelines mandated per study design (CONSORT/STROBE/PRISMA/CARE). Figure resolution ≥300 DPI in JPEG/EPS/TIFF/PICT format. AI policy: authors must disclose AI tool, version, manufacturer, and writing role on the title page; AI cannot be listed as author; AI-generated images prohibited. Particularly receptive to Korean and East Asian diabetes cohort studies and body-composition / metabolic-outcome research with single-institution observational designs.
+
+
+---
+
+## Verification
+- **Source:** https://e-dmj.org/authors/authors.php
+- **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/Endocrinology_and_Metabolism.md
+++ b/skills/find-journal/references/journal_profiles/Endocrinology_and_Metabolism.md
@@ -1,0 +1,37 @@
+# Endocrinology and Metabolism
+
+## Identity
+- **Abbreviation:** Endocrinol Metab (EnM)
+- **Publisher:** Korean Endocrine Society (KES)
+- **ISSN:** [TODO: verify at e-enm.org]
+- **Homepage:** https://e-enm.org
+- **Author guidelines:** https://e-enm.org/authors/authors.php
+
+## Scope
+Endocrinology and Metabolism is the official English-language journal of the Korean Endocrine Society covering endocrinology, metabolism, hormonal disorders, thyroid, adrenal, pituitary, bone metabolism, diabetes, and lipid metabolism — clinical, epidemiological, and basic-science research. The journal is particularly receptive to Korean and East Asian population studies on endocrine disorders and to research with explicit hormonal-axis or endocrine-mechanism framing.
+
+## Scope Keywords
+endocrinology, metabolism, thyroid disorders, adrenal disorders, pituitary disorders, bone metabolism, osteoporosis, diabetes mellitus, type 2 diabetes, lipid metabolism, dyslipidaemia, metabolic syndrome, hormonal axis, hormone replacement, Korean cohort, East Asian population, KES, mineral metabolism, calcium homeostasis, endocrine oncology
+
+## Article Types Accepted
+- Original Article (abstract ≤250, refs ≤50)
+- Review Article (abstract ≤200, refs ≤150)
+- Brief Report (1,200 words, abstract ≤150 unstructured, refs ≤20, ≤2 figures)
+- Editorial (1,000 words, refs ≤20)
+- Image (1,000 words, refs ≤5)
+- Letter to the Editor (1,000 words, refs ≤10, ≤1 figure)
+
+## Classification
+- **Tier:** Q2 (specialty endocrinology journal)
+- **Open Access:** Full OA, content freely available
+- **Field:** Endocrinology / Metabolism / Hormonal Disorders
+
+## Special Notes
+Endocrinology and Metabolism is the KES flagship English-language journal. Double-blind peer review with three anonymous specialist reviewers; review period capped at 3 months. Structured abstract (Background-Methods-Results-Conclusion) ≤250 words for Original Article. Reporting guidelines mandated per study design (CONSORT/STROBE/PRISMA/STARD). Figure resolution >300 DPI in JPEG/GIF/TIFF/BMP/PICT format with sequential Arabic numerals and letter sub-panels. AI policy: authors must clearly describe AI use in both manuscript and cover letter; AI cannot be listed as author; non-disclosure results in rejection or retraction. Particularly receptive to Korean and East Asian endocrinology studies and to research framed around hormonal-axis or endocrine-mechanism discussion. Body composition, diabetes, and metabolic syndrome research benefits from explicit endocrine framing in the manuscript narrative.
+
+
+---
+
+## Verification
+- **Source:** https://e-enm.org/authors/authors.php
+- **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/JCSM.md
+++ b/skills/find-journal/references/journal_profiles/JCSM.md
@@ -1,0 +1,39 @@
+# Journal of Cachexia, Sarcopenia and Muscle
+
+## Identity
+- **Abbreviation:** J Cachexia Sarcopenia Muscle (JCSM)
+- **Publisher:** Wiley
+- **ISSN:** [TODO: verify at JCSM journal page]
+- **Homepage:** https://onlinelibrary.wiley.com/journal/13989440
+- **Author guidelines:** https://onlinelibrary.wiley.com/page/journal/13989440/homepage/forauthors.html
+- **Submission portal:** https://authors.wiley.com/journal/JCSM/
+
+## Scope
+The Journal of Cachexia, Sarcopenia and Muscle is the dedicated international journal for cachexia, sarcopenia, body composition, and skeletal-muscle and adipose-tissue physiology/pathophysiology across the lifespan and across chronic diseases (cancer, heart failure, lung disease, cirrhosis, kidney failure, rheumatoid arthritis, sepsis, AIDS). The journal serves researchers and clinicians studying muscle wasting, lipolysis, sarcopenic obesity, ageing-related body composition changes, and prognostic/diagnostic biomarkers for these conditions.
+
+## Scope Keywords
+cachexia, sarcopenia, sarcopenic obesity, body composition, skeletal muscle, muscle wasting, adipose tissue, lipolysis, ageing, frailty, chronic disease, cancer cachexia, heart failure cachexia, COPD muscle wasting, cirrhosis sarcopenia, kidney failure cachexia, prognostic markers, body composition imaging, bioelectrical impedance, DXA, CT body composition, muscle biomarkers
+
+## Article Types Accepted
+- Original Article (4,500 words, abstract 400 structured data-rich, refs 40, ≤8 figures/tables with max 6 sub-sections per figure)
+- Review (6,000 words, abstract 400 unstructured data-rich, refs 120)
+- Editorial (invited only; 1,500 words; Facts & Numbers series allows abstract up to 400 words)
+- Research/Scientific Letter (1,200 words, 1 figure/table, 10 refs)
+- Short Report (1,500 words, ≤2 figures/tables, 10 refs)
+- Meeting Report (1,500 words, 20 refs)
+- Reply / Letter to the Editor (1,200 words)
+
+## Classification
+- **Tier:** Q1 (specialty journal — dedicated to cachexia/sarcopenia/body composition)
+- **Open Access:** Gold OA, APC required on acceptance (waivers/discounts may apply)
+- **Field:** Cachexia / Sarcopenia / Body Composition / Skeletal Muscle / Adipose Tissue
+
+## Special Notes
+JCSM is the dedicated international journal for cachexia, sarcopenia, and body composition research, published by Wiley under Gold Open Access (APC required on acceptance). **Single-blind peer review.** Continuous publication model (articles publish to online issue when ready; no issue pagination delay). Title cap ≤17 words / 120 characters. **Abstract must be data-rich (≤400 words, structured: Background/Methods/Results/Conclusions) with actual numbers, effect sizes, hazard ratios, 95% CIs, and p-values — "descriptive results abstracts are not acceptable."** Original Article body ≤4,500 words; 40 references in main + unlimited supplement (S1, S2, ...). **Only ONE corresponding author per submission**; multiple co-first or equal-contribution requests must be declared in cover letter. **For survival/prognostic studies, JCSM enforces strict reporting**: 1-year mortality rate with 95% CI (plus 5-year and/or 3-month as appropriate) in both abstract AND methods/results; Kaplan-Meier plots with "patients at risk" annotation at baseline + follow-up intervals; novel prognostic markers expected from cohorts with ≥60–100 events, novel prognostic scores ≥150–200 events. Validation in second cohort strongly recommended. Reference style flexible (since August 2024) but must be consistent and complete (author, year, journal/book, article title, volume, pages, DOI optional). Preprints permitted (declare server + accession/DOI in cover letter). AI policy: [TODO: verify at journal AI policy page] — Wiley publisher-wide policy generally requires disclosure of AI tools and bars AI as author.
+
+
+---
+
+## Verification
+- **Source:** https://onlinelibrary.wiley.com/page/journal/13989440/homepage/forauthors.html
+- **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/KJR.md
+++ b/skills/find-journal/references/journal_profiles/KJR.md
@@ -3,27 +3,36 @@
 ## Identity
 - **Abbreviation:** Korean J Radiol
 - **Publisher:** Korean Society of Radiology
-- **ISSN:** 1229-6929 / 2005-8330
+- **ISSN:** 1229-6929 (Print) / 2005-8330 (Electronic)
 - **Homepage:** https://www.kjronline.org/
-- **Author guidelines:** https://www.kjronline.org/authors/authors-information
+- **Author guidelines:** https://www.kjronline.org/index.php?body=Instruction
 
 ## Scope
-KJR publishes original research, reviews, and case reports across all subspecialties of diagnostic and interventional radiology, with particular strength in AI/radiomics, Korean population studies, and diseases prevalent in East Asia such as hepatocellular carcinoma, gastric cancer, and thyroid cancer.
+KJR publishes original research, reviews, and special articles across all subspecialties of diagnostic and interventional radiology. The journal explicitly excludes radiation oncology, dentistry, dental radiology, dental surgery, and translational/basic nuclear medicine studies. It has particular strength in AI/radiomics, Korean and East Asian population studies, and diseases prevalent in East Asia such as hepatocellular carcinoma, gastric cancer, and thyroid cancer.
 
 ## Scope Keywords
-diagnostic radiology, AI in radiology, radiomics, Korean radiology, hepatocellular carcinoma, thyroid imaging, gastric cancer imaging, CT, MRI, ultrasound, interventional radiology, liver imaging, breast imaging, chest imaging, deep learning, structured reporting
+diagnostic radiology, AI in radiology, radiomics, deep learning, Korean radiology, hepatocellular carcinoma, thyroid imaging, gastric cancer imaging, CT, MRI, ultrasound, interventional radiology, liver imaging, breast imaging, chest imaging, structured reporting, FDA/medical-device evaluation
 
 ## Article Types Accepted
 - Original Article
-- Review Article
-- Technical Note
-- Case Report
+- Brief Research Report
+- Review
+- Pictorial Essay
+- Focus
+- Recommendation and Guideline
+- Editorial
+- Uncover This Tech Term
+- Emerging Rad Dx
 - Letter to the Editor
 
 ## Classification
 - **Tier:** Q1
-- **Open Access:** Full OA (DOAJ indexed)
+- **Open Access:** Full OA (CC BY-NC 4.0, DOAJ indexed)
 - **Field:** Radiology (general)
 
 ## Special Notes
-KJR is the leading English-language radiology journal in Asia, fully open access with no APC for Korean Society of Radiology members. Indexed in PubMed/MEDLINE, SCIE, and Scopus. Requires 3 Key Messages after the abstract. Particularly receptive to AI/radiomics studies and Korean population data. Faster turnaround than Western journals (4-8 weeks to first decision). AI policy: follows ICMJE — disclose AI use in Methods.
+KJR is the leading English-language radiology journal in Asia, fully open access (USD 100 APC for accepted manuscripts; invited articles, Uncover This Tech Term, Emerging Rad Dx, and Letters are exempt). Indexed in PubMed/MEDLINE, SCIE, and Scopus. Particularly receptive to AI/radiomics studies and Korean population data. Faster turnaround than Western journals (Minor Revision within 30 days; Major Revision within 60 days). References: Vancouver style with first six authors listed, then "et al." (≥7 authors). AI policy follows the journal's "Ethical and Responsible Use of Generative AI" statement (KJR 2026; https://doi.org/10.3348/kjr.2026.0166): AI cannot be author or primary scholarly source; AI use beyond routine language assistance must be disclosed in the relevant section or Acknowledgments; AI as study subject must be described in Materials and Methods; reviewers/editors must preserve confidentiality and disclose AI use beyond routine language assistance.
+
+## Verification
+- **Source:** KJR-Instructions-202603.pdf (March 2026 official author instructions)
+- **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
+++ b/skills/find-journal/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
@@ -1,0 +1,36 @@
+# Korean Journal of Internal Medicine
+
+## Identity
+- **Abbreviation:** KJIM
+- **Publisher:** Korean Association of Internal Medicine
+- **ISSN:** 1226-3303 / 2005-6648
+- **Homepage:** https://www.kjim.org/
+- **Author guidelines:** https://www.kjim.org/authors/authors.php
+
+## Scope
+KJIM publishes original research, reviews, and clinical case reports across all subspecialties of internal medicine — endocrinology, gastroenterology, hematology-oncology, infectious diseases, nephrology, pulmonology, rheumatology, cardiology, geriatrics — with emphasis on Korean and East Asian clinical research.
+
+## Scope Keywords
+internal medicine, Korean cohort, East Asian medicine, endocrinology, gastroenterology, hematology, oncology, infectious disease, nephrology, pulmonology, rheumatology, cardiology, geriatrics, health screening, NHIS, clinical research, observational cohort
+
+## Article Types Accepted
+- Original Article
+- Review
+- Editorial
+- Images of Interest
+- Correspondence
+
+## Classification
+- **Tier:** Q2 (general internal medicine; verify current JCR rank)
+- **Open Access:** Full OA (CC BY-NC); APC $1,000 for Original Articles (2024-10-01)
+- **Field:** Internal medicine (general)
+
+## Special Notes
+Korean Association of Internal Medicine flagship; bimonthly publication; PubMed/PMC indexed; structured abstract requires Background/Aims, Methods, Results, Conclusions; KJIM-specific "Key Message" section is mandatory in Original Articles. Initial decision typically within 4 weeks. AI policy: mandatory AI disclosure in Acknowledgments with model name + version + source + application method; AI cannot be listed as author.
+
+
+---
+
+## Verification
+- **Source:** https://www.kjim.org/authors/authors.php
+- **Date:** 2026-05-21

--- a/skills/manage-refs/citation_styles/journal-of-cachexia-sarcopenia-and-muscle.csl
+++ b/skills/manage-refs/citation_styles/journal-of-cachexia-sarcopenia-and-muscle.csl
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Journal of Cachexia, Sarcopenia and Muscle</title>
+    <title-short>JCSM</title-short>
+    <id>http://www.zotero.org/styles/journal-of-cachexia-sarcopenia-and-muscle</id>
+    <link href="http://www.zotero.org/styles/journal-of-cachexia-sarcopenia-and-muscle" rel="self"/>
+    <link href="http://www.zotero.org/styles/nature-publishing-group-vancouver" rel="template"/>
+    <link href="http://onlinelibrary.wiley.com/journal/10.1007/13539.2190-6009/homepage/ForAuthors.html" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien</name>
+      <email>obrienpat86@gmail.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <issn>2190-5991</issn>
+    <eissn>2190-6009</eissn>
+    <updated>2017-07-18T11:04:51+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author" suffix=". ">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always" delimiter-precedes-et-al="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <et-al term="et-al" font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" suffix=". ">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always" delimiter-precedes-et-al="never"/>
+      <label strip-periods="true" prefix=", "/>
+      <et-al term="et-al" font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="publisher">
+    <group delimiter="; ">
+      <group delimiter=": ">
+        <text variable="publisher"/>
+        <text variable="publisher-place"/>
+      </group>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="page volume" match="none">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix=" doi:"/>
+          </if>
+          <else-if variable="URL">
+            <text variable="URL"/>
+            <group delimiter=" " prefix=". ">
+              <text term="accessed" text-case="capitalize-first"/>
+              <date form="text" variable="accessed"/>
+            </group>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="journal-title">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="container-title" form="short" font-style="italic" strip-periods="true"/>
+      </if>
+      <else>
+        <text variable="container-title" suffix=". " form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book thesis" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," vertical-align="sup">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+    <layout suffix=".">
+      <text variable="citation-number" suffix=". "/>
+      <text macro="author"/>
+      <text macro="title" suffix=". "/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group prefix=" " suffix=". ">
+            <text term="in" suffix=": " text-case="capitalize-first"/>
+            <text macro="editor"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
+          <group delimiter=". " prefix=" ">
+            <text macro="publisher"/>
+            <group delimiter=" ">
+              <label strip-periods="false" variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <text macro="journal-title"/>
+          <group delimiter=";">
+            <date variable="issued" prefix=" ">
+              <date-part name="year"/>
+            </date>
+            <group delimiter=":">
+              <text variable="volume" font-weight="bold"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -77,10 +77,16 @@ CAPTION_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Section header patterns for the manuscript body's caption sections
+# Section header patterns for the manuscript body's caption sections.
+# Longer alternatives MUST come first so that "FIGURE LEGENDS" is not
+# truncated to "FIGURE" by an earlier short match.
+# Markdown bold wrappers (``## **FIGURE LEGENDS**``) are tolerated.
 CAPTION_SECTION_RE = re.compile(
-    r"^#{1,3}\s+(Tables|Figures|Figure\s+Legends|Supplementary\s+Tables|"
-    r"Supplementary\s+Figures|Supplementary\s+Materials?)\b",
+    r"^#{1,3}\s+\*{0,2}"
+    r"(Supplementary\s+Tables?|Supplementary\s+Figures?|Supplementary\s+Materials?|"
+    r"Figure\s+Legends?|Table\s+(?:Captions?|Legends?)|"
+    r"Tables?|Figures?)"
+    r"\*{0,2}",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/skills/write-paper/references/journal_profiles/British_Journal_of_Radiology.md
+++ b/skills/write-paper/references/journal_profiles/British_Journal_of_Radiology.md
@@ -1,0 +1,161 @@
+# Journal Profile: British Journal of Radiology (BJR)
+
+## Basic Information
+
+- **Publisher:** Oxford University Press (on behalf of The British Institute of Radiology)
+- **Impact Factor:** [TODO: verify at journal site — typically reported in JCR]
+- **ISSN:** 0007-1285 (print) / 1748-880X (online)
+- **Frequency:** 12 issues per year (online)
+- **Scope:** All subspecialties of diagnostic radiology, interventional radiology, nuclear medicine, radiation oncology, radiation physics; particular interest in clinical research, methodology, and translational radiology
+- **Open Access:** Hybrid — optional Open Access under Creative Commons (CC BY or CC BY-NC); APC £2,393 for CC licenses; Read and Publish institutional agreements available
+- **Language:** English only
+
+---
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | Figures | Tables | References |
+|------|----------------|----------|---------|--------|------------|
+| Research Article | 3,000 words | 250 words (structured) | 10 | 5 | 50 |
+| Review | 4,000 words | 200 words (unstructured) | 12 | 5 | 100 |
+| Systematic Review | 3,000 words | 250 words (structured) | 10 | 5 | 50 |
+| Pictorial Review | 1,500 words | 200 words (unstructured) | 15 | 4 | 15 |
+| Guidelines | 4,000 words | 200 words (unstructured) | 12 | 5 | 100 |
+| Short Communication | 2,000 words | 250 words (structured) | 5 | 2 | 15 |
+| Commentary | 1,500 words | 200 words (unstructured) | 4 | 2 | 15 |
+| Letter to Editor | 750 words | None | 2 (max) | — | 10 |
+
+---
+
+## Abstract Requirements
+
+**Structured abstract** (Research Articles, Short Communications, Systematic Reviews) — 250 words, five required headings:
+
+```
+Objectives: [Primary aim of the study]
+Methods: [Design, population, intervention/exposure, comparator, outcome]
+Results: [Key findings with statistics and 95% CIs]
+Conclusions: [Main interpretation]
+Advances in knowledge: [What this study adds]
+```
+
+The "Advances in knowledge" heading is BJR-specific — it must explicitly state the novelty contribution and is checked by reviewers.
+
+**Unstructured abstract** (Reviews, Pictorial Reviews, Guidelines, Commentary) — 200 words, single paragraph.
+
+---
+
+## Required Sections (Research Article)
+
+Standard IMRAD:
+
+1. **Introduction**
+2. **Methods**
+3. **Results**
+4. **Discussion**
+
+Ethics, funding, conflict of interest, and data availability statements are required as separate end-matter sections.
+
+---
+
+## Statistical Reporting
+
+- Measures of variation must be included for all important results
+- Estimates of differences must be provided with 95% confidence limits
+- For diagnostic test evaluation: sensitivity, specificity, and predictive values are required
+- p-value reporting format: [TODO: verify at journal site — follow standard convention]
+- Statistical software identification: [TODO: verify — recommend stating software + version]
+
+---
+
+## Figure Requirements
+
+- **Resolution:** 300 DPI (color), 600 DPI (grayscale/combination), 1,200 DPI (monochrome line art)
+- **Formats accepted:** JPEG, PNG, TIFF, SVG, PDF, EPS
+- **Color:** accepted (online publication is in color)
+- **Maximum:** 10 figures + 5 tables for Research Articles (see manuscript-type table above)
+
+---
+
+## Common Rejection Reasons
+
+1. **Insufficient novelty** — BJR Research Articles are expected to clearly state advancement over existing literature in the dedicated "Advances in knowledge" abstract heading
+2. **Single-center study with limited generalizability** — multi-center or representative cohort designs preferred
+3. **Missing structured abstract elements** — particularly omission of the "Advances in knowledge" line
+4. **Inadequate statistical reporting** — confidence intervals and effect sizes required, not just p-values
+5. **Poor English language quality** — BJR expects professional editing prior to submission
+6. **Pictorial Review without sufficient teaching value** — pictorial submissions must demonstrate clear pedagogical contribution beyond image collection
+
+---
+
+## AI Writing Disclosure Policy
+
+- **Requirement level:** Required (mandatory disclosure)
+- **Permitted scope:** Content generation, image generation, code writing, data processing, translation — all permitted with disclosure; AI tools cannot be listed as authors
+- **Disclosure location:** Both (a) cover letter to editors AND (b) Methods or Acknowledgements section
+- **AI-generated images:** Must be disclosed; AI image policy aligns with COPE/ICMJE guidance
+- **Policy URL:** https://academic.oup.com/bjr/pages/author-guidelines
+
+---
+
+## Cover Letter
+
+Not mandatory per current author guidelines, but recommended; if AI tools were used in manuscript preparation, AI disclosure in the cover letter is required (see AI Writing Disclosure Policy above).
+
+---
+
+## Open Access and APC
+
+- **Hybrid model**: Subscription default; optional Open Access under CC BY or CC BY-NC
+- **APC:** £2,393 (for CC license; may vary — verify at submission)
+- **Read and Publish agreements:** institutional waiver may apply if author's institution has an OUP Read and Publish deal
+
+---
+
+## Peer Review
+
+- **Type:** Double-anonymized peer review (both author and reviewer identities blinded)
+- **Number of reviewers:** Typically 2 reviewers
+- **Turnaround:** [TODO: verify at journal site]
+
+Because BJR uses double-anonymized review, manuscript files (including supplementary materials and registry record PDFs) must be blinded prior to submission. Author identifiers (names, institutions, ORCID, funding grant IDs that identify a specific group) should be removed from all uploaded files except the separately-uploaded title page.
+
+---
+
+## Author Guidelines URL
+
+https://academic.oup.com/bjr/pages/author-guidelines
+
+---
+
+## Positioning
+
+BJR is well-suited for:
+- Clinical radiology research with clear translational impact
+- Methodology and radiation-physics studies that complement clinical findings
+- Studies with explicit "Advances in knowledge" framing
+- Authors seeking a UK/European-oriented general radiology audience with mid-range Q1/Q2 visibility
+
+| Dimension | British Journal of Radiology | Clinical Radiology | European Radiology |
+|-----------|-----------------------------|-------------------|--------------------|
+| Society | British Institute of Radiology | Royal College of Radiologists (UK) | European Society of Radiology |
+| Scope | Diagnostic + interventional + radiation oncology + physics | Diagnostic radiology (general) | Diagnostic radiology (general) |
+| Peer review | Double-anonymized | [varies] | Single-blind |
+| Emphasis | "Advances in knowledge" novelty statement; methodology and physics included | UK-leaning clinical practice | European multi-center studies, AI |
+| OA option | Hybrid (CC BY / CC BY-NC) | Hybrid | Hybrid |
+
+---
+
+## Formatting Notes
+
+- References: Vancouver style (numbered)
+- Units: SI units
+- Abbreviations: define at first use
+- Double-anonymized: blind all uploaded files except title page (see Peer Review section above)
+
+
+---
+
+## Verification
+- **Source:** https://academic.oup.com/bjr/pages/author-guidelines
+- **Date:** 2026-05-21

--- a/skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md
+++ b/skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md
@@ -1,0 +1,163 @@
+# Journal Profile: Diabetes & Metabolism Journal (DMJ)
+
+## Basic Information
+
+- **Publisher:** Korean Diabetes Association (KDA) — official publication
+- **Frequency:** Bimonthly — published on the first day of January, March, May, July, September, and November
+- **Impact Factor:** [TODO: verify at e-dmj.org — recent JCR year]
+- **ISSN:** [TODO: verify at e-dmj.org — print / online]
+- **Scope:** Diabetes, metabolic disorders, endocrinology — clinical and basic-science research. Particularly receptive to Korean and East Asian population studies on diabetes epidemiology, prevention, treatment, and complications.
+- **Open Access:** Yes — full open access under Creative Commons Attribution Non-Commercial License (CC BY-NC); content freely available online
+- **APC (Article Processing Charge):** [TODO: verify at e-dmj.org]
+- **Language:** English only
+- **Acceptance rate:** [TODO: verify at e-dmj.org — not stated on author instructions page]
+
+---
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | References | Figures/Tables |
+|------|----------------|----------|------------|----------------|
+| Original Article | 4,000 words (excluding abstract, references, legends) | <250 words (structured) | ≤50 | ≤6 |
+| Review Article | [TODO: verify — body limit not specified on page] | <200 words | ≤150 | [TODO: verify] |
+| Brief Report | 1,500 words (excluding references, abstract) | <180 words | ≤20 | ≤2 |
+| Editorial | [TODO: verify] | n/a | ≤20 | [TODO: verify] |
+| Letter to the Editor | 1,000 words | None | ≤10 | 1 figure OR 1 table |
+
+---
+
+## Abstract Requirements (Original Article)
+
+**Structured abstract, fewer than 250 words:**
+
+```
+Background: [Context and aim]
+Methods: [Design, population, intervention/exposure, comparator, outcomes, statistical approach]
+Results: [Primary outcome with effect sizes and 95% CIs; key secondary findings]
+Conclusion: [Main conclusion grounded in the results]
+```
+
+**Keywords:** 3–10 MeSH terms following the abstract.
+
+**Clinical trial registration:** Registration number required at the end of the abstract for clinical trials.
+
+---
+
+## Required Sections (Original Article)
+
+DMJ uses standard IMRAD structure with appropriate headings and subheadings in Methods and Results:
+
+1. **Introduction**
+2. **Methods**
+   - Subsections expected
+   - IRB approval statement required
+3. **Results**
+   - Subsections expected
+4. **Discussion**
+
+Title-page-level requirements: author affiliations, conflict-of-interest statement, disclosure of redundant publication risk, AI disclosure (see AI Policy below), corresponding-author contact.
+
+---
+
+## Statistical Reporting
+
+- "Describe the statistical analysis and the criteria for determining significance" in Methods section.
+- Professional statistician review available through the journal if needed.
+- Reporting guidelines mandated by study design (see Reporting Guidelines below).
+- [TODO: verify at e-dmj.org — specific p-value formatting, CI requirements, effect-size requirements]
+
+---
+
+## Reporting Guidelines
+
+Authors must follow appropriate reporting guidelines according to study design:
+
+- **CONSORT** — randomized controlled trials
+- **STROBE** — observational studies
+- **PRISMA** — systematic reviews and meta-analyses
+- **CARE** — case reports
+
+---
+
+## Figure and Table Requirements
+
+- **Resolution:** ≥300 DPI
+- **Format:** JPEG, EPS, TIFF, or PICT (also accepted embedded in RTF manuscripts or PDF)
+- **Photomicrographs:** Internal scale markers required
+- **Color:** Color images permitted
+- **AI-generated images:** Prohibited (see AI Policy)
+- **Maximum:** Up to 6 figures/tables for Original Article; 2 for Brief Report; 1 for Letter
+
+---
+
+## Common Rejection Reasons
+
+[TODO: confirm with editorial office or rejection-analysis source — page does not enumerate]
+
+Typical risks for any KDA-affiliated diabetes journal:
+1. **Out of scope** — manuscripts without a clear metabolic or diabetes focus may be deprioritized.
+2. **Word count overrun** — 4,000-word Original Article limit (excluding abstract, references, legends) is enforced.
+3. **Missing reporting guideline compliance** — STROBE/CONSORT/PRISMA/CARE checklist expected per study design.
+4. **Insufficient AI disclosure** — AI use must be declared on title page including tool/version/manufacturer/role.
+5. **Redundant publication risk not disclosed** — full statement required in cover letter and title page.
+
+---
+
+## Cover Letter
+
+Should include:
+
+- Full statement regarding any submissions or previous reports that might be considered redundant publications
+- Statement of any financial or other relationships that could lead to a conflict of interest
+- Manuscript title and corresponding-author contact information
+- Brief rationale for the journal as the target venue
+
+---
+
+## AI Writing Disclosure Policy
+
+- **Requirement level:** Required
+- **Permitted scope:** Authors must disclose use of AI technologies during manuscript submission, including tool names, versions, manufacturers, and the role AI played in writing
+- **Disclosure location:** Title page (statement regarding AI use must be included)
+- **AI as author:** AI cannot be listed as author or co-author
+- **AI-generated images:** Prohibited
+- **Policy URL:** https://e-dmj.org/authors/authors.php
+
+---
+
+## Author Guidelines URL
+
+https://e-dmj.org/authors/authors.php
+
+---
+
+## Submission Portal
+
+[TODO: verify at e-dmj.org — typical Korean society journals use Synapse/eM submission system]
+
+---
+
+## Positioning
+
+DMJ is well-suited for:
+- Diabetes epidemiology and incident-outcome cohort studies in Korean and East Asian populations
+- Metabolic syndrome / body composition / fatty liver studies with metabolic outcome focus
+- Single-institution observational research with diabetes-relevant primary endpoints
+- Clinical trials in diabetes management and prevention
+- Translational and mechanistic diabetes research
+
+**Cascade considerations:** Suitable as a primary submission target for Korean-cohort diabetes research and as a Tier-2 fallback after rejection from higher-IF endocrinology journals (Diabetes Care, Diabetologia, JCSM). Higher acceptance probability for region-specific population studies than Western-focused diabetes journals.
+
+| Dimension | Diabetes & Metabolism Journal | Diabetes Care | Diabetologia |
+|-----------|------------------------------|----------------|---------------|
+| Society | Korean Diabetes Association | American Diabetes Association | European Association for the Study of Diabetes |
+| Geographic emphasis | Korean / East Asian | Global, US-centric | Global, European-centric |
+| Word budget (Original) | 4,000 | [TODO: verify] | [TODO: verify] |
+| Scope flexibility | Broad — body composition, metabolic syndrome, complications, basic science | T2DM-focused, clinically driven | T2DM-focused, mechanism-oriented |
+
+
+---
+
+## Verification
+- **Source:** https://e-dmj.org/authors/authors.php
+- **Date:** 2026-05-21

--- a/skills/write-paper/references/journal_profiles/Endocrinology_and_Metabolism.md
+++ b/skills/write-paper/references/journal_profiles/Endocrinology_and_Metabolism.md
@@ -1,0 +1,167 @@
+# Journal Profile: Endocrinology and Metabolism (EnM)
+
+## Basic Information
+
+- **Publisher:** Korean Endocrine Society (KES) — official publication
+- **Frequency:** [TODO: verify at e-enm.org — not stated on author instructions page]
+- **Impact Factor:** [TODO: verify at e-enm.org — recent JCR year]
+- **ISSN:** [TODO: verify at e-enm.org — print / online]
+- **Scope:** Endocrinology, metabolism, hormonal disorders, thyroid, adrenal, pituitary, bone metabolism, diabetes, lipid metabolism — clinical and basic-science research. Particularly receptive to Korean and East Asian population studies on endocrine disorders.
+- **Open Access:** Yes — full open access; content is freely available online, downloadable, and printable
+- **APC (Article Processing Charge):** [TODO: verify at e-enm.org]
+- **Language:** English only
+- **Acceptance rate:** [TODO: verify at e-enm.org — not stated on author instructions page]
+
+---
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | References | Figures/Tables |
+|------|----------------|----------|------------|----------------|
+| Original Article | [TODO: verify — body limit not stated on page] | ≤250 words (structured) | ≤50 | [TODO: verify] |
+| Review Article | [TODO: verify] | ≤200 words | ≤150 | [TODO: verify] |
+| Brief Report | 1,200 words | ≤150 words (unstructured) | ≤20 | ≤2 |
+| Editorial | 1,000 words | n/a | ≤20 | [TODO: verify] |
+| Image | 1,000 words | n/a | ≤5 | [TODO: verify] |
+| Letter to the Editor | 1,000 words | n/a | ≤10 | ≤1 |
+
+---
+
+## Abstract Requirements (Original Article)
+
+**Structured abstract, ≤250 words:**
+
+```
+Background: [Context and aim]
+Methods: [Design, population, intervention/exposure, comparator, outcomes, statistical approach]
+Results: [Primary outcome with effect sizes and 95% CIs; key secondary findings]
+Conclusion: [Main conclusion grounded in the results]
+```
+
+**Keywords:** [TODO: verify keyword count and MeSH requirement at e-enm.org]
+
+---
+
+## Required Sections (Original Article)
+
+EnM uses standard IMRAD structure with headings and subheadings in Methods and Results:
+
+1. **Introduction**
+2. **Methods**
+   - Subsections expected
+3. **Results**
+   - Subsections expected
+4. **Discussion**
+
+Title-page-level requirements: full author list, conflict-of-interest statement, AI disclosure (see AI Policy below), corresponding-author contact, redundant-publication disclosure.
+
+---
+
+## Statistical Reporting
+
+[TODO: verify at e-enm.org — specific p-value formatting, CI requirements, effect-size requirements not enumerated on author instructions page]
+
+---
+
+## Reporting Guidelines
+
+EnM requests authors follow reporting guidelines according to study design:
+
+- **CONSORT** — randomized controlled trials
+- **STROBE** — observational studies
+- **PRISMA** — systematic reviews and meta-analyses
+- **STARD** — diagnostic accuracy studies
+
+---
+
+## Peer Review
+
+- **Type:** Double-blind — both authors and reviewers remain anonymous
+- **Reviewer count:** Three anonymous reviewers who are specialists in the relevant field
+- **Review period:** Maximum 3 months
+
+---
+
+## Figure and Table Requirements
+
+- **Resolution:** Exceeds 300 DPI
+- **Format:** JPEG, GIF, TIFF, BMP, or PICT
+- **Numbering:** Sequential Arabic numerals; letters for sub-panels (Fig. 1A, 1B)
+- **Color:** [TODO: verify color policy and online/print distinction at e-enm.org]
+- **Maximum:** [TODO: verify for Original Article; explicit limits given only for Brief Report (≤2), Letter (≤1)]
+
+---
+
+## Common Rejection Reasons
+
+[TODO: confirm with editorial office — page does not enumerate]
+
+Typical risks for any KES-affiliated endocrinology journal:
+1. **Out of scope** — submissions without a clear endocrine, metabolic, or hormonal focus may be deprioritized.
+2. **Insufficient endocrinology framing** — body composition, diabetes, or metabolic studies without explicit hormonal-axis or endocrine-mechanism discussion may be redirected to sibling journals.
+3. **Missing reporting guideline compliance** — STROBE/CONSORT/PRISMA/STARD checklist expected per study design.
+4. **AI disclosure non-compliance** — failure to disclose AI use in cover letter and manuscript may result in rejection or retraction.
+5. **Redundant publication risk not disclosed** — full statement required in cover letter regarding any prior submissions or related reports.
+
+---
+
+## Cover Letter
+
+Must include:
+
+- Full statement to the editor about all submissions and previous reports that might be regarded as redundant publication
+- Conflict-of-interest statement
+- Attestation that all authors approved the manuscript and meet authorship criteria
+- Corresponding-author contact information
+- AI use disclosure (if applicable; also in manuscript)
+
+---
+
+## AI Writing Disclosure Policy
+
+- **Requirement level:** Required when AI-assisted technologies are used
+- **Permitted scope:** "Authors should clearly describe how they used AI in the submitted manuscript and in their cover letter. Authors are fully responsible for the scientific integrity of AI-generated content."
+- **Disclosure location:** Both cover letter AND manuscript
+- **AI as author:** AI cannot be listed as author or co-author
+- **AI-generated images:** [TODO: verify at e-enm.org — not explicitly addressed on author instructions page]
+- **Non-disclosure penalty:** Results in rejection or retraction
+- **Policy URL:** https://e-enm.org/authors/authors.php
+
+---
+
+## Author Guidelines URL
+
+https://e-enm.org/authors/authors.php
+
+---
+
+## Submission Portal
+
+[TODO: verify at e-enm.org]
+
+---
+
+## Positioning
+
+EnM is well-suited for:
+- Endocrinology and hormonal-axis studies in Korean and East Asian populations
+- Thyroid, adrenal, pituitary, bone metabolism, lipid, and diabetes research with explicit endocrine framing
+- Single-institution observational endocrinology research
+- Translational and mechanistic endocrine studies
+- Population-based metabolic outcome studies with hormonal-axis discussion
+
+**Cascade considerations:** Suitable as a primary submission target for Korean-cohort endocrinology research with explicit hormonal-axis or endocrine-mechanism framing, and as a Tier-3 fallback after rejection from higher-IF diabetes/endocrinology journals (Diabetes Care, Diabetologia, JCSM, Diabetes & Metabolism Journal). Higher acceptance probability for region-specific endocrinology studies than Western-focused journals.
+
+| Dimension | Endocrinology and Metabolism | Diabetes & Metabolism Journal | Lancet Diabetes & Endocrinology |
+|-----------|------------------------------|-------------------------------|--------------------------------|
+| Society | Korean Endocrine Society | Korean Diabetes Association | Lancet family |
+| Geographic emphasis | Korean / East Asian | Korean / East Asian | Global, high-impact |
+| Scope | Broad endocrinology (thyroid, adrenal, pituitary, bone, diabetes, lipid) | Diabetes-focused metabolic | Diabetes-focused with global RCT/cohort emphasis |
+| Peer review timeline | ≤3 months | [TODO: verify] | [TODO: verify] |
+
+
+---
+
+## Verification
+- **Source:** https://e-enm.org/authors/authors.php
+- **Date:** 2026-05-21

--- a/skills/write-paper/references/journal_profiles/JCSM.md
+++ b/skills/write-paper/references/journal_profiles/JCSM.md
@@ -1,0 +1,266 @@
+# Journal Profile: Journal of Cachexia, Sarcopenia and Muscle (JCSM)
+
+## Basic Information
+
+- **Publisher:** Wiley
+- **Frequency:** Continuous publication (online articles published directly into online issue when ready; no issue curation or pagination delay)
+- **Impact Factor:** [TODO: verify at JCSM journal page — recent JCR year]
+- **ISSN:** [TODO: verify at JCSM journal page — print / online]
+- **Scope:** Cachexia, sarcopenia, body composition, and physiological/pathophysiological changes in skeletal muscle and fat tissue across the lifespan and in chronic illness (AIDS, cancer, chronic heart failure, chronic lung disease, liver cirrhosis, chronic kidney failure, rheumatoid arthritis, sepsis). Strong reception for diagnostic/assessment biomarker validation and mechanistic muscle-wasting and lipolysis studies.
+- **Open Access:** Gold Open Access — articles immediately free to read, download, and share after publication
+- **APC (Article Processing Charge):** Required upon acceptance; waivers/discounts may apply via institution, funder, or country waiver — see journal's Open Access page
+- **Language:** English only
+- **Acceptance rate:** [TODO: verify at JCSM journal page]
+
+---
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | References | Figures/Tables |
+|------|----------------|----------|------------|----------------|
+| Original Article | 4,500 (excluding abstract, references, tables, figures) | 400 words (structured, data-rich) | 40 (main); additional as supplement (S1, S2, ...) | 8 (max 6 sub-sections per figure, labelled a–f) |
+| Review | 6,000 (excluding abstract, references, tables, figures) | 400 words (unstructured but data/information-rich) | 120 (main); additional as supplement | 8 (max 6 sub-sections per figure) |
+| Editorial (by invitation only) | 1,500 | None typically (Facts & Numbers series: up to 400 words, data-rich) | 20 (exceptions for Facts & Numbers and statistical analyses) | 1–2 |
+| Research/Scientific Letter | 1,200 | n/a | 10 | 1 figure or table |
+| Short Report | 1,500 | n/a | 10 | up to 2 figures or tables |
+| Meeting Report | 1,500 | n/a | 20 | n/a |
+| Reply / Letters to the Editor | 1,200 | n/a | [TODO: verify] | [TODO: verify] |
+
+**Title length cap:** maximum 17 words OR 120 characters (whichever is shorter).
+
+---
+
+## Abstract Requirements (Original Article)
+
+**Structured abstract, ≤400 words, data-rich:**
+
+```
+Background: [Context and aim]
+Methods: [Design, population, intervention/exposure, comparator, outcomes, statistical approach]
+Results: [Numbers (cohort size, % female, mean age ± SD), percentages, percent differences,
+         correlations, hazard or odds ratios with 95% CIs, key p-values supporting main messages]
+Conclusions: [Main conclusion grounded in the results]
+```
+
+**Critical guidance from the journal:**
+- "Descriptive results abstracts are not acceptable" — must include actual numbers, effect sizes, p-values
+- For clinical studies, always mention N, % female, mean age ± SD
+- Omit filling words ("thus", "therefore", "moreover")
+- Minimize abbreviations in abstract and conclusion
+- "If in doubt, add more data rather than less"
+
+**Keywords:** 4–6 for indexing.
+
+---
+
+## Required Sections (Original Article)
+
+Article order:
+
+1. **Title page** — name(s), title (≤17 words / 120 chars), affiliation(s), corresponding-author email/phone/fax
+2. **Abstract** — structured (see above)
+3. **Keywords** — 4–6
+4. **Introduction**
+5. **Methods**
+6. **Results**
+7. **Discussion**
+8. **Acknowledgements** — funding, conflict of interest, ethical guidelines statement
+
+**Headings:** maximum 3 levels of displayed headings.
+
+---
+
+## Corresponding Author Policy (JCSM-specific)
+
+- **Only ONE corresponding author per submission.** The corresponding author is the sole contact and the only author who can access/modify the manuscript during editorial review.
+- **No post-acceptance authorship changes** — including adding/removing authors, changing the corresponding author, designating multiple first authors, or adjusting author order.
+- **Multiple co-first / equal contributions** — must be declared in the cover letter at submission; approval at Editor's discretion.
+
+**Manuscript-design implication:** if your study has co-corresponding authors at submission (common in observational research), only one can be the technical corresponding author; the other must be designated as a senior author with footnote acknowledgement.
+
+---
+
+## Ethical Standards
+
+- Helsinki Declaration adherence statement required
+- IRB approval statement required
+- Informed consent statement required (or waiver justification)
+- "The manuscript does not contain clinical studies or patient data" — required if not applicable
+- Identity-disclosing details must be omitted
+
+---
+
+## Statistical Reporting — JCSM-specific for Survival / Prognostic Studies
+
+JCSM enforces stricter survival-cohort reporting than most journals. **Applies to "Studies describing survival rates and prognostic associations":**
+
+- **Mandatory event reporting (in BOTH abstract AND methods/results):**
+  - Number of events observed in the overall cohort
+  - **1-year mortality rate with 95% CI**
+  - **5-year mortality rate with 95% CI** (if appropriate)
+  - **3-month mortality rate with 95% CI** (if appropriate)
+  - These serve "to assess the power of the study"
+- **Cohort size guidance:**
+  - **Novel prognostic markers**: cohort with ≥60–100 events
+  - **Novel prognostic scores**: cohort with ≥150–200 events
+  - **Validation in second cohort** strongly recommended for cutoffs derived from primary cohort
+- **Kaplan-Meier survival graphs**: must display number of "patients at risk" for each group at baseline and at follow-up intervals
+- **Figure legend or in-figure** for survival plots must include: HR or rate ratios with 95% CI and p-values, plus total number of events
+- **Clinical trials**:
+  - Pre-registered before start (provide NCT number etc.)
+  - ITT analysis for efficacy (other methods for safety / non-inferiority)
+  - One primary efficacy endpoint (or alpha-splitting / Hochberg justification)
+  - Statistical analysis plan in English submitted
+  - Trial protocol in English as appendix
+
+---
+
+## Reporting Guidelines
+
+JCSM does not enumerate a single mandatory checklist on the author guidelines page but enforces survival-cohort-specific reporting (see above). Standard reporting guideline adherence (STROBE for observational cohorts, CONSORT for trials, PRISMA for systematic reviews) is expected per general publication ethics.
+
+---
+
+## Figures and Tables
+
+- **Maximum:** 8 figures and/or tables within the manuscript (additional as Supporting Information, no limit)
+- **Sub-sections per figure:** max 6, labelled a–f
+- **Submit figures/tables as separate individual files**, not embedded in manuscript (due to quality)
+- **Vector graphics preferred:** EPS for line art / vector; TIFF for halftones; MS Office acceptable
+- **Resolution:**
+  - Line art (bitmap): ≥1,200 DPI
+  - Halftones: ≥300 DPI
+  - Combination (halftone + line + lettering): ≥600 DPI
+- **Color:** Free of charge for online; submit as RGB (8 bits per channel)
+- **Lettering:** Helvetica or Arial sans-serif, 2–3 mm (8–12 pt) at final size, consistent within figure
+- **Figure captions:** in text file, begin with "Fig." in bold + figure number in bold (no punctuation after number)
+- **Accessibility:**
+  - Descriptive captions for all figures
+  - Use patterns in addition to colors (colorblind-friendly)
+  - Lettering contrast ratio ≥4.5:1
+
+---
+
+## References
+
+- **Limits:** 40 for Original Article; 120 for Review (main manuscript)
+- **Overflow:** additional references as Supporting Information, numbered S1, S2, S3 ...
+- **Selection guidance:** journal discourages cutting list at 40/120 without curation; the supplement is for "secondary importance" references
+- **Citation style:** numerical in square brackets — `[3]`, `[5]`, `[1–3, 7]`
+- **Reference style (as of August 15, 2024):** no submission requirement for formatting; consistent style throughout manuscript with: author(s), journal/book title, article title (where applicable), year, volume/issue, pagination, DOI (optional). Journal will reformat to house style upon acceptance.
+
+---
+
+## Preprints
+
+Posting to community preprint servers (arXiv, bioRxiv, etc.) by the author is **permitted** and does not preclude publication. Requirements:
+
+- Identify the preprint server and accession #/DOI in the cover letter at submission
+- Upon publication, request that the preprint server adds the published-journal reference (with DOI link) to its record
+
+---
+
+## File Format and Formatting
+
+- **Manuscript file:** Word `.docx` (Word 2007+) or `.doc` (older); LaTeX accepted for math-heavy submissions
+- **Fonts:** Times Roman 10-point or equivalent plain font for text
+- **Italics:** for emphasis
+- **Pagination:** automatic page-numbering function
+- **Indents:** tab stops or commands, not space bar
+- **Tables:** table function, not spreadsheets
+- **Equations:** equation editor or MathType
+- **Footnotes:** use footnotes, not endnotes; consecutively numbered; not solely a reference citation
+- **Field functions:** do NOT use
+
+---
+
+## Cover Letter
+
+Should include:
+
+- Confirmation that work has not been published before and is not under consideration elsewhere
+- Confirmation that publication has been approved by all co-authors
+- Preprint declaration if applicable (server name + accession/DOI)
+- Co-first or equal-contribution designation requests
+- Conflict of interest summary
+- Permissions evidence if any previously-published figures/tables/text are reused
+
+---
+
+## AI Writing Disclosure Policy
+
+[TODO: verify at JCSM journal page + Wiley publisher AI policy — not enumerated on this Author Guidelines page]
+
+Wiley publisher-wide AI policy generally requires:
+- Disclosure of AI-assisted tools used in manuscript preparation in Methods or Acknowledgements
+- AI cannot be listed as author
+- AI-generated images typically banned or require explicit disclosure
+- Refer to Wiley's "Best Practice Guidelines on Research Integrity and Publishing Ethics" for current AI policy at the time of submission
+
+---
+
+## Peer Review
+
+**Single-blind peer review** — reviewers know author identities but authors do not know reviewer identities.
+
+All articles undergo rigorous peer review prior to acceptance.
+
+---
+
+## Common Rejection Reasons
+
+[TODO: verify with editorial office]
+
+Risks specific to JCSM author-guideline strict requirements:
+1. **Descriptive abstract without numbers** — JCSM explicitly states "descriptive results abstracts are not acceptable"; 400-word data-rich structure with effect sizes, CIs, p-values is mandatory
+2. **Missing 1-year / 5-year mortality rates with 95% CI** for survival or prognostic studies — required in both abstract and methods/results
+3. **Underpowered prognostic cohort** — novel prognostic markers expected from cohorts with ≥60–100 events; novel prognostic scores require ≥150–200 events
+4. **Missing Kaplan-Meier "patients at risk" annotation** — KM plots without numbers-at-risk at baseline and follow-up intervals are returned
+5. **Title overrun** — title >17 words or >120 characters returned for revision
+6. **Word count overrun** — Original Article >4,500 body words (excluding abstract, refs, tables, figures) flagged
+7. **Multiple corresponding authors at submission** — only one allowed; co-corresponding requests must be declared and approved in cover letter
+8. **Out of scope** — manuscripts without clear connection to cachexia, sarcopenia, body composition, or muscle/fat tissue pathophysiology may be deprioritized
+
+---
+
+## Submission Portal
+
+https://authors.wiley.com/journal/JCSM/
+
+---
+
+## Author Guidelines URL
+
+https://onlinelibrary.wiley.com/page/journal/13989440/homepage/forauthors.html
+
+---
+
+## Positioning
+
+JCSM is well-suited for:
+- Body composition cohort studies with metabolic, functional, or mortality outcomes
+- Sarcopenia and cachexia clinical and mechanistic research
+- Diagnostic biomarker validation for muscle wasting
+- Imaging-defined body-composition phenotype × clinical-outcome research
+- Skeletal-muscle and adipose-tissue mechanism studies
+- Prognostic marker / score studies meeting the 60–200 events cohort requirement
+
+**Cascade considerations:** Suitable as a primary submission target for body composition × metabolic outcome research with adequate event count and survival reporting. Cascade to Diabetologia (EASD), Diabetes Care (ADA), or Korean-society journals (DMJ, EnM) for body-composition or metabolic-outcome research that does not meet JCSM's strict prognostic-cohort thresholds.
+
+| Dimension | JCSM | Diabetologia | Lancet Diabetes & Endocrinology |
+|-----------|------|---------------|--------------------------------|
+| Society | Wiley (specialty) | EASD | Lancet family |
+| Scope | Cachexia / sarcopenia / body composition / muscle | Diabetes mechanism + RCT | Diabetes high-impact global RCT/cohort |
+| Word budget (Original) | 4,500 | [TODO: verify] | [TODO: verify] |
+| Abstract | 400 (structured, data-rich) | [TODO: verify] | [TODO: verify] |
+| References (Original) | 40 main + unlimited supplement | [TODO: verify] | [TODO: verify] |
+| Survival reporting | Strict (1-yr/5-yr mortality, patients-at-risk, ≥60–100 events for novel markers) | [TODO: verify] | [TODO: verify] |
+| Peer review | Single-blind | [TODO: verify] | [TODO: verify] |
+| OA model | Gold OA, APC required | [TODO: verify] | [TODO: verify] |
+
+
+---
+
+## Verification
+- **Source:** https://onlinelibrary.wiley.com/page/journal/13989440/homepage/forauthors.html
+- **Date:** 2026-05-21

--- a/skills/write-paper/references/journal_profiles/KJR.md
+++ b/skills/write-paper/references/journal_profiles/KJR.md
@@ -2,98 +2,135 @@
 
 ## Basic Information
 
-- **Publisher:** Korean Society of Radiology / Korean Institute of Medical Education and Evaluation
-- **Impact Factor:** ~4.5 (2023–2024)
-- **ISSN:** 2005-8330 (electronic)
-- **Scope:** All subspecialties of diagnostic and interventional radiology; medical imaging AI
-- **Open Access:** Yes — fully open access, indexed in DOAJ, PubMed/MEDLINE, Scopus, SCIE
-- **APC (Article Processing Charge):** None for KSR members; check current policy for non-members (~$800–1200 USD)
-- **Language:** English only for manuscripts; Korean author affiliations acceptable
+- **Publisher:** Korean Society of Radiology
+- **ISSN:** 1229-6929 (Print) / 2005-8330 (Electronic)
+- **Scope:** All subspecialties of diagnostic and interventional radiology; medical imaging AI. Excludes radiation oncology, dentistry, dental radiology, dental surgery, and translational/basic nuclear medicine studies.
+- **Open Access:** Yes — fully open access (CC BY-NC 4.0), indexed in DOAJ, PubMed/MEDLINE, Scopus, SCIE
+- **APC (Article Processing Charge):** USD 100 for accepted manuscripts. Exempt: invited articles, Uncover This Tech Term, Emerging Rad Dx, Letter to the Editor.
+- **Language:** English only for manuscripts
 
 ---
 
-## Manuscript Types and Word Limits
+## Manuscript Types and Limits
 
-| Type | Body Word Limit | Abstract | Figures | References |
-|------|----------------|----------|---------|------------|
-| Original Article | 4000 words | 250 words | 8 | 40 |
-| Review Article | 5000 words | 250 words | 12 | 60 |
-| Technical Note | 2000 words | 150 words | 5 | 20 |
-| Case Report | 1500 words | 200 words | 6 | 15 |
-| Letter to Editor | 500 words | None | 2 | 5 |
+Body Text excludes title, abstract, keywords, references, tables, and figure legends.
+
+| Type | Body | Abstract | Figures/Tables | References | Notes |
+|------|------|----------|----------------|------------|-------|
+| Original Article | ≤3000 words | ≤300 words (structured) | ≤7 | unspecified | Structured Introduction / Materials and Methods / Results / Discussion |
+| Brief Research Report | ≤2000 words | ≤300 words (structured) | ≤4 | unspecified | Short paper reporting evaluation of unique techniques, procedures, or small case series; formal statistical analysis may not be needed |
+| Review | ≤5000 words | ≤200 words (unstructured) | ≤10 | unspecified | Narrative comprehensive review; generally invited |
+| Pictorial Essay | ≤2000 words | ≤200 words (unstructured) | ≤20 | unspecified | More illustrative than narrative |
+| Focus | ≤2000 words | ≤200 words (unstructured) | ≤4 | unspecified | Shorter timely review/discussion; generally invited |
+| Recommendation and Guideline | unspecified | ≤200 words (unstructured) | unspecified | unspecified | Authoritative recommendations; must be supported by published studies or expert panels |
+| Editorial | ≤1000 words | No abstract | ≤2 | ≤20 | Generally invited |
+| Uncover This Tech Term | ≤1000 words | No abstract | ≤2 | ≤20 | Title format: "Uncover This Tech Term: xxx" |
+| Emerging Rad Dx | ≤1000 words | No abstract | ≤2 | ≤20 | Explains novel or emerging diseases/conditions |
+| Letter to the Editor | ≤800 words | No abstract | ≤2 | ≤10 | Unstructured without section headings |
+
+**Figure counting rule (PDF p.3 footnote):** A figure may contain multiple parts; **Fig. 1A-C and Fig. 2A-D are counted as two figures, not seven.** Use figure parts or composite figures appropriately to avoid an excessive number of figures.
 
 ---
 
-## Abstract Requirements
+## Abstract Requirements (Original Article and Brief Research Report)
 
-**Structured abstract, 250 words maximum:**
+**Structured abstract, ≤300 words:**
 
 ```
-Objective: [What was studied]
+Objective: [Study aim]
 Materials and Methods: [Design, population, index test, reference standard, statistics]
-Results: [Key findings with statistics and 95% CIs]
-Conclusion: [Main conclusion]
+Results: [Key findings with absolute numbers and/or rates, with 95% CIs or P values]
+Conclusion: [Main conclusion — must be consistent with Objective]
 ```
 
-**Key Messages** — 3 bullet points required (KJR-specific, similar to European Radiology Key Points):
-
-- Placed after the abstract (or sometimes on the title page — check submission portal)
-- Maximum 1 sentence each
-- Should cover: what was found, how it was found, why it matters
+Notes:
+- Objective and Conclusion must use the same wording and be consistent with the main text
+- Results must present actual numerical data; not statistical indicators alone
+- Reference citations are not allowed in the abstract
+- Abbreviations should be minimized; if used, define within the abstract at first use
 
 ---
 
 ## Required Sections (Original Article)
 
-KJR uses standard IMRAD structure:
+KJR uses IMRAD structure with KJR-specific section naming:
 
 1. **Introduction**
-2. **Materials and Methods**
-   - Ethical approval required: IRB number + approval statement + informed consent
+2. **Materials and Methods** (not "Methods")
+   - Ethics approval and informed consent statement required at the start
 3. **Results**
 4. **Discussion**
-5. **Conclusion** (brief final paragraph or subsection of Discussion)
-
-Note: KJR prefers "Materials and Methods" (not just "Methods").
 
 ---
 
 ## Ethics Statement
 
 **Human subjects:**
-"This study was approved by the Institutional Review Board of [Institution] (approval number: [XXX]), and the requirement for informed consent was [waived/obtained from all participants] because of the [retrospective nature of the study / prospective design]."
+> "This study was approved by the Institutional Review Board of [Institution] (approval number: [XXX]), and the requirement for informed consent was [waived/obtained from all participants] because of the [retrospective nature of the study / prospective design]."
 
 **Animal studies:**
-"All animal experiments were approved by the Institutional Animal Care and Use Committee of [Institution] (approval number: [XXX])."
+> "All animal experiments were approved by the Institutional Animal Care and Use Committee of [Institution] (approval number: [XXX])."
+
+---
+
+## AI Policy (KJR "Ethical and Responsible Use of Generative AI")
+
+Source: KJR-Instructions-202603.pdf p.2; https://doi.org/10.3348/kjr.2026.0166
+
+- AI tools must not be listed as authors or cited as a primary scholarly source
+- Authors remain fully responsible and accountable for all submitted content and shall be accountable for any ethical or legal breach
+- AI use beyond routine linguistic assistance must be clearly disclosed, with sufficient detail, in the relevant section of the manuscript or in the Acknowledgments
+- When AI itself is the subject of investigation, its use must be explicitly described in the Materials and Methods section
+- Reviewers and editors must safeguard the confidentiality of unpublished manuscripts. Uploading manuscript content or review text to AI services is prohibited unless confidentiality can be reliably assured
+- Reviewers and editors may use AI tools for non-core, assistive purposes under their supervision; core human reviewer functions must not be delegated to AI
+- Reviewers and editors who use AI tools beyond routine linguistic assistance must disclose such use to the journal
 
 ---
 
 ## Statistical Reporting
 
-- Exact p-values (not "P < .05"); values below .001 reported as "P < .001"
-- 95% confidence intervals required for all primary outcomes
-- Effect sizes with units
-- Report both statistical significance AND clinical significance
+- Use 12-point font, double-spaced, 3-cm margins (A4 or letter)
+- Report P values to three decimal places (0.xxx); P < 0.001 reported as "P < 0.001"
+- Do not use more than one decimal place for percentages (x.x%, not x.xx%)
+- Write large numbers with commas separating every three digits (e.g., 123,456,789)
+- 95% confidence intervals required for primary outcomes
+- Results must present absolute numbers and/or rates with appropriate indicators of statistical uncertainty (95% CIs or P values)
 
 ---
 
 ## Figure Requirements
 
-- **Resolution:** 300 DPI (600 DPI for line art and graphs)
-- **Format:** TIFF preferred; JPEG for clinical images
-- **Color:** Online publication is in color; print is grayscale — design figures to be interpretable in grayscale if possible
-- **Maximum 8 figures** for original articles
+- **Initial submission:** Embed images in the Word file as JPG/JPEG immediately following relevant figure legends
+- **Revised submission:** Upload images as separate JPG/JPEG (high-quality) or TIF/TIFF files; PNG not accepted
+- **Resolution:** At least 300 dpi; minimum 3 inches, maximum 7 inches in width and height after cropping
+- **Multi-part figures:** Use English letters after numerals (Fig. 1A, 1B, 1C); match figure number with image file name (e.g., Fig_1A.jpg)
+- **Figure number rule:** Composite/multi-part figures are counted by figure number, not by parts (Fig. 1A-C + Fig. 2A-D = 2 figures, not 7)
+- **Anonymization:** Remove all patient names and identifiers; remove all author/institution identifiers
+- **Color:** Online publication is in color; design figures interpretable in print if applicable
+- Written permission required for previously published figures
+
+---
+
+## References
+
+- Vancouver style; numbered consecutively in order of citation in the text
+- **First six authors listed, then "et al."** (≥7 authors). When 6 or fewer, list all authors. (PDF p.4 explicit)
+- Journal names abbreviated per Index Medicus
+- Inclusive page numbers (e.g., 111-114)
+- Unpublished data: cite parenthetically in text, not in reference list
+
+Example (PDF):
+> Park C, Kim JH, Kim PH, Kim SY, Gwon DI, Chu HH, et al. Imaging predictors of survival in patients with single small hepatocellular carcinoma treated with transarterial chemoembolization. *Korean J Radiol* 2021;22:213-224
 
 ---
 
 ## Common Rejection Reasons
 
-1. **Single-center study with small N** — KJR increasingly prefers multi-center or larger single-center series (N ≥ 100 for most original articles)
-2. **Missing Key Messages** — reviewers check these; vague or missing key messages signal a weak paper
-3. **Insufficient clinical relevance** — must explain "so what?" for Korean (or broader Asian/global) clinical practice
-4. **Incomplete ethics documentation** — IRB number required; missing institutional details causes desk rejection
-5. **Poor English language** — KJR provides language editing services but strongly prefers professionally edited manuscripts at submission
-6. **Replication without added value** — replicating a Western study in a Korean cohort is acceptable only if the Korean context adds new knowledge
+1. **Single-center study with small N** — KJR increasingly prefers multi-center or larger single-center series
+2. **Insufficient clinical relevance** — must explain "so what?" for Korean (or broader Asian/global) clinical practice
+3. **Incomplete ethics documentation** — IRB number required; missing institutional details cause desk rejection
+4. **Poor English language** — KJR provides language editing services but strongly prefers professionally edited manuscripts at submission
+5. **Replication without added value** — replicating a Western study in a Korean cohort is acceptable only if the Korean context adds new knowledge
 
 ---
 
@@ -106,19 +143,43 @@ KJR is well-suited for:
 - Studies that may not reach the impact threshold of higher-tier journals but are methodologically sound
 - Faster time to publication than European or American journals
 
-**Typical timeline:** Review 4–8 weeks; revision 4–8 weeks; acceptance to publication 4–6 weeks.
+**Typical timeline:** Minor Revision must be submitted within 30 days of decision; Major Revision within 60 days. Withdrawal not allowed after "under review" status entered.
 
 ---
 
 ## Author Guidelines URL
 
-https://www.kjronline.org/authors/authors-information
+https://www.kjronline.org/index.php?body=Instruction
+
+---
+
+## Submission Files Checklist (KJR portal)
+
+- Cover letter
+- Full Title Page (separate Word file, KJR template recommended)
+- Main Document (blinded, single Word file): blinded title page, structured abstract, ~5 keywords, body text, references, tables, figure legends
+- Supplement (separate Word document if applicable)
+- Figures: JPG/JPEG embedded for initial submission; separate JPG/JPEG/TIF/TIFF for revision
+- ICMJE COI Disclosure Form (per author, requested by journal after acceptance)
+- Statement of ethical approval and informed consent at start of Materials and Methods
 
 ---
 
 ## Formatting Notes
 
-- References: Vancouver style (numbered, superscripted in text)
-- Units: SI units throughout
-- Abbreviations: define at first use; avoid excessive abbreviations
-- Korean author names: acceptable to list in Korean alongside English; affiliation addresses should include full postal address
+- Manuscript in Microsoft Word format (doc or docx); not PDF
+- 12-point font, double-spaced on A4 or letter paper, ~3-cm margins
+- Do not number pages or lines manually (auto-generated on conversion)
+- SI units throughout (NCRP Report 82, JAMA 1986;255:2329-2339)
+- Abbreviations: define at first use; minimize use
+- Korean author names: use full author name (first, middle if exists, last); not initials
+- Authors should describe sex/gender appropriately; race/ethnicity must be justified
+- Geographic information (city, country) not required for commercial products
+
+---
+
+## Verification
+
+- **Source:** KJR-Instructions-202603.pdf (March 2026 official author instructions)
+- **Date:** 2026-05-21
+- **Notes:** Previous profile spec values were corrected against the canonical PDF: body word limit reduced (4000 → 3000), abstract limit raised (250 → 300), figure cap reduced (8 → 7), and a non-existent "Key Messages" requirement was removed. Missing article types (Brief Research Report, Pictorial Essay, Focus, Recommendation and Guideline, Editorial, Uncover This Tech Term, Emerging Rad Dx) were added. This retrofit aligns with the canonical PDF.

--- a/skills/write-paper/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
+++ b/skills/write-paper/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
@@ -1,0 +1,178 @@
+# Journal Profile: Korean Journal of Internal Medicine (KJIM)
+
+## Basic Information
+
+- **Publisher:** Korean Association of Internal Medicine
+- **Impact Factor:** [TODO: verify at journal site — typically reported in JCR]
+- **ISSN:** 1226-3303 (print) / 2005-6648 (online)
+- **Frequency:** Bimonthly (January, March, May, July, September, November)
+- **Scope:** All subspecialties of internal medicine — endocrinology, gastroenterology, hematology-oncology, infectious diseases, nephrology, pulmonology, rheumatology, cardiology, geriatrics — with emphasis on Korean and East Asian clinical research
+- **Open Access:** Yes — CC BY-NC reuse policy; PubMed Central indexed
+- **APC (Article Processing Charge):** $1,000 USD (₩1,000,000 KRW) for Original Articles; $300 USD (₩300,000 KRW) for Images of Interest; no charge for Correspondence (effective 2024-10-01)
+- **Language:** English only for manuscripts
+
+---
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | Figures/Tables | References | Authors |
+|------|----------------|----------|----------------|------------|---------|
+| Original Article | No specified maximum | 250 words (structured) | Not specified | Not specified | No limit |
+| Review | 7,500 words (excluding refs/tables/figures) | 200 words (unstructured) | Not specified | Not specified | No limit |
+| Editorial | 2,000 words (excluding refs/tables/figures) | None | Not specified | Not specified | No limit |
+| Images of Interest | 300 words total | None | 2 figures max | Not specified | Max 5 |
+| Correspondence | 500 words (excluding refs) | None | Not specified | 5 references max | No limit |
+
+---
+
+## Abstract Requirements
+
+**Structured abstract** (Original Articles) — 250 words, four required sections:
+
+```
+Background/Aims: [Rationale and primary objective]
+Methods: [Design, population, intervention/exposure, comparator, outcome]
+Results: [Key findings with statistics and 95% CIs]
+Conclusions: [Main interpretation]
+```
+
+**Keywords:** Up to 5 keywords; should refer to Index Medicus Medical Subject Headings (MeSH).
+
+**Unstructured abstract** (Reviews) — 200 words, single paragraph.
+
+---
+
+## Required Sections (Original Article)
+
+1. **Title page**
+2. **Abstract and keywords**
+3. **Introduction**
+4. **Methods**
+5. **Results**
+6. **Discussion**
+7. **Key Message** (KJIM-specific brief take-home statement)
+8. **Acknowledgments**
+9. **References**
+10. **Tables**
+11. **Figure legends**
+
+Note: KJIM requires an explicit "Key Message" section — a brief summary of the clinical implication, similar in spirit to the Key Points format used by other journals.
+
+---
+
+## Ethics Statement
+
+**Human subjects (Korean institutional template):**
+"This study was approved by the Institutional Review Board of [Institution] (approval number: [XXX]); the requirement for informed consent was [waived because of the retrospective nature of the study / obtained from all participants for prospective enrollment]."
+
+**Animal studies:** Approval from Institutional Animal Care and Use Committee (IACUC) required with approval number.
+
+---
+
+## Statistical Reporting
+
+- "Methods of statistical analysis and criteria for statistical significance should be described."
+- p-value format: [TODO: verify at journal site — recommend exact p-values with p < 0.001 below that threshold per ICMJE convention]
+- 95% confidence intervals: [TODO: verify — strongly recommended for primary outcomes per general medical-journal convention]
+- Statistical software and version: [TODO: verify — recommend stating software + version per ICMJE convention]
+
+---
+
+## Figure Requirements
+
+- **Resolution:** 600 DPI (color figures); 1,200 DPI (line art and graphs)
+- **Format:** EPS or TIF preferred; JPEG accepted for color figures
+- **Color:** accepted
+- **Maximum count:** Not specified at the article-type level — use judgment by manuscript type
+
+---
+
+## Common Rejection Reasons
+
+1. **Insufficient clinical relevance for internal medicine readership** — radiology-heavy or imaging-only studies must explicitly translate findings into internal-medicine practice implications
+2. **Single-center study with small N** — multi-center designs or representative national-cohort data preferred for Original Articles
+3. **Missing Key Message** — reviewers check for this section; vague or missing Key Message signals a weak clinical take-home
+4. **Incomplete ethics documentation** — IRB number, approval statement, and informed-consent statement all required
+5. **Poor English language quality** — Korean Association of Internal Medicine expects professionally edited English at submission
+6. **AI use not disclosed in Acknowledgments** — undisclosed AI use is grounds for desk rejection
+
+---
+
+## AI Writing Disclosure Policy
+
+- **Requirement level:** Required (mandatory disclosure)
+- **Permitted scope:** AI may assist in writing; AI cannot be listed as an author
+- **Disclosure location:** Acknowledgments section — must include "specific technical details about the AI model used, including its name, version, source, and the method of application"
+- **AI-generated images:** Not specified on page (recommend following ICMJE / COPE general guidance — avoid AI-generated images or disclose explicitly)
+- **Policy URL:** https://www.kjim.org/authors/authors.php
+
+---
+
+## Cover Letter
+
+Required. Must include:
+- Statement that "neither the submitted material nor portions thereof have been published previously or are under consideration for publication elsewhere"
+- Statement of any potential conflict of interest
+- Brief justification of fit with KJIM scope (internal-medicine clinical relevance)
+
+---
+
+## Open Access and APC
+
+- **CC BY-NC reuse policy** (non-commercial reuse permitted)
+- **APC (effective 2024-10-01):**
+  - Original Article: $1,000 USD (₩1,000,000 KRW)
+  - Images of Interest: $300 USD (₩300,000 KRW)
+  - Correspondence: free
+- PubMed Central indexed (open-access full-text deposit)
+
+---
+
+## Peer Review
+
+- **Type:** Single-blind (reviewer identities anonymized; author identities visible)
+- **Number of reviewers:** Not specified on page
+- **Initial decision turnaround:** Within 4 weeks of receipt (per journal statement)
+
+---
+
+## Author Guidelines URL
+
+https://www.kjim.org/authors/authors.php
+
+---
+
+## Positioning
+
+KJIM is well-suited for:
+- Korean and East Asian internal-medicine clinical research
+- Cross-disciplinary studies that connect imaging or laboratory findings to internal-medicine practice
+- Cohort studies with explicit Korean health-screening or NHIS-based data
+- Smaller single-center observational studies that may not reach radiology-specific or specialty-journal thresholds but have clear internal-medicine relevance
+- Faster initial decision (4 weeks) than many Western general-medicine journals
+
+| Dimension | Korean Journal of Internal Medicine | Yonsei Medical Journal | Journal of Korean Medical Science |
+|-----------|--------------------------------------|------------------------|-----------------------------------|
+| Society | Korean Association of Internal Medicine | Yonsei University College of Medicine | Korean Academy of Medical Sciences |
+| Scope | Internal medicine (general) | All medical specialties | All medical specialties |
+| Korean focus | Strong | Strong | Strong |
+| Open Access | Full OA (CC BY-NC) | Full OA | Full OA |
+| Indexing | PubMed/PMC, Scopus | PubMed/PMC, SCIE, Scopus | PubMed/PMC, SCIE, Scopus |
+| Article emphasis | Internal-medicine clinical research | Cross-disciplinary medical research | Korean medical science (broad) |
+
+---
+
+## Formatting Notes
+
+- References: Vancouver style (numbered, superscripted)
+- Units: SI units
+- Abbreviations: define at first use; avoid excessive abbreviations
+- Korean author names: provide in English; affiliation addresses should include full postal address
+- "Key Message" section is mandatory — do not omit
+
+
+---
+
+## Verification
+- **Source:** https://www.kjim.org/authors/authors.php
+- **Date:** 2026-05-21


### PR DESCRIPTION
## Summary

- **KJR profile retrofit** against March 2026 official PDF (4 corrections + 7 missing article types + full AI policy)
- **5 new profile pairs** (compact + detailed): BJR, DMJ, EnM, JCSM, KJIM
- **JCSM CSL** citation style added
- **`check_xref.py` regex priority bug fix** (`## **FIGURE LEGENDS**` was matching only "FIGURE")
- **`.gemini/` scratchpad** added to `.gitignore`
- **INTAKE document** tracking absorbed items vs deferred backlog

## KJR retrofit details

| Item | Before | After |
|---|---|---|
| Original Article body | 4000 words | ≤3000 words |
| Original Article abstract | 250 words | ≤300 words (structured) |
| Original Article figures | 8 | ≤7 (composite Fig.1A-C + Fig.2A-D = 2 figures, not 7) |
| Key Messages requirement | "3 bullet points required" | removed (not in PDF) |
| Reference style | Vancouver (unspecified) | first 6 authors, then "et al." |
| Article types | 5 listed | 10 listed (Brief Research Report, Pictorial Essay, Focus, Recommendation and Guideline, Editorial, Uncover This Tech Term, Emerging Rad Dx added) |
| AI policy | one line | 8 bullets from PDF |

Source: KJR-Instructions-202603.pdf (March 2026 official author instructions).

## check_xref regex fix

The previous `CAPTION_SECTION_RE` listed shorter patterns first:

```python
r"^#{1,3}\s+(Tables|Figures|Figure\s+Legends|Supplementary\s+Tables|"
r"Supplementary\s+Figures|Supplementary\s+Materials?)\b"
```

Against `## **FIGURE LEGENDS**` (with markdown bold), the `Figures?` alternative matched the leading `FIGURE` and the `LEGENDS` suffix was lost — figure cross-reference QC silently skipped the legends section. Fix: reorder so longest patterns come first, add IGNORECASE + bold-wrapper tolerance.

Regression test (PASS):
```
Input:  '## **FIGURE LEGENDS**\n# Tables\n### Supplementary Materials'
Output: ['FIGURE LEGENDS', 'Tables', 'Supplementary Materials']  ✓
```

## Test plan

- [x] PII scan passes on all staged files (rule oss-publication-pii-guard)
- [x] `bash scripts/validate_skills.sh` → ALL CHECKS PASSED
- [x] `python3 scripts/validate_skill_contracts.py` → 0 failures (25 migration warnings baseline)
- [x] Regex test against `## **FIGURE LEGENDS**` returns full `FIGURE LEGENDS` match
- [x] `grep -ni "Key Messages — 3 bullet points required"` returns no hits in retrofitted KJR.md
- [x] Pre-commit `validate_skills.sh` hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)