### PR TITLE
feat(search-lit): add East Asian name + CollectiveName heuristics to parse_pubmed

### DIFF
--- a/skills/search-lit/references/parse_pubmed.py
+++ b/skills/search-lit/references/parse_pubmed.py
@@ -18,9 +18,94 @@ Usage:
 
 import sys
 import json
+import re
 import xml.etree.ElementTree as ET
 from datetime import date
 from textwrap import shorten
+
+
+# Heuristic for East Asian name reverse-encoding in PubMed XML.
+# Cases observed: <LastName>Qiaoling</LastName><ForeName>Fu</ForeName> where
+# Fu is the actual family name. Pattern: LastName looks like a long given
+# name (≥3 alpha chars, no spaces) AND ForeName looks like a short surname
+# fragment (1-2 chars, no period). The naive test catches the common reverse
+# encoding without flagging legitimate short-surname authors.
+_EAST_ASIAN_REVERSE_THRESHOLD = 3  # LastName length lower bound for suspicion
+
+
+def _looks_east_asian_reversed(last: str, fore: str) -> bool:
+    """Return True if (LastName, ForeName) look swapped per PubMed encoding bug."""
+    if not last or not fore:
+        return False
+    # ForeName should look like a surname (1-2 chars, no spaces, no period)
+    # AND LastName should look like a multi-char given name.
+    return (
+        1 <= len(fore) <= 2
+        and fore.isalpha()
+        and "." not in fore
+        and len(last) >= _EAST_ASIAN_REVERSE_THRESHOLD
+        and last.isalpha()
+    )
+
+
+def _extract_authors(author_list_el):
+    """Walk an <AuthorList> element. Return (bib_authors, display_authors,
+    first_author_last, suspicions, has_collective_only).
+
+    - bib_authors: list of "Family, Given" strings for BibTeX `author = {...}`.
+      Corporate (<CollectiveName>) authors are double-braced.
+    - display_authors: list of "Last First" strings for human-readable output.
+    - first_author_last: surname of the first listed author (used for cite key).
+    - suspicions: list of human-readable warning strings (East Asian reverse
+      encoding, missing LastName, etc.).
+    - has_collective_only: True if AuthorList contains only <CollectiveName>
+      entries (no individual <LastName>). Caller should consider emitting
+      `@misc` instead of `@article` (guideline / consortium pattern).
+    """
+    bib_authors: list[str] = []
+    display_authors: list[str] = []
+    first_author_last = ""
+    suspicions: list[str] = []
+    individual_count = 0
+    collective_count = 0
+
+    if author_list_el is None:
+        return bib_authors, display_authors, "", suspicions, False
+
+    for au in author_list_el.findall("Author"):
+        last = au.findtext("LastName", "") or ""
+        fore = au.findtext("ForeName", "") or ""
+        collective = au.findtext("CollectiveName", "") or ""
+
+        if collective:
+            collective_count += 1
+            # Double-brace to prevent BibTeX from splitting on the comma /
+            # spaces inside the corporate name.
+            bib_authors.append("{" + collective + "}")
+            display_authors.append(collective)
+            if not first_author_last:
+                first_author_last = re.sub(r"[^A-Za-z]+", "", collective.split()[0]) or "Group"
+            continue
+
+        if last:
+            individual_count += 1
+            if _looks_east_asian_reversed(last, fore):
+                suspicions.append(
+                    f"East Asian name order suspected for '{last} {fore}' — "
+                    "PubMed XML may have LastName/ForeName swapped"
+                )
+            bib_authors.append(f"{last}, {fore}")
+            display_authors.append(f"{last} {fore}".strip())
+            if not first_author_last:
+                first_author_last = last
+            continue
+
+        # Author element with neither <LastName> nor <CollectiveName>: rare
+        # but possible. Record as suspicion, otherwise skip.
+        suspicions.append("Author element with no LastName and no CollectiveName")
+
+    has_collective_only = collective_count > 0 and individual_count == 0
+    return bib_authors, display_authors, first_author_last, suspicions, has_collective_only
 
 
 def parse_esearch(data: str) -> None:
@@ -103,15 +188,9 @@ def parse_efetch(data: str) -> None:
         # Pages
         pages = art.findtext("Pagination/MedlinePgn", "")
 
-        # Authors
+        # Authors (handles East Asian reverse encoding + CollectiveName)
         author_list = art.find("AuthorList")
-        authors = []
-        if author_list is not None:
-            for au in author_list.findall("Author"):
-                last = au.findtext("LastName", "")
-                fore = au.findtext("ForeName", "")
-                if last:
-                    authors.append(f"{last} {fore}".strip())
+        _, authors, _, suspicions, _ = _extract_authors(author_list)
 
         # DOI
         doi = ""
