### PR TITLE
feat(verify-refs): PMID/DOI duplicate detection (Gate 5, v1.2.0) + skill.yml drift fix

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -284,7 +284,7 @@ After each skill completes, verify that expected output files exist. If validati
 | `/make-figures` | `analysis/figures/_figure_manifest.md` with at least 1 entry | Parse manifest, verify listed files exist |
 | `/write-paper` | `manuscript/manuscript.md` (required), `manuscript/manuscript_final.docx` (required in --e2e) | Check file existence and non-empty |
 | `/check-reporting` | `qc/reporting_checklist.md` or inline report | Check file existence |
-| `/verify-refs` | `qc/reference_audit.json` (sole output) | Parse JSON; halt if `FABRICATED` or `MISMATCH` count > 0 (from `records[]`) |
+| `/verify-refs` | `qc/reference_audit.json` (sole output) | Parse JSON; halt if `submission_safe == false` (i.e., `FABRICATED` / `MISMATCH` count > 0 OR `duplicate_findings[]` nonempty) |
 | `/self-review` | Review report with JSON block (when --json) | Check JSON block is parseable |
 | `/manage-refs` | `manuscript/manuscript_final.docx`, `qc/xref_audit.json` | DOCX exists and non-empty; xref_audit.json has `submission_safe: true` (no P0 blocker rows) |
 | `/lit-sync` | `manuscript/_src/refs.bib` (mtime updated), `references/zotero_collection.json` | refs.bib mtime newer than collection snapshot; `refs_bib_refreshed: true` in collection JSON |

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -363,7 +363,7 @@ Numerical audits (2.5/2.5a/2.5b) cover in-text numbers; they do **not** cover re
        --allow-separate-attachments  # see Phase 2.5d for when this is appropriate
    ```
 
-3. **Read `qc/reference_audit.json`.** For each entry not marked `VERIFIED`, add a row to the reconciliation block below. `FABRICATED` entries are P0 Major Comments (block submission). `UNVERIFIED` entries are Minor Comments unless the manuscript is at a circulation/submission gate, in which case they escalate to Major.
+3. **Read `qc/reference_audit.json`.** For each entry not marked `VERIFIED`, add a row to the reconciliation block below. `FABRICATED` entries are P0 Major Comments (block submission). `UNVERIFIED` entries are Minor Comments unless the manuscript is at a circulation/submission gate, in which case they escalate to Major. For each `duplicate_findings[]` entry (category `duplicate_pmid` / `duplicate_doi`), add a Major Comment row noting the duplicated `ref_ids` pair and recommend cite renumbering — duplicates block submission (P0 Major) regardless of per-record `VERIFIED` status.
 
 4. **Cross-check placeholder drift.** `grep -n '\[@NEW:' manuscript/` — any remaining `[@NEW:topic]` placeholder at self-review stage is a P0: the citation was queued but never resolved. Include in the reconciliation block.
 
@@ -630,7 +630,7 @@ Here is how to address it with your existing data."
 | Gate | Severity | Trigger | Action on fail |
 |---|---|---|---|
 | Phase 2.5b cross-reference QC (delegate `/manage-refs scripts/check_xref.py`) | ENFORCED | MISSING_DOCX / MISSING_BODY / MISMATCH > 0 | P0 Major Comment, blocks submission |
-| Phase 2.5c reference hallucination scan (delegate `/verify-refs`) | ENFORCED | FABRICATED verdict in `records[]` | P0 Major Comment, blocks submission |
+| Phase 2.5c reference hallucination scan (delegate `/verify-refs`) | ENFORCED | `FABRICATED` in `records[]` OR nonempty `duplicate_findings[]` | P0 Major Comment, blocks submission |
 | `--fix` auto-fix loop (max 2 iterations) | ENFORCED in `/write-paper` Phase 7.4 chain | score still below threshold after 2 iterations | Route to write-paper Phase 7.4a Audit Recovery |
 | R0 numbering output | OPT-IN | `--r0-numbering` flag or downstream `/revise` consumer | Emits structured Anticipated Major/Minor Comments — consumable by `/revise` |
 | `--json` machine-readable output | OPT-IN | `--json` flag | Emits parseable JSON block consumed by `/orchestrate` post-skill validation |

--- a/skills/verify-refs/SKILL.md
+++ b/skills/verify-refs/SKILL.md
@@ -69,11 +69,13 @@ Full checkpoint protocol: `references/manual_checkpoint_guide.md`.
 The script uses DOI, PMID, CrossRef, and PubMed E-utilities where available. If
 network verification fails, it records `UNVERIFIED` rather than silently passing.
 
-## Output Contract (v1.1.1)
+## Output Contract (v1.2.0)
 
 | Artifact | Path | Purpose |
 |---|---|---|
-| Audit JSON | `qc/reference_audit.json` | Sole output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, submission-safe flag, full records |
+| Audit JSON | `qc/reference_audit.json` | Sole output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, `duplicate_findings[]`, submission-safe flag, full records |
+
+**v1.2.0 (2026-05)** adds `duplicate_findings[]` to the audit JSON and bumps `schema_version` to 3. Verbatim PMID or DOI duplicates within the reference list are flagged as MAJOR findings (resolves `/peer-review` Phase 2A P7). DOI normalization strips `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes plus trailing slashes before comparison so `https://doi.org/10.x/abc/` and `10.x/abc` collapse to one key. Both `submission_safe` and `fully_verified` now require `duplicate_findings` to be empty.
 
 **Removed in Phase 1A.2** (per `docs/artifact_contract.md`):
 - `references/verified_references.tsv` — record-level details now live inside `reference_audit.json` under `records[]`.
