### PR TITLE
feat(sync-submission): add cross-document N consistency gate (Phase 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ skills/**/HANDOFF_*.md
 
 # Gemini/Antigravity AI assistant scratchpad (per-session, not for repo)
 .gemini/
+_pr_drafts/

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -72,6 +72,62 @@ The registry is a project-local YAML mapping author identifiers (full names, nat
 - Gate 5: before freeze, confirm portal free-text fields (cover letter, data availability, acknowledgements, abstract, author contributions) match the manuscript body.
 - Gate 6 (double-blind journals): before freeze, export the portal's blinded review PDF and grep for all author identifiers across the entire upload set — manuscript, supplementary, cover letter, registry record PDFs (PROSPERO/ClinicalTrials), portal Letter-field text. A clean manuscript blind does not imply a clean portal blind.
 - Gate 7 (text-only docx rebuilds): never use `pandoc --reference-doc=manuscript.docx` for response/cover/supplementary text-only docx — the reference docx ships its embedded media (figure files) into the new docx, bloating size 50–100×. Use plain `pandoc input.md -o output.docx` for text-only artifacts.
+- Gate 8 (Phase 5 cross-document N consistency): before freeze, run `scripts/cross_document_n_check.py` over the manuscript bundle (abstract, body, PROSPERO record, cover letter, supplementary, INDEX, PRISMA flow caption). Any N category with >1 distinct integer value is a P0 drift. When a `FINAL_POOL_LOCK.yaml` is present, supply `--pool-lock` to make the locked counts the authoritative baseline. See "Phase 5 — Cross-document N consistency" below.
+
+## Phase 5 — Cross-document N consistency
+
+Multi-document cohort-size drift is a high-frequency desk-reject pattern.
+Manuscript abstracts, body prose, PROSPERO records, supplementary extraction
+sheets, and PRISMA flow captions all repeat the same `k included` / `k excluded`
+/ `N patients` totals — and any disagreement between them is read by reviewers
+as either a data-integrity failure or a late-edit failure. Either reading
+ends the round.
+
+`scripts/cross_document_n_check.py` scans the submission package, extracts
+every "N <noun>" claim by category (patients, cases, included, excluded,
+nodules, tumors, studies_total), and groups them by category. A category with
+more than one distinct integer value is a P0 drift.
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/cross_document_n_check.py" \
+    --root . \
+    --out qc/cross_document_n.json
+```
+
+When the project has frozen a `2_Data/FINAL_POOL_LOCK.yaml` from `/meta-analysis`
+Phase 3f.5, pass it as the authoritative anchor:
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/cross_document_n_check.py" \
+    --root . \
+    --pool-lock 2_Data/FINAL_POOL_LOCK.yaml \
+    --out qc/cross_document_n.json
+```
+
+Output `qc/cross_document_n.json`:
+
+```json
+{
+  "submission_safe": false,
+  "drift_count": 1,
+  "drifts": [
+    {
+      "category": "included",
+      "values": [63, 64],
+      "locations": [
+        {"file": "abstract.md", "line": 4, "value": 63, "context": "..."},
+        {"file": "supplementary/s1.md", "line": 12, "value": 64, "context": "..."}
+      ],
+      "severity": "MAJOR"
+    }
+  ],
+  "lock_violations": []
+}
+```
+
+Treat `submission_safe: false` as a halt. Resolve drift by tracing each
+location to its data artifact (extraction sheet, PRISMA cascade TSVs) and
+correcting the document(s) that disagree with the locked count.
 
 ## Verification Blind Spots
 

--- a/skills/sync-submission/scripts/cross_document_n_check.py
+++ b/skills/sync-submission/scripts/cross_document_n_check.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+cross_document_n_check.py — Phase 5 cross-document N consistency gate.
+
+Scans a submission package for cohort-size claims ("N patients", "k studies
+included", "n excluded", "M nodules", etc.) across manuscript body, abstract,
+PROSPERO record, cover letter, supplementary materials, INDEX, and PRISMA flow
+caption. Emits a drift report when the same logical quantity disagrees between
+documents.
+
+Why this gate exists
+====================
+Multi-document N drift is a high-frequency reviewer/editor desk-reject pattern.
+When a manuscript ships with k=63 in the abstract but k=64 in the supplementary
+extraction sheet, reviewers treat it as either a data-integrity failure or a
+late-edit failure. Either reading is fatal at peer review.
+
+Cross-project observations (anonymized):
+- Project (LLM reporting-quality SR example): five documents disagreed
+  INCLUDE=63 vs 64, EXCLUDE=108/109/111. Three EXCLUDE entries existed in the
+  extraction sheet without matching INCLUDE.
+- Project (DTA-MA example): Results prose PRISMA cascade
+  151+108+39+1+1+4=304 vs prose total "305" — off-by-one in the same paragraph.
+- Project (outcome-MA example): TS denominator 331 in prose vs 326 computed
+  from extraction table; Major complications 434 vs 439.
+- Project (intervention-MA example): "1,847 nodules" hallucinated in v3
+  against Results "881 + 402".
+
+Usage
+=====
+
+    python cross_document_n_check.py \\
+        --root path/to/project \\
+        --out qc/cross_document_n.json
+
+    python cross_document_n_check.py \\
+        --files manuscript.md abstract.md supplementary/s1.md \\
+        --out qc/cross_document_n.json
+
+Optional pool-lock anchor:
+
+    python cross_document_n_check.py \\
+        --root path/to/project \\
+        --pool-lock 2_Data/FINAL_POOL_LOCK.yaml \\
+        --out qc/cross_document_n.json
+
+When --pool-lock is supplied, every N value tied to a "locked" category
+(include_count / exclude_count / mixed_count) is asserted to match the lock
+exactly. Mismatches are P0 failures.
+
+Output (qc/cross_document_n.json):
+
+    {
+      "submission_safe": false,
+      "drift_count": 3,
+      "drifts": [
+        {
+          "category": "included",
+          "values": [63, 64],
+          "locations": [
+            {"file": "abstract.md",     "line": 4,  "value": 63, "context": "..."},
+            {"file": "supplementary/s1.md", "line": 12, "value": 64, "context": "..."}
+          ],
+          "severity": "MAJOR"
+        }
+      ],
+      "categories_scanned": ["patients", "studies", "included", "excluded", ...],
+      "files_scanned": ["abstract.md", "manuscript.md", ...]
+    }
+
+Exit codes:
+    0 = no drift
+    1 = drift detected
+    2 = invocation error (missing files, bad arguments)
+
+This script does not modify source files. It is read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# --------------------------------------------------------------------------
+# Pattern catalog
+# --------------------------------------------------------------------------
+
+# Each pattern maps to a normalized category label. The capture group is the
+# numeric value (commas removed downstream). We intentionally keep the unit
+# noun in the same alternation block so a single regex captures both "studies
+# included" and "included studies" variants.
+#
+# Category keys are stable and downstream consumers (lock files, drift
+# reports) reference them by name.
+PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "included",
+        re.compile(
+            r"(?:\b(?:included|including|we\s+included)\s+(\d{1,3}(?:,\d{3})*|\d+)\s+(?:studies|records|reports|articles|trials|papers)\b"
+            r"|\b(\d{1,3}(?:,\d{3})*|\d+)\s+(?:studies?\s+(?:were\s+)?included|included\s+studies?|"
+            r"records?\s+(?:were\s+)?included|included\s+records?|"
+            r"reports?\s+(?:were\s+)?included|included\s+reports?|"
+            r"articles?\s+(?:were\s+)?included|included\s+articles?)\b)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "excluded",
+        re.compile(
+            r"(?:\b(?:excluded|excluding|we\s+excluded)\s+(\d{1,3}(?:,\d{3})*|\d+)\s+(?:studies|records|reports|articles|trials|papers)\b"
+            r"|\b(\d{1,3}(?:,\d{3})*|\d+)\s+(?:studies?\s+(?:were\s+)?excluded|excluded\s+studies?|"
+            r"records?\s+(?:were\s+)?excluded|excluded\s+records?|"
+            r"reports?\s+(?:were\s+)?excluded|excluded\s+reports?|"
+            r"articles?\s+(?:were\s+)?excluded|excluded\s+articles?)\b)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "patients",
+        re.compile(
+            r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+patients?\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "cases",
+        re.compile(
+            r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+cases?\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "nodules",
+        re.compile(
+            r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+nodules?\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "tumors",
+        re.compile(
+            r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+(?:tumou?rs?|lesions?)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "studies_total",
+        re.compile(
+            r"\b(\d{1,3}(?:,\d{3})*|\d+)\s+studies\b(?!\s+(?:were\s+)?(?:included|excluded))",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+# File globs to scan when --root is supplied. Order is for output
+# determinism only; the algorithm is glob-then-sort.
+DEFAULT_GLOBS = (
+    "manuscript.md",
+    "manuscript/*.md",
+    "abstract.md",
+    "abstract/*.md",
+    "cover_letter.md",
+    "*cover_letter*.md",
+    "prospero/*.md",
+    "supplementary/*.md",
+    "supplementary/**/*.md",
+    "INDEX.md",
+    "submission/**/manuscript*.md",
+    "submission/**/abstract*.md",
+)
+
+
+# --------------------------------------------------------------------------
+# Data classes
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Hit:
+    file: str
+    line: int
+    value: int
+    context: str
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class Drift:
+    category: str
+    values: list[int]
+    locations: list[Hit]
+    severity: str = "MAJOR"
+
+    def as_dict(self) -> dict:
+        return {
+            "category": self.category,
+            "values": sorted(self.values),
+            "locations": [h.as_dict() for h in self.locations],
+            "severity": self.severity,
+        }
+
+
+@dataclass
+class Report:
+    submission_safe: bool
+    drift_count: int
+    drifts: list[Drift]
+    categories_scanned: list[str]
+    files_scanned: list[str]
+    lock_violations: list[dict] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "submission_safe": self.submission_safe,
+            "drift_count": self.drift_count,
+            "drifts": [d.as_dict() for d in self.drifts],
+            "categories_scanned": self.categories_scanned,
+            "files_scanned": self.files_scanned,
+            "lock_violations": self.lock_violations,
+        }
+
+
+# --------------------------------------------------------------------------
+# Core
+# --------------------------------------------------------------------------
+
+
+def _to_int(raw: str) -> int:
+    return int(raw.replace(",", ""))
+
+
+def scan_file(path: Path) -> list[tuple[str, Hit]]:
+    """Return (category, Hit) tuples for every matched N claim in path."""
+    out: list[tuple[str, Hit]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return out
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for category, pat in PATTERNS:
+            for m in pat.finditer(line):
+                # Patterns with alternation may capture into group 1 or 2;
+                # take whichever group fired.
+                raw = next((g for g in m.groups() if g is not None), None)
+                if raw is None:
+                    continue
+                try:
+                    value = _to_int(raw)
+                except ValueError:
+                    continue
+                # Skip implausibly small mentions like "2 patients" inside an
+                # example table heading. Threshold is intentionally generous —
+                # this gate cares about full-cohort drift, not in-text examples.
+                if value < 5:
+                    continue
+                context = line.strip()
+                if len(context) > 200:
+                    context = context[:200] + "..."
+                out.append((category, Hit(str(path), lineno, value, context)))
+    return out
+
+
+def collect_files(root: Path, extra_files: Iterable[Path] = ()) -> list[Path]:
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for pattern in DEFAULT_GLOBS:
+        for hit in sorted(root.glob(pattern)):
+            if hit.is_file() and hit.suffix.lower() in {".md", ".tex", ".txt"}:
+                rp = hit.resolve()
+                if rp not in seen:
+                    seen.add(rp)
+                    files.append(hit)
+    for f in extra_files:
+        rp = f.resolve()
+        if rp not in seen and f.is_file():
+            seen.add(rp)
+            files.append(f)
+    return files
+
+
+def detect_drifts(hits_by_cat: dict[str, list[Hit]]) -> list[Drift]:
+    """For each category, group hits by value. >1 distinct value = DRIFT."""
+    drifts: list[Drift] = []
+    for category, hits in hits_by_cat.items():
+        # group by value
+        by_value: dict[int, list[Hit]] = {}
+        for h in hits:
+            by_value.setdefault(h.value, []).append(h)
+        if len(by_value) <= 1:
+            continue
+        # collapse for report
+        all_hits = [h for hs in by_value.values() for h in hs]
+        drifts.append(
+            Drift(
+                category=category,
+                values=list(by_value.keys()),
+                locations=all_hits,
+                severity="MAJOR",
+            )
+        )
+    return drifts
+
+
+def check_pool_lock(
+    lock_path: Path,
+    hits_by_cat: dict[str, list[Hit]],
+) -> list[dict]:
+    """If a pool-lock yaml is supplied, assert each locked count matches."""
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        return [
+            {
+                "violation": "pyyaml-missing",
+                "detail": "Install PyYAML to enable --pool-lock checks.",
+            }
+        ]
+    try:
+        lock = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return [{"violation": "lock-read-error", "detail": str(exc)}]
+    if not isinstance(lock, dict):
+        return [{"violation": "lock-format", "detail": "lock root must be mapping"}]
+
+    violations: list[dict] = []
+    # Map lock keys to scan categories.
+    pairs = [
+        ("include_count", "included"),
+        ("exclude_count", "excluded"),
+        ("final_pool_n", "studies_total"),
+    ]
+    for lock_key, scan_cat in pairs:
+        if lock_key not in lock:
+            continue
+        try:
+            expected = int(lock[lock_key])
+        except (TypeError, ValueError):
+            violations.append(
+                {
+                    "violation": "lock-non-integer",
+                    "key": lock_key,
+                    "raw": lock[lock_key],
+                }
+            )
+            continue
+        hits = hits_by_cat.get(scan_cat, [])
+        for h in hits:
+            if h.value != expected:
+                violations.append(
+                    {
+                        "violation": "pool-lock-mismatch",
+                        "lock_key": lock_key,
+                        "expected": expected,
+                        "actual": h.value,
+                        "file": h.file,
+                        "line": h.line,
+                        "context": h.context,
+                    }
+                )
+    return violations
+
+
+def build_report(
+    files: list[Path],
+    pool_lock: Path | None = None,
+) -> Report:
+    hits_by_cat: dict[str, list[Hit]] = {}
+    for path in files:
+        for cat, hit in scan_file(path):
+            hits_by_cat.setdefault(cat, []).append(hit)
+
+    drifts = detect_drifts(hits_by_cat)
+    lock_violations: list[dict] = []
+    if pool_lock is not None:
+        lock_violations = check_pool_lock(pool_lock, hits_by_cat)
+
+    submission_safe = not drifts and not lock_violations
+    return Report(
+        submission_safe=submission_safe,
+        drift_count=len(drifts),
+        drifts=drifts,
+        categories_scanned=sorted(hits_by_cat.keys()),
+        files_scanned=[str(p) for p in files],
+        lock_violations=lock_violations,
+    )
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Phase 5 cross-document N consistency gate. Scans manuscript, "
+            "abstract, PROSPERO record, cover letter, and supplementary "
+            "materials for cohort-size disagreement."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Project root. When supplied, scans default glob set.",
+    )
+    parser.add_argument(
+        "--files",
+        type=Path,
+        nargs="*",
+        default=[],
+        help="Explicit file list (in addition to --root glob results).",
+    )
+    parser.add_argument(
+        "--pool-lock",
+        type=Path,
+        default=None,
+        help=(
+            "Path to FINAL_POOL_LOCK.yaml. When supplied, asserts every "
+            "locked count matches in scanned documents."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write JSON report to this path (in addition to stdout summary).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-drift stdout summary; rely on --out / exit code.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.root is None and not args.files:
+        parser.error("must supply --root or --files")
+
+    files: list[Path] = []
+    if args.root is not None:
+        if not args.root.is_dir():
+            parser.error(f"--root not a directory: {args.root}")
+        files.extend(collect_files(args.root, args.files))
+    else:
+        files.extend(p for p in args.files if p.is_file())
+
+    if not files:
+        parser.error("no readable files matched")
+
+    report = build_report(files, pool_lock=args.pool_lock)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report.as_dict(), indent=2), encoding="utf-8")
+
+    if not args.quiet:
+        if report.submission_safe:
+            print(
+                f"PASS: scanned {len(files)} files, "
+                f"{len(report.categories_scanned)} categories, no drift."
+            )
+        else:
+            print(
+                f"FAIL: {report.drift_count} drift(s), "
+                f"{len(report.lock_violations)} lock violation(s)."
+            )
+            for d in report.drifts:
+                print(f"  - {d.category}: values={sorted(d.values)}")
+                for h in d.locations:
+                    print(f"      {h.file}:{h.line}  N={h.value}  {h.context[:80]}")
+            for v in report.lock_violations:
+                print(f"  - LOCK {v}")
+
+    return 0 if report.submission_safe else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/sync-submission/tests/test_cross_document_n.sh
+++ b/skills/sync-submission/tests/test_cross_document_n.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Regression tests for sync-submission cross_document_n_check.py.
+#
+# Synthetic fixtures only (no project paths, no manuscript IDs).
+# Skip with NETWORK=0 — this script does not use the network.
+#
+# Usage:
+#   skills/sync-submission/tests/test_cross_document_n.sh
+# Exit codes:
+#   0 — all tests passed
+#   1 — at least one test regressed
+#   2 — environment problem
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/sync-submission/scripts/cross_document_n_check.py"
+TMP="$(mktemp -d -t cross_doc_n.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "ENV-ERR: script not found at $SCRIPT" >&2
+    exit 2
+fi
+command -v python3 >/dev/null 2>&1 || { echo "ENV-ERR: python3 missing" >&2; exit 2; }
+
+fail=0
+ran=0
+
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-50s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Case 1: two documents agreeing on N. Should PASS (exit 0).
+# --------------------------------------------------------------------------
+PROJ1="$TMP/case1_consistent"
+mkdir -p "$PROJ1"
+cat > "$PROJ1/abstract.md" <<'EOF'
+We included 42 studies after screening.
+EOF
+cat > "$PROJ1/manuscript.md" <<'EOF'
+Results section. Across 42 included studies, the pooled estimate was...
+EOF
+python3 "$SCRIPT" --root "$PROJ1" --out "$PROJ1/qc/n.json" --quiet
+assert_exit "case 1: consistent N (42 = 42)" 0 $?
+
+# --------------------------------------------------------------------------
+# Case 2: drift. Should FAIL (exit 1).
+# --------------------------------------------------------------------------
+PROJ2="$TMP/case2_drift"
+mkdir -p "$PROJ2"
+cat > "$PROJ2/abstract.md" <<'EOF'
+We included 63 studies after dual-reviewer screening.
+EOF
+cat > "$PROJ2/manuscript.md" <<'EOF'
+A total of 64 included studies were extracted for synthesis.
+EOF
+python3 "$SCRIPT" --root "$PROJ2" --out "$PROJ2/qc/n.json" --quiet
+assert_exit "case 2: drift (63 vs 64)" 1 $?
+# Verify the JSON content is well-formed and flags the right category.
+python3 - "$PROJ2/qc/n.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh:
+    rep = json.load(fh)
+assert rep["submission_safe"] is False, rep
+assert rep["drift_count"] == 1, rep
+assert rep["drifts"][0]["category"] == "included", rep
+vs = set(rep["drifts"][0]["values"])
+assert vs == {63, 64}, rep
+PY
+
+# --------------------------------------------------------------------------
+# Case 3: pool-lock mismatch.
+# --------------------------------------------------------------------------
+if python3 -c "import yaml" 2>/dev/null; then
+    PROJ3="$TMP/case3_lock"
+    mkdir -p "$PROJ3"
+    cat > "$PROJ3/abstract.md" <<'EOF'
+We included 50 studies after screening.
+EOF
+    cat > "$PROJ3/manuscript.md" <<'EOF'
+Across 50 included studies, the pooled estimate was ...
+EOF
+    cat > "$PROJ3/lock.yaml" <<'EOF'
+freeze_date: 2026-01-01
+final_pool_n: 48
+include_count: 48
+exclude_count: 100
+EOF
+    python3 "$SCRIPT" --root "$PROJ3" --pool-lock "$PROJ3/lock.yaml" \
+        --out "$PROJ3/qc/n.json" --quiet
+    assert_exit "case 3: pool-lock mismatch (50 vs locked 48)" 1 $?
+    python3 - "$PROJ3/qc/n.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh:
+    rep = json.load(fh)
+assert rep["lock_violations"], rep
+v = rep["lock_violations"][0]
+assert v["violation"] == "pool-lock-mismatch", v
+assert v["expected"] == 48, v
+assert v["actual"] == 50, v
+PY
+else
+    printf '  SKIP  %-50s reason=pyyaml unavailable\n' "case 3: pool-lock"
+fi
+
+# --------------------------------------------------------------------------
+# Case 4: explicit --files. Should also work.
+# --------------------------------------------------------------------------
+PROJ4="$TMP/case4_files"
+mkdir -p "$PROJ4/sub"
+cat > "$PROJ4/sub/a.md" <<'EOF'
+We included 30 patients in the analysis.
+EOF
+cat > "$PROJ4/sub/b.md" <<'EOF'
+30 patients were enrolled.
+EOF
+python3 "$SCRIPT" --files "$PROJ4/sub/a.md" "$PROJ4/sub/b.md" \
+    --out "$PROJ4/qc/n.json" --quiet
+assert_exit "case 4: explicit --files PASS (30 = 30)" 0 $?
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
# PR T1-1: Cross-document N consistency gate

**Title**: `feat(sync-submission): add cross-document N consistency gate (Phase 5)`

## Summary

Adds a new `scripts/cross_document_n_check.py` scanner and a Phase 5 gate to
`/sync-submission` that detects cohort-size drift across the manuscript
bundle (abstract, body, PROSPERO record, cover letter, supplementary,
INDEX, PRISMA flow caption). Optional `--pool-lock` flag anchors the scan
to a frozen `FINAL_POOL_LOCK.yaml` produced by `/meta-analysis` Phase 3f.5.

## Motivation

Multi-document N drift is a high-frequency reviewer/editor desk-reject
pattern. When a manuscript ships with `k=63` in the abstract but `k=64` in
the supplementary extraction sheet, reviewers read it as either a
data-integrity failure or a late-edit failure — either reading ends the
round.

Anonymized cross-project observations (all from the SR-MA and DTA-MA
families):
- Project (LLM reporting-quality SR example): five documents disagreed
  `INCLUDE=63 vs 64`, `EXCLUDE=108/109/111`. Three `EXCLUDE` entries existed
  in the extraction sheet without matching `INCLUDE`.
- Project (DTA-MA example): Results prose PRISMA cascade
  `151+108+39+1+1+4=304` vs prose total `305` — off-by-one in the same
  paragraph.
- Project (outcome-MA example): TS denominator `331` in prose vs `326`
  computed from extraction table; Major complications `434` vs `439`.
- Project (intervention-MA example): hallucinated aggregate count vs
  Results breakdown.

Cross-project frequency: 4+ in the past quarter.

## Changes

- `skills/sync-submission/scripts/cross_document_n_check.py` — new scanner.
  - 7 numeric-claim categories (`patients`, `cases`, `included`, `excluded`,
    `nodules`, `tumors`, `studies_total`)
  - Default file globs cover manuscript, abstract, PROSPERO, cover letter,
    supplementary, INDEX, submission/**.
  - Optional `--pool-lock` integrates with PR T1-5 lock files.
  - JSON output at `qc/cross_document_n.json` consumable by orchestrator.
- `skills/sync-submission/SKILL.md` — adds Gate 8 + Phase 5 narrative
  documenting motivation, command-line usage, and JSON contract.
- `skills/sync-submission/tests/test_cross_document_n.sh` — synthetic
  fixture regression with four cases (consistent, drift, lock mismatch,
  explicit `--files`).

## Test plan

- [x] `bash skills/sync-submission/tests/test_cross_document_n.sh` — 4/4 PASS
- [ ] `bash scripts/validate_skills.sh` — PII + frontmatter lint
- [ ] Smoke against a real SR-MA project package (anonymized synthetic)
- [ ] Integration with `/meta-analysis` Phase 3f.5 lock (PR T1-5)

## Related skills

- `/meta-analysis` (PR T1-5 produces the lock file consumed here)
- `/self-review`, `/check-reporting`
- `/verify-refs` (still the bib audit gate; this scanner is a separate
  numeric drift detector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Merge dependency**: T1-5 (#30) and T1-6 (#31) must merge first.
