### PR TITLE
feat(self-review): add reviewer-team consistency category K to 10-category screen

### DIFF
--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -175,7 +175,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
             ! -name "SKILL.md" -print0 2>/dev/null)
 
   # 6. Personal precedent leak (blocklist of project-specific identifiers)
-  # Covers: legacy project IDs (CK-N, MA-N, RFA-Adjunct, MeducAI, CBCT, etc.),
+  # Covers: legacy project IDs, project slugs, product names, etc.,
   # institution / mentor identifiers, numbered workspace folders, and the
   # historical prefix patterns (Paper ①②③). Keep additions in alphabetical
   # blocks so future maintainers can spot what is being filtered.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -163,6 +163,26 @@ before submission for item-level assessment."
 | Training vs fine-tuning | If pre-trained: was the model fine-tuned on study data? If vendor-provided: any access to training data composition? |
 | Proprietary limitations | For commercial AI or tools: are known limitations acknowledged? Can results be independently reproduced? |
 
+#### K. Reviewer-team consistency (SR/MA-only; fabrication-grade)
+
+| Check | What to look for |
+|-------|-----------------|
+| DUAL vs SINGLE conjunction **[CRITICAL]** | Methods or PROSPERO claims dual independent reviewers AND Discussion/Limitations admits single primary reviewer + 20% sample (or "deferred to before submission")? Mark as **MAJOR**, fabrication-grade. |
+
+Run the deterministic check at Phase 2 entry:
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
+    --manuscript manuscript.md \
+    --prospero prospero/record.md \
+    --out _audit_self/reviewer_team_consistency.md
+```
+
+Exit 1 = MAJOR red flag. Either claim alone is fine; the conjunction is
+read by reviewers as fabrication. Resolution path:
+1. Honest Methods/PROSPERO update (single-reviewer execution disclosed), OR
+2. Limitations confession rewritten if dual review was actually completed.
+
 ### Research-Type Adaptation
 
 Not all categories apply equally to every study type. Use this routing table:
@@ -179,6 +199,7 @@ Not all categories apply equally to every study type. Use this routing table:
 | H. Circularity | Full | Partial | N/A | N/A | N/A | Partial |
 | I. Protocol Heterogeneity | Full | Full | N/A | Per-study | N/A | Full |
 | J. Method Transparency | Full | Partial | Partial | N/A | N/A | Partial |
+| K. Reviewer-team consistency | N/A | N/A | N/A | Full | N/A | N/A |
 
 *Meta-analysis: Replace C with heterogeneity assessment (I-squared, prediction intervals),
 publication bias (funnel plot, Egger), and sensitivity/subgroup analyses.

--- a/skills/self-review/scripts/check_reviewer_team_consistency.py
+++ b/skills/self-review/scripts/check_reviewer_team_consistency.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+check_reviewer_team_consistency.py — fabrication-grade self-review check.
+
+Detects manuscripts that simultaneously claim dual independent reviewers
+(in Methods + PROSPERO) and confess to single-reviewer execution (in
+Discussion §Limitations). Either claim alone is fine; the conjunction is
+a fabrication-grade red flag.
+
+Why this check exists
+=====================
+Cross-project precedent (anonymized): a reporting-quality SR-of-AI-tools
+manuscript had:
+- Methods: "Two reviewers independently screened titles and abstracts ..."
+- PROSPERO record: "Two independent reviewers will perform full-text
+  screening and data extraction."
+- Discussion §Limitations: "Single primary reviewer; a 20% sample by an
+  additional reviewer is deferred to before submission."
+
+The conjunction admits in Limitations what Methods denies in narrative
+form. Reviewers and editors who notice this read it as fabrication-grade
+(the manuscript misrepresents what was actually done) and reject.
+
+Detection strategy
+==================
+Section-aware grep for two regex families:
+- DUAL claim: "(independently|dual|two reviewers|both reviewers|two
+  independent)" within Methods OR a PROSPERO record file.
+- SINGLE confession: "(single primary reviewer|one additional reviewer|
+  20% sample|sample of records|deferred to before submission|due to
+  resource constraints|by the first reviewer alone)" within Limitations
+  OR Discussion.
+
+Both present → MAJOR self-review red flag.
+
+Usage
+=====
+
+    python check_reviewer_team_consistency.py \\
+        --manuscript manuscript.md \\
+        --prospero prospero/record.md \\
+        --out _audit_self/reviewer_team_consistency.md
+
+Output
+======
+Markdown report at `--out` summarizing matches. Also a JSON sidecar at
+`--out` + ".json".
+
+Exit codes
+==========
+  0  no conflict
+  1  MAJOR red flag detected (both DUAL and SINGLE patterns present)
+  2  invocation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DUAL_PATTERNS = [
+    (
+        re.compile(r"\btwo\s+(?:independent\s+)?reviewers?\b", re.IGNORECASE),
+        "two reviewers",
+    ),
+    (re.compile(r"\bdual\s+(?:independent\s+)?(?:reviewers?|extractors?)\b", re.IGNORECASE),
+     "dual reviewers"),
+    (re.compile(r"\bindependent(?:ly)?\s+screened\b", re.IGNORECASE), "independently screened"),
+    (
+        re.compile(r"\bboth\s+reviewers?\s+(?:independently|extracted|screened)\b", re.IGNORECASE),
+        "both reviewers",
+    ),
+    (
+        re.compile(r"\bindependent(?:ly)?\s+(?:extracted|coded|assessed)\b", re.IGNORECASE),
+        "independent extraction",
+    ),
+    (
+        re.compile(r"\bindependent\s+reviewers?\b", re.IGNORECASE),
+        "independent reviewers",
+    ),
+]
+
+SINGLE_PATTERNS = [
+    (re.compile(r"\bsingle\s+primary\s+reviewer\b", re.IGNORECASE), "single primary reviewer"),
+    (
+        re.compile(r"\bone\s+additional\s+reviewer\b", re.IGNORECASE),
+        "one additional reviewer",
+    ),
+    (
+        re.compile(r"\b20\s*%?\s+sample\b", re.IGNORECASE),
+        "20% sample",
+    ),
+    (
+        re.compile(r"\bsample\s+of\s+records\b", re.IGNORECASE),
+        "sample of records",
+    ),
+    (
+        re.compile(r"\bdeferred\s+to\s+before\s+submission\b", re.IGNORECASE),
+        "deferred to before submission",
+    ),
+    (
+        re.compile(r"\bdue\s+to\s+resource\s+constraints\b", re.IGNORECASE),
+        "due to resource constraints",
+    ),
+    (
+        re.compile(r"\b(?:by|with)\s+(?:the\s+)?first\s+reviewer\s+(?:alone|only)\b", re.IGNORECASE),
+        "first reviewer alone",
+    ),
+]
+
+
+SECTION_HEADERS = {
+    "Methods": re.compile(
+        r"^#{1,3}\s*\*{0,2}(?:METHODS?|Method[s]?|Materials and Methods)\*{0,2}\s*$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "Discussion": re.compile(
+        r"^#{1,3}\s*\*{0,2}(?:DISCUSSION|Discussion)\*{0,2}\s*$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "Limitations": re.compile(
+        r"^#{1,3}\s*\*{0,2}(?:LIMITATIONS?|Limitations?|Study Limitations)\*{0,2}\s*$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+}
+
+
+@dataclass
+class Hit:
+    pattern_label: str
+    line: int
+    context: str
+
+
+@dataclass
+class Report:
+    submission_safe: bool
+    dual_hits: list[dict] = field(default_factory=list)
+    single_hits: list[dict] = field(default_factory=list)
+
+
+def split_sections(text: str) -> dict[str, str]:
+    out: dict[str, str] = {name: "" for name in SECTION_HEADERS}
+    headers: list[tuple[str, int, int]] = []
+    for name, pat in SECTION_HEADERS.items():
+        for m in pat.finditer(text):
+            headers.append((name, m.start(), m.end()))
+    headers.sort(key=lambda t: t[1])
+    for i, (name, _, hdr_end) in enumerate(headers):
+        end = headers[i + 1][1] if i + 1 < len(headers) else len(text)
+        out[name] = (out[name] + "\n" + text[hdr_end:end]).strip()
+    return out
+
+
+def scan_text(text: str, patterns: list[tuple[re.Pattern[str], str]]) -> list[Hit]:
+    hits: list[Hit] = []
+    lines = text.splitlines()
+    for lineno, line in enumerate(lines, start=1):
+        for pat, label in patterns:
+            if pat.search(line):
+                ctx = line.strip()
+                if len(ctx) > 200:
+                    ctx = ctx[:200] + "..."
+                hits.append(Hit(pattern_label=label, line=lineno, context=ctx))
+    return hits
+
+
+def hit_to_dict(h: Hit, source: str) -> dict:
+    return {
+        "source": source,
+        "pattern": h.pattern_label,
+        "line": h.line,
+        "context": h.context,
+    }
+
+
+def build_report(manuscript: str, prospero: str | None) -> Report:
+    sections = split_sections(manuscript)
+
+    dual_hits: list[dict] = []
+    single_hits: list[dict] = []
+
+    # Methods → DUAL evidence.
+    for h in scan_text(sections.get("Methods", ""), DUAL_PATTERNS):
+        dual_hits.append(hit_to_dict(h, "manuscript:Methods"))
+
+    # PROSPERO → DUAL evidence.
+    if prospero is not None:
+        for h in scan_text(prospero, DUAL_PATTERNS):
+            dual_hits.append(hit_to_dict(h, "prospero"))
+
+    # Discussion & Limitations → SINGLE evidence.
+    for region in ("Limitations", "Discussion"):
+        for h in scan_text(sections.get(region, ""), SINGLE_PATTERNS):
+            single_hits.append(hit_to_dict(h, f"manuscript:{region}"))
+
+    submission_safe = not (dual_hits and single_hits)
+    return Report(
+        submission_safe=submission_safe,
+        dual_hits=dual_hits,
+        single_hits=single_hits,
+    )
+
+
+def render_markdown(report: Report) -> str:
+    lines = ["# Reviewer-team consistency audit", ""]
+    if report.submission_safe:
+        lines.append(
+            "Status: **PASS** — no conjunction of DUAL claim + SINGLE confession."
+        )
+        lines.append("")
+        if report.dual_hits:
+            lines.append(f"DUAL claims found ({len(report.dual_hits)}, OK alone):")
+            for h in report.dual_hits:
+                lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}` — {h['context']}")
+        if report.single_hits:
+            lines.append("")
+            lines.append(f"SINGLE confessions found ({len(report.single_hits)}, OK alone):")
+            for h in report.single_hits:
+                lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}` — {h['context']}")
+    else:
+        lines.append("Status: **MAJOR red flag** — DUAL claim and SINGLE confession both present.")
+        lines.append("")
+        lines.append("Reviewers will read this as fabrication-grade. Fix one of:")
+        lines.append("1. Methods / PROSPERO honestly states single-reviewer execution.")
+        lines.append("2. The Limitations admission is rewritten if dual review was actually done.")
+        lines.append("")
+        lines.append("## DUAL claims (Methods / PROSPERO)")
+        for h in report.dual_hits:
+            lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
+            lines.append(f"  > {h['context']}")
+        lines.append("")
+        lines.append("## SINGLE confessions (Discussion / Limitations)")
+        for h in report.single_hits:
+            lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
+            lines.append(f"  > {h['context']}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reviewer-team consistency check (fabrication-grade self-review)."
+    )
+    parser.add_argument("--manuscript", type=Path, required=True)
+    parser.add_argument("--prospero", type=Path, default=None)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("_audit_self/reviewer_team_consistency.md"),
+    )
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.manuscript.is_file():
+        print(f"ERROR: manuscript not found: {args.manuscript}", file=sys.stderr)
+        return 2
+    prospero_text: str | None = None
+    if args.prospero is not None:
+        if not args.prospero.is_file():
+            print(f"ERROR: prospero not found: {args.prospero}", file=sys.stderr)
+            return 2
+        prospero_text = args.prospero.read_text(encoding="utf-8")
+
+    text = args.manuscript.read_text(encoding="utf-8")
+    report = build_report(text, prospero_text)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(render_markdown(report), encoding="utf-8")
+    json_out = args.out.with_suffix(args.out.suffix + ".json")
+    json_out.write_text(
+        json.dumps(
+            {
+                "submission_safe": report.submission_safe,
+                "dual_hits": report.dual_hits,
+                "single_hits": report.single_hits,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    if not args.quiet:
+        if report.submission_safe:
+            print(
+                f"PASS: no conjunction. DUAL={len(report.dual_hits)} "
+                f"SINGLE={len(report.single_hits)}"
+            )
+        else:
+            print(
+                f"FAIL: MAJOR red flag. DUAL={len(report.dual_hits)} "
+                f"SINGLE={len(report.single_hits)}"
+            )
+            print(f"See {args.out}")
+
+    return 0 if report.submission_safe else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/self-review/tests/test_reviewer_team_consistency.sh
+++ b/skills/self-review/tests/test_reviewer_team_consistency.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression tests for self-review check_reviewer_team_consistency.py.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/self-review/scripts/check_reviewer_team_consistency.py"
+TMP="$(mktemp -d -t reviewer_team.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+fail=0
+ran=0
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-50s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Case 1: clean — dual review claimed, no limits confession.
+# --------------------------------------------------------------------------
+cat > "$TMP/c1.md" <<'EOF'
+## **METHODS**
+Two reviewers independently screened titles and abstracts.
+
+## **DISCUSSION**
+The cohort overlap reduces effective sample size.
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c1.md" \
+    --out "$TMP/c1.md.audit" --quiet
+assert_exit "case 1: dual claim, no limits confession" 0 $?
+
+# --------------------------------------------------------------------------
+# Case 2: fabrication-grade — Methods dual + Limitations single confession.
+# --------------------------------------------------------------------------
+cat > "$TMP/c2.md" <<'EOF'
+## **METHODS**
+Two reviewers independently screened titles and abstracts and extracted data.
+
+## **DISCUSSION**
+
+### Limitations
+We used a single primary reviewer for data extraction; a 20% sample by an
+additional reviewer is deferred to before submission.
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c2.md" \
+    --out "$TMP/c2.md.audit" --quiet
+assert_exit "case 2: dual + single confession (FAIL)" 1 $?
+
+# Verify the markdown report flags both claim sides.
+grep -q "MAJOR red flag" "$TMP/c2.md.audit" || { echo "  FAIL c2 markdown body"; fail=$((fail + 1)); }
+grep -q "single primary reviewer" "$TMP/c2.md.audit" || { echo "  FAIL c2 markdown body"; fail=$((fail + 1)); }
+
+# --------------------------------------------------------------------------
+# Case 3: PROSPERO dual + Limitations single. Also FAIL.
+# --------------------------------------------------------------------------
+cat > "$TMP/c3.md" <<'EOF'
+## **METHODS**
+Records were screened against pre-specified eligibility criteria.
+
+## **DISCUSSION**
+### Limitations
+A single primary reviewer extracted data due to resource constraints.
+EOF
+cat > "$TMP/c3_prospero.md" <<'EOF'
+# PROSPERO record
+Two independent reviewers will perform full-text screening and data extraction.
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c3.md" --prospero "$TMP/c3_prospero.md" \
+    --out "$TMP/c3.md.audit" --quiet
+assert_exit "case 3: PROSPERO dual + limits single (FAIL)" 1 $?
+
+# --------------------------------------------------------------------------
+# Case 4: single confession alone (no dual claim) => PASS.
+# --------------------------------------------------------------------------
+cat > "$TMP/c4.md" <<'EOF'
+## **METHODS**
+Data extraction was performed by the first reviewer.
+
+## **DISCUSSION**
+### Limitations
+A single primary reviewer extracted data; this is a limitation of our review.
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c4.md" \
+    --out "$TMP/c4.md.audit" --quiet
+assert_exit "case 4: single confession only (PASS)" 0 $?
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
# PR T1-7: self-review reviewer-team consistency check

**Title**: `feat(self-review): add reviewer-team consistency category K to 10-category screen`

## Summary

Adds `scripts/check_reviewer_team_consistency.py` and a new self-review
category **K. Reviewer-team consistency** (SR/MA-only, fabrication-grade).

Detects manuscripts that simultaneously claim dual independent reviewers
(Methods + PROSPERO) and confess to single-reviewer execution
(Discussion §Limitations). Either claim alone is fine; the conjunction
is read by reviewers as fabrication-grade and causes rejection.

## Motivation

Cross-project precedent (anonymized): a reporting-quality SR-of-AI-tools
manuscript had:
- Methods: "Two reviewers independently screened titles and abstracts ..."
- PROSPERO record: "Two independent reviewers will perform full-text
  screening and data extraction."
- Discussion §Limitations: "Single primary reviewer; a 20% sample by an
  additional reviewer is deferred to before submission."

The conjunction admits in Limitations what Methods denies in narrative
form. Fabrication-grade red flag.

## Changes

- `skills/self-review/scripts/check_reviewer_team_consistency.py` —
  section-aware grep for DUAL patterns (Methods + PROSPERO) vs SINGLE
  patterns (Discussion + Limitations).
- `skills/self-review/SKILL.md`:
  - new category K with critical-tier check entry
  - command snippet showing how to invoke the script
  - resolution guidance (honest Methods rewrite vs Limitations rewrite)
  - K added to Research-Type Adaptation table (Full for Meta-Analysis,
    N/A elsewhere)
- `skills/self-review/tests/test_reviewer_team_consistency.sh` — 4 cases
  (clean / Methods+limits / PROSPERO+limits / single-only).

## Test plan

- [x] `bash skills/self-review/tests/test_reviewer_team_consistency.sh` —
  4/4 PASS
- [ ] `bash scripts/validate_skills.sh`
- [ ] Manual integration in a self-review walkthrough

## Related

- PR T1-2 (`/sync-submission` Phase 6 scope drift) — complementary
  detection family
- PRISMA-DTA reporting checks (existing `/check-reporting` integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