@@ -87,9 +89,10 @@ Sole-writer enforcement: `scripts/validate_project_contract.py` will flag any `r
 2. Run `scripts/verify_refs.py`.
 3. Read `qc/reference_audit.json`.
 4. Report all `FABRICATED` and `MISMATCH` rows first (from `records[]`).
-5. If `UNVERIFIED` rows remain, list them as manual checks and do not call the
+5. Report all `duplicate_findings[]` entries (verbatim PMID/DOI duplicates — cite renumbering required).
+6. If `UNVERIFIED` rows remain, list them as manual checks and do not call the
    manuscript fully submission-safe.
-6. If the user needs a human-readable table, summarize from `records[]` in chat — do not write a TSV.
+7. If the user needs a human-readable table, summarize from `records[]` in chat — do not write a TSV.
 
 ## Quality Gates
 
@@ -101,6 +104,11 @@ Sole-writer enforcement: `scripts/validate_project_contract.py` will flag any `r
   not match the authoritative source is downgraded to `MISMATCH` with
   `note = "first-author hallucination suspected"`. This catches the common
   LLM failure mode where a real DOI is paired with an invented author name.
+- Gate 5 (added 2026-05, v1.2.0): PMID/DOI duplicate detection within the
+  reference list. Verbatim duplicates (same PMID or normalized DOI) — a common
+  LLM citation-compilation artifact — are flagged as MAJOR findings in
+  `duplicate_findings[]`. `submission_safe == true` requires the list to be
+  empty. Resolves `/peer-review` Phase 2A P7.
 
 ## First-Author Cross-Check (Detail)
 

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -51,6 +51,24 @@ def clean_doi(doi: str) -> str:
     return doi.rstrip(".,;)].").lower()
 
 
