### PR TITLE
feat(verify-refs): v1.3.0 — full-author cross-check via PubMed efetch

### DIFF
--- a/skills/verify-refs/SKILL.md
+++ b/skills/verify-refs/SKILL.md
@@ -69,13 +69,15 @@ Full checkpoint protocol: `references/manual_checkpoint_guide.md`.
 The script uses DOI, PMID, CrossRef, and PubMed E-utilities where available. If
 network verification fails, it records `UNVERIFIED` rather than silently passing.
 
-## Output Contract (v1.2.0)
+## Output Contract (v1.3.0)
 
 | Artifact | Path | Purpose |
 |---|---|---|
-| Audit JSON | `qc/reference_audit.json` | Sole output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, `duplicate_findings[]`, submission-safe flag, full records |
+| Audit JSON | `qc/reference_audit.json` | Sole output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, `cited_authors[]`/`actual_authors[]`, `duplicate_findings[]`, submission-safe flag, full records |
 
-**v1.2.0 (2026-05)** adds `duplicate_findings[]` to the audit JSON and bumps `schema_version` to 3. Verbatim PMID or DOI duplicates within the reference list are flagged as MAJOR findings (resolves `/peer-review` Phase 2A P7). DOI normalization strips `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes plus trailing slashes before comparison so `https://doi.org/10.x/abc/` and `10.x/abc` collapse to one key. Both `submission_safe` and `fully_verified` now require `duplicate_findings` to be empty.
+**v1.2.0 (2026-05)** adds `duplicate_findings[]` to the audit JSON. Verbatim PMID or DOI duplicates within the reference list are flagged as MAJOR findings (resolves `/peer-review` Phase 2A P7). DOI normalization strips `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes plus trailing slashes before comparison so `https://doi.org/10.x/abc/` and `10.x/abc` collapse to one key. Both `submission_safe` and `fully_verified` now require `duplicate_findings` to be empty.
+
+**v1.3.0 (2026-05)** extends the author cross-check from first-author-only to the **full author list** and bumps `schema_version` to 4. For BibTeX inputs, every cited author family name is compared index-by-index against the authoritative source, and the cited-vs-source author counts are compared. PubMed `efetch.fcgi` (XML full record) is the truth source when a PMID is present — it is authoritative for given/family names where CrossRef is not (a documented case where CrossRef returned a wrong given name that PubMed efetch corrected). Records now carry `cited_authors[]`, `actual_authors[]`, `cited_author_count`, and `actual_author_count`. Motivation: a real AI-assisted manuscript registered a reference with a correct first author but seven of ten fabricated co-author names, and the first-author-only check passed it. Plain-text / TSV inputs, which cannot be parsed into a confident full list, degrade gracefully to the first-author check.
 
 **Removed in Phase 1A.2** (per `docs/artifact_contract.md`):
 - `references/verified_references.tsv` — record-level details now live inside `reference_audit.json` under `records[]`.
