### PR TITLE
feat(check-reporting): fail-fast guard for missing checklists (no silent from-memory fallback)

### DIFF
--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -53,7 +53,7 @@ compliance report suitable for journal submission.
   - `AMSTAR2.md` -- quality of systematic reviews (Shea et al. BMJ 2017)
   - `PRISMA_P.md` -- systematic review protocols (Shamseer et al. BMJ 2015)
   - `SWiM.md` -- synthesis without meta-analysis reporting (Campbell et al. BMJ 2020)
-- If a local checklist file is not found for a requested guideline, the skill constructs checklist items from its knowledge of the guideline.
+- Fail-fast contract: if a routed guideline has no vendored checklist file, the skill does **not** silently construct items from memory. It halts with a `MISSING_CHECKLIST_CONTRACT_VIOLATION` and surfaces the gap. A from-memory assessment is allowed only with the explicit `--allow-from-memory` opt-in, and that report must be clearly labelled NON-AUTHORITATIVE. See Step 2 and `scripts/check_checklist_exists.py`.
 
 ---
 
@@ -108,8 +108,27 @@ user specification.
 
 ### Step 2: Load Checklist
 
-1. Read the checklist file from `${CLAUDE_SKILL_DIR}/references/checklists/`.
-2. If the checklist file does not exist for the requested guideline, use your knowledge of the guideline to construct the checklist items and inform the user that a local checklist file was not found.
+1. **Run the fail-fast guard first** for every guideline you intend to apply:
+
+   ```bash
+   python "${CLAUDE_SKILL_DIR}/scripts/check_checklist_exists.py" --guideline "STARD-AI"
+   ```
+
+   - Exit 0 → the vendored checklist exists; read it from
+     `${CLAUDE_SKILL_DIR}/references/checklists/` and proceed.
+   - Exit 1 (`MISSING_CHECKLIST_CONTRACT_VIOLATION`) → the guideline is routed
+     but no checklist file is vendored. **Do not construct items from memory.**
+     Halt, report the violation to the user, and stop unless they explicitly
+     opt in (next bullet).
+   - Exit 2 (`UNKNOWN_GUIDELINE`) → the name is not recognised; confirm the
+     correct guideline with the user.
+
+2. **No silent fallback.** A from-memory checklist is permitted only when the
+   user explicitly accepts it — re-run the guard with `--allow-from-memory`
+   (exit 0 + a NON-AUTHORITATIVE warning). In that case the output report MUST
+   carry a prominent banner that the assessment was constructed from model
+   knowledge and is not backed by a vendored checklist, and `submission_safe`
+   must not be asserted on its basis.
 
 ### Step 3: Scan Manuscript
 

