### PR TITLE
revise: R1 vs R2+ cover-letter protocol + succinct, non-defensive R2R voice

### DIFF
--- a/skills/humanize/references/ai_patterns.md
+++ b/skills/humanize/references/ai_patterns.md
@@ -418,6 +418,15 @@ text under review is a response letter or cover letter. See the revise skill's
 `references/r2r_voice.md` for full before/after skeletons. Examples below are synthetic
 (a fictional deep-learning lung-nodule CT study).
 
+**Related (triage, not a fixed-string pattern):** *defensive over-elaboration* — pre-emptive
+cross-reviewer lobbying ("Reviewers 2 and 3 also accepted this"), defensive meta-comments ("we
+confirm this is unchanged and not softened"), manufactured paragraphs answering a satisfied
+reviewer, or a separate cover letter on an R2+ round when its content belongs in the
+response-letter head — is a succinctness / round-discipline issue, not a regex pattern, and is
+most common on R2+ rounds. The normative guidance lives in the revise skill (Step 5 +
+Response-Letter Voice), its `references/r2r_voice.md`, and the `rebuttal-letter-style` rule;
+humanize only cross-references it (no hard fail, no detection regex added here).
+
 ### Pattern 22: Editing-Mechanism / Change-Log Narration
 
 The response prose narrates *how the text was edited* — what was added, where, how many phrases

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -340,6 +340,16 @@ Three principles when drafting (the AI-tell patterns themselves are defined once
 - **Admit error plainly** when the reviewer is right ("The reviewer is correct; we have corrected this.") — natural humility reads as human and builds editor trust.
 - **Quote the new manuscript text** verbatim in quotation marks, then name its section — what experienced authors do, and the single strongest human signal across real letters.
 
+### Succinctness & non-defensiveness (especially R2+)
+
+Let the point-by-point prove the work; strip the pre-emptive defence. This matters most on **R2+ rounds**, where over-explaining reads as anxiety rather than rigor.
+
+- **No pre-emptive hand-holding.** Drop "Reviewers 2 and 3 also accepted this," "we left it unchanged because the other reviewers were satisfied," and similar cross-reviewer lobbying. Answer the comment in front of you.
+- **A satisfied reviewer gets one sentence.** If a reviewer is content or offers only praise, "We thank the reviewer." or a single sentence is the whole response. Do not manufacture paragraphs.
+- **Cut defensive meta-comments.** Remove "We confirm this statement is unchanged and not softened," "These passages already make the point, so no further text was added." State plainly where the matter is handled and move on.
+- **Fold methodology disclosure into the comment it answers.** Multiplicity, a SAP deviation, or an analysis caveat goes inside the relevant response — not into a separate "Statistical note" front section. Keep the disclosure (never hide a deviation), but keep it in place.
+- **Split, do not bundle.** When a reviewer packs several points into one paragraph, answer each as its own comment with that reviewer sentence quoted, not one block reply to the whole paragraph. Succinct means short *answers*, not fewer *comments*.
+
 See `${CLAUDE_SKILL_DIR}/references/r2r_voice.md` for the before/after gallery, response
 skeletons, and the meta-phrase conversion table.
 
@@ -383,6 +393,34 @@ Sincerely,
 On behalf of all authors
 ```
 
+### R1 vs R2+ cover-letter protocol
+
+The template above is the **R1** convention: a standalone editor cover letter (200-400 words).
+
+On an **R2+ round (second revision onward), do not write a separate cover letter.** Whatever you would say to the editor — the greeting and the brief change summary — belongs in the **head of the response-to-reviewers letter**, not in a second document. A standalone cover letter that merely restates the response letter's summary reads as redundant and, on later rounds, as boilerplate. If an earlier round already produced a `cover_letter_R1.md`, move it to `_superseded/`, exclude it from the R2+ package, and reuse the response-letter head verbatim in any portal "cover letter" field. (Exception: a journal that explicitly requires a separate cover letter at every round — then keep the head summary and the cover letter from duplicating each other.)
+
+**Response-letter head (R2+)** — placed at the top of `response_to_reviewers_R[N].md`, before the point-by-point:
+
+```
+Dear Dr. [Editor Name / "Editor-in-Chief"],
+
+Thank you for the opportunity to revise our manuscript once more. In brief, this
+revision [1-2 sentence summary of the principal changes — e.g., "adds the requested
+subgroup analysis and tempers the three comparisons the reviewers flagged as
+over-stated"].
+
+[If applicable: one sentence on a companion paper, a re-analysis, or a verification
+the editor requested.]
+
+All quotations below are from the revised manuscript. A point-by-point response to each
+comment follows.
+
+Sincerely,
+[First Author Name], on behalf of all authors
+```
+
+Keep the head to a short greeting, a one-paragraph "in brief," an optional companion/verification note, the single line stating quotations are from the revised manuscript, and the signature. Everything else is point-by-point.
+
 ---
 
 ## Step 6: Change Log
@@ -409,6 +447,10 @@ After all responses are drafted, check:
 - [ ] No `§` symbols and no editing-mechanism narration ("v2 adds one sentence", "grep verification", "No further manuscript change")
 - [ ] Acknowledgment openers varied (not one sentence repeated across responses)
 - [ ] Response letter AND cover letter ran through `/humanize` (patterns 22-24 triage hits reviewed; confirmed instances = 0; `§` = 0 hard)
+- [ ] (R2+) No separate cover letter — the editor greeting and "in brief" summary are folded into the response-letter head
+- [ ] (R2+) Satisfied reviewers get ≤1-2 sentences; no pre-emptive hand-holding or cross-reviewer lobbying
+- [ ] Multi-point reviewer paragraphs are split into discrete comments (reviewer sentence quoted + Response N), not answered as a block
+- [ ] Methodology disclosure (multiplicity, SAP deviation) is folded into the relevant response, not a separate front section
 - [ ] Cover letter is addressed to the correct editor
 - [ ] Response letter is 5000-8000 words
 - [ ] Tracked changes are enabled in the revised manuscript
@@ -432,10 +474,11 @@ For R2+, acknowledge whether R1 concerns were fully resolved. If a reviewer rais
 ## Word Count Guidance
 
 - Response letter total: 5000-8000 words (including quoted reviewer comments)
-- Cover letter: 200-400 words
+- Cover letter: 200-400 words (R1 only; on R2+ there is no separate cover letter — see Step 5)
 - MINOR response: 50-150 words
 - MAJOR response: 150-400 words
 - REBUTTAL response: 200-500 words
+- **R2+ rounds run leaner.** Most R1 concerns are already resolved, so the letter is shorter and a satisfied reviewer's response is 1-2 sentences. Do not pad an R2+ reply to reach the R1 range.
 
 ---
 
@@ -468,4 +511,5 @@ For R2+, acknowledge whether R1 concerns were fully resolved. If a reviewer rais
 | `/verify-refs --strict` post-revision | ENFORCED | FABRICATED / HIGH_MISMATCH_FIRST_AUTHOR > 0 | HALT R1 submission |
 | New analysis coordination | ENFORCED | reviewer asks for new analysis | route to `/analyze-stats` (and `/make-figures` if figure changes); never hand-write new numbers |
 | Cover letter to editor | ENFORCED at R1 submission | R1 missing editor cover letter | block submission |
+| R2+ cover-letter handling | ENFORCED at R2+ submission | standalone cover letter present on an R2+ round (not folded into the response-letter head) | move it to `_superseded/`; fold the summary into the head |
 | Response-letter voice / AI-tell | ENFORCED before submission | editing-mechanism narration, internal draft line refs, `§`, tooling leak, or repeated openers in response/cover letter | run `/humanize` (patterns 22-24 as triage; `§` = 0 hard); resolve confirmed tells before submission |

--- a/skills/revise/references/r2r_voice.md
+++ b/skills/revise/references/r2r_voice.md
@@ -152,6 +152,91 @@ internal line numbers, the `§` markers, or the internal FIX label.
 
 ---
 
+## Succinctness & non-defensiveness (R2+)
+
+Items 1-6 strip the *editing-mechanism* tell. These strip the *defensive over-elaboration* tell,
+which dominates later (R2+) rounds: pre-emptive lobbying, manufactured paragraphs for satisfied
+reviewers, and disclosure piled into a front section. The fix is always to say less and let the
+point-by-point carry the work. (Examples remain synthetic — a fictional imaging deep-learning study.)
+
+### 7. Pre-emptive hand-holding / cross-reviewer lobbying
+
+**AI-tell (bad):**
+"We respectfully note that Reviewers 1 and 3 found this analysis appropriate, and we left the
+primary endpoint unchanged on that basis. We hope Reviewer 2 will agree that the consensus of
+the panel supports our approach."
+
+**Natural (good):**
+"We retained the primary endpoint as pre-registered. Our reasoning is [one-sentence scientific
+justification]; we have added it to the Methods: '[new sentence].'"
+
+Why: answer the reviewer in front of you on the merits. Citing what other reviewers thought is
+lobbying, not science, and reads as defensive.
+
+### 8. Defensive meta-comment about an unchanged passage
+
+**AI-tell (bad):**
+"We confirm that this statement is unchanged and has not been softened or weakened in any way,
+and we emphasise that it already fully conveys the intended claim."
+
+**Natural (good):**
+"This is already stated in the Discussion: '[existing sentence].'"
+
+Why: point to where the matter is handled and stop. Insisting that nothing was weakened invites
+the suspicion that something was.
+
+### 9. Over-elaborated response to a satisfied reviewer
+
+> Reviewer: The revised manuscript is much improved and I have no further concerns.
+
+**AI-tell (bad):**
+"We are deeply grateful to the reviewer for this generous assessment. It has been a privilege to
+benefit from such careful and constructive guidance throughout, and we are delighted that the
+substantial revisions across the Methods, Results, and Discussion have fully addressed the
+concerns raised in the previous round."
+
+**Natural (good):**
+"Thank you."
+
+Why: a satisfied reviewer needs one sentence. A paragraph of gratitude is padding and reads as
+machine-generated filler.
+
+### 10. Methodology disclosure as a separate front section
+
+**AI-tell (bad):**
+A standalone "Statistical Note" at the top of the letter: "Before responding to individual
+comments, we wish to disclose that the subgroup analyses were not adjusted for multiplicity..."
+
+**Natural (good):** inside the response to the comment that raised it —
+"The reviewer is right to ask about multiplicity. These subgroup analyses were exploratory and
+are not adjusted for multiple comparisons; we now state this in the Methods and label them as
+exploratory in Table 3."
+
+Why: keep the disclosure (never hide a deviation) but put it where the reviewer raised it. A
+front-loaded "note" separates the admission from the question and reads as pre-emptive defence.
+
+### 11. Bundling a multi-point paragraph into one block reply
+
+> Reviewer: The introduction is too long, the cohort definition is unclear, and Figure 2 is
+> hard to read.
+
+**AI-tell (bad):**
+"We thank the reviewer for these helpful comments. We have shortened the introduction, clarified
+the cohort, and improved Figure 2 accordingly."
+
+**Natural (good):** split into three —
+"**Comment 1.** *'The introduction is too long.'* We have cut the introduction by roughly a
+third, removing [what]. …
+**Comment 2.** *'The cohort definition is unclear.'* We have added to the Methods: '[new
+sentence].' …
+**Comment 3.** *'Figure 2 is hard to read.'* We have remade Figure 2 with [change]. …"
+
+Why: each sub-point gets a quoted comment and a specific response. A single block reply hides
+which point you actually addressed and which you skipped. Succinct means short answers, not
+fewer comments.
+
+---
+
 ## Three response skeletons
 
 Pick the skeleton that matches the comment's substance; do not force every reply into one shape.
@@ -194,6 +279,21 @@ add [the requested item] in a subsequent revision."
 
 This is a common, courteous move: it shows you took the request seriously, gives a reason, and
 defers rather than flatly refusing.
+
+### Response-letter head (R2+)
+
+On R1 the editor gets a separate cover letter; on **R2+ there is no separate cover letter** — its
+content becomes the head of the response letter. Keep the head to a short greeting, a
+one-paragraph "in brief" summary of the principal changes, an optional one-sentence
+companion/verification note, the single line stating that all quotations are from the revised
+manuscript, and the signature. Then go straight to the point-by-point.
+
+"Dear Dr. [Editor], thank you for the opportunity to revise our manuscript once more. In brief,
+this revision [1-2 sentence change summary]. All quotations below are from the revised
+manuscript; a point-by-point response follows. Sincerely, [First Author], on behalf of all
+authors."
+
+Reuse this head verbatim in any portal "cover letter" field rather than writing a second document.
 
 ---
 
@@ -240,3 +340,7 @@ defers rather than flatly refusing.
 - [ ] New manuscript text quoted verbatim where a sentence-level change was made
 - [ ] Em dashes below threshold (see humanize Pattern 13)
 - [ ] Ran `/humanize` on both documents; triage hits reviewed, confirmed patterns 22-24 instances = 0 (`§` = 0 hard)
+- [ ] (R2+) No separate cover letter; its summary is folded into the response-letter head
+- [ ] Satisfied reviewers answered in 1-2 sentences; no cross-reviewer lobbying or defensive meta-comments
+- [ ] Multi-point reviewer paragraphs split into discrete, individually quoted comments
+- [ ] Methodology disclosures folded into the relevant response, not a separate front section


### PR DESCRIPTION
## Summary

Generalize an experienced senior mentor's R2-round rebuttal guidance into the public `/revise`, `r2r_voice`, and `/humanize` references. Motivation is generalized ("a senior mentor on an R2 round"); every example is synthetic (a fictional imaging deep-learning study). No identifiers.

## `skills/revise/SKILL.md`
- **Step 5** now branches **R1 vs R2+**. On R2+ there is no separate cover letter — its greeting and "in brief" summary fold into a new **Response-letter head (R2+)** template, reused verbatim in any portal cover-letter field.
- **Response-Letter Voice** gains a **Succinctness & non-defensiveness (especially R2+)** subsection: no pre-emptive hand-holding, a satisfied reviewer gets one sentence, cut defensive meta-comments, fold methodology disclosure into the comment it answers, and split multi-point paragraphs into discrete quoted comments.
- **Step 7** verification and the **Gates** table add the R2+ checks; **Word Count Guidance** notes R2+ rounds run leaner.

## `skills/revise/references/r2r_voice.md`
- New **Succinctness & non-defensiveness (R2+)** before/after gallery (items 7–11), the **Response-letter head (R2+)** template, and matching pre-submission checks.

## `skills/humanize/references/ai_patterns.md`
- One triage cross-reference in the R2R section. Defensive over-elaboration is a succinctness / round-discipline issue, not a fixed-string pattern; the normative guidance stays in the revise skill + `r2r_voice.md`. No new hard pattern and no detection regex added.

## Validators
`validate_skills.sh` and `validate_skill_contracts.py` pass (pre-commit hook included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