+def normalize_doi_for_dup(doi: str) -> str:
+    """Strict DOI normalization for duplicate detection.
+
+    Beyond clean_doi(): strips common URL prefixes and trailing slashes so that
+    `https://doi.org/10.1234/abc/` and `10.1234/abc` collapse to the same key.
+    """
+    if not doi:
+        return ""
+    s = doi.strip().lower()
+    for prefix in ("https://doi.org/", "http://doi.org/",
+                   "https://dx.doi.org/", "http://dx.doi.org/", "doi:"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    s = s.strip().rstrip("/")
+    return clean_doi(s)
+
+
 def read_docx(path: Path) -> str:
     with zipfile.ZipFile(path) as zf:
         xml = zf.read("word/document.xml")
@@ -378,12 +396,56 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
     return record
 
 
-def write_outputs(records: list[RefRecord], project_root: Path, source: Path) -> None:
-    """Audit-only writer (v1.1.1 Phase 1A.2).
+def detect_duplicates(records: list[RefRecord]) -> list[dict]:
+    """Detect verbatim PMID or DOI duplicates within the reference list.
+
+    Verbatim duplicates (same PMID or normalized DOI) are a common LLM
+    citation-compilation artifact and require cite renumbering before
+    submission.
+    """
+    seen_pmids: dict[str, str] = {}
+    seen_dois: dict[str, str] = {}
+    findings: list[dict] = []
+    for rec in records:
+        rec_id = rec.ref_id or "<unknown>"
+        pmid = (rec.pmid or "").strip()
+        if pmid:
+            if pmid in seen_pmids:
+                findings.append({
+                    "severity": "MAJOR",
+                    "category": "duplicate_pmid",
+                    "ref_ids": [seen_pmids[pmid], rec_id],
+                    "pmid": pmid,
+                    "note": "Verbatim duplicate reference. Cite renumbering required.",
+                })
+            else:
+                seen_pmids[pmid] = rec_id
+        doi = normalize_doi_for_dup(rec.doi or "")
+        if doi:
+            if doi in seen_dois:
+                findings.append({
+                    "severity": "MAJOR",
+                    "category": "duplicate_doi",
+                    "ref_ids": [seen_dois[doi], rec_id],
+                    "doi": doi,
+                    "note": "Verbatim duplicate reference. Cite renumbering required.",
+                })
+            else:
+                seen_dois[doi] = rec_id
+    return findings
+
+
+def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
+                  duplicate_findings: list[dict]) -> None:
+    """Audit-only writer (v1.2.0).
 
     Per docs/artifact_contract.md, /verify-refs is sole writer of qc/reference_audit.json
     only. It MUST NOT write to references/ (that directory is owned by /search-lit and
     /lit-sync). All per-record details live inside reference_audit.json.
+
+    v1.2.0 (2026-05): adds duplicate_findings[] for PMID/DOI duplicate detection
+    (Gate 5; resolves /peer-review Phase 2A P7). submission_safe and fully_verified
+    both require duplicate_findings to be empty.
     """
     qc_dir = project_root / "qc"
     qc_dir.mkdir(parents=True, exist_ok=True)
@@ -392,12 +454,22 @@ def write_outputs(records: list[RefRecord], project_root: Path, source: Path) ->
     for rec in records:
         counts[rec.status] = counts.get(rec.status, 0) + 1
     audit = {
-        "schema_version": 2,
+        "schema_version": 3,
         "source": str(source),
         "total_references": len(records),
         "counts": counts,
-        "submission_safe": counts.get("FABRICATED", 0) == 0 and counts.get("MISMATCH", 0) == 0,
-        "fully_verified": counts.get("UNVERIFIED", 0) == 0 and counts.get("FABRICATED", 0) == 0 and counts.get("MISMATCH", 0) == 0,
+        "duplicate_findings": duplicate_findings,
+        "submission_safe": (
+            counts.get("FABRICATED", 0) == 0
+            and counts.get("MISMATCH", 0) == 0
+            and len(duplicate_findings) == 0
+        ),
+        "fully_verified": (
+            counts.get("UNVERIFIED", 0) == 0
+            and counts.get("FABRICATED", 0) == 0
+            and counts.get("MISMATCH", 0) == 0
+            and len(duplicate_findings) == 0
+        ),
         "requires_manual_reference_check": counts.get("UNVERIFIED", 0) > 0,
         "records": [asdict(rec) for rec in records],
     }
@@ -437,13 +509,18 @@ def main() -> int:
         return 3
 
     verified = [verify_record(rec, args.offline, args.timeout) for rec in records]
-    write_outputs(verified, project_root, input_path)
+    duplicate_findings = detect_duplicates(verified)
+    write_outputs(verified, project_root, input_path, duplicate_findings)
 
     counts: dict[str, int] = {}
     for rec in verified:
         counts[rec.status] = counts.get(rec.status, 0) + 1
-    print(json.dumps({"total": len(verified), "counts": counts}, indent=2))
-    if counts.get("FABRICATED", 0) or counts.get("MISMATCH", 0):
+    print(json.dumps({
+        "total": len(verified),
+        "counts": counts,
+        "duplicate_findings_count": len(duplicate_findings),
+    }, indent=2))
+    if counts.get("FABRICATED", 0) or counts.get("MISMATCH", 0) or duplicate_findings:
         return 1
     if args.strict and counts.get("UNVERIFIED", 0):
         return 1

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -16,8 +16,6 @@ inputs:
   - manuscript.docx
   - references.bib
 outputs:
-  - references/verified_references.tsv
-  - references/library.bib
   - qc/reference_audit.json
 deterministic_scripts:
   - scripts/verify_refs.py

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -383,10 +383,11 @@ If any match is returned, HARD STOP. Report the unresolved placeholders to the
 user and loop back: owner runs `/search-lit` → `/lit-sync` to import entries,
 collaborators flag via owner. Do NOT proceed to 7.3.2 until the grep is clean.
 
-**7.3.2 — Audit.** Call `/verify-refs` on the current manuscript. Per v1.1.1
+**7.3.2 — Audit.** Call `/verify-refs` on the current manuscript. Per v1.2.0
 contract, its sole output is `qc/reference_audit.json` (no longer writes
 `references/*`). Parse that file: if `submission_safe: false`, stop the pipeline
-and surface the `FABRICATED` / `MISMATCH` records to the user. If
+and surface the `FABRICATED` / `MISMATCH` records AND any `duplicate_findings[]`
+entries (duplicate PMID/DOI; cite renumbering required) to the user. If
 `/verify-refs` is unavailable, fall back to `/search-lit --verify-only` and flag
 any unverified references with `[UNVERIFIED]` markers.
 


### PR DESCRIPTION
## Summary

Adds Gate 5 to `/verify-refs`: verbatim PMID and DOI duplicate detection within the reference list. Resolves `/peer-review` Phase 2A P7 (Reference duplicate detection probe).

## Why

LLM-assisted manuscript drafting frequently produces duplicate citations — same paper inserted twice with slightly different bibkeys (or once with bare DOI and once with `https://doi.org/...` URL form). Without this gate the manuscript ships with a stale reference list that needs cite-renumbering at journal copyediting stage, sometimes after acceptance.

## What changed

### `scripts/verify_refs.py`
- New `detect_duplicates()` pass after per-record PubMed/CrossRef verification.
- New `normalize_doi_for_dup()` helper — strips `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes plus trailing slashes so equivalent forms collapse to one key.
- Audit JSON gains `duplicate_findings[]` field; `schema_version` bumped 2 -> 3.
- `submission_safe` AND `fully_verified` now require `duplicate_findings` to be empty (no inconsistent state where all records are OK but duplicates remain).
- `main()` exits 1 if FABRICATED/MISMATCH count > 0 OR `duplicate_findings` nonempty.

### `SKILL.md` 
- Output Contract bumped (v1.1.1) -> (v1.2.0); `duplicate_findings[]` documented.
- Workflow Step 5 (new) reports duplicates before UNVERIFIED triage.
- New **Gate 5**: PMID/DOI duplicate detection.

### `skill.yml` drift fix
- Drop stale outputs `references/verified_references.tsv` + `references/library.bib`. These were removed in Phase 1A.2 per SKILL.md but the contract file still advertised them.

### Downstream consumer doc propagation (so the gate actually halts pipelines)
- `skills/orchestrate/SKILL.md:287` — halt condition now references `submission_safe == false` (covers FABRICATED/MISMATCH OR duplicate_findings).
- `skills/self-review/SKILL.md:366` — each `duplicate_findings[]` entry becomes a P0 Major Comment row.
- `skills/self-review/SKILL.md:633` (Gates table) — trigger extended to nonempty `duplicate_findings[]`.
- `skills/write-paper/SKILL.md:386-391` — surface `duplicate_findings` alongside FABRICATED/MISMATCH.

## Test plan

- [x] Synthetic 8-entry bib (1 PMID dup pair + 1 DOI dup pair + 1 URL-vs-bare-DOI normalization dup pair + 2 unique) -> 3 `duplicate_findings`, exit 1
- [x] 2-entry dup-free baseline -> `duplicate_findings == []`, `submission_safe == true`, exit 0
- [x] `bash scripts/validate_skills.sh` 40 skills 0 FAIL
- [x] `python3 scripts/validate_skill_contracts.py` 15 v2 PASS / 25 migration warnings / 0 failures
- [x] PII grep across 6 modified files: 0 hits