### PR TITLE
Public-surface hardening: count-drift CI gate, README quick-start, contributor funnel, DOI badge fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a skill that produces wrong, broken, or unsafe output
+title: "[bug] <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please keep any pasted output public/synthetic — strip
+        real names, manuscript IDs, and institution-specific context before posting.
+  - type: input
+    id: skill
+    attributes:
+      label: Which skill?
+      placeholder: e.g. check-reporting, verify-refs, write-paper
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What the skill produced versus what you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The request you made and any inputs (anonymized).
+      placeholder: |
+        1. Invoked /... with ...
+        2. ...
+        3. Observed ...
+    validations:
+      required: true
+  - type: textarea
+    id: validator
+    attributes:
+      label: Validator / console output (if any)
+      description: Output from the repo validators or the agent, fenced in a code block.
+      render: shell
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OS + agent (e.g. macOS 15 / Claude Code 1.x, Codex, Cursor)
+    validations:
+      required: true
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Public-repo hygiene
+      options:
+        - label: This report contains no real names, manuscript IDs, project codes, hospital names, or patient-level details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/Aperivue/medsci-skills/discussions
+    about: Ask questions, share workflows, or discuss ideas before opening an issue.
+  - name: Contributing guide
+    url: https://github.com/Aperivue/medsci-skills/blob/main/CONTRIBUTING.md
+    about: How to add a skill, the PR checklist, and PII/publication hygiene rules.

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,35 @@
+name: Documentation improvement
+description: Report unclear, missing, or outdated documentation
+title: "[docs] <short summary>"
+labels: ["documentation", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation fixes are some of the most useful contributions. This is a great
+        first issue. Please point at the specific file or section.
+  - type: input
+    id: location
+    attributes:
+      label: Which document or file?
+      placeholder: e.g. README.md Quick Start, docs/setup/mac.md, skills/verify-refs/SKILL.md
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear, missing, or wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: A proposed wording or the missing information, if you have one.
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Public-repo hygiene
+      options:
+        - label: This report contains no real names, manuscript IDs, project codes, hospital names, or patient-level details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/skill_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_request.yml
@@ -1,0 +1,69 @@
+name: Skill request
+description: Propose a new skill for a recurring medical-research workflow
+title: "[skill] <short name>"
+labels: ["enhancement", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a skill. MedSci Skills is intentionally narrow — a
+        physician-researcher's manuscript pipeline. A good proposal explains the
+        recurring workflow, the artifacts it should produce, and where it sits in the
+        research lifecycle. Please keep examples public/synthetic (no real names,
+        manuscript IDs, or institution-specific context).
+  - type: textarea
+    id: purpose
+    attributes:
+      label: What workflow should this skill automate?
+      description: The recurring task, the target users, and the problem it solves.
+      placeholder: e.g. "Generate a PRISMA-compliant search-strategy appendix from a list of databases and query strings."
+    validations:
+      required: true
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Research-lifecycle stage
+      description: Where in the pipeline does this fit?
+      options:
+        - Topic discovery / literature
+        - Study design / sample size / protocol
+        - Data preparation / de-identification / cleaning
+        - Statistics / figures
+        - Writing / humanize / reporting compliance
+        - Journal selection / submission / peer review / revision
+        - Presentation
+        - Other (explain below)
+    validations:
+      required: true
+  - type: textarea
+    id: io
+    attributes:
+      label: Inputs and outputs
+      description: What does the skill consume, and what artifacts does it produce?
+      placeholder: "Inputs: ... | Outputs: ..."
+    validations:
+      required: true
+  - type: textarea
+    id: why-skill
+    attributes:
+      label: Why a new skill rather than an existing one?
+      description: Which existing skill is closest, and why does it not cover this?
+    validations:
+      required: true
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Are you willing to open a pull request?
+      options:
+        - "Yes, I can draft the skill"
+        - "Maybe, with guidance"
+        - "No, requesting only"
+    validations:
+      required: true
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Public-repo hygiene
+      options:
+        - label: This request contains no real names, manuscript IDs, project codes, hospital names, or patient-level details.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for contributing to MedSci Skills. Keep PRs small and reviewable.
+See CONTRIBUTING.md for the full workflow and PII/publication hygiene rules.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] New skill
+- [ ] Fix or improvement to an existing skill
+- [ ] Deterministic script / validator
+- [ ] Documentation
+- [ ] Other (describe above)
+
+## Validators
+
+- [ ] `bash scripts/validate_skills.sh`
+- [ ] `python3 scripts/validate_skill_contracts.py`
+- [ ] `python3 scripts/validate_catalog_consistency.py`
+- [ ] `python3 scripts/validate_routing_assets.py --strict`
+
+## Catalog consistency
+
+- [ ] If this PR **adds or removes a skill, reporting checklist, or journal profile**, I updated `metadata/catalog_counts.json` to match the new disk count, and `validate_catalog_consistency.py` passes. (Counts are a single source of truth — the README badge, tagline, and skill docs must all agree.)
+
+## PII and publication hygiene
+
+- [ ] No private project identifiers, manuscript IDs, collaborator names, patient-level examples, or institution-specific hidden context.
+- [ ] No personal absolute paths, private emails, or document metadata with author names.
+- [ ] Examples use public or synthetic datasets.
+
+## Documentation
+
+- [ ] New scripts include a short usage example and deterministic expected behavior.
+- [ ] The skill documentation states when the skill should **not** be used.
+- [ ] Public-facing copy is suitable for an open-source repository.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+MedSci Skills community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our standard
+
+This project adopts the **Contributor Covenant, version 2.1**, as its code of conduct.
+The full text — including the expected behavior, unacceptable behavior, enforcement
+responsibilities, scope, and enforcement guidelines — is available at:
+
+- https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+By participating, contributors agree to uphold that standard. In short: be respectful
+and constructive, assume good faith, and help keep discussion focused on the work.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull requests,
+discussions, and any other project channel) and also when an individual is officially
+representing the project in public spaces.
+
+## Reporting
+
+Code of Conduct concerns can be reported **privately** to the project maintainer
+identified in this repository's [`CITATION.cff`](CITATION.cff), reachable through their
+public GitHub profile. Reports of platform abuse may also be made to GitHub through the
+[report abuse](https://github.com/contact/report-abuse) channel.
+
+Please **do not** open a public issue to report a Code of Conduct concern — use the
+private channels above. All reports will be reviewed and handled with discretion.
+
+## Attribution
+
+This Code of Conduct adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Thank you for helping make medical research workflows more reproducible and less
 - Public demo improvements using open or synthetic datasets.
 - Documentation that helps clinicians install, test, or safely adapt the skills.
 
+Per-skill documentation is sourced from each `skills/<skill-name>/SKILL.md` (and is intended to be generated into `docs/skills/` rather than hand-maintained in parallel — a duplicated copy drifts from the skill). Improve the `SKILL.md` itself; see `docs/seed_issues.md` for the planned auto-generation work.
+
 ## Skill Addition Workflow
 
 1. Open an issue describing the workflow, target users, expected artifacts, and safety boundaries.
@@ -62,4 +64,4 @@ For JOSS readiness, contributions should strengthen open-source practice signals
 
 ## Code of Conduct
 
-Until a repository-specific `CODE_OF_CONDUCT.md` is added, contributors are expected to follow the Contributor Covenant principles: https://www.contributor-covenant.org/
+This project follows its [Code of Conduct](CODE_OF_CONDUCT.md), which adopts the Contributor Covenant. By participating, you agree to uphold it.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Skills](https://img.shields.io/badge/Skills-42-brightgreen?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-Claude_Code-blueviolet?style=flat-square)
 ![Built by](https://img.shields.io/badge/Built_by-Physician--Researcher-blue?style=flat-square)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20155321.svg)](https://doi.org/10.5281/zenodo.20155321)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20155321-blue?style=flat-square)](https://doi.org/10.5281/zenodo.20155321)
 [![Citation](https://img.shields.io/badge/Cite-CITATION.cff-blue?style=flat-square)](CITATION.cff)
 
 ![MedSci Skills](assets/social-preview.png)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **42 skills that actually work.** Built by a physician-researcher, tested on real publications.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![Skills](https://img.shields.io/badge/Skills-40-brightgreen?style=flat-square)
+![Skills](https://img.shields.io/badge/Skills-42-brightgreen?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-Claude_Code-blueviolet?style=flat-square)
 ![Built by](https://img.shields.io/badge/Built_by-Physician--Researcher-blue?style=flat-square)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20155321.svg)](https://doi.org/10.5281/zenodo.20155321)
@@ -21,14 +21,19 @@
 
 ---
 
-## What's New
+## Quick Start
 
-The v2.10 cycle expands the public workflow surface while tightening release hygiene:
+**No terminal?** Use the classroom installer ZIP — download, unzip, double-click the installer, then restart your agent app (see [Installation](#installation)).
 
-- `/peer-review` v2.10 adds the Phase 2A SR-MA 8-probe extension (P1-P8) for systematic review meta-analyses (PR #22).
-- `/verify-refs` v1.2.0 adds Gate 5 PMID/DOI duplicate detection plus synchronous `submission_safe` / `fully_verified` propagation (PR #23).
-- `/meta-analysis` adds SR-MA dual-extractor workflow support, cohort overlap detection, and a supplementary 8-file pack (PR #24).
-- Validator coverage now enforces the PII blocklist across `templates/` and `scripts/` as well as skill documentation.
+**Have git?** Install every skill in three commands:
+
+```bash
+git clone https://github.com/Aperivue/medsci-skills.git
+mkdir -p ~/.claude/skills
+cp -r medsci-skills/skills/* ~/.claude/skills/
+```
+
+Restart Claude Code, then start with **`/orchestrate`** — it classifies your request and routes you to the right skill. Full install options (Codex, Cursor, individual skills) are in [Installation](#installation).
 
 ---
 
@@ -51,6 +56,9 @@ data = load_breast_cancer()  # 569 samples, zero download
 
 **Output from `orchestrate --e2e`** ([see full demo](demo/01_wisconsin_bc/)):
 
+<details>
+<summary>Full output list — manuscript, figures, STARD flow, checklist, slides (click to expand)</summary>
+
 | Output | Description |
 |--------|-------------|
 | [Manuscript](demo/01_wisconsin_bc/manuscript/manuscript.md) | IMRAD draft, ~1,900 words |
@@ -64,6 +72,8 @@ data = load_breast_cancer()  # 569 samples, zero download
 | [Presentation](demo/01_wisconsin_bc/presentation/presentation.pptx) | 12 slides with speaker notes |
 | [Cover Letter](demo/01_wisconsin_bc/submission/radiology_ai/cover_letter.md) | Example submission cover letter |
 
+</details>
+
 **Pipeline:** `analyze-stats` &rarr; `make-figures` &rarr; `write-paper` &rarr; AI pattern scan &rarr; `check-reporting` (STARD) &rarr; `self-review` &rarr; DOCX build &rarr; `present-paper`
 
 ### Demo 2: Meta-Analysis — BCG Vaccine Efficacy
@@ -74,6 +84,9 @@ data(dat.bcg)  # 13 RCTs, 357,347 participants (Colditz et al. 1994)
 ```
 
 **Output from `orchestrate --e2e`** ([see full demo](demo/02_metafor_bcg/)):
+
+<details>
+<summary>Full output list — manuscript, forest/bubble plots, PRISMA flow, checklist, slides (click to expand)</summary>
 
 | Output | Description |
 |--------|-------------|
@@ -88,6 +101,8 @@ data(dat.bcg)  # 13 RCTs, 357,347 participants (Colditz et al. 1994)
 | [Pipeline Log](demo/02_metafor_bcg/qc/_pipeline_log.md) | 7-step E2E execution trace |
 | [Presentation](demo/02_metafor_bcg/presentation/presentation.pptx) | 12 slides with speaker notes |
 
+</details>
+
 **Pipeline:** `analyze-stats` (R metafor) &rarr; `make-figures` &rarr; `write-paper` &rarr; AI pattern scan &rarr; `check-reporting` (PRISMA 2020) &rarr; `self-review` &rarr; DOCX build &rarr; `present-paper`
 
 ### Demo 3: Epidemiology — NHANES Obesity & Diabetes
@@ -98,6 +113,9 @@ data(dat.bcg)  # 13 RCTs, 357,347 participants (Colditz et al. 1994)
 ```
 
 **Output from `orchestrate --e2e`** ([see full demo](demo/03_nhanes_obesity/)):
+
+<details>
+<summary>Full output list — manuscript, prevalence/OR plots, STROBE flow, checklist, slides (click to expand)</summary>
 
 | Output | Description |
 |--------|-------------|
@@ -111,6 +129,8 @@ data(dat.bcg)  # 13 RCTs, 357,347 participants (Colditz et al. 1994)
 | [Self-Review](demo/03_nhanes_obesity/qc/self_review.md) | Score 85/100 PASS (2 fix iterations; initial 75), 4 major / 5 minor |
 | [Pipeline Log](demo/03_nhanes_obesity/qc/_pipeline_log.md) | 7-step E2E execution trace |
 | [Presentation](demo/03_nhanes_obesity/presentation/presentation.pptx) | 12 slides with speaker notes |
+
+</details>
 
 **Pipeline:** `analyze-stats` &rarr; `make-figures` &rarr; `write-paper` &rarr; AI pattern scan &rarr; `check-reporting` (STROBE) &rarr; `self-review` &rarr; DOCX build &rarr; `present-paper`
 
@@ -146,6 +166,16 @@ project/
 ```
 
 The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `submission/` directory is created after journal selection via `/find-journal`.
+
+---
+
+## What's New
+
+The current cycle hardens public readiness:
+
+- Two new skills — `/generate-codebook` (citable data dictionary / codebook from a dataset) and `/version-dataset` (dataset reproducibility locks).
+- A catalog-count single source of truth (`metadata/catalog_counts.json`) with a CI gate that fails the build on any skill- or guideline-count drift across the README, badges, and skill docs — including the reporting-guideline figure, now corrected and enforced.
+- The PII / precedent guard now scans the full public surface (`templates/`, `scripts/`, and root docs), not just skill documentation.
 
 ---
 
@@ -339,7 +369,7 @@ Projects declare their source-of-truth layout in `SSOT.yaml`, and a `qc/migratio
 ### Meta-Analysis Failure Modes
 `/meta-analysis` ships empirical failure-mode references (data integrity, review orchestration, submission package drift, post-submission release ops) with four automation hooks: `scripts/prisma_5way_consistency.py` (DI-6 PRISMA number consistency), `scripts/extraction_consensus_log_init.py` (DI-1 dual-extraction scaffold), `scripts/tag_cleanup_gate.sh` (DI-8 placeholder tag gate), and `scripts/verify_package_integrity.py` (SPD SHA-256 manifest for submission bundles).
 
-### 33 Reporting Guidelines & RoB Tools Built-in
+### 32 Reporting Guidelines & RoB Tools Built-in
 `check-reporting` includes bundled checklists for 32 guidelines and risk-of-bias tools: STROBE, STARD, STARD-AI, TRIPOD, TRIPOD+AI, PRISMA 2020, PRISMA-DTA, PRISMA-P, MOOSE, ARRIVE, CONSORT, CARE, SPIRIT, CLAIM, SQUIRE 2.0, CLEAR, GRRAS, MI-CLEAR-LLM, SWiM, AMSTAR 2, QUADAS-2, QUADAS-C, RoB 2, ROBINS-I, ROBINS-E, ROBIS, ROB-ME, PROBAST, PROBAST+AI, NOS, COSMIN, RoB NMA. Includes Results/Discussion section boundary checks and machine-readable JSON summary for pipeline integration.
 
 ### Publication-Ready Output

--- a/docs/seed_issues.md
+++ b/docs/seed_issues.md
@@ -1,0 +1,64 @@
+# Seed Issues
+
+Copy-paste-ready issues a maintainer can file on GitHub to seed the contributor funnel.
+These are drafts — paste the body into a new issue and apply the suggested labels. They
+are intentionally scoped so a first-time contributor can pick one up.
+
+---
+
+## 1. Auto-generate per-skill docs from `SKILL.md` (+ CI drift gate)
+
+**Labels:** `good first issue`, `documentation`, `enhancement`
+
+**Body:**
+
+Per-skill documentation currently lives only inside each `skills/<skill>/SKILL.md`. A
+hand-maintained parallel copy under `docs/skills/` would drift, so we want it generated.
+
+Build a small, deterministic, stdlib-only generator:
+
+- `scripts/gen_skill_docs.py` reads the YAML frontmatter of every `skills/<skill>/SKILL.md`
+  (`name`, `description`, `triggers`, `tools`, `model`) and writes one
+  `docs/skills/<skill>.md` index page per skill, plus a `docs/skills/README.md` index
+  linking them all.
+- The page should link back to the source `SKILL.md` and list the skill's reference
+  files if present.
+- Add a `--check` mode that fails (non-zero exit) when the generated output is stale
+  relative to the current `SKILL.md` files, and wire it into `.github/workflows/validate.yml`
+  so doc drift fails CI — the same pattern as `scripts/validate_catalog_consistency.py`.
+
+Acceptance:
+- Running the generator produces `docs/skills/<skill>.md` for all skills.
+- `--check` passes immediately after generation and fails after an unsynced `SKILL.md` edit.
+- No personal paths, names, or PII in generated output (it is sourced from public SKILL.md).
+
+---
+
+## 2. Polish the 10 core skills' `SKILL.md` for first-time readers
+
+**Labels:** `help wanted`, `documentation`
+
+**Body:**
+
+The most-used skills should each open with a crisp "what it does / when to use / when NOT
+to use / minimal example" so a new clinician can orient in under a minute. Pick one skill,
+tighten its `SKILL.md` opening, and confirm the validators still pass
+(`bash scripts/validate_skills.sh`). One skill per PR keeps reviews small.
+
+Core skills to polish (claim one in a comment):
+
+- [ ] orchestrate
+- [ ] write-paper
+- [ ] analyze-stats
+- [ ] make-figures
+- [ ] check-reporting
+- [ ] verify-refs
+- [ ] meta-analysis
+- [ ] revise
+- [ ] peer-review
+- [ ] sync-submission
+
+Acceptance:
+- The skill's `SKILL.md` clearly states purpose, when to use, when not to use, and a
+  minimal example.
+- `bash scripts/validate_skills.sh` and `python3 scripts/validate_skill_contracts.py` pass.

--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -11,9 +11,12 @@ Three layers:
   1. Recompute every count from disk (the real ground truth).
   2. Assert metadata/catalog_counts.json matches disk — the SSOT cannot lie.
   3. Assert the count claims in README / orchestrate / check-reporting match the
-     SSOT. Guideline claims are matched by the word "guideline"; the skill self-
-     count by the "skills that actually work" tagline — so comparison/marketing
-     lines about *other* repos ("400-900 skills", "869 skills") are never touched.
+     SSOT. Guideline claims are matched (case-insensitively, so a "### 33 Reporting
+     Guidelines" heading is caught) by the word "guideline"; the skill self-count by
+     both the "skills that actually work" tagline and the README shields badge
+     (img.shields.io/badge/Skills-N-). The badge regex is scoped to the shields URL so
+     arbitrary prose never trips it, and comparison/marketing lines about *other* repos
+     ("400-900 skills", "869 skills") are never touched.
 
 Exit 0 when everything agrees; non-zero on any drift. Stdlib-only.
 """
@@ -55,6 +58,9 @@ GUIDELINE_CLAIM_FILES = [
     "skills/make-figures/references/reporting_guideline_figure_map.md",
 ]
 SKILLS_TAGLINE_FILES = ["README.md"]
+# README shields badge (img.shields.io/badge/Skills-N-...). Scoped to the badge URL so
+# only the literal badge count is checked, never arbitrary "Skills" prose.
+SKILLS_BADGE_FILES = ["README.md"]
 
 
 def doc_claims() -> list[tuple[str, int, int, str]]:
@@ -70,8 +76,9 @@ def doc_claims() -> list[tuple[str, int, int, str]]:
     g = truth["reporting_guidelines"]
     s = truth["skills"]
 
-    guide_re = re.compile(r"\b(\d{1,2})\s+(?:reporting\s+)?guidelines\b")
+    guide_re = re.compile(r"\b(\d{1,2})\s+(?:reporting\s+)?guidelines\b", re.IGNORECASE)
     skills_re = re.compile(r"\*\*(\d+)\s+skills that actually work")
+    badge_re = re.compile(r"img\.shields\.io/badge/Skills-(\d+)-")
 
     for rel in GUIDELINE_CLAIM_FILES:
         f = ROOT / rel
@@ -88,6 +95,14 @@ def doc_claims() -> list[tuple[str, int, int, str]]:
         for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
             for m in skills_re.finditer(line):
                 out.append((rel, int(m.group(1)), s, f"L{i} skills tagline"))
+
+    for rel in SKILLS_BADGE_FILES:
+        f = ROOT / rel
+        if not f.exists():
+            continue
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for m in badge_re.finditer(line):
+                out.append((rel, int(m.group(1)), s, f"L{i} skills badge"))
     return out
 
 


### PR DESCRIPTION
## Summary

Public-readiness hardening for the repo (not new features): close skill-count drift, make the count validator actually gate it, tighten the README top-of-funnel, and wire up the contributor intake forms.

## Count integrity
- `validate_catalog_consistency.py` now gates the README shields **badge** (`img.shields.io/badge/Skills-N-`) and matches guideline-count claims **case-insensitively**, so a `### 33 Reporting Guidelines` heading no longer slips past the check.
- Fixed the two live drifts the extended gate caught: badge `Skills-40 → 42` and the `33 Reporting Guidelines` heading `→ 32`. `metadata/catalog_counts.json` (42 / 32) was already correct and is unchanged.

## README top-of-funnel
- Added a **Quick Start** (install + first command) directly under the hero so install is above the fold.
- Collapsed the three heavy demo output tables under `<details>`.
- Refreshed and demoted the stale **What's New** below the demos.
- Fixed the **DOI badge**: the Zenodo-hosted SVG sends `Cache-Control: no-cache`, which GitHub's Camo proxy can't cache, so it rendered as a broken image. Swapped to a shields.io static DOI badge (Camo-cacheable) that keeps the link to the real DOI.

## Contributor funnel
- `.github/ISSUE_TEMPLATE/` forms: `skill_request`, `bug_report`, `docs_improvement`, plus `config.yml` (blank issues off; Discussions + Contributing contact links).
- `.github/pull_request_template.md` mirrors the CONTRIBUTING checklist and adds a catalog-count-bump reminder.
- `CODE_OF_CONDUCT.md` adopts the Contributor Covenant 2.1 by reference; CONTRIBUTING points at it.
- `docs/seed_issues.md` stages two ready-to-file issues (auto-generate `docs/skills/` from `SKILL.md` frontmatter + CI gate; polish the 10 core skills).

## Validators
`validate_catalog_consistency.py`, `validate_skills.sh`, `validate_skill_contracts.py`, and `validate_routing_assets.py --strict` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
