### PR TITLE
feat(calc-sample-size): add observational cohort precision branch reference

### DIFF
--- a/skills/calc-sample-size/SKILL.md
+++ b/skills/calc-sample-size/SKILL.md
@@ -19,9 +19,11 @@ Python (alternative), interpret effect sizes clinically, and produce IRB-ready j
 ## Reference Files
 
 - **Formulas**: `${CLAUDE_SKILL_DIR}/references/formulas.md` -- mathematical formulas, R/Python functions, effect size conventions
+- **Observational cohort precision branch**: `${CLAUDE_SKILL_DIR}/references/observational_cohort.md`
 - **Existing R template**: See `analyze-stats` skill at `references/templates/sample_size.R` for the 7 original tests
 
 Read `formulas.md` before generating calculation code.
+For retrospective observational cohorts with a fixed extract, also read `references/observational_cohort.md` and report event budget / confidence-interval precision instead of forcing a prospective recruitment-style power calculation.
 
 ## Cross-Skill References
 

--- a/skills/calc-sample-size/references/observational_cohort.md
+++ b/skills/calc-sample-size/references/observational_cohort.md
@@ -1,0 +1,49 @@
+# Observational Cohort Sample Size: Precision Branch
+
+Use this reference when a cohort study is extraction-constrained or when the goal is precision rather than formal power.
+
+## When To Use
+
+- Retrospective hospital-based cohort with all eligible records included.
+- National database cohort where the sample is fixed by release permissions.
+- Sparse-event outcome where the real question is whether confidence intervals are narrow enough to support a claim.
+
+## Core Checks
+
+1. Primary estimand: risk difference, odds ratio, hazard ratio, incidence rate, or mean difference.
+2. Event count: total events and events per modeled parameter.
+3. Precision target: acceptable confidence interval half-width or maximum acceptable upper bound.
+4. Model complexity: covariate count relative to events.
+5. Fragility: subgroup and sensitivity analyses with smaller denominators.
+
+## Rule-of-Thumb Gates
+
+| Situation | Minimum check |
+|---|---|
+| Logistic or Cox model | Events per parameter and shrinkage/penalization consideration |
+| Sparse binary outcome | Exact or profile-likelihood confidence intervals |
+| Incidence rate | Poisson exact CI around event rate |
+| Null association claim | Upper CI bound must exclude clinically meaningful effect |
+| Subgroup analysis | Interaction test plus event count per subgroup |
+
+## Manuscript Phrase
+
+"The study size was determined by all eligible participants in the released cohort. We therefore evaluated statistical informativeness by the number of outcome events, events per modeled parameter, and the width of the 95% confidence intervals around the primary estimate rather than by a conventional a priori recruitment target."
+
+## Minimal R Sketch
+
+```r
+events <- 130
+parameters <- 8
+epv <- events / parameters
+
+rate <- 130 / 250000
+poisson.test(130, T = 250000)$conf.int
+```
+
+## Reviewer-Safe Interpretation
+
+- If events are sparse, do not write "no association" without discussing the upper confidence bound.
+- If EPV is below 10, state that estimates are exploratory or use penalized/sparse models.
+- If a subgroup has few events, report it descriptively even when the p-value looks attractive.
+


### PR DESCRIPTION
## Summary
Adds a **precision-branch** reference for retrospective / fixed-extract observational cohorts to `calc-sample-size`. These designs are constrained by available records, not a prospective recruitment target — forcing a conventional a priori power calculation misframes the design and invites reviewer pushback.

## Changes
- **New** `skills/calc-sample-size/references/observational_cohort.md` — when-to-use, core checks (estimand / event count / precision target / model complexity / fragility), rule-of-thumb gates (EPV, exact CIs, Poisson exact, null-claim upper bound), a reviewer-safe manuscript phrase, a minimal R sketch, and reviewer-safe interpretation notes.
- **Edit** `skills/calc-sample-size/SKILL.md` — wire the new reference into Reference Files so the skill reaches for it when the cohort is extraction-constrained.

## Provenance
Salvaged from the stale local WIP branch `feat/tier1-PR6-preserved-wip` (2026-05-23). That branch's make-figures STROBE additions were superseded by PR #7; its `_pr_drafts/` were gitignored scratch. This reference file was the only OSS-clean, still-missing piece and is extracted as its own focused PR.

## Validation
- `bash scripts/validate_skills.sh` → ALL CHECKS PASSED (0 failures)
- `python3 scripts/validate_skill_contracts.py` → 0 contract failures
- No PII / personal paths (validator precedent + path blocklist clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)