### PR TITLE
feat(check-reporting): routing-asset integrity gate + vendor 4 previously-excluded checklists

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run validate_skills.sh (PII + structure)
         run: bash scripts/validate_skills.sh
+
+      - name: Run validate_routing_assets.py (SKILL.md asset references must exist)
+        run: python3 scripts/validate_routing_assets.py --strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 # Local-only scripts (not for public distribution)
 /fulltext-retrieval/
 
-# License-restricted checklists (local use only, not for distribution)
-skills/check-reporting/references/checklists/CARE.md
-skills/check-reporting/references/checklists/CLAIM_2024.md
-skills/check-reporting/references/checklists/CONSORT.md
-skills/check-reporting/references/checklists/SPIRIT.md
-
 # Large public data files (download via scripts)
 *.XPT
 *.xpt

--- a/scripts/validate_routing_assets.py
+++ b/scripts/validate_routing_assets.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Routing-asset integrity check for medsci-skills (codex Improvement C).
+
+A SKILL.md may route to a bundled asset (a checklist, a script, a template) by
+name. If that file does not exist on disk, the skill silently degrades — at best
+a confusing failure, at worst a fabrication path (see /check-reporting, where
+SKILL.md advertised CONSORT/CARE/SPIRIT/CLAIM checklists that were never
+vendored). This validator enforces the invariant: every asset a SKILL.md
+references must exist.
+
+Two scans, deliberately narrow to avoid prose false positives:
+
+  A. ${CLAUDE_SKILL_DIR}/<path>  — every skill-dir-relative asset path in any
+     skills/*/SKILL.md must resolve to an existing file (handles ../ cross-skill
+     references such as verify-refs -> manage-refs).
+
+  B. check-reporting Reference Files bullets — each ``Name.md`` listed with a
+     `-- description` under the checklists block must exist in
+     references/checklists/.
+
+Exit 0 when every referenced asset exists. With --strict, exit 1 if any are
+missing (CI gate). Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# ${CLAUDE_SKILL_DIR}/<relative path ending in an asset extension>
+SKILL_DIR_REF = re.compile(
+    r"\$\{CLAUDE_SKILL_DIR\}/([A-Za-z0-9_./\-]+\.[A-Za-z0-9]+)"
+)
+# A bulleted "`Name.md` -- description" asset declaration (en-dash or --).
+BULLET_ASSET = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_./\-]*\.md)`\s*(?:--|—)")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def scan_skill_dir_refs(skill_md: Path) -> list[tuple[str, Path]]:
+    """Return (referenced_rel_path, resolved_path) for every missing asset."""
+    skill_dir = skill_md.parent
+    txt = skill_md.read_text(encoding="utf-8")
+    missing: list[tuple[str, Path]] = []
+    for m in SKILL_DIR_REF.finditer(txt):
+        rel = m.group(1)
+        resolved = (skill_dir / rel).resolve()
+        if not resolved.exists():
+            missing.append((f"${{CLAUDE_SKILL_DIR}}/{rel}", resolved))
+    return missing
+
+
+def scan_checkreporting_bullets(root: Path) -> list[tuple[str, Path]]:
+    """check-reporting Reference Files checklist bullets must exist."""
+    skill_md = root / "skills" / "check-reporting" / "SKILL.md"
+    if not skill_md.exists():
+        return []
+    cdir = root / "skills" / "check-reporting" / "references" / "checklists"
+    txt = skill_md.read_text(encoding="utf-8")
+    # Restrict to the "Reference Files" section to avoid matching prose elsewhere.
+    start = txt.find("## Reference Files")
+    end = txt.find("\n## ", start + 1) if start != -1 else -1
+    section = txt[start:end] if start != -1 else txt
+    missing: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    for m in BULLET_ASSET.finditer(section):
+        fn = m.group(1)
+        if fn in seen:
+            continue
+        seen.add(fn)
+        if not (cdir / fn).exists():
+            missing.append((f"checklists/{fn}", cdir / fn))
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate that SKILL.md-referenced assets exist.")
+    parser.add_argument("--scan", nargs="*", help="Explicit SKILL.md paths to scan (default: skills/*/SKILL.md).")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero if any referenced asset is missing.")
+    args = parser.parse_args()
+
+    root = repo_root()
+    if args.scan:
+        skill_mds = [Path(p).resolve() for p in args.scan]
+    else:
+        skill_mds = sorted((root / "skills").glob("*/SKILL.md"))
+
+    total_refs = 0
+    missing_all: list[tuple[str, str, Path]] = []  # (skill, ref, resolved)
+
+    for skill_md in skill_mds:
+        skill_name = skill_md.parent.name
+        refs = scan_skill_dir_refs(skill_md)
+        # count checked refs for reporting
+        total_refs += len(SKILL_DIR_REF.findall(skill_md.read_text(encoding="utf-8")))
+        for ref, resolved in refs:
+            missing_all.append((skill_name, ref, resolved))
+
+    bullet_missing = scan_checkreporting_bullets(root)
+    for ref, resolved in bullet_missing:
+        missing_all.append(("check-reporting", ref, resolved))
+
+    print("=" * 41)
+    print(" Routing-Asset Integrity")
+    print("=" * 41)
+    print(f"Scanned {len(skill_mds)} SKILL.md; {total_refs} ${{CLAUDE_SKILL_DIR}} asset refs "
+          f"+ check-reporting checklist bullets.")
+    if not missing_all:
+        print("OK: every referenced asset exists.")
+        return 0
+
+    print(f"\nMISSING ({len(missing_all)}):")
+    for skill_name, ref, resolved in missing_all:
+        try:
+            shown = resolved.relative_to(root)
+        except ValueError:
+            shown = resolved
+        print(f"  [{skill_name}] {ref}  ->  {shown} (absent)")
+
+    if args.strict:
+        print("\nROUTING_ASSET_INTEGRITY_VIOLATION: referenced assets are missing.", file=sys.stderr)
+        return 1
+    print("\n(non-strict: reported only; rerun with --strict to fail.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -34,10 +34,10 @@ compliance report suitable for journal submission.
   - `ROBINS_I.md` -- non-randomised studies risk of bias (CC BY, Sterne et al. BMJ 2016)
   - `PROBAST.md` -- prediction model risk of bias (CC BY, Wolff et al. Ann Intern Med 2019)
   - `NOS.md` -- observational study quality (public domain, Ottawa Hospital)
-  - `CONSORT.md` -- randomised controlled trials
-  - `CARE.md` -- case reports
-  - `SPIRIT.md` -- study protocols
-  - `CLAIM_2024.md` -- AI/ML in clinical imaging
+  - `CONSORT.md` -- randomised controlled trials, CONSORT 2025 (CC BY 4.0, Hopewell et al. BMJ 2025)
+  - `CARE.md` -- case reports, CARE 2013 (CC BY-NC 4.0, Gagnier et al. J Clin Epidemiol 2014)
+  - `SPIRIT.md` -- clinical trial protocols, SPIRIT 2025 (CC BY 4.0, Chan et al. BMJ 2025)
+  - `CLAIM_2024.md` -- AI/ML in clinical imaging, CLAIM 2024 Update (RSNA open access, Tejani et al. Radiol Artif Intell 2024)
   - `MI_CLEAR_LLM.md` -- LLM accuracy studies in healthcare (CC BY-NC 4.0, Park et al. KJR 2024; 2025 update)
   - `SQUIRE_2.md` -- quality improvement in healthcare/education (CC BY, Ogrinc et al. BMJ Qual Saf 2016)
   - `CLEAR.md` -- radiomics studies (CC BY 4.0, Kocak et al. Insights Imaging 2023)
@@ -69,7 +69,7 @@ user specification.
 | Study Type | Primary Guideline | AI Extension |
 |------------|------------------|--------------|
 | Observational study | STROBE | -- |
-| Randomized controlled trial | CONSORT 2010 | CONSORT-AI |
+| Randomized controlled trial | CONSORT 2025 | CONSORT-AI |
 | Diagnostic accuracy study | STARD 2015 | STARD-AI |
 | Prediction model (development/validation) | TRIPOD | TRIPOD+AI |
 | Systematic review / meta-analysis | PRISMA 2020 | -- |
@@ -87,7 +87,7 @@ user specification.
 | Risk of bias (measurement properties) | COSMIN RoB | -- |
 | Quality assessment (observational) | NOS | -- |
 | Case report | CARE | -- |
-| Study protocol | SPIRIT | SPIRIT-AI |
+| Study protocol | SPIRIT 2025 | SPIRIT-AI |
 | Animal study | ARRIVE 2.0 | -- |
 | AI/ML study in clinical imaging | CLAIM 2024 | -- |
 | LLM accuracy evaluation in healthcare | MI-CLEAR-LLM | STARD-AI or CLAIM 2024 (use alongside) |

--- a/skills/check-reporting/references/LICENSES.md
+++ b/skills/check-reporting/references/LICENSES.md
@@ -17,7 +17,25 @@ Attribution for bundled reporting guideline checklists.
 | PROBAST.md | PROBAST | Wolff RF et al. Ann Intern Med 2019 | CC BY |
 | NOS.md | Newcastle-Ottawa Scale | Wells GA et al. Ottawa Hospital Research Institute | Public Domain |
 | MI_CLEAR_LLM.md | MI-CLEAR-LLM 2025 | Park SH et al. Korean J Radiol 2024;25(10):865-868; 2025 update KJR 2025;26(12):1123-1132 | CC BY-NC 4.0 |
+| CONSORT.md | CONSORT 2025 | Hopewell S et al. BMJ 2025;389:e081123 | CC BY 4.0 |
+| SPIRIT.md | SPIRIT 2025 | Chan AW et al. BMJ 2025;389:e081477 | CC BY 4.0 |
+| CARE.md | CARE 2013 | Gagnier JJ et al. J Clin Epidemiol 2014;67(1):46-51 | CC BY-NC 4.0 |
+| CLAIM_2024.md | CLAIM 2024 Update | Tejani AS et al. Radiol Artif Intell 2024;6(4):e240300 | RSNA, open access |
 
 These files are educational summaries of published assessment tools. The original
-checklist documents should be cited in any manuscript that uses them. All files are
-compatible with the MIT license of this repository.
+checklist documents should be cited in any manuscript that uses them.
+
+## Third-party licenses (NOT covered by the repository MIT license)
+
+Most files above are CC BY / CC0 / public domain and redistribute freely with
+attribution. The following retain their own licenses and are **not** placed under
+this repository's MIT license — downstream use must comply with the original terms:
+
+- **CARE.md** and **MI_CLEAR_LLM.md** are **CC BY-NC 4.0**: free to copy and
+  redistribute **with attribution for non-commercial purposes**. Commercial use
+  requires permission from the original rights holders.
+- **CLAIM_2024.md** is an educational summary of an RSNA open-access checklist
+  (© RSNA). Cite Tejani et al. 2024; consult RSNA for commercial reuse terms.
+
+All files remain educational summaries that cite their source; they do not relicense
+the underlying guidelines.

--- a/skills/check-reporting/references/checklists/CARE.md
+++ b/skills/check-reporting/references/checklists/CARE.md
@@ -1,0 +1,102 @@
+# CARE Checklist
+
+**CAse REports (CARE) guidelines**
+Version: CARE 2013
+Source: https://www.care-statement.org
+Reference: Gagnier JJ, Kienle G, Altman DG, Moher D, Sox H, Riley D. The CARE guidelines: consensus-based clinical case report guideline development. J Clin Epidemiol 2014;67(1):46-51.
+
+## Checklist Items (13 topics)
+
+### Title and Key Words
+
+| # | Item | Description |
+|---|------|-------------|
+| 1 | Title | The words "case report" should appear in the title along with the diagnosis or intervention of primary focus. |
+| 2 | Key Words | Two to five key words that identify topics in this case report, including "case report". |
+
+### Abstract
+
+| # | Item | Description |
+|---|------|-------------|
+| 3a | Abstract — Introduction | What is unique about this case and what does it add to the scientific literature? |
+| 3b | Abstract — Main concerns | The patient's main concerns and important clinical findings. |
+| 3c | Abstract — Diagnoses, interventions, outcomes | The primary diagnoses, interventions, and outcomes. |
+| 3d | Abstract — Conclusion | What are one or more "take-away" lessons from this case report? |
+
+### Introduction
+
+| # | Item | Description |
+|---|------|-------------|
+| 4 | Introduction | One or two paragraphs summarizing why this case is unique (may include references). |
+
+### Patient Information
+
+| # | Item | Description |
+|---|------|-------------|
+| 5a | Patient Information | De-identified demographic and other patient information. |
+| 5b | Patient Information | Main concerns and symptoms of the patient. |
+| 5c | Patient Information | Medical, family, and psychosocial history including relevant genetic information. |
+| 5d | Patient Information | Relevant past interventions and their outcomes. |
+
+### Clinical Findings
+
+| # | Item | Description |
+|---|------|-------------|
+| 6 | Clinical Findings | Describe the significant physical examination and other clinical findings. |
+
+### Timeline
+
+| # | Item | Description |
+|---|------|-------------|
+| 7 | Timeline | Historical and current information from this episode of care organized as a timeline (figure or table). |
+
+### Diagnostic Assessment
+
+| # | Item | Description |
+|---|------|-------------|
+| 8a | Diagnostic Assessment | Diagnostic methods (e.g., physical examination, laboratory testing, imaging, questionnaires). |
+| 8b | Diagnostic Assessment | Diagnostic challenges (e.g., access to testing, financial, or cultural). |
+| 8c | Diagnostic Assessment | Diagnostic reasoning including other diagnoses considered. |
+| 8d | Diagnostic Assessment | Prognostic characteristics (e.g., staging) where applicable. |
+
+### Therapeutic Intervention
+
+| # | Item | Description |
+|---|------|-------------|
+| 9a | Therapeutic Intervention | Types of therapeutic intervention (e.g., pharmacologic, surgical, preventive, self-care). |
+| 9b | Therapeutic Intervention | Administration of therapeutic intervention (e.g., dosage, strength, duration). |
+| 9c | Therapeutic Intervention | Changes in therapeutic intervention (with rationale). |
+
+### Follow-up and Outcomes
+
+| # | Item | Description |
+|---|------|-------------|
+| 10a | Follow-up and Outcomes | Clinician- and patient-assessed outcomes (when appropriate). |
+| 10b | Follow-up and Outcomes | Important follow-up diagnostic and other test results. |
+| 10c | Follow-up and Outcomes | Intervention adherence and tolerability (and how this was assessed). |
+| 10d | Follow-up and Outcomes | Adverse and unanticipated events. |
+
+### Discussion
+
+| # | Item | Description |
+|---|------|-------------|
+| 11a | Discussion | A scientific discussion of the strengths and limitations associated with this case report. |
+| 11b | Discussion | Discussion of the relevant medical literature with references. |
+| 11c | Discussion | The scientific rationale for any conclusions (including assessment of possible causes). |
+| 11d | Discussion | The primary "take-away" lessons of this case report (without references) in a one-paragraph conclusion. |
+
+### Patient Perspective
+
+| # | Item | Description |
+|---|------|-------------|
+| 12 | Patient Perspective | The patient should share their perspective on the treatment(s) they received, when appropriate. |
+
+### Informed Consent
+
+| # | Item | Description |
+|---|------|-------------|
+| 13 | Informed Consent | Did the patient give informed consent? Provide if requested. |
+
+---
+
+*Educational summary of the CARE 2013 checklist (CC BY-NC 4.0). Cite the original guideline (Gagnier et al. 2014) and consult https://www.care-statement.org for the authoritative, full checklist with explanation and elaboration.*

--- a/skills/check-reporting/references/checklists/CLAIM_2024.md
+++ b/skills/check-reporting/references/checklists/CLAIM_2024.md
@@ -1,0 +1,128 @@
+# CLAIM 2024 Checklist
+
+**Checklist for Artificial Intelligence in Medical Imaging**
+Version: CLAIM 2024 Update
+Source: https://pubs.rsna.org/doi/10.1148/ryai.240300
+Reference: Tejani AS, Klontzas ME, Gatti AA, Mongan JT, Moy L, Park SH, Kahn CE Jr. Checklist for Artificial Intelligence in Medical Imaging (CLAIM): 2024 Update. Radiol Artif Intell 2024;6(4):e240300.
+
+> Note: The 2024 update replaces "ground truth" with "reference standard" and discourages "validation" in favour of "internal/external testing". Each item is answered Yes / No / Not Applicable with the manuscript location cited.
+
+## Checklist Items (44 items)
+
+### Title and Abstract
+
+| # | Item | Description |
+|---|------|-------------|
+| 1 | Title | Identify the study as employing AI methodology and name the specific technology category (e.g., deep learning). |
+| 2 | Abstract | Structured summary including study design, methods, results, and conclusions; population details, data partitions, prospective/retrospective status, statistical analysis, outcomes, and availability of resources. |
+
+### Introduction
+
+| # | Item | Description |
+|---|------|-------------|
+| 3 | Background | Scientific and clinical background, current practice, intended use, and clinical role of the AI approach. |
+| 4 | Objectives | Study aims, objectives, and hypotheses (if not data-driven). |
+
+### Methods — Study Design
+
+| # | Item | Description |
+|---|------|-------------|
+| 5 | Study design | Prospective or retrospective study. |
+| 6 | Study goal | Goal of the study (e.g., model creation, feasibility, trial type, intended use for the classification task). |
+
+### Methods — Data
+
+| # | Item | Description |
+|---|------|-------------|
+| 7 | Data sources | State data sources; provide links to publicly available datasets. |
+| 8 | Eligibility | Inclusion and exclusion criteria and selection methodology for the data. |
+| 9 | Preprocessing | Data preprocessing steps (e.g., normalization, resampling, window/level adjustment). |
+| 10 | Subset selection | Selection of data subsets and training of personnel involved. |
+| 11 | De-identification | De-identification methods meeting HIPAA/GDPR/AI Act standards. |
+| 12 | Missing data | How missing data were handled and potential biases from imputation. |
+| 13 | Acquisition protocol | Image acquisition protocol parameters (e.g., manufacturer, sequences, resolution). |
+
+### Methods — Reference Standard
+
+| # | Item | Description |
+|---|------|-------------|
+| 14 | Reference standard definition | Method for obtaining the reference standard, with precise and replicable definitions. |
+| 15 | Reference standard rationale | Rationale for choosing the reference standard versus alternatives. |
+| 16 | Annotators | Source, qualifications, and training materials of annotators. |
+| 17 | Annotation procedures | Test-set annotation procedures, software version, and any NLP/automated approaches. |
+| 18 | Annotation variability | Measurement of inter- and intra-rater variability and method of discrepancy resolution. |
+
+### Methods — Data Partitions
+
+| # | Item | Description |
+|---|------|-------------|
+| 19 | Partition assignment | Partition assignment (train/tune/test), proportions, justification, and class-imbalance handling. |
+| 20 | Partition disjointness | Level of partition disjointness (patient-, series-, or image-level). |
+
+### Methods — Testing Data
+
+| # | Item | Description |
+|---|------|-------------|
+| 21 | Test set size | Testing-set size derived from a power calculation or AUC-based estimation. |
+
+### Methods — Model
+
+| # | Item | Description |
+|---|------|-------------|
+| 22 | Model architecture | Complete model architecture (inputs, outputs, layers, pooling, normalization). |
+| 23 | Software | Software libraries, frameworks, packages, and version numbers. |
+| 24 | Initialization | Parameter initialization; transfer-learning sources, if used. |
+
+### Methods — Training
+
+| # | Item | Description |
+|---|------|-------------|
+| 25 | Training procedures | Training procedures, data augmentation, convergence monitoring, and all hyperparameters. |
+| 26 | Model selection | Method and metrics for selecting the best-performing model. |
+| 27 | Ensembling | If an ensemble approach is used, details of each model and how outputs are combined. |
+
+### Methods — Evaluation
+
+| # | Item | Description |
+|---|------|-------------|
+| 28 | Performance metrics | Performance metrics and comparison to published models. |
+| 29 | Uncertainty | Measures of uncertainty (e.g., standard deviation, confidence intervals) and statistical significance tests. |
+| 30 | Robustness | Robustness or sensitivity analysis. |
+| 31 | Explainability | If applied, explainability/interpretability methods and their validation. |
+| 32 | Internal testing | Internal-data evaluation and consistency between training and test performance. |
+| 33 | External testing | External-data testing, or justification for its omission. |
+| 34 | Trial registration | If applicable, compliance with ICMJE clinical-trial registration requirements. |
+
+### Results — Data
+
+| # | Item | Description |
+|---|------|-------------|
+| 35 | Inclusion/exclusion numbers | Numbers of patients/examinations included and excluded, with a flowchart. |
+| 36 | Demographics | Demographic and clinical characteristics per partition; identify potential sources of bias. |
+
+### Results — Model Performance
+
+| # | Item | Description |
+|---|------|-------------|
+| 37 | Performance reporting | Final model performance benchmarked against the reference standard across partitions and subgroups. |
+| 38 | Accuracy estimates | Diagnostic accuracy estimates with 95% confidence intervals; ROC analysis; address class imbalance. |
+| 39 | Failure analysis | Failure analysis with a confusion matrix; examples of incorrect classifications in the medical context. |
+
+### Discussion
+
+| # | Item | Description |
+|---|------|-------------|
+| 40 | Limitations | Study limitations (methods, materials, biases, generalisability). |
+| 41 | Implications | Clinical implications, intended use, practice changes, and barriers to translation. |
+
+### Other Information
+
+| # | Item | Description |
+|---|------|-------------|
+| 42 | Full protocol | Reference to the full protocol or technical details if exceeding journal word limits. |
+| 43 | Availability | Availability of software, model, and data, and access conditions. |
+| 44 | Funding | Funding sources and the role of funders. |
+
+---
+
+*Educational summary of the CLAIM 2024 Update checklist (© RSNA, open access). Cite the original (Tejani et al., Radiol Artif Intell 2024;6(4):e240300) and consult the RSNA article for the authoritative, full checklist.*

--- a/skills/check-reporting/references/checklists/CONSORT.md
+++ b/skills/check-reporting/references/checklists/CONSORT.md
@@ -1,0 +1,86 @@
+# CONSORT 2025 Checklist
+
+**Consolidated Standards of Reporting Trials**
+Version: CONSORT 2025
+Source: https://www.consort-spirit.org
+Reference: Hopewell S, Chan AW, Collins GS, et al. CONSORT 2025 statement: updated guideline for reporting randomised trials. BMJ 2025;389:e081123 (published simultaneously in BMJ, JAMA, Lancet, Nature Medicine, PLoS Medicine).
+
+> Note: CONSORT 2025 supersedes CONSORT 2010. It is a 30-item checklist (seven new items, three revised, one deleted) restructured with a new Open Science section.
+
+## Checklist Items (30 items)
+
+### Title and Abstract
+
+| # | Item | Description |
+|---|------|-------------|
+| 1a | Title | Identification as a randomised trial. |
+| 1b | Abstract | Structured summary of the trial design, methods, results, and conclusions. |
+
+### Open Science
+
+| # | Item | Description |
+|---|------|-------------|
+| 2 | Trial registration | Name of trial registry, identifying number (with URL) and date of registration. |
+| 3 | Protocol and SAP | Where the trial protocol and statistical analysis plan can be accessed. |
+| 4 | Data, code, materials | Where and how the individual de-identified participant data (including data dictionary), statistical code and any other materials can be accessed. |
+| 5a | Funding | Sources of funding and other support (e.g., supply of drugs), and role of funders in the design, conduct, analysis and reporting of the trial. |
+| 5b | Conflicts of interest | Financial and other conflicts of interest of the manuscript authors. |
+
+### Introduction
+
+| # | Item | Description |
+|---|------|-------------|
+| 6 | Background | Scientific background and rationale. |
+| 7 | Objectives | Specific objectives related to benefits and harms. |
+
+### Methods
+
+| # | Item | Description |
+|---|------|-------------|
+| 8 | Patient and public involvement | Details of patient or public involvement in the design, conduct and reporting of the trial. |
+| 9 | Trial design | Description of trial design including type of trial (e.g., parallel group, crossover), allocation ratio, and framework. |
+| 10 | Changes to trial | Important changes to the trial after it commenced including any outcomes or analyses that were not prespecified, with reason. |
+| 11 | Settings and locations | Settings (e.g., community, hospital) and locations (e.g., countries, sites) where the trial was conducted. |
+| 12a | Eligibility — participants | Eligibility criteria for participants. |
+| 12b | Eligibility — sites/deliverers | If applicable, eligibility criteria for sites and for individuals delivering the interventions. |
+| 13 | Interventions | Intervention and comparator with sufficient details to allow replication. |
+| 14 | Outcomes | Prespecified primary and secondary outcomes, including the specific measurement variable, analysis metric, method of aggregation, and time point for each outcome. |
+| 15 | Harms | How harms were defined and assessed (e.g., systematically, non-systematically). |
+| 16a | Sample size | How sample size was determined, including all assumptions supporting the sample size calculation. |
+| 16b | Interim analyses | Explanation of any interim analyses and stopping guidelines. |
+| 17a | Randomisation — sequence | Who generated the random allocation sequence and the method used. |
+| 17b | Randomisation — restriction | Type of randomisation and details of any restriction (e.g., stratification, blocking and block size). |
+| 18 | Allocation concealment | Mechanism used to implement the random allocation sequence (e.g., central computer/telephone; sequentially numbered, opaque, sealed containers). |
+| 19 | Implementation | Whether the personnel who enrolled and those who assigned participants to the interventions had access to the random allocation sequence. |
+| 20a | Blinding — who | Who was blinded after assignment to interventions (e.g., participants, care providers, outcome assessors, data analysts). |
+| 20b | Blinding — how | If blinded, how blinding was achieved and description of the similarity of interventions. |
+| 21a | Statistical methods | Statistical methods used to compare groups for primary and secondary outcomes, including harms. |
+| 21b | Analysis populations | Definition of who is included in each analysis (e.g., all randomised participants), and in which group. |
+| 21c | Missing data | How missing data were handled in the analysis. |
+| 21d | Additional analyses | Methods for any additional analyses (e.g., subgroup and sensitivity analyses), distinguishing prespecified from post hoc. |
+
+### Results
+
+| # | Item | Description |
+|---|------|-------------|
+| 22a | Participant flow — numbers | For each group, the numbers of participants who were randomly assigned, received intended intervention, and were analysed for the primary outcome. |
+| 22b | Participant flow — losses | For each group, losses and exclusions after randomisation, together with reasons. |
+| 23a | Recruitment — dates | Dates defining the periods of recruitment and follow-up for outcomes of benefits and harms. |
+| 23b | Recruitment — stopping | If relevant, why the trial ended or was stopped. |
+| 24a | Intervention as administered | Intervention and comparator as they were actually administered (e.g., where appropriate, who delivered the intervention/comparator, how participants adhered, whether they were delivered as intended). |
+| 24b | Concomitant care | Concomitant care received during the trial for each group. |
+| 25 | Baseline data | A table showing baseline demographic and clinical characteristics for each group. |
+| 26 | Outcomes and estimation | For each primary and secondary outcome, by group: the number of participants included in the analysis, the number with available data at the outcome time point, result for each group, and the estimated effect size and its precision. |
+| 27 | Harms | All harms or unintended events in each group. |
+| 28 | Ancillary analyses | Any other analyses performed, including subgroup and sensitivity analyses, distinguishing pre-specified from post hoc. |
+
+### Discussion
+
+| # | Item | Description |
+|---|------|-------------|
+| 29 | Interpretation | Interpretation consistent with results, balancing benefits and harms, and considering other relevant evidence. |
+| 30 | Limitations | Trial limitations, addressing sources of potential bias, imprecision, generalisability, and, if relevant, multiplicity of analyses. |
+
+---
+
+*Educational summary of the CONSORT 2025 checklist (CC BY 4.0). Cite the original statement (Hopewell et al., BMJ 2025) and consult https://www.consort-spirit.org for the authoritative, full checklist with explanation and elaboration.*

--- a/skills/check-reporting/references/checklists/SPIRIT.md
+++ b/skills/check-reporting/references/checklists/SPIRIT.md
@@ -1,0 +1,112 @@
+# SPIRIT 2025 Checklist
+
+**Standard Protocol Items: Recommendations for Interventional Trials**
+Version: SPIRIT 2025
+Source: https://www.consort-spirit.org
+Reference: Chan AW, Hopewell S, Moher D, et al. SPIRIT 2025 statement: updated guideline for protocols of randomised trials. BMJ 2025;389:e081477 (published simultaneously in BMJ, JAMA, Lancet, Nature Medicine, PLoS Medicine).
+
+> Note: SPIRIT 2025 supersedes SPIRIT 2013. It is a 34-item checklist (two new items, five revised, five deleted/merged) restructured with a new Open Science section. Use for clinical trial *protocols* (CONSORT is for the completed trial report).
+
+## Checklist Items (34 items)
+
+### Administrative Information
+
+| # | Item | Description |
+|---|------|-------------|
+| 1a | Title | Title stating the trial design, population, and interventions, with identification as a protocol. |
+| 1b | Abstract | Structured summary of trial design and methods, including items from the World Health Organization Trial Registration Data Set. |
+| 2 | Protocol version | Version date and identifier. |
+| 3a | Roles — contributors | Names, affiliations, and roles of protocol contributors. |
+| 3b | Roles — sponsor contact | Name and contact information for the trial sponsor. |
+| 3c | Roles — sponsor role | Role of trial sponsor and funders in design, conduct, analysis, and reporting of trial; including any authority over these activities. |
+| 3d | Roles — committees | Composition, roles, and responsibilities of the coordinating site, steering committee, endpoint adjudication committee, data management team, and other individuals or groups overseeing the trial, if applicable. |
+
+### Open Science
+
+| # | Item | Description |
+|---|------|-------------|
+| 4 | Trial registration | Name of trial registry, identifying number (with URL), and date of registration. If not yet registered, name of intended registry. |
+| 5 | Protocol and SAP | Where the trial protocol and statistical analysis plan can be accessed. |
+| 6 | Data, code, materials | Where and how the individual de-identified participant data (including data dictionary), statistical code, and any other materials will be accessible. |
+| 7a | Funding | Sources of funding and other support (e.g., supply of drugs). |
+| 7b | Conflicts of interest | Financial and other conflicts of interest for principal investigators and steering committee members. |
+| 8 | Dissemination | Plans to communicate trial results to participants, healthcare professionals, the public, and other relevant groups (e.g., reporting in trial registry, plain language summary, publication). |
+
+### Introduction
+
+| # | Item | Description |
+|---|------|-------------|
+| 9a | Background | Scientific background and rationale, including summary of relevant studies (published and unpublished) examining benefits and harms for each intervention. |
+| 9b | Comparator choice | Explanation for choice of comparator. |
+| 10 | Objectives | Specific objectives related to benefits and harms. |
+
+### Methods: Patient and Public Involvement, Trial Design
+
+| # | Item | Description |
+|---|------|-------------|
+| 11 | Patient and public involvement | Details of, or plans for, patient or public involvement in the design, conduct, and reporting of the trial. |
+| 12 | Trial design | Description of trial design including type of trial (e.g., parallel group, crossover), allocation ratio, and framework (e.g., superiority, equivalence, non-inferiority, exploratory). |
+
+### Methods: Participants, Interventions, and Outcomes
+
+| # | Item | Description |
+|---|------|-------------|
+| 13 | Study setting | Settings (e.g., community, hospital) and locations (e.g., countries, sites) where the trial will be conducted. |
+| 14a | Eligibility — participants | Eligibility criteria for participants. |
+| 14b | Eligibility — sites/deliverers | If applicable, eligibility criteria for sites and for individuals who will deliver the interventions (e.g., surgeons, physiotherapists). |
+| 15a | Interventions — description | Intervention and comparator with sufficient details to allow replication including how, when, and by whom they will be administered. If relevant, where additional materials describing the intervention and comparator (e.g., intervention manual) can be accessed. |
+| 15b | Interventions — modifications | Criteria for discontinuing or modifying allocated intervention/comparator for a trial participant (e.g., drug dose change in response to harms, participant request, or improving/worsening disease). |
+| 15c | Interventions — adherence | Strategies to improve adherence to intervention/comparator protocols, if applicable, and any procedures for monitoring adherence (e.g., drug tablet return, sessions attended). |
+| 15d | Interventions — concomitant care | Concomitant care that is permitted or prohibited during the trial. |
+| 16 | Outcomes | Primary and secondary outcomes, including the specific measurement variable (e.g., systolic blood pressure), analysis metric (e.g., change from baseline, final value, time to event), method of aggregation (e.g., median, proportion), and time point for each outcome. |
+| 17 | Harms | How harms are defined and will be assessed (e.g., systematically, non-systematically). |
+| 18 | Participant timeline | Time schedule of enrolment, interventions (including any run-ins and washouts), assessments, and visits for participants. A schematic diagram is highly recommended. |
+| 19 | Sample size | How sample size was determined, including all assumptions supporting the sample size calculation. |
+| 20 | Recruitment | Strategies for achieving adequate participant enrolment to reach target sample size. |
+
+### Methods: Assignment of Interventions
+
+| # | Item | Description |
+|---|------|-------------|
+| 21a | Allocation — sequence | Who will generate the random allocation sequence and the method used. |
+| 21b | Allocation — restriction | Type of randomisation (simple or restricted) and details of any factors for stratification. To reduce predictability, other details of any planned restriction (e.g., blocking) should be provided in a separate document unavailable to those who enrol participants or assign interventions. |
+| 22 | Allocation concealment | Mechanism used to implement the random allocation sequence (e.g., central computer/telephone; sequentially numbered, opaque, sealed containers), describing any steps to conceal the sequence until interventions are assigned. |
+| 23 | Implementation | Whether the personnel who will enrol and those who will assign participants to the interventions will have access to the random allocation sequence. |
+| 24a | Blinding — who | Who will be blinded after assignment to interventions (e.g., participants, care providers, outcome assessors, data analysts). |
+| 24b | Blinding — how | If blinded, how blinding will be achieved and description of the similarity of interventions. |
+| 24c | Blinding — unblinding | If blinded, circumstances under which unblinding is permissible, and procedure for revealing a participant's allocated intervention during the trial. |
+
+### Methods: Data Collection, Management, and Analysis
+
+| # | Item | Description |
+|---|------|-------------|
+| 25a | Data collection | Plans for assessment and collection of trial data, including any related processes to promote data quality (e.g., duplicate measurements, training of assessors) and a description of trial instruments (e.g., questionnaires, laboratory tests) along with their reliability and validity, if known. Reference to where data collection forms can be accessed, if not in the protocol. |
+| 25b | Retention | Plans to promote participant retention and complete follow-up, including list of any outcome data to be collected for participants who discontinue or deviate from intervention protocols. |
+| 26 | Data management | Plans for data entry, coding, security, and storage, including any related processes to promote data quality (e.g., double data entry; range checks for data values). Reference to where details of data management procedures can be accessed, if not in the protocol. |
+| 27a | Statistical methods | Statistical methods used to compare groups for primary and secondary outcomes, including harms. |
+| 27b | Analysis populations | Definition of who will be included in each analysis (e.g., all randomised participants), and in which group. |
+| 27c | Missing data | How missing data will be handled in the analysis. |
+| 27d | Additional analyses | Methods for any additional analyses (e.g., subgroup and sensitivity analyses). |
+
+### Methods: Monitoring
+
+| # | Item | Description |
+|---|------|-------------|
+| 28a | Data monitoring committee | Composition of data monitoring committee (DMC); summary of its role and reporting structure; statement of whether it is independent from the sponsor and funder; conflicts of interest and reference to where further details about its charter can be found, if not in the protocol. Alternatively, an explanation of why a DMC is not needed. |
+| 28b | Interim analyses | Explanation of any interim analyses and stopping guidelines, including who will have access to these interim results and make the final decision to terminate the trial. |
+| 29 | Trial monitoring | Frequency and procedures for monitoring trial conduct. If there is no monitoring, give explanation. |
+
+### Ethics and Dissemination
+
+| # | Item | Description |
+|---|------|-------------|
+| 30 | Research ethics approval | Plans for seeking research ethics committee/institutional review board approval. |
+| 31 | Protocol amendments | Plans for communicating important protocol modifications to relevant parties. |
+| 32a | Consent | Who will obtain informed consent or assent from potential trial participants or authorised proxies, and how. |
+| 32b | Ancillary consent | Additional consent provisions for collection and use of participant data and biological specimens in ancillary studies, if applicable. |
+| 33 | Confidentiality | How personal information about potential and enrolled participants will be collected, shared, and maintained in order to protect confidentiality before, during, and after the trial. |
+| 34 | Ancillary and post-trial care | Provisions, if any, for ancillary and post-trial care, and for compensation to those who suffer harm from trial participation. |
+
+---
+
+*Educational summary of the SPIRIT 2025 checklist (CC BY 4.0). Cite the original statement (Chan et al., BMJ 2025) and consult https://www.consort-spirit.org for the authoritative, full checklist with explanation and elaboration.*

--- a/skills/present-paper/SKILL.md
+++ b/skills/present-paper/SKILL.md
@@ -567,7 +567,7 @@ Record `critic_pass: yes | partial | no` and `refine_rounds: N` in `_quick_revie
 ### Note Injection Script
 
 Generate a tailored `inject_notes.py` following the pattern in
-`${CLAUDE_SKILL_DIR}/references/inject_speaker_notes.py`. The generated script should
+`${CLAUDE_SKILL_DIR}/scripts/inject_speaker_notes.py`. The generated script should
 contain only the `notes` dictionary customized for this presentation and the main
 injection loop from the template.
 


### PR DESCRIPTION
## Problem (codex Improvement C)
`check-reporting/SKILL.md` advertised `CONSORT.md`, `CARE.md`, `SPIRIT.md`, and `CLAIM_2024.md` in its Reference Files block — but **all four were `.gitignore`d** as *"License-restricted (local use only, not for distribution)"*. The public distribution never shipped them, so every request quietly fell back to a from-memory checklist (the exact silent-fabrication path PR #42 closes). `present-paper` also pointed at `references/inject_speaker_notes.py` when the file lives under `scripts/`.

## License review
Surfaced the `.gitignore` exclusion to the maintainer before acting. With informed sign-off, all four are cleared for distribution **as educational summaries with per-file attribution**:

| File | Version | License | Distribution |
|---|---|---|---|
| CONSORT.md | CONSORT 2025 (30 items) | CC BY 4.0 | ✅ |
| SPIRIT.md | SPIRIT 2025 (34 items) | CC BY 4.0 | ✅ |
| CARE.md | CARE 2013 (13 topics) | CC BY-NC 4.0 | ✅ (same NC license as already-shipped `MI_CLEAR_LLM.md`) |
| CLAIM_2024.md | CLAIM 2024 (44 items) | RSNA open access | ✅ (educational summary, cite original) |

All sourced authoritatively from the current published statements (the official sites have moved to CONSORT/SPIRIT 2025) — no fabrication.

## Changes
- **Vendor** the four checklists, matching the existing item-table format + educational-summary disclaimer.
- **`.gitignore`**: remove the four exclusions so the files ship.
- **`LICENSES.md`**: four new attributions + a new **"Third-party licenses"** section stating that the CC BY-NC files (CARE, MI_CLEAR_LLM) and the RSNA file (CLAIM) retain their own terms and are **not** under the repo's MIT license; downstream commercial use must comply with the originals.
- **SKILL.md**: Reference Files bullets + auto-detection table updated to current versions (CONSORT 2025, SPIRIT 2025).
- **New** `scripts/validate_routing_assets.py`: scans every `skills/*/SKILL.md` for `${CLAUDE_SKILL_DIR}/<path>` asset references (handles `../` cross-skill paths) + the check-reporting checklist bullets, failing if any referenced file is absent. **Wired into `validate.yml` as a `--strict` CI gate.**
- **Fix** the `present-paper` `references/` → `scripts/` path so the gate is green.

## Validation
- `validate_skills.sh` → ALL CHECKS PASSED; contract validator → 0 failures
- `validate_routing_assets.py --strict` → OK (40 SKILL.md, 142 asset refs, 0 missing)
- Negative test: a planted missing reference is correctly flagged (`ROUTING_ASSET_INTEGRITY_VIOLATION`, exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)