### PR TITLE
feat(revise,humanize): response-to-reviewers (R2R) voice methodology

### DIFF
--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanize
-description: Detect and remove AI writing patterns from academic manuscripts. Scans for 21 common AI-generated text patterns and rewrites flagged passages to sound naturally human-written while preserving technical accuracy.
+description: Detect and remove AI writing patterns from academic manuscripts and response-to-reviewers letters. Scans for 24 common AI-generated text patterns and rewrites flagged passages to sound naturally human-written while preserving technical accuracy.
 triggers: humanize, AI patterns, AI 문체, remove AI writing, make it sound natural, 자연스럽게, de-AI
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
@@ -20,7 +20,7 @@ wrote it, while preserving every technical claim, number, and citation.
 
 ## Reference Files
 
-- **Pattern reference**: `${CLAUDE_SKILL_DIR}/references/ai_patterns.md` -- full 21-pattern list with expanded examples for medical/radiology manuscripts (Pattern 19–21 added 2026-05-01 from senior MA reviewer feedback)
+- **Pattern reference**: `${CLAUDE_SKILL_DIR}/references/ai_patterns.md` -- full 24-pattern list with expanded examples for medical/radiology manuscripts (Pattern 19–21 are senior-MA-reviewer red flags; Pattern 22–24 are response-to-reviewers letter patterns)
 - **Source material**: Based on matsuikentaro1/humanizer_academic and Wikipedia: Signs of AI writing
 
 Always read the pattern reference file at the start of a humanize session.
@@ -31,7 +31,8 @@ Always read the pattern reference file at the start of a humanize session.
 
 ### Phase 1: Scan
 
-Read the manuscript section(s) provided by the user and scan for all 21 patterns.
+Read the manuscript section(s) provided by the user and scan for all 24 patterns. For
+response-to-reviewers letters and cover letters, prioritise patterns 22-24.
 
 **For each pattern found:**
 1. Record the pattern number and name.
@@ -70,7 +71,7 @@ Present findings to the user with actionable summary.
 - **LOW** (0 occurrences): Clean for this pattern.
 
 **AI Pattern Score:**
-- Count total pattern instances across all 21 categories.
+- Count total pattern instances across all 24 categories.
 - Compute density: instances per 1000 words.
 - Target: < 2.0 instances per 1000 words.
 
@@ -106,7 +107,7 @@ Rewrite flagged passages following these rules:
 
 ### Phase 4: Verify
 
-Re-scan the rewritten text using the same 21 patterns.
+Re-scan the rewritten text using the same 24 patterns.
 
 **Output: Verification Report**
 
@@ -130,7 +131,7 @@ If the density remains above 2.0, run another fix-verify cycle (max 3 rounds).
 
 ---
 
-## The 21 Detection Patterns
+## The 24 Detection Patterns
 
 ### Content Patterns
 
@@ -178,6 +179,14 @@ If the density remains above 2.0, run another fix-verify cycle (max 3 rounds).
 | 20 | Methods/Results self-reference parenthetical | "(Methods §X)", "(Results §3.1)", "(Methods, Section 2.3)" | Drop the parenthetical or shorten to "(see Methods)" |
 | 21 | AI Disclosure boilerplate (body) | "## Artificial Intelligence Disclosure", "Generative AI was not used to create..." in manuscript body | Remove from body → place in cover letter / submission form only (per `~/.claude/rules/journal-ai-image-policies.md`) |
 
+### Response-Letter Patterns (R2R)
+
+Patterns 22-24 apply only when scanning a response-to-reviewers letter or editor cover letter,
+not manuscript bodies. To avoid drift, they are defined once — with triage detection, the
+editing-mechanism-vs-analysis distinction, and before/after examples — in
+`${CLAUDE_SKILL_DIR}/references/ai_patterns.md` (Response-Letter Patterns section). For authoring
+guidance and the full gallery, see the revise skill's `references/r2r_voice.md`.
+
 ---
 
 ## Section-Specific Focus
@@ -195,6 +204,7 @@ When scanning a full manuscript, prioritize these patterns per section:
 | Methods (MA / SR) | 19, 20, 21 | § markers, self-reference parentheticals, AI Disclosure boilerplate are senior-MA-reviewer red flags |
 | Discussion (MA / SR) | 19, 20 | Self-reference parentheticals especially common when discussing methods |
 | Body (any) | 21 | AI Disclosure belongs in cover letter / submission form, not manuscript body |