@@ -99,31 +101,50 @@ Sole-writer enforcement: `scripts/validate_project_contract.py` will flag any `r
 - Gate 1: stop submission if any row is `FABRICATED`.
 - Gate 2: require user confirmation before accepting `UNVERIFIED` references.
 - Gate 3: rerun after any reference edits.
-- Gate 4 (added 2026-04-26): first-author surname is cross-checked against
-  CrossRef/PubMed. A row whose DOI resolves but whose cited first author does
-  not match the authoritative source is downgraded to `MISMATCH` with
-  `note = "first-author hallucination suspected"`. This catches the common
-  LLM failure mode where a real DOI is paired with an invented author name.
+- Gate 4 (added 2026-04-26; extended to full-author in v1.3.0): the cited
+  author list is cross-checked against the authoritative source (PubMed efetch
+  preferred, then CrossRef, then PubMed esummary). A row whose DOI/PMID resolves
+  but whose cited authors do not match — at any index, or in total count — is
+  downgraded to `MISMATCH`. First-author mismatches get
+  `note = "first-author hallucination suspected"`; #2..#N family or count
+  mismatches get `note = "non-first-author hallucination or count mismatch"`.
+  This catches the LLM failure mode where a real DOI is paired with invented
+  author names anywhere in the list, not just the lead author. Intentional CSL
+  et-al truncation (cited fewer than source) can be silenced per-entry with a
+  BibTeX `_audit_truncated = <N>` field.
 - Gate 5 (added 2026-05, v1.2.0): PMID/DOI duplicate detection within the
   reference list. Verbatim duplicates (same PMID or normalized DOI) — a common
   LLM citation-compilation artifact — are flagged as MAJOR findings in
   `duplicate_findings[]`. `submission_safe == true` requires the list to be
   empty. Resolves `/peer-review` Phase 2A P7.
 
-## First-Author Cross-Check (Detail)
+## Author Cross-Check (Detail)
 
-Driven by an actual incident: Paper 3 submitted to BMC Medical Education had
-ref 8 cited as "Ebrahimi S, et al." with the correct DOI for a Ballard et al.
-task force whitepaper. Pre-patch verify-refs marked it OK because DOI resolved.
-Post-patch it is correctly flagged as `MISMATCH`.
+Driven by two actual incidents. First (Gate 4 origin): a manuscript had a
+reference cited with a plausible lead author but the correct DOI for an entirely
+different author's whitepaper. Pre-patch verify-refs marked it OK because the
+DOI resolved; post-patch it is `MISMATCH`. Second (v1.3.0 extension): an
+AI-assembled `.bib` registered a reference with the correct first author but
+seven of ten fabricated co-author names — the first-author-only check passed it,
+and it would have shipped to reviewers. The full-author cross-check catches it.
 
-- Comparison is tolerant: case, diacritics, hyphen vs space, and name
-  particles ("von", "van", "de", ...) are normalized before matching.
-- If the cited surname cannot be parsed confidently (`first_author_guess`
-  empty), the check is skipped silently — no false MISMATCH from formatting
-  ambiguity.
+- The authoritative author list is taken from PubMed `efetch.fcgi` (XML) when a
+  PMID is present, falling back to CrossRef (DOI) and then PubMed esummary.
+  efetch is preferred because CrossRef is unreliable for given names.
+- For BibTeX inputs, the full cited list is parsed (`cited_authors[]`,
+  balanced-brace aware, LaTeX-accent tolerant) and compared family-by-family and
+  by total count against `actual_authors[]`.
+- Comparison is tolerant: case, diacritics (NFKD plus Turkish/Polish/Czech/
+  German/Nordic special letters), hyphen vs space, and name particles
+  ("von", "van", "de", ...) are normalized before matching.
+- If the cited authors cannot be parsed confidently, the check degrades to the
+  first-author surname comparison, and if even that is empty it is skipped
+  silently — no false MISMATCH from formatting ambiguity.
 - Title-only PubMed search does not return an authoritative author and is
   therefore excluded from this check.
+- Intentional truncation (a bib that cites only the first author, or first five
+  + et al., by design) would otherwise trip the count check; mark such entries
+  with `_audit_truncated = <N>` to downgrade the count mismatch to a note.
 
 ## What This Skill Does NOT Do
 

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -19,7 +19,7 @@ import time
 import urllib.parse
 import urllib.request
 import zipfile
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
@@ -37,7 +37,17 @@ class RefRecord:
     doi: str = ""
     pmid: str = ""
     year_guess: str = ""
-    first_author_guess: str = ""
+    first_author_guess: str = ""  # back-compat (= cited_authors[0] when available)
+    # v1.3.0: full author cross-check (AI-assisted-drafting hallucination motivation)
+    cited_authors: list = field(default_factory=list)        # family names parsed from bib/tsv/text
+    actual_authors: list = field(default_factory=list)        # family names from authoritative source
+    cited_author_count: int = 0
+    actual_author_count: int = 0
+    # v1.3.0: intentional truncate marker. Set via BibTeX field `_audit_truncated = N`
+    # (any non-empty value); when present, count mismatch is downgraded to a note
+    # and does not trigger MISMATCH status. Use when CSL renders first-1 or first-5
+    # + et al. and the trailing authors are deliberately omitted from the bib.
+    audit_truncated: bool = False
     status: str = "UNVERIFIED"
     evidence: str = ""
     note: str = ""
@@ -101,7 +111,24 @@ def parse_bib(text: str) -> list[RefRecord]:
         pmid_match = re.search(r"pmid\s*=\s*[\{\"]?(\d{5,9})", entry, re.I)
         year_match = re.search(r"year\s*=\s*[\{\"]?((?:19|20)\d{2})", entry, re.I)
         raw = normalize_space(entry)
-        author_match = re.search(r"author\s*=\s*[\{\"](.+?)[\}\"]\s*,", entry, re.I | re.S)
+        # Balanced-brace aware author capture (handles "\~{n}" LaTeX escapes that
+        # would otherwise terminate a non-greedy {.+?} match prematurely).
+        author_field = ""
+        am = re.search(r"author\s*=\s*\{", entry, re.I)
+        if am:
+            start = am.end()
+            depth = 1
+            j = start
+            while j < len(entry) and depth > 0:
+                if entry[j] == "{":
+                    depth += 1
+                elif entry[j] == "}":
+                    depth -= 1
+                j += 1
+            author_field = entry[start : j - 1]
+        cited = parse_bib_authors(author_field)
+        # v1.3.0: intentional truncate marker (any non-empty `_audit_truncated`)
+        trunc_match = re.search(r"_audit_truncated\s*=\s*[\{\"]?([^,}\"]+)", entry, re.I)
         records.append(
             RefRecord(
                 ref_id=key_match.group(1) if key_match else f"ref_{len(records)+1}",
@@ -110,7 +137,10 @@ def parse_bib(text: str) -> list[RefRecord]:
                 doi=clean_doi(doi_match.group(1)) if doi_match else "",
                 pmid=pmid_match.group(1) if pmid_match else "",
                 year_guess=year_match.group(1) if year_match else "",
-                first_author_guess=parse_first_author(author_match.group(1)) if author_match else "",
+                first_author_guess=cited[0] if cited else (parse_first_author(author_field) if author_field else ""),
+                cited_authors=cited,
+                cited_author_count=len(cited),
+                audit_truncated=bool(trunc_match and trunc_match.group(1).strip().lower() not in ("", "false", "0", "no")),
             )
         )
     return records
@@ -194,6 +224,34 @@ def parse_reference_lines(text: str) -> list[RefRecord]:
 _NAME_PARTICLES = {"von", "van", "de", "del", "della", "dos", "da", "le", "la", "du", "den", "der", "ten"}
 
 
+def parse_bib_authors(author_field: str) -> list:
+    """Parse BibTeX author field into a list of family-name strings.
+
+    Handles "Last, First and Last, First" and "First Last and First Last" forms.
+    Strips simple LaTeX accents and braces.
+    """
+    if not author_field:
+        return []
+    raw = re.sub(r"\s+", " ", author_field).strip()
+    parts = re.split(r"\s+and\s+", raw)
+    families: list[str] = []
+    for name in parts:
+        n = name.strip()
+        if not n:
+            continue
+        if "," in n:
+            family = n.split(",", 1)[0].strip()
+        else:
+            toks = n.split()
+            family = toks[-1] if toks else ""
+        # Strip simple LaTeX accents: \~{n}, \"{o}, \`{a} → underlying char
+        family = re.sub(r"\\[\"'`~^=.]?\{?([A-Za-zà-ÿ])\}?", r"\1", family)
+        family = re.sub(r"[{}]", "", family).strip()
+        if family and family != "others":
+            families.append(family)
+    return families
+
+
 def parse_first_author(raw: str) -> str:
     """Extract first-author surname from a Vancouver/AMA/BibTeX-style citation.
 
@@ -227,10 +285,24 @@ def parse_first_author(raw: str) -> str:
 
 
 def _normalize_surname(name: str) -> str:
-    n = name.lower().strip()
-    # strip diacritics best-effort
-    repl = str.maketrans("àáâãäåèéêëìíîïòóôõöùúûüñç", "aaaaaaeeeeiiiiooooouuuunc")
-    n = n.translate(repl)
+    """Strip diacritics + lowercase for surname comparison.
+
+    Coverage (v1.3.0): Latin-with-accents (NFKD decomposes), Turkish
+    (ş→s, ğ→g, ı→i), Polish/Czech (ł, đ — not NFKD-decomposable, handled below),
+    German ß→ss, Nordic ø/æ/œ → o/ae/oe. Motivation: a Turkish surname
+    `Çolakoğlu` vs PubMed `Colakoglu` false-positive MISMATCH.
+    """
+    import unicodedata
+    n = unicodedata.normalize("NFKD", name)
+    n = "".join(c for c in n if not unicodedata.combining(c))
+    n = n.lower().strip()
+    # Multi-char + non-NFKD-decomposable mappings
+    multi = {
+        "ß": "ss", "þ": "th", "ł": "l", "đ": "d", "ı": "i",
+        "ø": "o", "æ": "ae", "œ": "oe",
+    }
+    for k, v in multi.items():
+        n = n.replace(k, v)
     n = re.sub(r"[^a-z\s\-]", "", n)
     n = re.sub(r"\s+", " ", n).strip()
     return n
@@ -276,77 +348,148 @@ def http_json(url: str, timeout: int) -> dict | None:
         return None
 
 
-def verify_crossref(doi: str, timeout: int) -> tuple[str, str, str]:
-    """Returns (status, evidence, first_author_family)."""
+def verify_crossref(doi: str, timeout: int) -> tuple[str, str, list]:
+    """Returns (status, evidence, family_names).
+
+    v1.3.0: returns full author family list instead of first-author only.
+    CrossRef API is not authoritative for given names (documented case: CrossRef
+    returned "Vasileios", PubMed efetch & the curated record = "Victoria").
+    Use verify_pubmed_efetch as the truth source when PMID is available.
+    """
     url = "https://api.crossref.org/works/" + urllib.parse.quote(doi)
     data = http_json(url, timeout)
     if not data or data.get("status") != "ok":
-        return "UNVERIFIED", "CrossRef DOI lookup failed", ""
+        return "UNVERIFIED", "CrossRef DOI lookup failed", []
     msg = data.get("message", {})
     title = " ".join(msg.get("title") or [])
     year_parts = (((msg.get("issued") or {}).get("date-parts") or [[None]])[0])
     year = str(year_parts[0]) if year_parts and year_parts[0] else ""
-    authors = msg.get("author") or []
-    first_author = ""
-    if authors:
-        first_author = (authors[0].get("family") or authors[0].get("name") or "").strip()
+    authors_raw = msg.get("author") or []
+    families: list[str] = []
+    for a in authors_raw:
+        fam = (a.get("family") or a.get("name") or "").strip()
+        if fam:
+            families.append(fam)
     evidence = "CrossRef DOI OK"
     if title:
         evidence += f"; title={title[:120]}"
     if year:
         evidence += f"; year={year}"
-    if first_author:
-        evidence += f"; first_author={first_author}"
-    return "OK", evidence, first_author
+    if families:
+        evidence += f"; authors={len(families)} (first={families[0]})"
+    return "OK", evidence, families
 
 
-def verify_pubmed_pmid(pmid: str, timeout: int) -> tuple[str, str, str]:
-    """Returns (status, evidence, first_author_family)."""
+def verify_pubmed_pmid(pmid: str, timeout: int) -> tuple[str, str, list]:
+    """Returns (status, evidence, family_names).
+
+    Uses esummary (fast). Returns family-name approximation by stripping trailing
+    initial block from "Surname Initials" form. Authoritative names → call
+    verify_pubmed_efetch().
+    """
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?" + urllib.parse.urlencode(
         {"db": "pubmed", "id": pmid, "retmode": "json"}
     )
     data = http_json(url, timeout)
     if not data:
-        return "UNVERIFIED", "PubMed PMID lookup failed", ""
+        return "UNVERIFIED", "PubMed PMID lookup failed", []
     result = data.get("result", {})
     item = result.get(pmid)
     if not item:
-        return "FABRICATED", "PMID not found in PubMed", ""
+        return "FABRICATED", "PMID not found in PubMed", []
     if item.get("error"):
-        return "FABRICATED", f"PubMed PMID error: {item['error']}", ""
+        return "FABRICATED", f"PubMed PMID error: {item['error']}", []
     title = html.unescape(item.get("title", ""))
-    authors = item.get("authors") or []
-    first_author = ""
-    if authors:
-        # PubMed esummary "name" is "Surname Initials" e.g. "Reichheld FF"
-        full = (authors[0].get("name") or "").strip()
-        # strip trailing initials block
+    authors_raw = item.get("authors") or []
+    families: list[str] = []
+    for a in authors_raw:
+        if a.get("authtype") not in (None, "Author"):
+            continue
+        full = (a.get("name") or "").strip()
+        # esummary "name" is "Surname Initials" e.g. "Reichheld FF"
         m = re.match(r"^(.+?)\s+[A-Z]{1,4}$", full)
-        first_author = m.group(1).strip() if m else full
-    evidence = f"PubMed PMID OK; title={title[:120]}"
-    if first_author:
-        evidence += f"; first_author={first_author}"
-    return "OK", evidence, first_author
+        fam = m.group(1).strip() if m else full
+        if fam:
+            families.append(fam)
+    evidence = f"PubMed PMID OK; title={title[:120]}; authors={len(families)}"
+    if families:
+        evidence += f" (first={families[0]})"
+    return "OK", evidence, families
 
 
-def verify_pubmed_title(title: str, timeout: int) -> tuple[str, str, str]:
-    """Returns (status, evidence, first_author_family). Title-only search cannot
-    return a confident first author, so the third element is always ""."""
+def verify_pubmed_efetch(pmid: str, timeout: int) -> tuple[str, str, list, list]:
+    """Authoritative PubMed full author record via efetch.fcgi (XML).
+
+    Returns (status, evidence, family_names, given_names). Use given_names for
+    given-name cross-check (CrossRef-vs-PubMed disagreement, e.g. a documented
+    case: CrossRef "Vasileios" vs PubMed "Victoria" — PubMed is authoritative).
+    """
+    url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?" + urllib.parse.urlencode(
+        {"db": "pubmed", "id": pmid, "retmode": "xml"}
+    )
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "medsci-skills/verify-refs (mailto:example@example.com)"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            xml_text = resp.read().decode("utf-8", "replace")
+    except Exception:
+        return "UNVERIFIED", "PubMed efetch failed", [], []
+    families: list[str] = []
+    givens: list[str] = []
+    # Per-Author block: <Author ValidYN="Y"><LastName>X</LastName><ForeName>Y</ForeName>...
+    for am in re.finditer(
+        r'<Author\s+ValidYN="Y"[^>]*>(.*?)</Author>', xml_text, re.S
+    ):
+        block = am.group(1)
+        lm = re.search(r"<LastName>([^<]+)</LastName>", block)
+        fm = re.search(r"<ForeName>([^<]+)</ForeName>", block)
+        if lm:
+            families.append(html.unescape(lm.group(1)).strip())
+            givens.append(html.unescape(fm.group(1)).strip() if fm else "")
+    if not families:
+        return "UNVERIFIED", "PubMed efetch returned no author elements", [], []
+    return (
+        "OK",
+        f"PubMed efetch OK; authors={len(families)} (first={families[0]})",
+        families,
+        givens,
+    )
+
+
+def verify_pubmed_title(title: str, timeout: int) -> tuple[str, str, list]:
+    """Title-only search returns no confident author list."""
     if not title:
-        return "UNVERIFIED", "No DOI, PMID, or usable title", ""
+        return "UNVERIFIED", "No DOI, PMID, or usable title", []
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?" + urllib.parse.urlencode(
         {"db": "pubmed", "term": title, "retmode": "json", "retmax": "3"}
     )
     data = http_json(url, timeout)
     if not data:
-        return "UNVERIFIED", "PubMed title search failed", ""
+        return "UNVERIFIED", "PubMed title search failed", []
     ids = data.get("esearchresult", {}).get("idlist", [])
     if not ids:
-        return "UNVERIFIED", "No PubMed title match", ""
-    return "OK", f"PubMed title match; PMID candidates={','.join(ids)}", ""
+        return "UNVERIFIED", "No PubMed title match", []
+    return "OK", f"PubMed title match; PMID candidates={','.join(ids)}", []
 
 
 def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
+    """v1.3.0: full-author cross-check.
+
+    Authoritative source priority for the actual author list:
+      1. PubMed efetch (XML full-record) — best (motivation: CrossRef returned a
+         wrong given name "Vasileios" vs PubMed efetch authoritative "Victoria";
+         also catches AI-generated bib entries with hallucinated #2..#N family
+         names — a real AI-assembled bib registered 7 of 10 fabricated co-author names).
+      2. CrossRef DOI (fallback when no PMID).
+      3. PubMed esummary (fast count check; family-name approximation only).
+    All cited authors (BibTeX) are compared family-by-family against the
+    authoritative list AND total counts are compared. Any cited author beyond
+    the actual list, any per-index family mismatch, and any count mismatch are
+    each reported. When no full cited list was parsed (TSV / plain text), the
+    check degrades to the first-author surname comparison (Gate 4 behaviour).
+    """
     if offline:
         if record.doi or record.pmid:
             record.status = "UNVERIFIED"
@@ -356,32 +499,94 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
             record.evidence = "No identifier; offline mode"
         return record
 
-    checks: list[tuple[str, str, str]] = []
-    if record.doi:
-        checks.append(verify_crossref(record.doi, timeout))
-        time.sleep(0.2)
+    statuses: list[str] = []
+    evidence_parts: list[str] = []
+    actual_authors: list[str] = []
+    actual_givens: list[str] = []
+    sources_consulted: list[str] = []
+
+    # Step 1 — PubMed efetch (authoritative) when PMID present.
     if record.pmid:
-        checks.append(verify_pubmed_pmid(record.pmid, timeout))
+        st, ev, fams, givens = verify_pubmed_efetch(record.pmid, timeout)
         time.sleep(0.2)
-    if not checks:
-        checks.append(verify_pubmed_title(record.title_guess, timeout))
+        statuses.append(st)
+        evidence_parts.append(ev)
+        if st == "OK" and fams:
+            actual_authors = fams
+            actual_givens = givens
+            sources_consulted.append("pubmed_efetch")
+        # also run esummary for FABRICATED detection (efetch returns valid XML even for
+        # unknown PMIDs in some edge cases; esummary's "error" field is decisive).
+        st_es, ev_es, fams_es = verify_pubmed_pmid(record.pmid, timeout)
         time.sleep(0.2)
+        statuses.append(st_es)
+        evidence_parts.append(ev_es)
+        if not actual_authors and st_es == "OK" and fams_es:
+            actual_authors = fams_es
+            sources_consulted.append("pubmed_esummary")
 
-    statuses = [s for s, _, _ in checks]
-    evidence_parts = [e for _, e, _ in checks]
+    # Step 2 — CrossRef DOI (used only when efetch did not provide a list).
+    if record.doi:
+        st_cr, ev_cr, fams_cr = verify_crossref(record.doi, timeout)
+        time.sleep(0.2)
+        statuses.append(st_cr)
+        evidence_parts.append(ev_cr)
+        if not actual_authors and st_cr == "OK" and fams_cr:
+            actual_authors = fams_cr
+            sources_consulted.append("crossref")
 
-    # First-author cross-check: only meaningful when an authoritative source
-    # returned OK and a non-empty author. Stays silent on UNVERIFIED rows so
-    # we don't double-penalize them.
-    actual_authors = [a for s, _, a in checks if s == "OK" and a]
-    author_mismatch = False
-    if record.first_author_guess and actual_authors:
+    # Step 3 — title-only fallback (no confident author list).
+    if not statuses:
+        st_t, ev_t, _ = verify_pubmed_title(record.title_guess, timeout)
+        time.sleep(0.2)
+        statuses.append(st_t)
+        evidence_parts.append(ev_t)
+
+    # Full-author cross-check
+    record.actual_authors = actual_authors
+    record.actual_author_count = len(actual_authors)
+    if record.cited_authors and not record.cited_author_count:
+        record.cited_author_count = len(record.cited_authors)
+
+    mismatches: list[str] = []
+    if record.cited_authors and actual_authors:
+        compare_n = min(len(record.cited_authors), len(actual_authors))
+        for i in range(compare_n):
+            cited = record.cited_authors[i]
+            if not author_surnames_match(cited, actual_authors[i]):
+                mismatches.append(
+                    f"#{i+1} family: cited='{cited}' vs source='{actual_authors[i]}'"
+                )
+        # cited has more authors than source — always flag (cannot be intentional)
+        for i in range(compare_n, len(record.cited_authors)):
+            mismatches.append(
+                f"#{i+1} extra cited='{record.cited_authors[i]}' (source has only {len(actual_authors)} authors)"
+            )
+        # source has more authors than cited — count mismatch, suppressed under
+        # `_audit_truncated` marker (intentional CSL et-al truncation).
+        if record.cited_author_count != record.actual_author_count:
+            if record.audit_truncated and record.cited_author_count < record.actual_author_count:
+                evidence_parts.append(
+                    f"NOTE: intentional truncate ({record.cited_author_count} of {record.actual_author_count}; "
+                    f"`_audit_truncated` marker set)"
+                )
+            else:
+                mismatches.append(
+                    f"AUTHOR COUNT: cited={record.cited_author_count} vs source={record.actual_author_count}"
+                )
+    elif record.first_author_guess and actual_authors:
+        # No parsed cited author list (TSV / plain-text input) — degrade to the
+        # first-author surname cross-check (Gate 4 behaviour).
         if not any(author_surnames_match(record.first_author_guess, a) for a in actual_authors):
-            author_mismatch = True
-            evidence_parts.append(
-                f"AUTHOR MISMATCH: cited='{record.first_author_guess}' vs source='{actual_authors[0]}'"
+            mismatches.append(
+                f"#1 family: cited='{record.first_author_guess}' vs source='{actual_authors[0]}'"
             )
 
+    author_mismatch = bool(mismatches)
+    if author_mismatch:
+        evidence_parts.append("AUTHOR MISMATCH | " + " | ".join(mismatches))
+
+    # Status precedence
     if "OK" in statuses and "FABRICATED" in statuses:
         record.status = "MISMATCH"
     elif "OK" in statuses:
@@ -390,9 +595,23 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
         record.status = "FABRICATED"
     else:
         record.status = "UNVERIFIED"
+
+    # Note classification (most informative wins)
     if author_mismatch and not record.note:
-        record.note = "first-author hallucination suspected (DOI/title correct, surname differs)"
-    record.evidence = " | ".join(evidence_parts)
+        # Distinguish first-author hallucination (high reviewer salience)
+        first_cited = record.cited_authors[0] if record.cited_authors else record.first_author_guess
+        first_bad = (
+            first_cited
+            and actual_authors
+            and not author_surnames_match(first_cited, actual_authors[0])
+        )
+        if first_bad:
+            record.note = "first-author hallucination suspected (DOI/PMID correct, family differs)"
+        else:
+            record.note = "non-first-author hallucination or count mismatch (DOI/PMID correct)"
+    record.evidence = " | ".join(p for p in evidence_parts if p)
+    if sources_consulted:
+        record.evidence += f" | source={'+'.join(sources_consulted)}"
     return record
 
 
@@ -437,7 +656,7 @@ def detect_duplicates(records: list[RefRecord]) -> list[dict]:
 
 def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
                   duplicate_findings: list[dict]) -> None:
-    """Audit-only writer (v1.2.0).
+    """Audit-only writer (v1.3.0).
 
     Per docs/artifact_contract.md, /verify-refs is sole writer of qc/reference_audit.json
     only. It MUST NOT write to references/ (that directory is owned by /search-lit and
@@ -446,6 +665,12 @@ def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
     v1.2.0 (2026-05): adds duplicate_findings[] for PMID/DOI duplicate detection
     (Gate 5; resolves /peer-review Phase 2A P7). submission_safe and fully_verified
     both require duplicate_findings to be empty.
+
+    v1.3.0 (2026-05): full-author cross-check. records[] now carry cited_authors[],
+    actual_authors[], and author counts; schema_version bumps to 4. MISMATCH now
+    fires on any #2..#N family hallucination or author-count mismatch, not just the
+    first author (motivation: a bib entry with a real first author but 7/10
+    fabricated co-author given names previously passed audit).
     """
     qc_dir = project_root / "qc"
     qc_dir.mkdir(parents=True, exist_ok=True)
