### PR TITLE
feat(manage-refs): add check_xref.py --vN-docx-md5 + --vN-md flags for v_(N+1) docx body-XML grep

### DIFF
--- a/skills/manage-refs/SKILL.md
+++ b/skills/manage-refs/SKILL.md
@@ -85,6 +85,7 @@ Validated 2026-05-01 against a 21-reference meta-analysis manuscript
 | Wire native Zotero CWYW field codes into a .docx (live Refresh in Word) | `scripts/inject_zotero_cwyw.py` | Co-author Word workflow, post-circulation editability |
 | Manuscript ↔ rendered DOCX cross-reference QC | `scripts/check_xref.py --strict` | Submission gate (P0 blocker on mismatch) |
 | Figures/tables submitted as separate attachments (radiology, most medical journals) | `check_xref.py --strict --allow-separate-attachments` | Downgrades `MISSING_DOCX` to WARN; `MISSING_BODY`/`MISMATCH` remain P0 |
+| **v_(N+1) docx build-time regeneration check** | `check_xref.py --vN-docx-md5 <prev>.docx [--vN-md <prev>.md]` | Defense-in-depth: identity = unmodified seed copy; missing diff lines = body not regenerated |
 | **Master pre-submission gate** (recommended before any submission) | `scripts/pre_submission_gate.sh` | Chains `check_citation_keys` → `verify_refs --strict` → `render_pandoc` (optional) → `check_xref --strict`; single artifact `qc/pre_submission_gate.json` |
 | Bibliographic audit against PubMed / CrossRef | **delegate** to `/verify-refs` | Audit-only — keep writer/auditor separation |
 
@@ -177,6 +178,32 @@ User shipped a manuscript and a reviewer flagged a Table/Figure mismatch.
    medical journals), pass `--allow-separate-attachments`. `MISSING_DOCX` rows
    are then recorded as WARN rather than FAIL; `MISSING_BODY` and `MISMATCH`
    remain P0 because they indicate SSOT drift, not attachment policy.