+| Response to Reviewers / cover letter | 22, 23, 24 (+ 13, 16, 19) | Editing-mechanism narration, internal draft line numbers, and tooling leaks are the dominant tells in machine-drafted rebuttals (see ai_patterns.md R2R section) |
 
 ---
 
@@ -204,6 +214,7 @@ When scanning a full manuscript, prioritize these patterns per section:
 |---------------|---------------------------|
 | `/write-paper` | Phase 7 (Polish) -- automatic scan before submission |
 | `/peer-review` | When reviewing one's own manuscript for AI patterns |
+| `/revise` | When drafting response-to-reviewers letters and cover letters -- patterns 22-24 are the enforced gate before submission |
 
 When called by another skill, return the verification report so the calling skill can check
 the pass/fail status.
@@ -235,5 +246,6 @@ the pass/fail status.
 | Pattern 19 — `§` symbol | ENFORCED (senior MA reviewer prep) | `grep -c "§" manuscript.md` > 0 | auto-strip; verify post-rewrite count == 0 |
 | Pattern 20 — `(see Methods §X)` self-reference | ENFORCED | match found | rewrite to direct section name reference |
 | Pattern 21 — AI Disclosure paragraph in body | ENFORCED | "Generative AI was not used..." paragraph in manuscript body | move to cover letter or remove |
+| Patterns 22-24 — R2R editing-mechanism / draft line-number / tooling leak | TRIAGE (response letters); `§` = 0 hard | detection greps in ai_patterns.md R2R section surface candidates | review each hit (analysis narration, quoted additions, revised-manuscript page/line are NOT tells); rewrite confirmed tells to substantive prose |
 | Citation preservation invariant | ENFORCED | any pre-existing `[@bibkey]` removed by rewrite | revert that single rewrite; flag for user |
 | Numerical preservation invariant | ENFORCED | any number changed by rewrite | revert; flag for user |

--- a/skills/humanize/references/ai_patterns.md
+++ b/skills/humanize/references/ai_patterns.md
@@ -1,7 +1,9 @@
 # AI Writing Pattern Reference for Medical/Radiology Manuscripts
 
-Detailed reference for the 18 AI writing patterns, with expanded examples and suggested
-rewrites specifically tailored for medical imaging and radiology research.
+Detailed reference for the 24 AI writing patterns, with expanded examples and suggested
+rewrites specifically tailored for medical imaging and radiology research. Patterns 1-18 are
+the general set; 19-21 are senior-MA-reviewer red flags; 22-24 are response-to-reviewers (R2R)
+letter patterns.
 
 Sources:
 - matsuikentaro1/humanizer_academic (English 18 patterns)
@@ -407,12 +409,84 @@ AI 모델이 본문에서 섹션을 가리킬 때 `§` 기호를 자주 사용. 
 
 ---
 
