### PR TITLE
feat(meta-analysis): add Phase 4 entry gate — extraction TSV ↔ adjudication TSV consistency assert

### DIFF
--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -220,6 +220,44 @@ ID sets. The Markdown consensus document remains the human explanation.
 
 **Goal**: Create standardized extraction forms and extract 2x2 or effect size data.
 
+#### 4.0 Entry gate (MANDATORY): pool composition lock ↔ adjudication TSV
+
+Before any extraction work begins, run the deterministic UID-set check
+to confirm that the round-3 adjudication TSV and `FINAL_POOL_LOCK.yaml`
+(produced in Phase 3f.5) agree on which UIDs are included.
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/check_pool_consistency.py" \
+    --lock 2_Data/FINAL_POOL_LOCK.yaml \
+    --adjudication-tsv 2_Screening/round3_adjudication.tsv \
+    --decision-col round3_decision \
+    --uid-col uid \
+    --include-labels "INCLUDE,INCLUDE_MIXED" \
+    --out qc/pool_consistency.json
+```
+
+Output `qc/pool_consistency.json`:
+
+```json
+{
+  "submission_safe": false,
+  "match": false,
+  "lock_include_n": 42,
+  "tsv_include_n": 43,
+  "in_lock_not_tsv": ["UID_007"],
+  "in_tsv_not_lock": ["UID_055"]
+}
+```
+
+The gate fails closed: any UID disagreement blocks extraction. To
+resolve, either (a) re-freeze the lock with the corrected set of UIDs
+and propagate to downstream artifacts, or (b) correct the adjudication
+TSV if a row was mis-labeled. Do NOT proceed to Phase 4 with a
+mismatch — the resulting extraction matrix will not align with the
+locked pool, and the drift surfaces as a fabrication-grade red flag at
+peer review.
+
+
 > **Failure-mode cross-ref** → `references/data_integrity_checklist.md` DI-1~DI-5 are mandatory during extraction (2x2 arm-swap, KM audit trail, methodology mismatch, PRISMA 5-way drift, single-source k).
 
 **Recommended extraction form**: For SR-MA targeting high-impact radiology / medical AI journals, use `${CLAUDE_SKILL_DIR}/templates/extraction_form_v2.md`. Dual-extractor + source-page-reference + verbatim-quote columns prevent the 2x2 cell-swap and cohort-overlap blind spots surfaced in recent SR-MA peer-review cycles. New required columns: `cohort_source`, `source_page_ref`, `source_verbatim_quote`, `extraction_consensus_status`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool`.

