### PR TITLE
feat(meta-analysis): SR-MA dual-extractor + cohort overlap + supplementary 8-file (v2.10 alignment)

### DIFF
--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -152,6 +152,21 @@ for skill_dir in "$SKILLS_DIR"/*/; do
       _add_if_tracked "$f"
     done < <(find "${skill_dir}references" -type f \( $TEXT_EXTS \) -print0 2>/dev/null)
   fi
+  # Extended scope (2026-05): templates/ and scripts/ subdirs. Same blocklist
+  # patterns apply — these dirs were previously silently excluded and could
+  # carry vendored PII (manuscript IDs, author names, project paths) into
+  # downstream skill consumers without detection. Includes .py / .sh source
+  # since docstrings and comments are the typical PII vector.
+  if [ -d "${skill_dir}templates" ]; then
+    while IFS= read -r -d '' f; do
+      _add_if_tracked "$f"
+    done < <(find "${skill_dir}templates" -type f \( $TEXT_EXTS -o -name "*.py" -o -name "*.sh" \) -print0 2>/dev/null)
+  fi
+  if [ -d "${skill_dir}scripts" ]; then
+    while IFS= read -r -d '' f; do
+      _add_if_tracked "$f"
+    done < <(find "${skill_dir}scripts" -type f \( $TEXT_EXTS -o -name "*.py" -o -name "*.sh" \) -print0 2>/dev/null)
+  fi
   # Also catch top-level skill scratchpads (skills/<name>/TODO_*.md, HANDOFF.md)
   # and skill.yml / capabilities.yml that some skills keep alongside SKILL.md.
   while IFS= read -r -d '' f; do

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -40,6 +40,11 @@ with specialized support for diagnostic test accuracy (DTA) meta-analyses.
 - **Submission package drift**: `${CLAUDE_SKILL_DIR}/references/submission_package_drift.md` -- multi-journal folder hygiene, `DO_NOT_EDIT_HERE` gate, `_build.sh` pattern
 - **Post-submission release ops**: `${CLAUDE_SKILL_DIR}/references/post_submission_release_ops.md` -- Zenodo DOI gating, tag-cleanup gates, reject-retarget versioning
 
+### Built-in Templates (`${CLAUDE_SKILL_DIR}/templates/`)
+
+- **Extraction Form v2** (`templates/extraction_form_v2.md`) -- dual-extractor schema with `source_page_ref`, `source_verbatim_quote`, `cohort_source`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool` columns. Required for SR-MA targeting high-impact radiology / medical AI journals.
+- **Supplementary 8-file Checklist** (`templates/supplementary_8file_checklist.md`) -- S1-S8 mandatory package (PRISMA, PROSPERO, search strategy, exclusion list, extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication bias) with a submission-gate bash check.
+
 ---
 
 ## Meta-Analysis Types
@@ -217,6 +222,8 @@ ID sets. The Markdown consensus document remains the human explanation.
 
 > **Failure-mode cross-ref** → `references/data_integrity_checklist.md` DI-1~DI-5 are mandatory during extraction (2x2 arm-swap, KM audit trail, methodology mismatch, PRISMA 5-way drift, single-source k).
 
+**Recommended extraction form**: For SR-MA targeting high-impact radiology / medical AI journals, use `${CLAUDE_SKILL_DIR}/templates/extraction_form_v2.md`. Dual-extractor + source-page-reference + verbatim-quote columns prevent the 2x2 cell-swap and cohort-overlap blind spots surfaced in recent SR-MA peer-review cycles. New required columns: `cohort_source`, `source_page_ref`, `source_verbatim_quote`, `extraction_consensus_status`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool`.
+
 #### 4.0 AI-drafted starting document gate
 
 Before opening the extraction form: if a senior mentor or collaborator has shared an AI-drafted starting document (Claude / ChatGPT / Gemini draft of the study list, 2x2 cells, or effect estimates) — even when the sender flags it as "참고용" — apply `~/.claude/rules/ai-drafted-document-policy.md`:
@@ -278,6 +285,38 @@ When comparing extraction results between independent reviewers (minimum 2), che
 3. **Kaplan-Meier estimate distinction**: KM curve estimates differ from raw event counts. Always record the data source (Table vs KM curve vs text) during extraction.
 4. **Discrepancy resolution**: List all discrepancies → verify against original text → reach consensus → if consensus fails, use third reviewer. Log all consensus decisions in `{project}/consensus_log.md`.
 5. **Dataset lock**: After resolving all discrepancies, lock the final dataset. Any subsequent changes require documented justification with date.
+
+#### Phase 4c: Extraction QC & Cohort Overlap Detection
+
+After dual-extractor consensus, run two QC scripts before locking the extraction table for statistical synthesis.
+
+**1. 2x2 Cell Integrity Check** -- `scripts/dta_extraction_qc.py`:
+
+Validates manuscript forest-plot cells (TP / FN / TN / FP) against source-paper-reported sens/spec within a tolerance (default 0.02). Catches sens/spec swap at extraction stage -- a common error pattern where a single-study k=1 subgroup outlier flips conclusions due to cell-assignment swap.
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/dta_extraction_qc.py" \
+  --input 2_Extraction/extraction.csv \
+  --tolerance 0.02 \
+  --out 2_Extraction/qc/dta_extraction_qc.tsv
+```
+
+Any `FLAG_SWAP` or `FLAG_MISMATCH` row requires third-reviewer adjudication before Phase 6 statistical synthesis.
+
+**2. Cohort Overlap Check** -- `scripts/cohort_overlap_check.py`:
+
+Clusters included studies by (a) shared public ICU/EHR database (MIMIC-IV, eICU, MIMIC-III, KNHIS, UK Biobank, Optum, MarketScan, TriNetX, IBM), (b) same institution + overlapping enrollment period, (c) shared first-author surname + ±2y year proximity. Flags HIGH / MEDIUM overlap confidence.
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cohort_overlap_check.py" \
+  --input 2_Extraction/studies.csv \
+  --enrich \
+  --out 2_Extraction/qc/cohort_overlap.md
+```
+
+HIGH-confidence overlap pairs require Limitations acknowledgment + sensitivity analysis excluding one of the pair.
+
+Cross-links: `/peer-review` Phase 2A P1 (cell integrity) + P2 (cohort overlap).
 
 ### Phase 5: Risk of Bias Assessment
 
@@ -497,6 +536,26 @@ All four scripts are repo-shipped as of 2026-04 (FOLLOWUPS P10). Non-zero exit =
 
 ---
 
+## Empirical Lessons (2026-05)
+
+Synthesized from recent SR-MA peer-review cycles. Drives the Phase 4 extraction form schema, Phase 4c QC scripts, and submission-gate enhancements documented above.
+
+1. **Dual-extractor + source-page-reference + verbatim quote** is mandatory for 2x2 cell integrity. Single-extractor without source-page citation invites sens/spec swap that is invisible to forest-plot-level review.
+
+2. **Cohort overlap detection** must cluster by shared public database + institution + author. Independent-cohort assumption for MA pooling fails when multiple included studies use the same public ICU/EHR cohort with overlapping enrollment windows. Sensitivity analysis excluding overlap is the minimum acknowledgment.
+
+3. **Diagnostic subset N transparency** in mixed DTA + prognostic MAs: report `sample_n_dta_pool` separately from `sample_n_prognostic_pool` with explicit prevalence. Aggregate N in Abstract misleads readers about diagnostic-subset power.
+
+4. **k=1 subgroups are not robust**: any subgroup p-value driven by a single included study must be reframed as exploratory or removed from formal subgroup test. Post-hoc subgroups require PROSPERO amendment with visible record.
+
+5. **Supplementary 8-file package** is the minimum bar for high-impact journals: PRISMA checklist, PROSPERO PDF, full search strategy, full-text exclusion list with reasons, per-study extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication-bias analyses. See `templates/supplementary_8file_checklist.md`.
+
+6. **PROSPERO 13-char ID format** (`CRD42` + YYYY + 6-digit sequential); pre-2020 IDs may be 12 chars. Non-numeric tails or >13 chars are format anomalies. Request live registration URL in cover letter for protocol cross-check.
+
+7. **AI Disclosure presence** for SR-MA submissions to RYAI / Radiology / RSNA / Lancet / JAMA / BMJ / Nature families. Absence triggers MINOR-to-MAJOR finding at peer review.
+
+---
+
 ## DTA-Specific Pitfalls (Always Check)
 
 | Pitfall | Problem | Solution |
@@ -534,6 +593,7 @@ When the number of included studies is small (< 10):
 | Need self-review | `/self-review` | Pre-submission quality check |
 | Co-author circulation (Phase 9) | `/gws` + `/handoff` | Thread-reply send, deadline task registration |
 | Self-audit recovery entrypoint (Phase 10) | `/write-paper` Step 7.4a | Recovery branch for polish pipelines that surface structural audit failures |
+| `/sync-submission` SR-MA gate | `/sync-submission` | Before submission, verify supplementary package matches all 8 files in `templates/supplementary_8file_checklist.md` (PRISMA, PROSPERO, search strategy, exclusion list, extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication bias). AI Disclosure presence check (cross-link `/peer-review` Phase 2A P8). Cite-list duplicate check via `/verify-refs` Gate 5 (duplicate PMID/DOI). |
 
 ---
 

--- a/skills/meta-analysis/scripts/cohort_overlap_check.py
+++ b/skills/meta-analysis/scripts/cohort_overlap_check.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Cohort Overlap Detection — flag included-study pairs sharing same data source.
+
+Motivation: recent SR-MA peer-review cycles found included studies using
+overlapping public ICU/EHR cohorts (MIMIC-IV, eICU, KNHIS, UK Biobank) without
+explicit acknowledgment. Independent-cohort assumption for MA pooling is then
+violated. This script reads a study list with PMID + extracted cohort metadata,
+fetches missing fields from PubMed efetch when needed, and reports clusters by
+(a) shared public database, (b) shared institution + overlapping enrollment
+period, (c) shared author surname + year proximity.
+
+Usage:
+    python3 cohort_overlap_check.py --input studies.csv --out overlap_report.md
+
+Input CSV schema (recommended columns):
+    study_id, pmid, country, institution, database_source, enrollment_period_start,
+    enrollment_period_end, first_author, year, sample_n
+
+`database_source` examples: "MIMIC-IV", "eICU", "KNHIS", "UK Biobank", "institutional",
+"multi-center prospective". Use empty string if unknown — script will attempt PubMed
+fetch to infer.
+
+Outputs a Markdown report listing:
+- HIGH-CONFIDENCE OVERLAP pairs (same database + overlapping period)
+- MEDIUM-CONFIDENCE candidates (same institution OR same author surname + year ±2)
+- UNDETERMINED (insufficient metadata)
+"""
+import argparse
+import csv
+import json
+import sys
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+PUBLIC_DBS = [
+    "MIMIC-IV", "MIMIC-III", "eICU", "MIMIC", "MarketScan", "Optum",
+    "NHANES", "KNHANES", "KNHIS", "UK Biobank", "Biobank Japan",
+    "TriNetX", "All of Us", "VA Corporate Data Warehouse", "PCORnet",
+    "SEER", "NSQIP",
+]
+
+
+def fetch_pubmed_affiliation(pmid: str, timeout: int = 10) -> dict:
+    """Fetch first-author affiliation + abstract Methods snippet via efetch."""
+    url = (
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+        f"?db=pubmed&id={pmid}&retmode=xml"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            data = resp.read()
+    except Exception as e:
+        return {"pmid": pmid, "error": str(e)}
+
+    root = ET.fromstring(data)
+    art = root.find(".//Article")
+    if art is None:
+        return {"pmid": pmid, "error": "no Article element"}
+
+    title = art.findtext("ArticleTitle", "") or ""
+    aff = root.findtext(".//Author/AffiliationInfo/Affiliation", "") or ""
+    abstract = " ".join(
+        (ab.text or "") for ab in root.findall(".//AbstractText")
+    )
+
+    # Heuristic database detection from abstract
+    db_hit = ""
+    for db in PUBLIC_DBS:
+        if db.lower() in abstract.lower():
+            db_hit = db
+            break
+
+    return {
+        "pmid": pmid,
+        "title": title,
+        "affiliation": aff,
+        "database_hit": db_hit,
+    }
+
+
+def periods_overlap(s1: str, e1: str, s2: str, e2: str) -> Optional[bool]:
+    """Return True/False/None (None = insufficient data). YYYY-MM strings."""
+    if not (s1 and e1 and s2 and e2):
+        return None
+    try:
+        return not (e1 < s2 or e2 < s1)
+    except Exception:
+        return None
+
+
+def cluster_by_db(rows: list[dict]) -> dict[str, list[dict]]:
+    """Group rows by database_source (non-empty)."""
+    clusters = defaultdict(list)
+    for r in rows:
+        db = (r.get("database_source") or "").strip()
+        if db and db.lower() != "institutional":
+            clusters[db].append(r)
+    return {k: v for k, v in clusters.items() if len(v) >= 2}
+
+
+def cluster_by_institution(rows: list[dict]) -> dict[str, list[dict]]:
+    clusters = defaultdict(list)
+    for r in rows:
+        inst = (r.get("institution") or "").strip()
+        if inst:
+            # Normalize: lowercase, strip "Department of X, " prefix
+            key = inst.lower().split(",")[0].strip()
+            clusters[key].append(r)
+    return {k: v for k, v in clusters.items() if len(v) >= 2}
+
+
+def cluster_by_author_year(rows: list[dict]) -> dict[str, list[dict]]:
+    clusters = defaultdict(list)
+    for r in rows:
+        surname = (r.get("first_author") or "").strip().split()[0].lower() if r.get("first_author") else ""
+        if surname:
+            clusters[surname].append(r)
+    return {k: v for k, v in clusters.items() if len(v) >= 2}
+
+
+def write_report(out_path: Path, db_clusters, inst_clusters, author_clusters,
+                 enriched: list[dict]) -> None:
+    lines = ["# Cohort Overlap Report", ""]
+
+    lines.append(f"Total studies analyzed: **{len(enriched)}**")
+    lines.append("")
+
+    lines.append("## HIGH-CONFIDENCE: Same public database")
+    if db_clusters:
+        for db, rows in db_clusters.items():
+            lines.append(f"\n### Database: **{db}** ({len(rows)} studies)")
+            for r in rows:
+                period = (
+                    f"{r.get('enrollment_period_start','?')}"
+                    f"-{r.get('enrollment_period_end','?')}"
+                )
+                lines.append(
+                    f"- {r.get('study_id','?')} (PMID {r.get('pmid','?')}, "
+                    f"N={r.get('sample_n','?')}, period {period})"
+                )
+            # Period overlap check (pairwise)
+            for i in range(len(rows)):
+                for j in range(i + 1, len(rows)):
+                    o = periods_overlap(
+                        rows[i].get("enrollment_period_start", ""),
+                        rows[i].get("enrollment_period_end", ""),
+                        rows[j].get("enrollment_period_start", ""),
+                        rows[j].get("enrollment_period_end", ""),
+                    )
+                    if o is True:
+                        lines.append(
+                            f"  - WARN Period overlap: {rows[i]['study_id']} <-> {rows[j]['study_id']}"
+                        )
+                    elif o is None:
+                        lines.append(
+                            f"  - QUERY Period overlap undetermined: "
+                            f"{rows[i]['study_id']} <-> {rows[j]['study_id']}"
+                        )
+    else:
+        lines.append("None.")
+
+    lines.append("\n## MEDIUM: Same institution (single-center cluster)")
+    if inst_clusters:
+        for inst, rows in inst_clusters.items():
+            lines.append(f"\n### Institution: **{inst}** ({len(rows)} studies)")
+            for r in rows:
+                lines.append(f"- {r.get('study_id','?')} (PMID {r.get('pmid','?')})")
+    else:
+        lines.append("None.")
+
+    lines.append("\n## LOWER: Same author surname +/-2y year")
+    if author_clusters:
+        for surname, rows in author_clusters.items():
+            years = [int(r["year"]) for r in rows if str(r.get("year","")).isdigit()]
+            year_span = max(years) - min(years) if years else None
+            tag = "(within +/-2y)" if year_span is not None and year_span <= 2 else "(>2y span)"
+            lines.append(f"\n### Surname: **{surname}** {tag} - {len(rows)} studies")
+            for r in rows:
+                lines.append(f"- {r.get('study_id','?')} ({r.get('year','?')})")
+    else:
+        lines.append("None.")
+
+    lines.append("\n## Recommendation")
+    lines.append(
+        "- For HIGH-CONFIDENCE overlap pairs: sensitivity analysis excluding one, "
+        "explicit Limitations acknowledgment, cohort-source column in Table 1."
+    )
+    lines.append(
+        "- For MEDIUM: request author institution + ORCID to verify cohort independence."
+    )
+
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Cohort overlap detector for SR-MA")
+    p.add_argument("--input", required=True, type=Path, help="Input CSV")
+    p.add_argument("--out", required=True, type=Path, help="Output Markdown report")
+    p.add_argument("--enrich", action="store_true",
+                   help="Fetch PubMed efetch for missing database/affiliation")
+    args = p.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: input not found: {args.input}", file=sys.stderr)
+        return 1
+
+    with args.input.open(newline="", encoding="utf-8") as fin:
+        rows = list(csv.DictReader(fin))
+
+    if args.enrich:
+        for r in rows:
+            if not r.get("database_source") and r.get("pmid"):
+                info = fetch_pubmed_affiliation(r["pmid"])
+                if info.get("database_hit"):
+                    r["database_source"] = info["database_hit"]
+                if not r.get("institution") and info.get("affiliation"):
+                    r["institution"] = info["affiliation"][:80]
+
+    db_clusters = cluster_by_db(rows)
+    inst_clusters = cluster_by_institution(rows)
+    author_clusters = cluster_by_author_year(rows)
+
+    write_report(args.out, db_clusters, inst_clusters, author_clusters, rows)
+
+    n_db = sum(len(v) for v in db_clusters.values())
+    n_inst = sum(len(v) for v in inst_clusters.values())
+    print(
+        f"Cohort overlap: {len(db_clusters)} DB clusters ({n_db} studies), "
+        f"{len(inst_clusters)} institution clusters ({n_inst} studies)"
+    )
+    print(f"Report: {args.out}")
+
+    return 1 if db_clusters else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/meta-analysis/scripts/dta_extraction_qc.py
+++ b/skills/meta-analysis/scripts/dta_extraction_qc.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+DTA Extraction QC — cross-check forest plot 2x2 cells against source paper sens/spec.
+
+Motivation: recent SR-MA peer-review cycles found extracted (TP, FN, TN, FP)
+cells with sensitivity/specificity values swapped versus the source paper. In
+single-study k=1 subgroups this can invert reported p-values. This script
+validates extracted cells against source-reported sens/spec with a tolerance and
+FLAGs mismatches for manual review. It does NOT auto-correct.
+
+Usage:
+    python3 dta_extraction_qc.py --input extraction.csv --tolerance 0.02 --out qc_report.tsv
+
+Input CSV schema (required columns):
+    study_id          - e.g., "StudyA_2021_1"
+    source_pmid       - PubMed ID (string)
+    source_sens       - decimal 0-1 (e.g., 0.978)
+    source_spec       - decimal 0-1 (e.g., 0.554)
+    extracted_tp      - int (TP cell)
+    extracted_fn      - int (FN cell)
+    extracted_tn      - int (TN cell)
+    extracted_fp      - int (FP cell)
+    source_cohort     - e.g., "external_test_set" (which cohort the source values come from)
+    source_page_ref   - e.g., "Table 3 page 7" (audit trail)
+
+Output:
+    Tab-separated table with one row per study, columns:
+    study_id | extracted_sens | extracted_spec | source_sens | source_spec
+            | sens_diff | spec_diff | status | swap_suspected | message
+"""
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+
+def compute_sens_spec(tp: int, fn: int, tn: int, fp: int) -> tuple[float, float]:
+    """Return (sensitivity, specificity)."""
+    sens = tp / (tp + fn) if (tp + fn) > 0 else float("nan")
+    spec = tn / (tn + fp) if (tn + fp) > 0 else float("nan")
+    return sens, spec
+
+
+def check_row(row: dict, tol: float) -> dict:
+    """Return augmented row with status/diff fields."""
+    try:
+        tp = int(row["extracted_tp"])
+        fn = int(row["extracted_fn"])
+        tn = int(row["extracted_tn"])
+        fp = int(row["extracted_fp"])
+        source_sens = float(row["source_sens"])
+        source_spec = float(row["source_spec"])
+    except (KeyError, ValueError) as e:
+        return {**row, "status": "PARSE_ERROR", "message": str(e)}
+
+    ext_sens, ext_spec = compute_sens_spec(tp, fn, tn, fp)
+    sens_diff = abs(ext_sens - source_sens)
+    spec_diff = abs(ext_spec - source_spec)
+
+    # Swap detection: extracted_sens ≈ source_spec AND extracted_spec ≈ source_sens
+    swap_sens_match = abs(ext_sens - source_spec) <= tol
+    swap_spec_match = abs(ext_spec - source_sens) <= tol
+    swap_suspected = swap_sens_match and swap_spec_match
+
+    if sens_diff <= tol and spec_diff <= tol:
+        status = "OK"
+        message = "Match within tolerance."
+    elif swap_suspected:
+        status = "FLAG_SWAP"
+        message = (
+            f"Possible sens/spec SWAP. "
+            f"Extracted (sens={ext_sens:.3f}, spec={ext_spec:.3f}) matches "
+            f"source swapped (source_sens={source_sens:.3f}, source_spec={source_spec:.3f})."
+        )
+    else:
+        status = "FLAG_MISMATCH"
+        message = (
+            f"Discrepancy beyond tolerance ({tol:.3f}). "
+            f"Check source_page_ref={row.get('source_page_ref','?')}."
+        )
+
+    return {
+        **row,
+        "extracted_sens": f"{ext_sens:.4f}",
+        "extracted_spec": f"{ext_spec:.4f}",
+        "sens_diff": f"{sens_diff:.4f}",
+        "spec_diff": f"{spec_diff:.4f}",
+        "swap_suspected": "YES" if swap_suspected else "NO",
+        "status": status,
+        "message": message,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="DTA extraction sens/spec QC")
+    p.add_argument("--input", required=True, type=Path, help="Input CSV file")
+    p.add_argument("--tolerance", type=float, default=0.02,
+                   help="Absolute tolerance for sens/spec match (default 0.02 = 2 percentage points)")
+    p.add_argument("--out", required=True, type=Path, help="Output TSV report")
+    args = p.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: input file not found: {args.input}", file=sys.stderr)
+        return 1
+
+    with args.input.open(newline="", encoding="utf-8") as fin:
+        reader = csv.DictReader(fin)
+        rows = [check_row(r, args.tolerance) for r in reader]
+
+    fieldnames = [
+        "study_id", "source_pmid", "source_cohort", "source_page_ref",
+        "extracted_tp", "extracted_fn", "extracted_tn", "extracted_fp",
+        "extracted_sens", "extracted_spec", "source_sens", "source_spec",
+        "sens_diff", "spec_diff", "swap_suspected", "status", "message",
+    ]
+    with args.out.open("w", newline="", encoding="utf-8") as fout:
+        writer = csv.DictWriter(fout, fieldnames=fieldnames, delimiter="\t",
+                                extrasaction="ignore")
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+    # Summary stats
+    n = len(rows)
+    n_ok = sum(1 for r in rows if r.get("status") == "OK")
+    n_swap = sum(1 for r in rows if r.get("status") == "FLAG_SWAP")
+    n_mismatch = sum(1 for r in rows if r.get("status") == "FLAG_MISMATCH")
+    n_err = sum(1 for r in rows if r.get("status") == "PARSE_ERROR")
+
+    print(f"DTA QC: {n} studies | OK={n_ok} | SWAP={n_swap} | MISMATCH={n_mismatch} | PARSE_ERROR={n_err}")
+    print(f"Report: {args.out}")
+
+    return 1 if (n_swap + n_mismatch + n_err) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/meta-analysis/templates/extraction_form_v2.md
+++ b/skills/meta-analysis/templates/extraction_form_v2.md
@@ -1,0 +1,129 @@
+# SR-MA Data Extraction Form v2
+
+**Version**: v2.0
+**Motivation**: Recent SR-MA peer-review cycles surfaced three recurring extraction-stage failure modes — diagnostic 2×2 cell sens/spec swap, undisclosed cohort overlap via shared public databases, and undocumented diagnostic vs prognostic subset N. v2 adds three column families to prevent recurrence.
+
+## Coverage
+
+Use this form for any SR-MA with diagnostic accuracy and/or prognostic prediction outcomes. Compatible with QUADAS-AI / PROBAST-AI / METRICS frameworks.
+
+## Column schema (CSV / Google Sheets)
+
+### Identity (always required)
+
+| Column | Description | Example |
+|---|---|---|
+| `study_id` | Internal ID (`<Surname>_<Year>_<seq>`) | `StudyA_2021_1` |
+| `pmid` | PubMed ID | `00000000` |
+| `doi` | DOI | `10.xxxx/example.YYYY.NNNNNN` |
+| `first_author_lastname` | LastName from PubMed | `Surname` |
+| `first_author_forename` | ForeName from PubMed | `Forename` |
+| `year` | Publication year | `2021` |
+| `country` | Per affiliation (use country of cohort, not publisher) | `[Country]` |
+| `journal` | Full journal name | `[Journal Full Title]` |
+| `study_design` | retrospective / prospective / case-control / cross-sectional | `retrospective` |
+
+### Cohort source (NEW in v2 — prevents undisclosed overlap)
+
+| Column | Description | Example |
+|---|---|---|
+| `cohort_source` | One of: `institutional` / `multi-center prospective` / `MIMIC-IV` / `eICU` / `MIMIC-III` / `KNHIS` / `UK Biobank` / `TriNetX` / `Optum` / `MarketScan` / `SEER` / etc. | `MIMIC-IV` |
+| `institution_primary` | Verbatim institution name from corresponding-author affiliation | `Tertiary Academic Medical Center, [City]` |
+| `institutions_additional` | Pipe-separated additional centers | `Other Affiliated Hospital` |
+| `enrollment_period_start` | YYYY-MM | `2017-01` |
+| `enrollment_period_end` | YYYY-MM | `2019-12` |
+| `data_sharing_statement` | Yes / No / NotReported | `NotReported` |
+| `overlap_flag_reviewer1` | Reviewer 1 suspects cohort overlap with which study_id (or empty) | `StudyB_YYYY` |
+| `overlap_flag_reviewer2` | Reviewer 2's overlap flag | `StudyB_YYYY` |
+
+### Sample sizes (diagnostic subset N transparency)
+
+| Column | Description | Example |
+|---|---|---|
+| `sample_n_total` | Total study N | `452` |
+| `sample_n_train` | Training set N | `273` |
+| `sample_n_internal_test` | Internal test N | `68` |
+| `sample_n_external_test` | External test N | `111` |
+| `sample_n_dta_pool` | N contributing to DTA bivariate (sens/spec extraction) | `111` |
+| `sample_n_prognostic_pool` | N contributing to prognostic AUC pool | `0` |
+| `prevalence_in_dta_pool` | (TP+FN) / sample_n_dta_pool | `0.414` |
+
+### DTA outcome extraction (2×2 cell integrity)
+
+For each cohort that contributes to bivariate pool, extract:
+
+| Column | Description | Example |
+|---|---|---|
+| `dta_cohort_label` | Which cohort the values come from (must match `sample_n_external_test` or similar) | `external_test` |
+| `tp` | True positive count | `45` |
+| `fn` | False negative count | `1` |
+| `tn` | True negative count | `36` |
+| `fp` | False positive count | `29` |
+| `extracted_sens` | TP / (TP+FN), decimal | `0.978` |
+| `extracted_spec` | TN / (TN+FP), decimal | `0.554` |
+| **`source_sens_reported`** | Sensitivity as reported in source paper (decimal) | `0.978` |
+| **`source_spec_reported`** | Specificity as reported in source paper (decimal) | `0.554` |
+| **`source_page_ref`** | Page + Table/Figure number in source paper | `Table 3, p.7` |
+| **`source_verbatim_quote`** | Verbatim sentence containing the sens/spec values | `"The deep-integrated model achieved a sensitivity of 0.978..."` |
+| `extractor1_initials` | First extractor | `R1` |
+| `extractor2_initials` | Second extractor | `R2` |
+| `extraction_consensus_status` | Resolved / DiscussNeeded / Conflict | `Resolved` |
+
+**QC**: Run `scripts/dta_extraction_qc.py` with `--tolerance 0.02` after dual-extractor entry. Any FLAG_SWAP or FLAG_MISMATCH requires third-reviewer adjudication.
+
+### Prognostic outcome extraction (PROBAST-AI compatible)
+
+| Column | Description | Example |
+|---|---|---|
+| `prognostic_outcome_type` | mortality / AKI / disease_progression / readmission / etc. | `mortality` |
+| `prognostic_endpoint_definition` | Verbatim definition | `In-hospital all-cause death within index admission` |
+| `auc_point` | Reported AUC, decimal | `0.87` |
+| `auc_ci_lower` | 95% CI lower | `0.83` |
+| `auc_ci_upper` | 95% CI upper | `0.90` |
+| `validation_type` | internal / external / leave-one-out / k-fold | `external` |
+| `calibration_reported` | Yes / No | `No` |
+| `dca_reported` | Decision curve analysis Yes/No | `No` |
+
+### Risk of bias (per-study × per-domain)
+
+QUADAS-AI (for DTA studies):
+
+| Column | Description |
+|---|---|
+| `quadasai_d1_patient_selection` | Low / High / Unclear |
+| `quadasai_d2_index_test` | Low / High / Unclear |
+| `quadasai_d3_reference_standard` | Low / High / Unclear |
+| `quadasai_d4_flow_timing` | Low / High / Unclear |
+| `quadasai_d1_justification` | Verbatim short reason |
+| `quadasai_d2_justification` | ... |
+| ... | (same for D3, D4) |
+| `quadasai_overall` | Low / High / Unclear (consensus) |
+
+PROBAST-AI (for prognostic studies): D1 Participants / D2 Predictors / D3 Outcome / D4 Analysis — same Low/High/Unclear + justification.
+
+METRICS: 4 domains (data, model dev, validation, reporting) per study.
+
+### Authors of extraction record
+
+| Column | Description |
+|---|---|
+| `extraction_date_initial` | YYYY-MM-DD |
+| `extraction_date_consensus` | YYYY-MM-DD |
+| `cohens_kappa_d1` | Pre-adjudication inter-rater κ for domain D1 |
+| ... | (record κ for each pre-adjudication discrepancy domain) |
+
+## Workflow (dual-extractor consensus)
+
+1. Extractor 1 + Extractor 2 independently fill all cells, source_page_ref, source_verbatim_quote
+2. Run `dta_extraction_qc.py --tolerance 0.02` → flag mismatches
+3. Pre-adjudication κ recorded for D1-D4
+4. Discrepancies → third-reviewer adjudication, consensus_status updated
+5. Run `cohort_overlap_check.py --enrich` → populate database_source via PubMed if missing
+6. Manual review of HIGH/MEDIUM clusters → confirm or override
+7. Lock extraction (read-only) before statistical analysis
+
+## Related
+
+- `scripts/dta_extraction_qc.py`
+- `scripts/cohort_overlap_check.py`
+- `templates/supplementary_8file_checklist.md`

--- a/skills/meta-analysis/templates/supplementary_8file_checklist.md
+++ b/skills/meta-analysis/templates/supplementary_8file_checklist.md
@@ -1,0 +1,94 @@
+# SR-MA Supplementary Package — 8-File Standard
+
+**Motivation**: Recent SR-MA peer reviews surfaced supplementary packages that contained only figure captions (≈90 lines), missing PRISMA checklist, exclusion list, extraction table, per-study RoB — despite Methods citing "Supplementary Table S1". Below is the minimum package to avoid this pattern.
+
+**Apply to**: every SR-MA submission. Radiology / Radiology-AI / European Radiology / JCSM / Lancet family / JAMA family / BMJ family all expect this level of supplementary.
+
+## 8 mandatory files
+
+### S1 — PRISMA / PRISMA-DTA / PRISMA-S checklist
+
+- 27-item PRISMA 2020 (general) or PRISMA-DTA (diagnostic accuracy SR-MA)
+- Each item filled with main-manuscript page reference (`p.3, lines 45-48`)
+- Use checklist template from your institutional checklist store
+- For pure search reporting: PRISMA-S 16-item additional
+
+### S2 — PROSPERO protocol PDF (snapshot + amendments)
+
+- Download from prospero.york.ac.uk at registration AND at submission
+- Include all amendments with date + rationale
+- **If subgroup analyses changed post-registration**: explicit amendment record with date
+
+### S3 — Full search strategy verbatim (per database)
+
+- Each database (PubMed / Embase / Cochrane / Scopus / Web of Science) with:
+  - Search date (YYYY-MM-DD)
+  - Final string verbatim (copy-paste from interface)
+  - Filter use (date, language, study type)
+  - Number of records retrieved per database
+
+### S4 — Full-text exclusion list with reasons (PRISMA item 16b)
+
+- Every full-text article excluded with:
+  - First author, year, title
+  - PMID / DOI
+  - Exclusion reason (one of pre-specified categories)
+- Use Rayyan export or equivalent
+
+### S5 — Per-study data extraction table
+
+- One row per included study × all extracted variables (use `extraction_form_v2.md` schema)
+- Include `source_page_ref` + `source_verbatim_quote` for outcome cells (DTA 2×2 or AUC)
+- Locked read-only file (CSV + PDF snapshot)
+
+### S6 — Per-study × per-domain risk-of-bias table
+
+- For DTA: QUADAS-AI (4 domains × N_diagnostic studies) + applicability concerns
+- For prognostic: PROBAST-AI (4 domains × N_prognostic studies)
+- Per-cell: Low / High / Unclear + 1-line justification
+- Optionally: METRICS framework parallel column
+- Include pre-adjudication Cohen's κ per domain
+
+### S7 — Subgroup forest plots (all pre-specified + clearly labeled exploratory)
+
+- Each forest plot with:
+  - Subgroup label
+  - "Pre-specified in PROSPERO" or "Exploratory (post-hoc)" tag
+  - Heterogeneity (I², τ²) per stratum
+  - **k=1 strata excluded from formal test OR flagged as descriptive only**
+
+### S8 — Sensitivity analyses + publication bias
+
+- Leave-one-out for primary outcome (forest plot or table)
+- Cohort overlap sensitivity analysis (exclude one of HIGH-confidence overlap pair)
+- Deeks' funnel asymmetry test for DTA studies (mada::funnel)
+- Funnel plot + Egger / Begg for prognostic AUC pooling
+- Trim-and-fill if asymmetry detected
+
+## Submission gate check
+
+Before submitting, verify:
+
+```bash
+ls -la submission/supplementary/
+# Expected: at minimum 8 files (S1-S8)
+
+# Each file size > 5 KB (figure caption only is ~3 KB)
+for f in submission/supplementary/S*.{md,pdf,csv,docx}; do
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null)
+  echo "$f: $size bytes"
+done
+```
+
+If any S-file is missing or only contains figure captions → **NOT READY for submission**.
+
+## Cross-link to AI Disclosure (`/sync-submission` gate)
+
+The supplementary checklist should be combined with the AI Disclosure presence check. Most major imaging journals require an affirmative or negative disclosure statement either in manuscript text or in S-file metadata.
+
+## Related
+
+- `templates/extraction_form_v2.md`
+- `scripts/dta_extraction_qc.py`
+- `scripts/cohort_overlap_check.py`
+- `/peer-review` Phase 2A P5 (supplementary completeness probe)


### PR DESCRIPTION
## Summary

Promotes the SR-MA extraction-stage lessons surfaced in recent peer-review cycles into the `/meta-analysis` pipeline so the failure modes are prevented upstream rather than caught at peer review. Aligns with `/peer-review` Phase 2A (PR #22) and `/verify-refs` Gate 5 (PR #23).

## Why

Recent SR-MA peer-review cycles repeatedly surfaced extraction-stage failure modes that the existing meta-analysis Phase 4 did not actively prevent: 2x2 cell sens/spec swap, undisclosed cohort overlap via shared public databases, missing diagnostic vs prognostic subset N transparency, supplementary packages stripped to figure captions only. Reviewers cannot reliably catch these at forest-plot level. The fix is to ship a dual-extractor schema + two QC scripts + a submission-gate checklist so the patterns are addressed during extraction.

## What changed

### New templates (`skills/meta-analysis/templates/`)
- `extraction_form_v2.md` — dual-extractor schema. Adds `source_page_ref`, `source_verbatim_quote` (audit trail), `cohort_source`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool` columns.
- `supplementary_8file_checklist.md` — S1-S8 mandatory submission package (PRISMA / PROSPERO / search / exclusion list / extraction / RoB / forests / sensitivity).

### New scripts (`skills/meta-analysis/scripts/`)
- `dta_extraction_qc.py` — validates 2x2 cells against source-reported sens/spec; FLAG_SWAP detection prevents single-study k=1 subgroup outlier sign-flip.
- `cohort_overlap_check.py` — clusters by shared public database / institution / first-author surname; flags HIGH/MEDIUM overlap requiring sensitivity analysis.

### `SKILL.md` (5 spots)
- Reference Files: new "Built-in Templates" block.
- Phase 4 (Data Extraction): recommended extraction form link with required new columns called out.
- **Phase 4c (new)**: Extraction QC & Cohort Overlap Detection — invocation examples + adjudication routing + `/peer-review` Phase 2A cross-links.
- **Empirical Lessons (2026-05) section** (new): 7 abstract principles synthesized from recent peer-review cycles. No case IDs, no author names.
- Skill Interactions: `/sync-submission` SR-MA gate row links to 8-file checklist + AI Disclosure + `/verify-refs` Gate 5 cite-dup check.

### Validator extension (`scripts/validate_skills.sh`)
- `integrity_files` scope extended from `{SKILL.md, references/, top-level}` to also include `templates/` + `scripts/`. The existing `precedent_patterns` blocklist (project IDs, mentor initials, author names, Korean prose) now scans the vendored content for the same patterns. Includes `.py` + `.sh` since docstrings/comments are the typical PII vector.
- Pre-existing templates/scripts across all 40 skills verified clean before extension (manual grep, 0 hits).

## Test plan

- [x] `bash scripts/validate_skills.sh` — 40 skills 0 FAIL with extended scope
- [x] `python3 scripts/validate_skill_contracts.py` — 15 v2 PASS / 25 migration warnings / 0 failures (baseline maintained)
- [x] Synthetic test: `dta_extraction_qc.py` on 3-row CSV (1 OK + 1 FLAG_SWAP + 1 FLAG_MISMATCH) exit 1 with correct per-row classification
- [x] Synthetic test: `cohort_overlap_check.py` on 4-row CSV (MIMIC-IV pair + institution pair) — HIGH-confidence DB cluster + MEDIUM institution cluster reported, exit 1
- [x] PII grep across all new files (RYAI manuscript IDs, author names, PMIDs, project paths): 0 hits