+
+### D'. v_(N+1) docx regeneration check (build-time companion)
+
+When building v_(N+1) from a frozen v_N, the v_(N+1) docx MUST differ
+from v_N docx by content — a byte-identical copy is a silent seed-copy
+that will revert markdown edits at peer review. `check_xref.py` carries
+two flags for the build-time companion to the submission-time gate
+in `scripts/verify_package_integrity.py --assert-vN-docx-changed`:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_xref.py" \
+    --md manuscript_v2.md \
+    --docx manuscript_v2.docx \
+    --vN-docx-md5 manuscript_v1.docx \
+    --vN-md manuscript_v1.md \
+    --strict
+```
+
+- `--vN-docx-md5` alone: MD5 identity check. Identical bytes = FAIL.
+- `--vN-docx-md5 + --vN-md`: additionally extracts the markdown-only diff
+  between v_N and v_(N+1) and verifies each ≥40-char diff line appears
+  verbatim (whitespace-normalized, case-insensitive) in the new docx
+  body XML. Missing diff lines = body did not pick up the markdown edits.
+
+Output records the result under `vN_docx_check` in `qc/xref_audit.json`.
+Either failure mode causes a non-zero exit even without `--strict`.
 
 ### E. Master pre-submission gate (recommended end-to-end chain)
 

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -20,16 +20,34 @@ Inputs
   --out PATH        JSON audit (default: qc/xref_audit.json)
   --strict          exit 1 on any non-OK finding (submission gate)
   --quiet           suppress stdout summary table
+  --vN-docx-md5 PATH
+                    v_N (previous version) docx path. When supplied:
+                    (a) asserts the new --docx MD5 differs from this docx
+                        (identity = unmodified seed copy);
+                    (b) when --vN-md is also supplied, computes the
+                        markdown-only diff and verifies each diff line
+                        appears verbatim in the new docx body XML.
+  --vN-md PATH      v_N markdown path (used by --vN-docx-md5 diff check).
+
+v_(N+1) docx regeneration check
+-------------------------------
+Defense-in-depth at build time (complements verify_package_integrity.py
+--assert-vN-docx-changed which runs at submission time). If a markdown
+body change exists between v_N and v_(N+1) but the v_(N+1) docx is a
+byte-identical copy of v_N, the change will silently revert at peer
+review. The check fails fast at the QC stage.
 
 Output
 ------
   qc/xref_audit.json with submission_safe boolean and per-label rows.
-  Stdout: human-readable 3-way matrix.
+  When --vN-docx-md5 is used, the JSON also carries a `vN_docx_check`
+  block with `identical_bytes` and `diff_line_misses` fields.
 
 Exit codes
 ----------
   0  all OK (or non-strict and only warnings)
   1  --strict and at least one non-OK finding
+     OR v_N docx identity / diff-miss assertion failure
   2  argument / IO error
 
 Dependencies
@@ -376,6 +394,90 @@ def render_summary(findings: list[Finding], cited_count: int) -> str:
     return "\n".join(lines)
 
 
+def _md5_of(path: Path) -> str:
+    import hashlib
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _docx_body_text(docx_path: Path) -> str:
+    """Concatenate all w:t text content from a docx for substring search."""
+    import zipfile
+    try:
+        with zipfile.ZipFile(docx_path, "r") as z:
+            xml = z.read("word/document.xml").decode("utf-8", errors="replace")
+    except (zipfile.BadZipFile, KeyError, OSError):
+        return ""
+    # Strip XML tags — we only need text content for verbatim grep.
+    return re.sub(r"<[^>]+>", " ", xml)
+
+
+def _markdown_diff_lines(vN_md: Path, new_md: Path) -> list[str]:
+    """Lines present in new_md but not in vN_md (added/changed lines).
+
+    Trimmed to non-trivial substrings (≥40 chars after stripping markdown
+    metacharacters) so that the verbatim grep is meaningful.
+    """
+    old_lines = set(vN_md.read_text(encoding="utf-8").splitlines())
+    out: list[str] = []
+    for ln in new_md.read_text(encoding="utf-8").splitlines():
+        if ln in old_lines:
+            continue
+        # Strip leading markdown noise (headers, list markers) and YAML.
+        clean = re.sub(r"^[\s#>*\-_+~`|]+", "", ln).strip()
+        if len(clean) >= 40:
+            out.append(clean)
+    return out
+
+
+def run_vN_docx_check(
+    new_docx: Path,
+    vN_docx: Path,
+    new_md: Path | None,
+    vN_md: Path | None,
+) -> dict:
+    """Returns {identical_bytes, diff_line_misses, error?}.
+
+    identical_bytes is True if v_N and new docx have the same MD5.
+    diff_line_misses lists v_N→v_(N+1) markdown additions that do NOT
+    appear in the new docx body XML.
+    """
+    out: dict = {
+        "vN_docx": str(vN_docx),
+        "new_docx": str(new_docx),
+        "identical_bytes": False,
+        "diff_line_misses": [],
+    }
+    if not vN_docx.is_file():
+        out["error"] = f"v_N docx not found: {vN_docx}"
+        return out
+    if not new_docx.is_file():
+        out["error"] = f"new docx not found: {new_docx}"
+        return out
+    if _md5_of(vN_docx) == _md5_of(new_docx):
+        out["identical_bytes"] = True
+        return out  # Identity already disqualifies — no point checking diff.
+
+    if new_md is not None and vN_md is not None:
+        if not new_md.is_file() or not vN_md.is_file():
+            out["error"] = "v_N md or new md not found"
+            return out
+        diff_lines = _markdown_diff_lines(vN_md, new_md)
+        body_text = _docx_body_text(new_docx)
+        # Light normalization: collapse runs of whitespace.
+        body_norm = re.sub(r"\s+", " ", body_text).lower()
+        misses: list[str] = []
+        for diff in diff_lines:
+            needle = re.sub(r"\s+", " ", diff).lower()
+            if needle not in body_norm:
+                misses.append(diff[:120])
+        out["diff_line_misses"] = misses
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--md", required=True, type=Path, help="manuscript.md path")
@@ -388,6 +490,28 @@ def main() -> int:
         help="Downgrade MISSING_DOCX from FAIL to WARN for figures/tables that are "
              "submitted as separate attachment files (common in radiology and many "
              "medical journals). MISSING_BODY and MISMATCH remain FAIL regardless.",
