### PR TITLE
feat(sync-submission): add v_(N+1) docx regeneration gate (Phase 7)

### DIFF
--- a/scripts/verify_package_integrity.py
+++ b/scripts/verify_package_integrity.py
@@ -6,22 +6,39 @@ manuscript and previously-built journal packages. Implements the
 `SUBMISSION/{journal}/` discipline from
 `skills/meta-analysis/references/submission_package_drift.md`.
 
-Two modes:
+Three modes:
   1. `--record`: compute checksums and write MANIFEST.checksums.json
   2. `--verify` (default): compare current state against recorded manifest
+  3. `--assert-vN-docx-changed`: assert v_(N+1) docx MD5 ≠ v_N docx MD5
 
 Usage:
     python3 scripts/verify_package_integrity.py --record \\
         [--submission-root SUBMISSION] [--journal <name>]
     python3 scripts/verify_package_integrity.py --verify \\
         [--submission-root SUBMISSION] [--journal <name>] [--json]
+    python3 scripts/verify_package_integrity.py --assert-vN-docx-changed \\
+        --vN-docx old/manuscript.docx --new-docx new/manuscript.docx
 
 Per SPD-2, these files are journal-editable and excluded from drift checks:
 cover_letter.docx, title_page.docx, highlights.txt, checklist.md,
 response_to_reviewers.docx, MANIFEST.md, MANIFEST.checksums.json,
 DO_NOT_EDIT_HERE.md.
 