--- a/skills/meta-analysis/scripts/check_pool_consistency.py
+++ b/skills/meta-analysis/scripts/check_pool_consistency.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+check_pool_consistency.py — Phase 4 entry gate.
+
+Asserts UID-set equality between (a) the frozen `FINAL_POOL_LOCK.yaml`
+and (b) the actual round-3 adjudication TSV that feeds extraction. Blocks
+Phase 4 (data extraction) until the two agree.
+
+Why this gate exists
+====================
+Cross-project precedent (anonymized): an LLM reporting-quality SR carried
+five documents that disagreed on INCLUDE/EXCLUDE counts. Three EXCLUDE
+rows existed in the downstream extraction sheet without matching INCLUDE
+decisions. The drift traced to a post-freeze adjudication change that
+propagated to the extraction TSV but not the lock — or the other way
+around. Either direction is fatal at peer review.
+
+The gate fails CLOSED: if the lock and the extraction sheet disagree on
+even one UID, extraction is blocked.
+
+Inputs
+======
+
+  --lock PATH              FINAL_POOL_LOCK.yaml (Phase 3f.5 artifact)
+  --adjudication-tsv PATH  round3_adjudication.tsv (Phase 3c artifact)
+  --decision-col NAME      column holding the decision label
+                           (default: "round3_decision")
+  --uid-col NAME           column holding the UID (default: "uid")
+  --include-labels LIST    decisions counted as INCLUDE
+                           (default: "INCLUDE,INCLUDE_MIXED")
+  --out PATH               JSON report (default: qc/pool_consistency.json)
+
+Output JSON
+===========
+
+    {
+      "submission_safe": false,
+      "lock_include_n": 42,
+      "tsv_include_n": 43,
+      "in_lock_not_tsv": ["UID_007"],
+      "in_tsv_not_lock": ["UID_055"],
+      "match": false
+    }
+
+Exit codes
+==========
+  0  lock and TSV agree on the UID set
+  1  disagreement (PR T1-5 blocks extraction)
+  2  invocation error (missing files, missing columns)
+
+Read-only script. No file modification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+def load_lock_uids(lock_path: Path, label_set: list[str]) -> set[str]:
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        print(
+            "ERROR: PyYAML required for --lock parsing. pip install PyYAML",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    data = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        print(f"ERROR: lock file not a mapping: {lock_path}", file=sys.stderr)
+        sys.exit(2)
+    # INCLUDE_MIXED maps to mixed_uids in the lock template.
+    uids: set[str] = set()
+    if "INCLUDE" in label_set:
+        uids.update(str(u) for u in (data.get("include_uids") or []))
+    if "INCLUDE_MIXED" in label_set:
+        uids.update(str(u) for u in (data.get("mixed_uids") or []))
+    if "MIXED" in label_set:
+        uids.update(str(u) for u in (data.get("mixed_uids") or []))
+    if "EXCLUDE" in label_set:
+        uids.update(str(u) for u in (data.get("exclude_uids") or []))
+    return uids
+
+
+def load_tsv_uids(
+    tsv_path: Path,
+    decision_col: str,
+    uid_col: str,
+    label_set: set[str],
+) -> set[str]:
+    # Allow .tsv or .csv (sniff by extension).
+    delim = "," if tsv_path.suffix.lower() == ".csv" else "\t"
+    with tsv_path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter=delim)
+        if reader.fieldnames is None:
+            print(f"ERROR: empty TSV: {tsv_path}", file=sys.stderr)
+            sys.exit(2)
+        if uid_col not in reader.fieldnames:
+            print(
+                f"ERROR: uid column {uid_col!r} not in TSV columns "
+                f"{reader.fieldnames!r}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if decision_col not in reader.fieldnames:
+            print(
+                f"ERROR: decision column {decision_col!r} not in TSV columns "
+                f"{reader.fieldnames!r}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        uids: set[str] = set()
+        for row in reader:
+            decision = (row.get(decision_col) or "").strip()
+            if decision in label_set:
+                uid = (row.get(uid_col) or "").strip()
+                if uid:
+                    uids.add(uid)
+        return uids
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Phase 4 entry gate: asserts UID-set equality between the frozen "
+            "FINAL_POOL_LOCK.yaml and the round-3 adjudication TSV."
+        )
+    )
+    parser.add_argument("--lock", type=Path, required=True)
+    parser.add_argument("--adjudication-tsv", type=Path, required=True)
+    parser.add_argument("--decision-col", default="round3_decision")
+    parser.add_argument("--uid-col", default="uid")
+    parser.add_argument(
+        "--include-labels",
+        default="INCLUDE,INCLUDE_MIXED",
+        help="Comma-separated decision labels counted as included.",
+    )
+    parser.add_argument("--out", type=Path, default=Path("qc/pool_consistency.json"))
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.lock.is_file():
+        print(f"ERROR: lock not found: {args.lock}", file=sys.stderr)
+        return 2
+    if not args.adjudication_tsv.is_file():
+        print(f"ERROR: TSV not found: {args.adjudication_tsv}", file=sys.stderr)
+        return 2
+
+    labels = [s.strip() for s in args.include_labels.split(",") if s.strip()]
+    label_set = set(labels)
+    lock_uids = load_lock_uids(args.lock, labels)
+    tsv_uids = load_tsv_uids(
+        args.adjudication_tsv, args.decision_col, args.uid_col, label_set
+    )
+
+    in_lock_only = sorted(lock_uids - tsv_uids)
+    in_tsv_only = sorted(tsv_uids - lock_uids)
+    match = not in_lock_only and not in_tsv_only
+
+    report = {
+        "submission_safe": match,
+        "match": match,
+        "lock_include_n": len(lock_uids),
+        "tsv_include_n": len(tsv_uids),
+        "in_lock_not_tsv": in_lock_only,
+        "in_tsv_not_lock": in_tsv_only,
+        "include_labels": labels,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if not args.quiet:
+        if match:
+            print(f"PASS: lock and TSV agree ({len(lock_uids)} UIDs).")
+        else:
+            print(
+                f"FAIL: lock includes {len(lock_uids)} UIDs, TSV includes "
+                f"{len(tsv_uids)} UIDs."
+            )
+            if in_lock_only:
+                print(f"  In lock but not TSV ({len(in_lock_only)}):")
+                for u in in_lock_only[:10]:
+                    print(f"    - {u}")
+                if len(in_lock_only) > 10:
+                    print(f"    ... and {len(in_lock_only) - 10} more")
+            if in_tsv_only:
+                print(f"  In TSV but not lock ({len(in_tsv_only)}):")
+                for u in in_tsv_only[:10]:
+                    print(f"    - {u}")
+                if len(in_tsv_only) > 10:
+                    print(f"    ... and {len(in_tsv_only) - 10} more")
+
+    return 0 if match else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/meta-analysis/tests/test_pool_consistency.sh
+++ b/skills/meta-analysis/tests/test_pool_consistency.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Regression tests for meta-analysis check_pool_consistency.py.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/meta-analysis/scripts/check_pool_consistency.py"
+TMP="$(mktemp -d -t pool_consist.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+python3 -c "import yaml" 2>/dev/null || { echo "SKIP: pyyaml unavailable"; exit 0; }
+
+fail=0
+ran=0
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-50s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Case 1: lock and TSV agree on 3 UIDs => PASS
+# --------------------------------------------------------------------------
+mkdir -p "$TMP/c1"
+cat > "$TMP/c1/lock.yaml" <<'EOF'
+freeze_date: "2026-01-01"
+final_pool_n: 3
+include_count: 3
+exclude_count: 0
+mixed_count: 0
+include_uids: [UID_001, UID_002, UID_003]
+exclude_uids: []
+mixed_uids: []
+EOF
+cat > "$TMP/c1/r3.tsv" <<'EOF'
+uid	round3_decision	notes
+UID_001	INCLUDE	ok
+UID_002	INCLUDE	ok
+UID_003	INCLUDE	ok
+UID_004	EXCLUDE	out of scope
+EOF
+python3 "$SCRIPT" --lock "$TMP/c1/lock.yaml" \
+    --adjudication-tsv "$TMP/c1/r3.tsv" \
+    --out "$TMP/c1/report.json" --quiet
+assert_exit "case 1: lock and TSV agree" 0 $?
+
+# --------------------------------------------------------------------------
+# Case 2: TSV has extra UID => FAIL
+# --------------------------------------------------------------------------
+mkdir -p "$TMP/c2"
+cat > "$TMP/c2/lock.yaml" <<'EOF'
+include_uids: [UID_001, UID_002]
+exclude_uids: []
+mixed_uids: []
+EOF
+cat > "$TMP/c2/r3.tsv" <<'EOF'
+uid	round3_decision
+UID_001	INCLUDE
+UID_002	INCLUDE
+UID_009	INCLUDE
+EOF
+python3 "$SCRIPT" --lock "$TMP/c2/lock.yaml" \
+    --adjudication-tsv "$TMP/c2/r3.tsv" \
+    --out "$TMP/c2/report.json" --quiet
+assert_exit "case 2: TSV extra UID (FAIL)" 1 $?
+python3 - "$TMP/c2/report.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh: r = json.load(fh)
+assert "UID_009" in r["in_tsv_not_lock"], r
+assert not r["in_lock_not_tsv"], r
+PY
+
+# --------------------------------------------------------------------------
+# Case 3: lock has extra UID => FAIL
+# --------------------------------------------------------------------------
+mkdir -p "$TMP/c3"
+cat > "$TMP/c3/lock.yaml" <<'EOF'
+include_uids: [UID_001, UID_002, UID_999]
+mixed_uids: []
+exclude_uids: []
+EOF
+cat > "$TMP/c3/r3.tsv" <<'EOF'
+uid	round3_decision
+UID_001	INCLUDE
+UID_002	INCLUDE
+EOF
+python3 "$SCRIPT" --lock "$TMP/c3/lock.yaml" \
+    --adjudication-tsv "$TMP/c3/r3.tsv" \
+    --out "$TMP/c3/report.json" --quiet
+assert_exit "case 3: lock extra UID (FAIL)" 1 $?
+python3 - "$TMP/c3/report.json" <<'PY' || fail=$((fail + 1))
+import json, sys
+with open(sys.argv[1]) as fh: r = json.load(fh)
+assert "UID_999" in r["in_lock_not_tsv"], r
+PY
+
+# --------------------------------------------------------------------------
+# Case 4: missing decision column => exit 2
+# --------------------------------------------------------------------------
+mkdir -p "$TMP/c4"
+cat > "$TMP/c4/lock.yaml" <<'EOF'
+include_uids: [UID_001]
+mixed_uids: []
+exclude_uids: []
+EOF
+cat > "$TMP/c4/r3.tsv" <<'EOF'
+uid	notes
+UID_001	whatever
+EOF
+python3 "$SCRIPT" --lock "$TMP/c4/lock.yaml" \
+    --adjudication-tsv "$TMP/c4/r3.tsv" \
+    --out "$TMP/c4/report.json" --quiet 2>/dev/null
+assert_exit "case 4: missing decision col (exit 2)" 2 $?
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
# PR T1-6: meta-analysis Phase 4 entry gate

**Title**: `feat(meta-analysis): add Phase 4 entry gate — extraction TSV ↔ adjudication TSV consistency assert`

## Summary

Adds `scripts/check_pool_consistency.py` and a Phase 4.0 entry gate that
asserts UID-set equality between the frozen `FINAL_POOL_LOCK.yaml`
(Phase 3f.5) and the round-3 adjudication TSV. Blocks extraction when
the two disagree.

## Motivation

Pair with PR T1-5 (lock file). The lock alone is not enough — a stale
extraction sheet whose UID set diverges from the lock will silently
produce a synthesis matrix that does not correspond to the locked pool.
This gate catches the divergence at the point of entry into Phase 4 so
the bad matrix never gets built.

Cross-project precedent: same anonymized LLM reporting-quality SR cited
in PR T1-5. Three EXCLUDE rows existed in the extraction sheet without
matching INCLUDE decisions in the adjudication TSV.

## Changes

- `skills/meta-analysis/scripts/check_pool_consistency.py` — new script.
  - Reads lock YAML and adjudication TSV (or CSV).
  - Default include labels: `INCLUDE,INCLUDE_MIXED`.
  - Configurable `--decision-col`, `--uid-col`, `--include-labels`.
  - JSON output `qc/pool_consistency.json` with `in_lock_not_tsv` /
    `in_tsv_not_lock` set differences.
  - Exit codes: 0 / 1 / 2.
- `skills/meta-analysis/SKILL.md`:
  - Phase 4.0 entry gate narrative
  - Cross-link to Phase 3f.5 lock
- `skills/meta-analysis/tests/test_pool_consistency.sh` — 4 cases
  (agree, TSV extra UID, lock extra UID, missing decision col).

## Test plan

- [x] `bash skills/meta-analysis/tests/test_pool_consistency.sh` — 4/4 PASS
- [ ] `bash scripts/validate_skills.sh`
- [ ] Integration with the `--pool-lock` flag in
  `scripts/cross_document_n_check.py` (PR T1-1).

## Related

- PR T1-5 (lock template)
- PR T1-1 (`/sync-submission` Phase 5 consumes the same lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Merge dependency**: T1-5 (#30) must merge first — provides `FINAL_POOL_LOCK.yaml` schema.