+    )
+    parser.add_argument(
+        "--vN-docx-md5",
+        dest="vN_docx_md5",
+        type=Path,
+        default=None,
+        help=(
+            "v_N docx path. Asserts the new --docx MD5 != this docx. "
+            "Identity = unmodified seed copy = FAIL."
+        ),
+    )
+    parser.add_argument(
+        "--vN-md",
+        dest="vN_md",
+        type=Path,
+        default=None,
+        help=(
+            "v_N manuscript markdown path (companion to --vN-docx-md5). "
+            "When supplied, every line added in v_(N+1) markdown must "
+            "appear verbatim in the new docx body XML; missing diff "
+            "lines fail."
+        ),
     )
     args = parser.parse_args()
 
@@ -424,8 +548,31 @@ def main() -> int:
     ]
     submission_safe = len(blockers) == 0
 
+    vN_check: dict | None = None
+    vN_check_failed = False
+    if args.vN_docx_md5 is not None:
+        if args.docx is None:
+            print(
+                "ERROR: --vN-docx-md5 requires --docx (the new manuscript docx).",
+                file=sys.stderr,
+            )
+            return 2
+        vN_check = run_vN_docx_check(
+            new_docx=args.docx,
+            vN_docx=args.vN_docx_md5,
+            new_md=args.md,
+            vN_md=args.vN_md,
+        )
+        if vN_check.get("error"):
+            print(f"ERROR: vN docx check: {vN_check['error']}", file=sys.stderr)
+            return 2
+        if vN_check["identical_bytes"]:
+            vN_check_failed = True
+        if vN_check["diff_line_misses"]:
+            vN_check_failed = True
+
     payload = {
-        "version": "1.1",
+        "version": "1.2",
         "manuscript": str(args.md),
         "docx": str(args.docx) if args.docx else None,
         "policy": {
@@ -442,8 +589,9 @@ def main() -> int:
             "blockers": len(blockers),
             "warnings": len(warnings),
         },
-        "submission_safe": submission_safe,
+        "submission_safe": submission_safe and not vN_check_failed,
         "findings": [asdict(f) for f in findings],
+        "vN_docx_check": vN_check,
     }
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
@@ -459,8 +607,24 @@ def main() -> int:
             )
         if not submission_safe:
             print(f"[check_xref] SUBMISSION BLOCKED: {len(blockers)} cross-reference defect(s).")
+        if vN_check is not None:
+            if vN_check["identical_bytes"]:
+                print(
+                    "[check_xref] FAIL: v_(N+1) docx is byte-identical to "
+                    "v_N docx — unmodified seed copy, regenerate via "
+                    "pandoc / Zotero CWYW."
+                )
+            elif vN_check["diff_line_misses"]:
+                print(
+                    f"[check_xref] FAIL: {len(vN_check['diff_line_misses'])} "
+                    "markdown diff line(s) absent from new docx body. "
+                    "v_(N+1) docx body did not pick up the markdown edits."
+                )
+                for miss in vN_check["diff_line_misses"][:5]:
+                    print(f"    - {miss}")
 
-    if args.strict and not submission_safe:
+    block_exit = args.strict and not submission_safe
+    if block_exit or vN_check_failed:
         return 1
     return 0
 