@@ -137,6 +216,8 @@ def parse_efetch(data: str) -> None:
         print(f"**DOI**: {doi}")
         if abstract:
             print(f"**Abstract**: {shorten(abstract, width=500, placeholder='...')}")
+        for note in suspicions:
+            print(f"> ⚠ {note}")
         print()
 
 
@@ -177,21 +258,23 @@ def generate_bibtex(data: str) -> None:
                 doi = aid.text or ""
 
         author_list = art.find("AuthorList")
-        bib_authors = []
-        first_author_last = ""
-        if author_list is not None:
-            for au in author_list.findall("Author"):
-                last = au.findtext("LastName", "")
-                fore = au.findtext("ForeName", "")
-                if last:
-                    bib_authors.append(f"{last}, {fore}")
-                    if not first_author_last:
-                        first_author_last = last
+        bib_authors, _, first_author_last, suspicions, has_collective_only = \
+            _extract_authors(author_list)
 
         # Generate citation key
         key = f"{first_author_last}_{year}_{pmid}" if first_author_last else f"PMID_{pmid}"
 
-        print(f"@article{{{key},")
+        # Corporate / consortium guideline (e.g., KDIGO, AHA/ACC) — emit as
+        # @misc so BibTeX styles render the body of the entry without trying
+        # to format a personal author. Vancouver / AMA CSL handle both
+        # @article and @misc with author = {{Organization Name}}.
+        entry_type = "misc" if has_collective_only else "article"
+
+        # Prepend suspicion comments so they survive .bib copy/paste audits.
+        for note in suspicions:
+            print(f"% [VERIFY] {note}")
+
+        print(f"@{entry_type}{{{key},")
         print(f"  author    = {{{' and '.join(bib_authors)}}},")
         print(f"  title     = {{{title}}},")
         print(f"  journal   = {{{journal_full}}},")


### PR DESCRIPTION
# PR T2-B: parse_pubmed East Asian + CollectiveName handling

## Summary

Adds two anti-hallucination heuristics to
`skills/search-lit/references/parse_pubmed.py`:

1. **East Asian name reverse encoding** — detects `<LastName>` /
   `<ForeName>` swap (LastName ≥3 alpha chars + ForeName 1-2 alpha
   chars), emits `% [VERIFY]` comment above the BibTeX entry and a ⚠
   note in efetch markdown. Author order preserved verbatim; the
   script never silently swaps.
2. **CollectiveName (corporate / consortium guideline) handling** —
   emits `{{Group Name}}` double-brace author + switches BibTeX entry
   type from `@article` to `@misc` when AuthorList contains only
   `<CollectiveName>` entries.

## Motivation

Cross-project observations:

- A first-author "Fu 2024" PubMed XML entry encoded the given name in
  LastName and the family name in ForeName. Naive parsers produced a
  BibTeX entry with the wrong first-author surname; downstream
  `/verify-refs` first-author cross-check then flagged a mismatch
  against the authoritative PubMed efetch source. The pre-detection
  heuristic in this PR raises a `% [VERIFY]` flag at bib-generation
  time so the user is aware before the downstream audit catches it.
- KDIGO 2024 CKD guideline citations: the AuthorList contains
  `<CollectiveName>KDIGO Working Group</CollectiveName>`. Previously
  these authors were silently dropped, leaving the BibTeX entry with
  an empty author field. The new handling emits the corporate name as
  a double-braced author and switches to `@misc`, matching the
  `manuscript-references` corporate-author convention.

Both heuristics align with the v2.10 INTAKE Phase 4 deferred backlog
items from the East Asian name / corporate author E2E feedback cycle.

## Changes

- `skills/search-lit/references/parse_pubmed.py`:
  - new `_looks_east_asian_reversed(last, fore)` helper
  - new `_extract_authors(author_list_el)` helper (returns bib /
    display authors, first author surname, suspicions list, and a
    `has_collective_only` flag)
  - `parse_efetch` uses the helper and prints ⚠ notes for each suspicion
  - `generate_bibtex` uses the helper, prepends `% [VERIFY]` comments,
    and switches entry type to `@misc` when corporate-only

## Test plan

- [x] `validate_skills.sh` ALL CHECKS PASSED
- [x] `validate_skill_contracts.py` 0 failures
- [x] Smoke test against synthetic XML containing Fu 2024 reverse case
      + KDIGO Working Group CollectiveName case. Both produce correct
      output with appropriate ⚠ / `% [VERIFY]` notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)