+## Response-Letter Patterns (R2R)
+
+These three patterns are specific to response-to-reviewers (R2R) letters and editor cover
+letters. They rarely appear in manuscript bodies but dominate machine-drafted rebuttals,
+where the model narrates the editing process instead of the science. Apply them whenever the
+text under review is a response letter or cover letter. See the revise skill's
+`references/r2r_voice.md` for full before/after skeletons. Examples below are synthetic
+(a fictional deep-learning lung-nodule CT study).
+
+### Pattern 22: Editing-Mechanism / Change-Log Narration
+
+The response prose narrates *how the text was edited* — what was added, where, how many phrases
+were swapped, which pass produced it — instead of stating what changed and why. The reviewer
+reads this as auto-generated and as checklist-clearing rather than scientific engagement.
+
+**Scope — this targets editing-mechanism narration only (avoid over-flagging):** narrating a
+*new analysis you ran* ("we performed a sensitivity analysis restricted to one eye per patient,
+and the result held") is the science the reviewer asked for — never flag it. Likewise "we added
+a sentence to the Methods: '...'", structured `Response:` / `Changes made:` blocks, and
+`Original → Revised` before/after pairs are normal human conventions. The tell is the *editing
+mechanism* layered on top, not the act of describing, quoting, or locating a change.
+
+**Watch phrases (the tell):** version-prefixed edits ("v2 Methods adds one sentence"), "we
+softened six phrases", "demoted the term at all N locations", "a grep-and-soften pass", "the v2
+revision changes", bare "No further manuscript change" stubs, "reframed via the vocabulary cascade".
+
+| # | BAD (editing-mechanism) | GOOD (substantive / science) |
+|---|---|---|
+| 1 | "v2 Methods adds one sentence: '...'. This is a short visible clarification rather than only in the Limitations." | "We agree the design is observational; we have added to the Methods: '...'" |
+| 2 | "We softened six over-interpretive phrases in Results and Discussion." | "We have rephrased the over-interpretive passages; for example, '...' now reads '...'." |
+| 3 | "No further manuscript change was applied." | "The existing Discussion text already addresses this; the relevant statement is '...'." |
+
+**Detection (triage, not auto-fail):** `grep -inE "v[0-9]+ .*(add|demote|soften|reframe)|softened [0-9a-z]+ phrases|no further (manuscript )?change|grep-and-soften|vocabulary cascade|demoted .* at all [0-9]+" response_to_reviewers.md` — review each hit and flag only genuine editing-mechanism narration, never analysis narration or quoted additions.
+**Fix strategy:** Delete the mechanism narration. State the substantive change and quote the new sentence; omit how it was found or made.
+
+### Pattern 23: Internal Line-Number Reference Tone
+
+Pointing reviewers to internal draft/markdown line numbers ("(line 43)", "at lines 43, 49,
+58, 60, 77–79"). These never match the reviewer's view of the revised manuscript and read as
+a diff log. Section names are what authors actually use.
+
+| # | BAD | GOOD |
+|---|-----|------|
+| 1 | "We clarified this at line 43." | "We clarified this in the Methods (Design subsection)." |
+| 2 | "Single-sentence clarifications were added at lines 43, 49, 58, 60, and 77–79." | "We added short clarifications to the Methods covering the design, the intervention, and the outcome definitions." |
+| 3 | "v2 line 127 retains this sentence and adds the adjustment after it." | "In the Results (Between-group comparison) we retained the original sentence and added the adjustment immediately after." |
+
+**Not a tell:** a **revised-manuscript** page/line ("page 7, lines 177-178") when the letter
+states once that all page/line numbers refer to the revised manuscript the reviewer is reading.
+The tell is the *internal draft* line number that will not match the reviewer's PDF.
+
+**Detection:** `grep -inE "\(line [0-9]+|at lines? [0-9]+|line [0-9]+(–|-)[0-9]+" response_to_reviewers.md` → review each hit; keep only those that demonstrably point to the revised manuscript.
+**Fix strategy:** Replace internal/draft line numbers with a section name; keep revised-manuscript page/line only if it matches what the reviewer sees.
+
+### Pattern 24: Tooling / Scaffolding Leak
+
+Exposing internal tooling, verification mechanics, or draft scaffolding to the reviewer:
+grep counts, internal FIX/category codes, references to "the circulated bundle" or "the
+internal supplementary index", or `§` self-references carried into the response letter.
+
+| # | BAD | GOOD |
+|---|-----|------|
+| 1 | "Final grep verification returned zero occurrences across the circulated bundle." | (delete — describe the corrected wording instead) |
+| 2 | "Addressed via the FIX-1 vocabulary cascade." | "We replaced [old term] with [new term] throughout the manuscript." |
+| 3 | "These strings remain only in the internal supplementary index, which is not part of the circulated bundle." | (delete — never reference internal scaffolding to a reviewer) |
+| 4 | "as reframed in §Discussion" | "as reframed in the Discussion" |
+
+**Detection (triage, except `§`):** `grep -inE "grep verification|grep-and-soften|circulated bundle|internal (supplementary )?index|FIX-[0-9]|vocabulary cascade|§" response_to_reviewers.md cover_letter.md` — only `§` is a hard 0 (always a tell). The other terms can rarely be legitimate (e.g., "a cascade detector", "we grep-checked our own data pipeline"), so confirm each hit is an internal-tooling reference before flagging.
+**Fix strategy:** Strip confirmed references to internal tooling, verification passes, and draft scaffolding. The reviewer should see only the science and the substantive changes.
+
+---
+
 ## Section-Specific Application Guide
 
 ### Abstract (ALL patterns)
 
 The abstract is the most visible section and the most likely to be checked for AI writing.
-Apply all 18 patterns with zero tolerance.
+Apply all applicable patterns (1-21) with zero tolerance.
 
 **Common abstract issues:**
 - Pattern 1 in the Background sentence.
@@ -448,6 +522,15 @@ Apply all 18 patterns with zero tolerance.
 - The conclusion should be 1-3 sentences stating the main finding and its specific implication.
 - No significance inflation, no generic optimism.
 
+### Response to Reviewers / Cover letter (Patterns 22, 23, 24 — plus 13, 16, 19)
+
+- Response letters and cover letters are reviewer-facing argument, not change-logs. The
+  dominant AI-tell here is the editing-mechanism register (Pattern 22), internal draft
+  line-number pointers (Pattern 23), and tooling/scaffolding leaks (Pattern 24).
+- Also sweep for em dashes (13), filler phrases (16), and `§` markers (19).
+- Patterns 1-18 still apply where relevant, but 22-24 are the highest-yield checks for this
+  document type.
+
 ---
 
 ## Quick Checklist (Pre-Submission)
@@ -471,3 +554,9 @@ Run this checklist on the final manuscript before submission:
 - [ ] § (section sign) 0건 (Pattern 19) — `grep -c "§"` = 0
 - [ ] (Methods §X) / (Results §Y) self-reference 0건 (Pattern 20)
 - [ ] AI Disclosure boilerplate 본문 0건 (Pattern 21) — cover letter / submission form 전용
+
+### Response letters / cover letters only (Patterns 22-24)
+
+- [ ] No editing-mechanism narration (Pattern 22) — "v2 adds one sentence", "softened N phrases", "No further manuscript change" (analysis narration and quoted additions are fine)
+- [ ] No internal draft line-number pointers (Pattern 23) — "(line NN)", "at lines N, M" (revised-manuscript page/line is fine)
+- [ ] No tooling/scaffolding leak (Pattern 24) — "grep", "FIX-N", "circulated bundle", "internal index", `§`

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -25,6 +25,12 @@ When the user provides reviewer comments (pasted text, PDF, or file path), or re
 
 ---
 
+## Reference Files
+
+- **Response-letter voice gallery**: `${CLAUDE_SKILL_DIR}/references/r2r_voice.md` -- before/after examples, three response skeletons (accept / partial-accept / polite-rebuttal), and a meta-phrase-to-natural conversion table. Read it before drafting the Response to Reviewers document.
+
+---
+
 ## Step 1: Parse and Number All Comments
 
 Read the full decision letter. Extract every discrete comment from every reviewer and the editor.
@@ -226,6 +232,8 @@ We believe this issue does not warrant [the specific change requested]
 because [reason]. We hope the reviewer finds this explanation satisfactory.
 ```
 
+**Voice caution:** The acknowledgment lines in these templates are schematic placeholders, not literal text to paste under every comment. Repeating the same opener ("We thank the reviewer for this important suggestion.") across a dozen responses is itself an AI-tell that careful reviewers notice. Vary the openers and apply the **Response-Letter Voice & AI-Tell Avoidance** section below before finalizing any response.
+
 ---
 
 ## 5-Category Triage Strategy
@@ -302,6 +310,49 @@ carefully read the manuscript:
 
 ---
 
+## Response-Letter Voice & AI-Tell Avoidance
+
+A response-to-reviewers letter is a reviewer-facing scientific argument, not an internal
+change-log. The dominant AI-tell in machine-drafted letters is the **editing-mechanism
+register**: prose that narrates *how the text was edited* ("the revised Methods adds one
+sentence at line 88", "a grep-and-soften pass replaced six phrases", "no further manuscript
+change") instead of stating, in plain language, what changed and why.
+
+Three principles when drafting (the AI-tell patterns themselves are defined once in humanize
+`references/ai_patterns.md`, patterns 22-24 — this section is the authoring guidance):
+
+1. **Write the change and the science, not the editing mechanism.** Describe what changed and
+   why, and quote the new sentence. Never narrate the diff: no version prefixes ("v2 adds..."),
+   no "softened N phrases", no grep/verification language, no internal FIX codes, no bare "No
+   further manuscript change" stubs. Describing a *new analysis you ran* ("we performed a
+   sensitivity analysis and found X") is the science, not a tell — that is welcome.
+2. **No `§` symbols, no internal draft line numbers.** A revised-manuscript page/line
+   ("page 7, lines 177-178", stated once as referring to the revised manuscript) is fine;
+   only internal draft line numbers that will not match the reviewer's view are banned.
+3. **Format is free.** Free prose, a structured `Response:` / `Changes made:` block, an
+   `Original → Revised` pair, or a left-comment/right-response table are all standard human
+   conventions. Pick any; strip only the mechanism narration.
+
+### Reviewer-facing tone
+
+- **Vary openers.** "We thank the reviewer for this point." / "We agree." / "This is an important concern." / "We have addressed this as follows." Do not repeat one acknowledgment sentence down the whole letter.
+- **Calibrate the stance**: full agreement, partial agreement with a bounded clarification, or a polite, evidence-backed rebuttal. Match the register to the substance.
+- **Admit error plainly** when the reviewer is right ("The reviewer is correct; we have corrected this.") — natural humility reads as human and builds editor trust.
+- **Quote the new manuscript text** verbatim in quotation marks, then name its section — what experienced authors do, and the single strongest human signal across real letters.
+
+See `${CLAUDE_SKILL_DIR}/references/r2r_voice.md` for the before/after gallery, response
+skeletons, and the meta-phrase conversion table.
+
+### Mandatory pre-submission scan
+
+Before circulating or uploading the response letter and cover letter, run `/humanize` on
+**both documents**. The R2R AI-tell patterns (22-24) are defined in humanize
+`references/ai_patterns.md`; together with 13 (em dash), 16 (filler), and 19 (`§`) they form
+the response-letter scan. Also apply `~/.claude/rules/manuscript-style-classical.md` (`§`,
+em-dash, heading discipline) — the same senior-reviewer red flags apply to the letter.
+
+---
+
 ## Step 5: Cover Letter to Editor
 
 **Output location:** `revision/R[N]/cover_letter_R[N].md`
@@ -354,6 +405,10 @@ After all responses are drafted, check:
 - [ ] Every REBUTTAL is backed by cited evidence or clear scientific reasoning
 - [ ] All new statistics include 95% CI and exact p-values
 - [ ] Page/line number references match the revised manuscript (not the original)
+- [ ] No internal draft line numbers ("(line 43)"); locations point to section names or revised-manuscript page/line
+- [ ] No `§` symbols and no editing-mechanism narration ("v2 adds one sentence", "grep verification", "No further manuscript change")
+- [ ] Acknowledgment openers varied (not one sentence repeated across responses)
+- [ ] Response letter AND cover letter ran through `/humanize` (patterns 22-24 triage hits reviewed; confirmed instances = 0; `§` = 0 hard)
 - [ ] Cover letter is addressed to the correct editor
 - [ ] Response letter is 5000-8000 words
 - [ ] Tracked changes are enabled in the revised manuscript
@@ -413,3 +468,4 @@ For R2+, acknowledge whether R1 concerns were fully resolved. If a reviewer rais
 | `/verify-refs --strict` post-revision | ENFORCED | FABRICATED / HIGH_MISMATCH_FIRST_AUTHOR > 0 | HALT R1 submission |
 | New analysis coordination | ENFORCED | reviewer asks for new analysis | route to `/analyze-stats` (and `/make-figures` if figure changes); never hand-write new numbers |
 | Cover letter to editor | ENFORCED at R1 submission | R1 missing editor cover letter | block submission |
+| Response-letter voice / AI-tell | ENFORCED before submission | editing-mechanism narration, internal draft line refs, `§`, tooling leak, or repeated openers in response/cover letter | run `/humanize` (patterns 22-24 as triage; `§` = 0 hard); resolve confirmed tells before submission |

--- a/skills/revise/references/r2r_voice.md
+++ b/skills/revise/references/r2r_voice.md
@@ -1,0 +1,242 @@
+# Response-Letter Voice Reference (R2R / Rebuttal)
+
+A reference for writing response-to-reviewers (R2R) letters and editor cover letters that
+read as human-written scientific argument rather than machine-generated change-logs. Use
+alongside the **Response-Letter Voice & AI-Tell Avoidance** section of the revise SKILL.md.
+
+All examples below are **synthetic** (a fictional deep-learning lung-nodule CT study) and are
+illustrative only. They contain no real study, author, or institution.
+
+Sources:
+- matsuikentaro1/humanizer_academic principles (general AI-writing patterns)
+- Register calibrated from the conventions of published point-by-point response letters
+
+---
+
+## The core problem: the editing-mechanism register
+
+Machine-drafted response letters narrate *how the text was edited* instead of the *science*.
+The result reads like a diff log: which line changed, how many phrases were swapped, what a
+verification pass returned. A careful reviewer reads this as auto-generated and as evidence
+the authors are clearing a checklist rather than engaging with the critique.
+
+The fix is one habit: **state what changed and why in plain prose, quote the new sentence,
+name the section — and say nothing about the mechanism by which you found or made the edit.**
+
+This targets the *editing* mechanism only. Narrating a **new analysis you ran** is the science
+the reviewer asked for and is welcome — e.g., "we performed a sensitivity analysis restricted to
+one observation per patient, and the primary findings held." The tell is describing the
+text-editing operation ("we softened six phrases", "v2 adds a sentence"), not describing the
+analysis or its result.
+
+---
+
+## Two acceptable formats (the structure is not the problem)
+
+Real published response letters use any of several formats, and all read as human:
+
+- **A. Free prose** — "We agree. We have added to the Methods: '...'."
+- **B. Structured** — a `Response:` paragraph followed by a `Changes made:` (or `Action taken in
+  the revised manuscript:`) block, often with `Original: '...'` → `Revised: '...'` before/after
+  pairs and the section and revised-manuscript page/line.
+- **C. Two-column table** — reviewer comment on the left, author response on the right.
+
+Other normal conventions seen across real letters: restating the reviewer's comment before
+responding, and numbering multiple changes within one response as (1), (2), (3).
+
+The AI-tell is **not** the structure, the tables, or the before/after pairs — careful authors
+write all of these. The tell is the **editing-mechanism narration** layered on top: version
+prefixes ("v2 adds..."), internal draft line numbers, grep/verification language, internal FIX
+codes, `§` markers, and bare "No further manuscript change" stubs. Keep whichever format you
+like; strip the mechanism.
+
+---
+
+## Before / after gallery
+
+### 1. Version-prefixed change narration + internal line numbers
+
+> Reviewer: The causal language overstates an observational design.
+
+**AI-tell (bad):**
+"v2 Methods §Design (line 43) adds one sentence: 'The user/non-user contrast is reported
+descriptively and is not interpreted as evidence of efficacy.' This is a short visible
+clarification in the manuscript body rather than only in the Limitations."
+
+**Natural (good):**
+"We agree. The design is observational, so we have added a sentence to the Methods (Design
+subsection) making the descriptive intent explicit: 'The user/non-user contrast is reported
+descriptively and is not interpreted as evidence of efficacy.' The corresponding causal
+phrasing in the Results has been removed."
+
+Why: the natural version keeps the quoted new sentence and a section-name pointer but drops
+the version prefix, the `§` marker, the internal line number, and the meta-commentary about
+*where* the clarification sits.
+
+### 2. Tooling / verification leak
+
+> Reviewer: Several results are described as "numerical trends," which is speculative.
+
+**AI-tell (bad):**
+"A grep-and-soften pass replaced six phrases. Final grep verification across the manuscript
+and the circulated supplementary tables returned zero occurrences of 'numerical trend',
+'consistent direction', or 'possible relationship'."
+
+**Natural (good):**
+"We have rephrased these passages so that non-significant point estimates are no longer
+presented as trends. For example, 'users showed a numerically larger reduction' now reads
+'the point estimate favoured the user arm, but the 95% confidence interval crossed zero and
+is uninformative for inference.'"
+
+Why: the reviewer cares about the corrected wording and the principle behind it, not that the
+authors ran a search to confirm the strings were gone.
+
+### 3. Redundant "no change" stubs
+
+> Reviewer: Retention was low.
+
+**AI-tell (bad):**
+"This was already reported in v1. No further manuscript change was applied."
+
+**Natural (good):**
+"We have kept the retention figure but moved it to the front of the Conclusions so it leads
+the feasibility assessment rather than appearing as an aside: the final retention of 58%
+fell short of the 80% target and is the binding constraint on the present pilot."
+
+Why: even when little changes, reply with substance. A bare "no change" stub repeated across
+comments is a hallmark of checklist-driven drafting.
+
+### 4. Uniform openers
+
+**AI-tell (bad):** every response begins "We thank the reviewer for this important suggestion."
+
+**Natural (good):** vary by stance —
+- "We agree, and have revised accordingly."
+- "This is a fair concern about generalisability."
+- "We see how the original wording invited this reading; we have corrected it."
+- "We respectfully maintain the original analysis, for the reasons below."
+
+### 5. Admitting an error
+
+**AI-tell (bad):**
+"v3 corrects the acquisition-time value at line 211 per the reviewer's observation."
+
+**Natural (good):**
+"The reviewer is correct. During revision we found an error in the reported acquisition time;
+the correct value is 15 s per phase. We have corrected this in the Methods and apologise for
+the oversight."
+
+### 6. Tempering an over-claim (the most common revision task)
+
+> Reviewer: Several results are described as "significantly outperformed," but the confidence
+> intervals overlap; this overstates the evidence.
+
+**AI-tell (bad):**
+"v2 grep-and-soften pass replaced 'significantly outperformed' at lines 14, 88, and 203. Final
+grep verification across the circulated manuscript returned zero occurrences of
+'significantly', 'consistent direction', or 'numerical superiority' (§Results, §Discussion).
+FIX-2 vocabulary cascade applied."
+
+**Natural (good):**
+"We fully agree. Given the overlapping 95% confidence intervals, 'significantly outperformed'
+overstated the evidence. We have tempered this language in the Abstract, Results, and
+Discussion to describe the difference as a modest, consistent improvement rather than a
+statistically significant one. For example, in the Results:
+*Original:* 'the 2.5D model significantly outperformed the 2D model.'
+*Revised:* 'the 2.5D model achieved a modestly higher C-index (0.71 vs 0.68); the confidence
+intervals overlap, so this is a consistent but not statistically significant difference.'"
+
+Why: the natural version makes the same correction the reviewer asked for, shows the exact
+before/after wording, and names the affected sections — without the grep narration, the
+internal line numbers, the `§` markers, or the internal FIX label.
+
+---
+
+## Three response skeletons
+
+Pick the skeleton that matches the comment's substance; do not force every reply into one shape.
+
+### A. Full agreement (most common)
+
+> [quote the reviewer comment]
+
+"We agree. We have [substantive change] in the [section]. The revised text reads:
+'[new sentence verbatim].'"
+
+Keep it to 2-5 sentences. Quote the new text; name the section; stop.
+
+### B. Partial agreement with a bounded clarification
+
+> [quote the reviewer comment]
+
+"The reviewer raises a valid point about [aspect]. We have [the part you accept] in the
+[section]. We have not [the part you decline] because [specific scientific reason]; instead,
+we [the bounded alternative], which addresses the underlying concern without [the cost of the
+full request]."
+
+### C. Polite, evidence-backed rebuttal
+
+> [quote the reviewer comment]
+
+"We understand the concern that [restate the reviewer's point fairly]. We respectfully
+maintain [your position] because [reasoning grounded in the data or design]. [If literature
+supports you: 'This is consistent with (Author, Year), who showed ...'] To make this clearer
+to readers, we have added a sentence to the [section]: '[new sentence].'"
+
+Never open a rebuttal combatively, and never write "the reviewer is wrong." Frame disagreement
+as a shared interest in getting the interpretation right.
+
+### Graceful defer (when you decline an addition but want to leave the door open)
+
+"We considered [the requested addition], but believe [the change already made] adequately
+addresses the underlying concern without [the cost]. If the reviewer prefers, we are happy to
+add [the requested item] in a subsequent revision."
+
+This is a common, courteous move: it shows you took the request seriously, gives a reason, and
+defers rather than flatly refusing.
+
+---
+
+## Meta-phrase to natural-expression conversion
+
+| Editing-mechanism phrase | Natural reviewer-facing phrasing |
+|---|---|
+| "v2 adds one sentence at line 88" | "we have added to the [section]: '...'" |
+| "softened six over-interpretive phrases" | "we have rephrased the over-interpretive passages so that ..." |
+| "grep verification returned zero occurrences" | (delete entirely — describe the corrected wording instead) |
+| "No further manuscript change" | "the existing text in the [section] already addresses this; the relevant statement is ..." |
+| "the FIX-1 vocabulary cascade" | (delete — name the actual wording change) |
+| "(Methods §X)" / "see §Discussion" | "in the Methods" / "in the Discussion" |
+| "the internal supplementary index (not in the circulated bundle)" | (delete — never reference internal scaffolding) |
+| "demoted the term throughout at all 13 locations" | "we have replaced [old term] with [new term] throughout the manuscript" |
+
+---
+
+## Location-pointer rule
+
+- Point to changes by **section name** ("in the Methods, Statistical analysis subsection").
+- A **revised-manuscript page and/or line number is acceptable and common** ("Methods, page 7,
+  lines 177-178") *when those numbers refer to the revised manuscript the reviewer is reading*
+  (state once at the top: "all page and line numbers refer to the revised manuscript"). This
+  is a normal human convention, not an AI-tell.
+- What is banned is the **internal markdown/draft line number** ("line 43" pointing into your
+  working file) — it will not match the reviewer's PDF and reads as a diff log. If you cannot
+  guarantee the line number matches the reviewer's manuscript, use the section name only.
+- When the change is a sentence or two, **quote the new text** in quotation marks. This is
+  concrete, verifiable, and reads as the work of an author who knows their own manuscript.
+- For larger changes (a new paragraph, a restructured subsection), summarise the change in
+  one sentence and point to the section; do not transcribe the whole block.
+
+---
+
+## Pre-submission checklist (response letter + cover letter)
+
+- [ ] `grep -c "§"` = 0
+- [ ] No internal line-number references ("(line NN)", "at lines N, M, ...")
+- [ ] No version-prefixed change narration ("v2 adds...", "the v3 revision demotes...")
+- [ ] No tooling/verification leak ("grep", "softened N phrases", "circulated bundle", internal FIX labels)
+- [ ] No bare "No further manuscript change" stubs — each reply carries substance
+- [ ] Openers varied across responses
+- [ ] New manuscript text quoted verbatim where a sentence-level change was made
+- [ ] Em dashes below threshold (see humanize Pattern 13)
+- [ ] Ran `/humanize` on both documents; triage hits reviewed, confirmed patterns 22-24 instances = 0 (`§` = 0 hard)


### PR DESCRIPTION
## Summary
- Adds reviewer-facing voice / AI-tell-avoidance guidance for response-to-reviewers (R2R) letters and editor cover letters.
- **Single source of truth**: R2R detection patterns 22-24 are defined once in `humanize/references/ai_patterns.md`; the authoring gallery, response skeletons, and meta-phrase conversion table live once in `revise/references/r2r_voice.md`; both `SKILL.md` files are thin pointers (no duplicated definitions).
- Pattern 22 is scoped to **editing-mechanism / change-log narration** and explicitly excludes analysis/science narration. Detection is **triage** (review each hit); only the section sign is a hard zero. Revised-manuscript page/line references, quoted additions, and structured/table formats are explicitly NOT tells.
- Calibrated against real published author response letters across multiple radiology journals. All examples shipped in the skills are **synthetic** (a fictional radiology study).

## Test plan
- [x] `bash scripts/validate_skills.sh` — ALL CHECKS PASSED (0 failures, 0 meta-doc PII)
- [x] Patterns 22-24 defined in exactly one file (ai_patterns.md); SKILL.md files cross-link, do not redefine
- [x] False-positive self-test: patterns 22-24 flag nothing in the human-letter calibration set
- [x] No real author names, manuscript IDs, institutions, or personal paths in added content

🤖 Generated with [Claude Code](https://claude.com/claude-code)