--- a/skills/manage-refs/tests/test_vN_docx_check.sh
+++ b/skills/manage-refs/tests/test_vN_docx_check.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Regression tests for check_xref.py --vN-docx-md5 / --vN-md flags.
+#
+# Builds minimal synthetic docx files via zipfile (no pandoc/Word required).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/manage-refs/scripts/check_xref.py"
+TMP="$(mktemp -d -t vN_docx_xref.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+fail=0
+ran=0
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-50s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# Helper: build a minimal docx with given body text.
+build_docx() {
+    local body_text="$1"
+    local out="$2"
+    python3 - "$body_text" "$out" <<'PY'
+import sys, zipfile
+body_text, out = sys.argv[1], sys.argv[2]
+doc_xml = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+    '<w:body><w:p><w:r><w:t xml:space="preserve">' + body_text + '</w:t></w:r></w:p>'
+    '</w:body></w:document>'
+)
+content_types = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/word/document.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+    '</Types>'
+)
+rels = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="word/document.xml"/></Relationships>'
+)
+with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("[Content_Types].xml", content_types)
+    z.writestr("_rels/.rels", rels)
+    z.writestr("word/document.xml", doc_xml)
+PY
+}
+
+# --------------------------------------------------------------------------
+# Setup: minimal manuscript markdown + docx
+# --------------------------------------------------------------------------
+VN_MD="$TMP/v1.md"
+cat > "$VN_MD" <<'EOF'
+# Manuscript
+
+## Methods
+The cohort included 100 patients.
+
+## Figure Legends
+**Figure 1.** Pipeline overview.
+EOF
+NEW_MD="$TMP/v2.md"
+cat > "$NEW_MD" <<'EOF'
+# Manuscript
+
+## Methods
+The cohort included 100 patients enrolled across three sites in this prospective study.
+
+## Figure Legends
+**Figure 1.** Pipeline overview.
+EOF
+
+VN_DOCX="$TMP/v1.docx"
+NEW_DOCX_REGEN="$TMP/v2_regen.docx"
+NEW_DOCX_COPY="$TMP/v2_copy.docx"
+NEW_DOCX_STALE="$TMP/v2_stale.docx"
+
+build_docx "The cohort included 100 patients. Figure 1 Pipeline overview." "$VN_DOCX"
+# Regenerated docx: contains the new diff line verbatim.
+build_docx "The cohort included 100 patients enrolled across three sites in this prospective study. Figure 1 Pipeline overview." "$NEW_DOCX_REGEN"
+# "Copy" docx: byte-identical to v_N.
+cp "$VN_DOCX" "$NEW_DOCX_COPY"
+# Stale docx: different bytes than v_N but missing the new markdown line.
+build_docx "Some text that differs from v_N but lacks the markdown diff." "$NEW_DOCX_STALE"
+
+# --------------------------------------------------------------------------
+# Case 1: regenerated docx contains markdown diff. PASS.
+# --------------------------------------------------------------------------
+python3 "$SCRIPT" --md "$NEW_MD" --docx "$NEW_DOCX_REGEN" \
+    --vN-docx-md5 "$VN_DOCX" --vN-md "$VN_MD" \
+    --out "$TMP/c1.json" --quiet
+assert_exit "case 1: regenerated docx, diff propagated" 0 $?
+
+# --------------------------------------------------------------------------
+# Case 2: identical bytes. FAIL.
+# --------------------------------------------------------------------------
+python3 "$SCRIPT" --md "$NEW_MD" --docx "$NEW_DOCX_COPY" \
+    --vN-docx-md5 "$VN_DOCX" --vN-md "$VN_MD" \
+    --out "$TMP/c2.json" --quiet
+assert_exit "case 2: identical bytes (FAIL)" 1 $?
+python3 - "$TMP/c2.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh: rep = json.load(fh)
+assert rep["vN_docx_check"]["identical_bytes"] is True, rep
+PY
+
+# --------------------------------------------------------------------------
+# Case 3: different bytes but missing diff line. FAIL.
+# --------------------------------------------------------------------------
+python3 "$SCRIPT" --md "$NEW_MD" --docx "$NEW_DOCX_STALE" \
+    --vN-docx-md5 "$VN_DOCX" --vN-md "$VN_MD" \
+    --out "$TMP/c3.json" --quiet
+assert_exit "case 3: different bytes, missing diff (FAIL)" 1 $?
+python3 - "$TMP/c3.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh: rep = json.load(fh)
+assert rep["vN_docx_check"]["identical_bytes"] is False, rep
+assert rep["vN_docx_check"]["diff_line_misses"], rep
+PY
+
+# --------------------------------------------------------------------------
+# Case 4: --vN-docx-md5 without --docx. Should error (exit 2).
+# --------------------------------------------------------------------------
+python3 "$SCRIPT" --md "$NEW_MD" \
+    --vN-docx-md5 "$VN_DOCX" --vN-md "$VN_MD" \
+    --out "$TMP/c4.json" --quiet 2>/dev/null
+assert_exit "case 4: --vN-docx-md5 without --docx" 2 $?
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
# PR T1-4: manage-refs check_xref.py --vN-docx-md5 flag