-Exit codes: 0 clean, 1 drift detected, 2 bad args / missing root.
+v_(N+1) docx regeneration gate
+==============================
+Cross-project precedent (anonymized): an outcome-MA submission package at
+v_(N+1) carried a markdown body change with a 2-paragraph edit, but the
+v_(N+1) docx in the submission folder was byte-identical (MD5 collision)
+to the v_N docx — a silent copy of the v_N seed that never went through
+the pandoc / Zotero CWYW regeneration step. When uploaded to the EM
+portal, the markdown change would have silently reverted at peer review.
+
+The `--assert-vN-docx-changed` mode is a defense-in-depth gate: if a new
+submission is being built from a prior version, the v_(N+1) docx MUST
+have a different MD5 than the v_N docx. Identity = unmodified seed copy
+= block submission.
+
+Exit codes: 0 clean, 1 drift / assertion fail, 2 bad args / missing root.
 """
 
 from __future__ import annotations
@@ -53,6 +70,53 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def md5_file(path: Path) -> str:
+    """MD5 of file bytes. Used for v_N ↔ v_(N+1) docx identity check.
+
+    MD5 collisions are irrelevant here — we use it because the precedent
+    failure mode is a literal `cp` of v_N over v_(N+1), which a byte-stable
+    hash detects with any algorithm. MD5 is faster and produces shorter
+    log lines than SHA256.
+    """
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def assert_vN_docx_changed(vN_docx: Path, new_docx: Path) -> int:
+    """Defense-in-depth: v_(N+1) docx MUST differ from v_N docx.
+
+    Returns:
+        0 — different (PASS)
+        1 — identical (FAIL, block submission)
+        2 — file missing
+    """
+    if not vN_docx.is_file():
+        print(f"ERROR: v_N docx not found: {vN_docx}", file=sys.stderr)
+        return 2
+    if not new_docx.is_file():
+        print(f"ERROR: new docx not found: {new_docx}", file=sys.stderr)
+        return 2
+    vN_hash = md5_file(vN_docx)
+    new_hash = md5_file(new_docx)
+    if vN_hash == new_hash:
+        print(
+            "FAIL: v_(N+1) docx is byte-identical to v_N docx "
+            f"(MD5={new_hash[:12]}...). The v_(N+1) docx appears to be an "
+            "unmodified seed copy from v_N. Regenerate via pandoc citeproc "
+            "OR Zotero CWYW field-code-safe re-patch before submission.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"PASS: v_N MD5={vN_hash[:12]}...  v_(N+1) MD5={new_hash[:12]}...  "
+        "(different, OK)"
+    )
+    return 0
 
 
 def scan_journal_dir(journal_dir: Path) -> dict[str, str]:
@@ -150,10 +214,39 @@ def main() -> int:
     mode = ap.add_mutually_exclusive_group()
     mode.add_argument("--record", action="store_true", help="Record checksums")
     mode.add_argument("--verify", action="store_true", help="Verify checksums (default)")
+    mode.add_argument(
+        "--assert-vN-docx-changed",
+        action="store_true",
+        help=(
+            "Assert v_(N+1) docx MD5 != v_N docx MD5. Requires --vN-docx and "
+            "--new-docx. Fails with exit 1 if identical (silent seed copy)."
+        ),
+    )
     ap.add_argument("--submission-root", default="SUBMISSION", help="Submission root dir")
     ap.add_argument("--journal", default=None, help="Single journal (default: all)")
     ap.add_argument("--json", action="store_true", help="Emit JSON report (verify mode)")
+    ap.add_argument(
+        "--vN-docx",
+        type=Path,
+        default=None,
+        help="Path to v_N docx (frozen previous submission).",
+    )
+    ap.add_argument(
+        "--new-docx",
+        type=Path,
+        default=None,
+        help="Path to v_(N+1) docx (current submission candidate).",
+    )
     args = ap.parse_args()
+
+    if args.assert_vN_docx_changed:
+        if args.vN_docx is None or args.new_docx is None:
+            print(
+                "ERROR: --assert-vN-docx-changed requires --vN-docx AND --new-docx",
+                file=sys.stderr,
+            )
+            return 2
+        return assert_vN_docx_changed(args.vN_docx, args.new_docx)
 
     root = Path(args.submission_root).resolve()
     if not root.is_dir():

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -72,6 +72,31 @@ The registry is a project-local YAML mapping author identifiers (full names, nat
 - Gate 5: before freeze, confirm portal free-text fields (cover letter, data availability, acknowledgements, abstract, author contributions) match the manuscript body.
 - Gate 6 (double-blind journals): before freeze, export the portal's blinded review PDF and grep for all author identifiers across the entire upload set — manuscript, supplementary, cover letter, registry record PDFs (PROSPERO/ClinicalTrials), portal Letter-field text. A clean manuscript blind does not imply a clean portal blind.
 - Gate 7 (text-only docx rebuilds): never use `pandoc --reference-doc=manuscript.docx` for response/cover/supplementary text-only docx — the reference docx ships its embedded media (figure files) into the new docx, bloating size 50–100×. Use plain `pandoc input.md -o output.docx` for text-only artifacts.
+- Gate 10 (Phase 7 v_(N+1) docx regeneration): when building a new submission from a frozen prior version, run `scripts/verify_package_integrity.py --assert-vN-docx-changed --vN-docx <prev>.docx --new-docx <next>.docx`. Identical MD5 = unmodified seed copy = block submission. Defense-in-depth — required even when the upstream pipeline appears to have regenerated the docx.
+
+## Phase 7 — v_(N+1) docx regeneration gate
+
+When a v_N submission package was frozen and a v_(N+1) is being built
+(after a markdown body edit, reviewer round, or cascade-rejection
+re-target), the v_(N+1) docx MUST differ from the v_N docx. The most
+common silent-revert pattern is a `cp v_N/manuscript.docx
+v_(N+1)/manuscript.docx` step that skips the pandoc / Zotero CWYW
+regeneration entirely. The markdown body is then edited, but the docx
+the portal receives is the frozen v_N — the change silently reverts at
+peer review.
+
+Run the byte-identity assertion at the top of the v_(N+1) submission
+gate:
+
+```bash
+python3 /path/to/medsci-skills/scripts/verify_package_integrity.py \
+    --assert-vN-docx-changed \
+    --vN-docx SUBMISSION/<journal>/v<N>/manuscript.docx \
+    --new-docx SUBMISSION/<journal>/v<N+1>/manuscript.docx
+```
+
+Identical MD5 → exit 1 with explanatory error. Block submission until
+the regeneration step is fixed.
 
 ## Verification Blind Spots
 

--- a/skills/sync-submission/tests/test_vN_docx_assertion.sh
+++ b/skills/sync-submission/tests/test_vN_docx_assertion.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression tests for verify_package_integrity.py --assert-vN-docx-changed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/verify_package_integrity.py"
+TMP="$(mktemp -d -t vNdocx.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+fail=0
+ran=0
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-50s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# Case 1: identical bytes => FAIL
+printf 'identical bytes\n' > "$TMP/vN.docx"
+cp "$TMP/vN.docx" "$TMP/vNplus1.docx"
+python3 "$SCRIPT" --assert-vN-docx-changed \
+    --vN-docx "$TMP/vN.docx" --new-docx "$TMP/vNplus1.docx" >/dev/null 2>&1
+assert_exit "case 1: identical bytes (FAIL)" 1 $?
+
+# Case 2: different bytes => PASS
+printf 'different bytes for v_(N+1)\n' > "$TMP/vNplus1.docx"
+python3 "$SCRIPT" --assert-vN-docx-changed \
+    --vN-docx "$TMP/vN.docx" --new-docx "$TMP/vNplus1.docx" >/dev/null 2>&1
+assert_exit "case 2: different bytes (PASS)" 0 $?
+
+# Case 3: missing v_N => exit 2
+python3 "$SCRIPT" --assert-vN-docx-changed \
+    --vN-docx "$TMP/nonexistent.docx" --new-docx "$TMP/vNplus1.docx" >/dev/null 2>&1
+assert_exit "case 3: missing v_N (exit 2)" 2 $?
+
+# Case 4: missing --new-docx arg => exit 2
+python3 "$SCRIPT" --assert-vN-docx-changed \
+    --vN-docx "$TMP/vN.docx" >/dev/null 2>&1
+assert_exit "case 4: missing --new-docx (exit 2)" 2 $?
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
# PR T1-3: v_(N+1) docx MD5 ≠ v_N docx assertion

**Title**: `feat(sync-submission): add v_(N+1) docx regeneration gate (Phase 7)`

## Summary

Extends `scripts/verify_package_integrity.py` with an
`--assert-vN-docx-changed` mode that compares two docx files by MD5 and
exits non-zero when they are byte-identical. Documents the gate in
`/sync-submission` SKILL.md as Phase 7.

## Motivation

Cross-project precedent (anonymized): an outcome-MA submission package
at v_(N+1) shipped with a v_(N+1) markdown body change (two-paragraph
edit) but the v_(N+1) docx in the submission folder was byte-identical
to the v_N docx — a silent `cp` over the v_N seed that never went
through the pandoc / Zotero CWYW regeneration step.

When uploaded to the EM portal, the markdown changes would have silently
reverted at peer review. P0 active submission blocker.

This gate adds defense-in-depth: even if the upstream regeneration
pipeline appears to have run, the byte-identity check catches the case
where it didn't.

## Changes

- `scripts/verify_package_integrity.py`:
  - new `md5_file()` helper
  - new `assert_vN_docx_changed()` function with explanatory FAIL message
  - new `--assert-vN-docx-changed` mode + `--vN-docx` / `--new-docx`
    arguments (mutually exclusive with `--record` / `--verify`)
  - module docstring updated to document third mode
- `skills/sync-submission/SKILL.md`: Gate 10 + Phase 7 narrative.
- `skills/sync-submission/tests/test_vN_docx_assertion.sh` — 4 cases
  (identical / different / missing v_N / missing --new-docx arg).

## Test plan

- [x] `bash skills/sync-submission/tests/test_vN_docx_assertion.sh` — 4/4 PASS
- [ ] `bash scripts/validate_skills.sh`
- [ ] Companion check at v_(N+1) build time via PR T1-4
  (`check_xref.py --vN-docx-md5`).

## Related

- `/manage-refs` (PR T1-4 adds the build-time companion)
- `/revise` (revision-round rebuilds invoke this gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Pairs with**: T1-4 (#29) for defense-in-depth v_(N+1) docx regeneration.