--- a/skills/check-reporting/scripts/check_checklist_exists.py
+++ b/skills/check-reporting/scripts/check_checklist_exists.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Fail-fast guard for /check-reporting checklist routing.
+
+The /check-reporting skill assesses a manuscript against a vendored reporting
+guideline checklist (references/checklists/*.md). Historically, when a routed
+checklist file was absent the skill silently fell back to constructing the
+checklist "from its knowledge of the guideline" — a fabrication path that is
+exactly what the rest of the skill exists to prevent. This guard makes that
+case loud:
+
+  - The requested guideline resolves to a vendored file that exists  -> exit 0.
+  - It resolves to a known guideline whose file is ABSENT            -> exit 1,
+    prints MISSING_CHECKLIST_CONTRACT_VIOLATION.
+  - The name is not a recognised guideline                           -> exit 2,
+    prints UNKNOWN_GUIDELINE.
+
+`--allow-from-memory` is the single explicit opt-in escape hatch: it downgrades
+exit 1/2 to exit 0 but always emits a NON-AUTHORITATIVE warning, so a
+construct-from-memory assessment can never happen silently.
+
+Source of truth for "what is vendored" is the checklists directory on disk, not
+this file — the alias map only translates display names to filename stems.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# Display/guideline name (normalised) -> checklist filename stem.
+# Keys are normalised by _norm(): lowercased, with spaces/hyphens/dots/plus/
+# underscores and a trailing 4-digit year stripped. The stem is the expected
+# file under references/checklists/<stem>.md. A stem whose file is absent is a
+# contract violation, surfaced loudly rather than silently fabricated.
+ALIAS_TO_STEM = {
+    "strobe": "STROBE",
+    "consort": "CONSORT",
+    "consortai": "CONSORT_AI",
+    "stard": "STARD",
+    "stardai": "STARD_AI",
+    "tripod": "TRIPOD",
+    "tripodai": "TRIPOD_AI",
+    "prisma": "PRISMA_2020",
+    "prismadta": "PRISMA_DTA",
+    "prismap": "PRISMA_P",
+    "arrive": "ARRIVE_2",
+    "care": "CARE",
+    "spirit": "SPIRIT",
+    "spiritai": "SPIRIT_AI",
+    "claim": "CLAIM_2024",
+    "miclearllm": "MI_CLEAR_LLM",
+    "squire": "SQUIRE_2",
+    "clear": "CLEAR",
+    "moose": "MOOSE",
+    "grras": "GRRAS",
+    "swim": "SWiM",
+    "amstar": "AMSTAR2",
+    "amstar2": "AMSTAR2",
+    "quadas": "QUADAS2",
+    "quadas2": "QUADAS2",
+    "quadasc": "QUADAS_C",
+    "rob2": "RoB2",
+    "robinsi": "ROBINS_I",
+    "robinse": "ROBINS_E",
+    "robis": "ROBIS",
+    "robme": "ROB_ME",
+    "robnma": "RoB_NMA",
+    "probast": "PROBAST",
+    "probastai": "PROBAST_AI",
+    "nos": "NOS",
+    "cosmin": "COSMIN_RoB",
+    "cosminrob": "COSMIN_RoB",
+}
+
+EXIT_OK = 0
+EXIT_MISSING = 1
+EXIT_UNKNOWN = 2
+
+
+def _norm(name: str) -> str:
+    """Normalise a guideline name to an alias key.
+
+    Lowercase, drop a trailing 4-digit year, then strip spaces/hyphens/dots/
+    plus/underscores. "STARD-AI" -> "stardai"; "AMSTAR 2" -> "amstar2";
+    "CONSORT 2010" -> "consort"; "TRIPOD+AI" -> "tripodai".
+    """
+    n = name.strip().lower()
+    n = re.sub(r"\b(19|20)\d{2}\b", "", n)          # drop version year
+    n = re.sub(r"[\s\-_.+]", "", n)                 # strip spaces/-/_/./+
+    return n
+
+
+def checklist_dir(skill_dir: Path) -> Path:
+    return skill_dir / "references" / "checklists"
+
+
+def resolve_stem(guideline: str) -> str | None:
+    return ALIAS_TO_STEM.get(_norm(guideline))
+
+
+def available_stems(cdir: Path) -> list[str]:
+    if not cdir.is_dir():
+        return []
+    return sorted(p.stem for p in cdir.glob("*.md"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail-fast guard: confirm a routed reporting-guideline checklist is vendored."
+    )
+    parser.add_argument("--guideline", help="Guideline name, e.g. 'STROBE', 'STARD-AI', 'CONSORT 2010'.")
+    parser.add_argument(
+        "--skill-dir",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="check-reporting skill root (default: inferred from this script).",
+    )
+    parser.add_argument(
+        "--allow-from-memory",
+        action="store_true",
+        help="Explicit opt-in: downgrade a missing/unknown checklist to exit 0 with a "
+             "NON-AUTHORITATIVE warning instead of failing. Never silent.",
+    )
+    parser.add_argument(
+        "--simulate-missing-checklist",
+        action="store_true",
+        help="Force the missing-file path (for contract tests).",
+    )
+    parser.add_argument("--list", action="store_true", help="List vendored checklist files and exit.")
+    args = parser.parse_args()
+
+    skill_dir = Path(args.skill_dir).resolve()
+    cdir = checklist_dir(skill_dir)
+
+    if args.list:
+        stems = available_stems(cdir)
+        print(f"{len(stems)} vendored checklists in {cdir}:")
+        for s in stems:
+            print(f"  {s}")
+        return EXIT_OK
+
+    if args.simulate_missing_checklist:
+        print("MISSING_CHECKLIST_CONTRACT_VIOLATION: simulated missing checklist "
+              "(guideline routed but no vendored file).", file=sys.stderr)
+        if args.allow_from_memory:
+            print("WARNING: --allow-from-memory set; a from-memory (NON-AUTHORITATIVE) "
+                  "assessment would proceed. The report MUST be marked non-vendored.")
+            return EXIT_OK
+        return EXIT_MISSING
+
+    if not args.guideline:
+        parser.error("--guideline is required (or use --list / --simulate-missing-checklist)")
+
+    stem = resolve_stem(args.guideline)
+    if stem is None:
+        print(f"UNKNOWN_GUIDELINE: '{args.guideline}' is not a recognised reporting guideline.",
+              file=sys.stderr)
+        if args.allow_from_memory:
+            print("WARNING: --allow-from-memory set; proceeding from memory for an unrecognised "
+                  "guideline (NON-AUTHORITATIVE). The report MUST be marked non-vendored.")
+            return EXIT_OK
+        return EXIT_UNKNOWN
+
+    path = cdir / f"{stem}.md"
+    if path.is_file():
+        print(f"OK: {args.guideline} -> references/checklists/{stem}.md")
+        return EXIT_OK
+
+    print(f"MISSING_CHECKLIST_CONTRACT_VIOLATION: '{args.guideline}' resolves to "
+          f"'{stem}.md' which is not vendored under {cdir}.", file=sys.stderr)
+    if args.allow_from_memory:
+        print(f"WARNING: --allow-from-memory set; proceeding from memory for '{args.guideline}' "
+              f"(NON-AUTHORITATIVE). The report MUST be marked non-vendored.")
+        return EXIT_OK
+    return EXIT_MISSING
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/check-reporting/tests/test_checklist_fail_fast.sh
+++ b/skills/check-reporting/tests/test_checklist_fail_fast.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Regression tests for check-reporting check_checklist_exists.py (fail-fast guard).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/check-reporting/scripts/check_checklist_exists.py"
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+fail=0
+ran=0
+
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    ran=$((ran + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        printf '  PASS  %-52s exit=%s\n' "$label" "$actual"
+    else
+        printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    ran=$((ran + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        printf '  PASS  %-52s\n' "$label"
+    else
+        printf '  FAIL  %-52s (missing: %s)\n' "$label" "$needle"
+        fail=$((fail + 1))
+    fi
+}
+
+run() { python3 "$SCRIPT" "$@" >/dev/null 2>&1; echo $?; }
+
+# 1. Vendored checklists that exist on disk -> exit 0.
+assert_exit "STROBE present" 0 "$(run --guideline STROBE)"
+assert_exit "STARD-AI alias present" 0 "$(run --guideline STARD-AI)"
+assert_exit "TRIPOD+AI alias present" 0 "$(run --guideline 'TRIPOD+AI')"
+assert_exit "AMSTAR 2 alias present" 0 "$(run --guideline 'AMSTAR 2')"
+assert_exit "RoB 2 alias present" 0 "$(run --guideline 'RoB 2')"
+assert_exit "QUADAS-C alias present" 0 "$(run --guideline QUADAS-C)"
+
+# 2. Advertised-but-unvendored guidelines -> exit 1 (contract violation).
+assert_exit "CONSORT 2010 missing" 1 "$(run --guideline 'CONSORT 2010')"
+assert_exit "CARE missing" 1 "$(run --guideline CARE)"
+assert_exit "SPIRIT missing" 1 "$(run --guideline SPIRIT)"
+assert_exit "CLAIM 2024 missing" 1 "$(run --guideline 'CLAIM 2024')"
+
+# 3. Unrecognised guideline -> exit 2.
+assert_exit "unknown guideline" 2 "$(run --guideline NOT-A-REAL-GUIDELINE)"
+
+# 4. Explicit opt-in downgrades missing/unknown to exit 0 but warns (never silent).
+assert_exit "opt-in missing -> 0" 0 "$(run --guideline CARE --allow-from-memory)"
+assert_exit "opt-in unknown -> 0" 0 "$(run --guideline NOPE --allow-from-memory)"
+optin_out="$(python3 "$SCRIPT" --guideline CARE --allow-from-memory 2>&1)"
+assert_contains "opt-in emits NON-AUTHORITATIVE warning" "NON-AUTHORITATIVE" "$optin_out"
+
+# 5. Contract-test simulation (codex Improvement B "Prove" step).
+sim_out="$(python3 "$SCRIPT" --simulate-missing-checklist 2>&1)"
+assert_exit "simulate-missing-checklist" 1 "$(run --simulate-missing-checklist)"
+assert_contains "simulate emits standard violation code" "MISSING_CHECKLIST_CONTRACT_VIOLATION" "$sim_out"
+
+# 6. Violation message carries the standardized machine-greppable code.
+viol_out="$(python3 "$SCRIPT" --guideline 'CONSORT 2010' 2>&1)"
+assert_contains "missing emits standard violation code" "MISSING_CHECKLIST_CONTRACT_VIOLATION" "$viol_out"
+
+printf '\n%d/%d checks passed\n' "$((ran - fail))" "$ran"
+[[ "$fail" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Problem
SKILL.md instructed: *"If the checklist file does not exist for the requested guideline, use your knowledge of the guideline to construct the checklist items."* That is a **silent fabrication path** — the exact failure mode the rest of `/check-reporting` exists to prevent.

It also masked a concrete gap: SKILL.md's Reference Files block lists `CONSORT.md`, `CARE.md`, `SPIRIT.md`, and `CLAIM_2024.md` as vendored, but **none of those files exist on disk**. Requesting any of them quietly produced a from-memory assessment indistinguishable from a vendored one.

## Change (codex Improvement B)
- **New** `scripts/check_checklist_exists.py` — resolves a guideline name to its expected checklist filename (alias map covers STARD-AI, TRIPOD+AI, AMSTAR 2, RoB 2, QUADAS-C, …) and checks the checklists directory (disk = source of truth):
  - vendored file present → exit 0
  - routed but file absent → exit 1, `MISSING_CHECKLIST_CONTRACT_VIOLATION`
  - unrecognised guideline → exit 2, `UNKNOWN_GUIDELINE`
  - `--allow-from-memory` → downgrades 1/2 to exit 0 but **always** prints a `NON-AUTHORITATIVE` warning (never silent)
  - `--simulate-missing-checklist`, `--list` for tests/inspection
- **SKILL.md Step 2** rewritten to run the guard first and halt on a violation. The from-memory path now requires the explicit opt-in + a `NON-AUTHORITATIVE` banner in the report, and may not assert `submission_safe` on its basis.
- **New** `tests/test_checklist_fail_fast.sh` — 17 checks, all passing, including the codex "Prove" step (`--simulate-missing-checklist` → non-zero + standardized code).

## Scope note
The four phantom checklist references (`CONSORT/CARE/SPIRIT/CLAIM`) are deliberately left for the **routing-asset integrity PR** (codex Improvement C), which is where the remove-vs-vendor decision belongs. This PR makes the gap *loud* rather than silent.

## Validation
- `bash scripts/validate_skills.sh` → ALL CHECKS PASSED (0 failures)
- `python3 scripts/validate_skill_contracts.py` → 0 contract failures
- `bash skills/check-reporting/tests/test_checklist_fail_fast.sh` → 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)