**Title**: `feat(manage-refs): add check_xref.py --vN-docx-md5 + --vN-md flags for v_(N+1) docx body-XML grep`

## Summary

Adds build-time defense-in-depth flags to
`skills/manage-refs/scripts/check_xref.py`:

- `--vN-docx-md5 <path>`: assert v_(N+1) docx MD5 ≠ v_N docx MD5.
- `--vN-md <path>`: in addition to the MD5 check, extract the
  markdown-only diff between v_N and v_(N+1) and verify each ≥40-char
  diff line appears verbatim (whitespace-normalized, case-insensitive)
  in the new docx body XML.

## Motivation

Same precedent as PR T1-3 (silent v_N → v_(N+1) docx copy leaving
markdown body changes un-rendered). T1-3 catches at submission time via
`scripts/verify_package_integrity.py --assert-vN-docx-changed`; T1-4
catches at build time via the `/manage-refs` xref QC chain — failing
earlier in the pipeline so the bad artifact never reaches
`/sync-submission`.

Defense in depth is warranted because both gates can mis-fire under
unusual user workflows: a build that bypasses `check_xref.py` would
skip T1-4 but still hit T1-3 at the freeze stage, and vice versa.

## Changes

- `skills/manage-refs/scripts/check_xref.py`:
  - `_md5_of()`, `_docx_body_text()`, `_markdown_diff_lines()`,
    `run_vN_docx_check()` helpers
  - `--vN-docx-md5` / `--vN-md` argparse flags
  - JSON output gains `vN_docx_check` block (version bumped to 1.2)
  - Either MD5 identity or any missing diff line forces non-zero exit
    even without `--strict`
- `skills/manage-refs/SKILL.md`:
  - Decision table row for build-time regeneration check
  - New Workflow D' section with command + behavior summary
- `skills/manage-refs/tests/test_vN_docx_check.sh`:
  - synthetic docx builder via stdlib `zipfile` (no pandoc / Word
    dependency)
  - 4 cases (regenerated, identical, stale-different, missing-arg)

## Test plan

- [x] `bash skills/manage-refs/tests/test_vN_docx_check.sh` — 4/4 PASS
- [ ] `bash scripts/validate_skills.sh`
- [ ] Integration check against `scripts/verify_package_integrity.py`
  (PR T1-3) so the two gates do not conflict.

## Related

- PR T1-3 (`scripts/verify_package_integrity.py --assert-vN-docx-changed`)
- `/sync-submission` Phase 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Pairs with**: T1-3 (#28) for defense-in-depth v_(N+1) docx regeneration (build-time + submission-time).
