### PR TITLE
feat(peer-review): add Phase 2A SR-MA 8-probe extension (v2.9 -> v2.10)

### DIFF
--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -57,6 +57,63 @@ methodology and study design.
 6. **Prioritize**: Rank issues by impact on validity. Select top 3-5 for Major, 3-4 for Minor. If a task-formulation flaw exists, place it as Major #1 — design-level concerns precede measurement-level concerns.
 7. **Gate**: Present findings to user — "Here are the key issues I found — do you agree with this prioritization?"
 
+### Phase 2A: Systematic Review / Meta-Analysis Extension
+
+Apply this 8-probe checklist **only when manuscript type is "Systematic Review", "Meta-Analysis", or "Systematic Review and Meta-Analysis"**. These probes complement (do not replace) the generic Phase 2 issue checklist.
+
+**SR-MA reviews almost always justify Tier 3 word budget** (1000-1400w) — apply ≥3 of P1-P5 triggering = Tier 3 default.
+
+**P1 — DTA 2×2 cell extraction integrity (spot-check)**:
+- For SR-MA with diagnostic accuracy outcomes, select ≥2 outlier studies (k=1 subgroup studies, extreme sens/spec, single-study outliers driving subgroup p-values).
+- For each, retrieve source paper sensitivity / specificity (PubMed abstract or full-text).
+- Compare manuscript forest plot cells (TP/TP+FN, TN/TN+FP) against source values.
+- Common error: **sens/spec swap** at cell level. If a study has source sens=A% / spec=B% but manuscript forest reports sens=B% / spec=A%, this is a cell-assignment error.
+- If found, register as MAJOR (#1 if it drives a reported subgroup p-value).
+
+**P2 — Cohort overlap probe**:
+- Identify clusters in included studies sharing: (a) institution name, (b) author surname + year proximity, (c) public ICU/EHR database (MIMIC-IV, eICU, MIMIC-III, KNHIS, UK Biobank, Optum, MarketScan, IBM).
+- For each cluster, fetch PubMed efetch affiliation + abstract Methods database source.
+- Flag pairs sharing same data source + overlapping enrollment period as "high-confidence overlap".
+- Manuscript should acknowledge in Limitations + perform sensitivity analysis. If absent → MAJOR.
+
+**P3 — Diagnostic subset N transparency (mixed DTA + prognostic MA)**:
+- Compute bivariate pool denominator (TP+FP+TN+FN) from Table 2 or forest plot.
+- Compare to total N reported in Abstract.
+- If diagnostic subset is <50% of total without explicit "diagnostic subset N = X / Y" in Results → MAJOR transparency gap.
+
+**P4 — k=1 subgroup flag**:
+- Inspect subgroup analyses for strata with k=1 (single included study).
+- If a reported subgroup p-value is driven by k=1 stratum → flag MAJOR.
+- Recommend reframing as exploratory or removing from formal subgroup test.
+
+**P5 — Supplementary completeness check**:
+- SR-MA supplementary must contain at minimum:
+  - PRISMA / PRISMA-DTA checklist with page refs
+  - Full-text exclusion list with reasons (per PRISMA 2020 item 16b)
+  - Per-study data extraction table
+  - Per-study × per-domain risk-of-bias table (QUADAS-2 / QUADAS-AI / PROBAST / PROBAST-AI)
+  - Full search strategy verbatim per database
+- If supplementary contains only figure captions or is missing 3+ of these → MAJOR.
+
+**P6 — PROSPERO ID format + live URL request**:
+- Standard PROSPERO format: `CRD42` + 4-digit YYYY + 6-digit sequential = 13 chars total. Some pre-2020 IDs are 12 chars (5-digit sequential).
+- IDs with >13 chars or non-numeric tail → FORMAT_ANOMALY (MAJOR).
+- Always request authors provide live registration URL in cover letter for protocol cross-check.
+
+**P7 — Reference duplicate detection** (extends `/verify-refs`):
+- Run `/verify-refs` (PubMed + CrossRef). In addition to standard checks, detect duplicate PMID or DOI within reference list.
+- Verbatim duplicates indicate LLM-assisted reference compilation error → MAJOR (cite renumbering required).
+
+**P8 — AI Disclosure presence**:
+- `grep -iE "chatgpt|gpt-|llm|generative ai|ai was used|ai-assisted|copilot|claude|gemini|chatbot|large language model"` on manuscript body.
+- If 0 matches AND journal requires AI Disclosure (RYAI / Radiology / RSNA family / Lancet family / JAMA family / most BMJ family / Nature family) → flag MINOR-to-MAJOR.
+
+**Output template (P1 example)**:
+> "I spot-checked [Author Year] (PMID [...]) against the source paper and found that the values in Figure X are swapped. The source paper reports external-test sensitivity A% / specificity B% (n=N); the manuscript forest entries place [num1/denom1] in the sensitivity slot (which is the source's specificity numerator/denominator) and [num2/denom2] in the specificity slot (which is the source's sensitivity)."
+
+**Output template (P2 example)**:
+> "[Author1 Year1] uses [Database] (N=...). [Author2 Year2] uses [Database] (N=...). These are nearly certainly overlapping patient pools, and statistical independence assumption for MA pooling is violated. I'd suggest a sensitivity analysis excluding one of the two studies, plus an explicit cohort-source column in Table 1."
+
 ### Phase 3: Draft Review
 
 Generate `{manuscript_id}_review_draft.md`:
@@ -149,6 +206,7 @@ After drafting, verify mechanically:
    - ≥50% of Minor requests use hedged forms ("I'd suggest," "could," "would help") rather than imperative ("must," bare "Please [verb]")
    - General Comments names ≥2 specific strengths before listing concerns
    - At most 1 typo/grammar Minor Comment, only if in formal section or systematic
+9. **SR-MA-specific QC** (if Phase 2A applied): For each P1–P8 probe used, verify the corresponding Major comment cites source PMID + source page/table reference + verbatim quote. Reviews citing extraction errors without source-page reference are not actionable for authors.
 
 Fix all issues found, then present to user.
 


### PR DESCRIPTION
## Summary

Adds Phase 2A "Systematic Review / Meta-Analysis Extension" to `/peer-review` skill. 8-probe checklist activated when the manuscript type is SR / MA / SR-MA.

## Why

Recent SR-MA peer-review cycles surfaced patterns that the generic Phase 2 issue checklist does not catch systematically. These patterns are domain-specific to SR-MA work and are most relevant when reviewing for radiology / medical AI journals.

## What changed

- New Phase 2A subsection (between Phase 2 step 7 and Phase 3)
- 8 probes: P1 DTA cell integrity, P2 cohort overlap, P3 diagnostic subset N transparency, P4 k=1 subgroup, P5 supplementary completeness, P6 PROSPERO format, P7 reference duplicate, P8 AI Disclosure
- 2 output templates (P1 cell swap, P2 DB overlap)
- Self-QC bullet 9 — SR-MA-specific QC requiring source-page reference + verbatim quote

## Test plan

- [ ] Apply Phase 2A on a real SR-MA review to confirm probe outputs actionable comments
- [ ] Cross-check with `/verify-refs` companion PR (PMID/DOI duplicate detection)
- [ ] Verify Tier 3 word budget triggers correctly (>=3 of P1-P5)
- [ ] PII scan passes (no manuscript ID / author / institution leaks)

PII pre-flight: `grep -nE 'RYAI|KJR-|INSI-D|EURE-D|...' skills/peer-review/SKILL.md` -> 0 hits.

Validators: `validate_skills.sh` 40 skills 0 FAIL + `validate_skill_contracts.py` 15 v2 PASS / 25 migration warnings (baseline maintained).