@@ -454,7 +679,7 @@ def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
     for rec in records:
         counts[rec.status] = counts.get(rec.status, 0) + 1
     audit = {
-        "schema_version": 3,
+        "schema_version": 4,
         "source": str(source),
         "total_references": len(records),
         "counts": counts,

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -5,7 +5,7 @@ owner_domain: reference_integrity
 when_to_use:
   - Audit-only verification of manuscript references against PubMed and CrossRef
   - Pre-submission citation hallucination check (PostToolUse hook trigger on circulation/submission docx)
-  - Detecting first-author hallucination (DOI real but author name wrong — Paper 3 ref 8 incident pattern)
+  - Detecting author hallucination (DOI real but a cited author name wrong at any position — full-author cross-check against PubMed efetch, v1.3.0)
   - LLM-assisted drafting gate — `--strict` mode required when AI generated or rewrote citations
 when_NOT_to_use:
   - Adding new references (use /search-lit + /lit-sync)


### PR DESCRIPTION
## Problem
The v1.2.0 author check compared only the **first-author surname**. Co-author hallucinations at positions #2..#N passed audit. A correct first author does not verify the remaining cited authors.

## Change
Extends the cross-check to the **full author list** while preserving v1.2.0 duplicate detection (Gate 5):

- `RefRecord` gains `cited_authors[]`, `actual_authors[]`, `cited_author_count`, `actual_author_count`.
- `parse_bib` parses the full BibTeX author field (balanced-brace aware, LaTeX-accent tolerant) via new `parse_bib_authors()`.
- `verify_record` sources the authoritative list from **PubMed `efetch.fcgi` (XML full record)** first — authoritative for given/family names where CrossRef is not — then CrossRef, then PubMed esummary. Every cited family name is compared index-by-index, counts are compared; #2..#N or count mismatches flag `MISMATCH` with a distinguishing note.
- `_normalize_surname` upgraded to NFKD + Turkish/Polish/Czech/German/Nordic special-letter folding (fixes diacritic false positives).
- TSV / plain-text inputs degrade gracefully to the first-author check. Intentional CSL et-al truncation silenced per-entry via a BibTeX `_audit_truncated` field.
- `schema_version` bumps 3 → 4; `records[]` now expose the author lists.

## Verification (end-to-end against live PubMed)
- A correct 6-author entry passes — including the `Gotzsche` (cited) vs `Gøtzsche` (PubMed) diacritic case → OK.
- An entry with a correct first author (`Schulz`) but two fabricated co-authors (`Fabricatedname`, `Inventedperson`) is correctly flagged `MISMATCH` with note `non-first-author hallucination or count mismatch`.

## Provenance
Integrates the stale local branch `feat/verify-refs-full-author` (2026-05-11), which was never merged — PR #23 added an unrelated duplicate-detection feature under the same "v1.2.0" label. Rebased onto current main (preserving Gate 5) and generalized to drop project-identifying strings per the repo's privacy hardening direction. Documented as expected behavior in the user's global citation-safety rules.

## Validation
- `bash scripts/validate_skills.sh` → ALL CHECKS PASSED (0 failures)
- `python3 scripts/validate_skill_contracts.py` → 0 contract failures
- No PII / project fingerprints (precedent blocklist + manual grep clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)