### PR TITLE
docs(positioning): sharpen wedge, drop volatile competitor counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **42 skills that actually work.** Built by a physician-researcher, tested on real publications.
 
+*MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog. It competes on clinical submission reliability, not skill count.*
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Skills](https://img.shields.io/badge/Skills-42-brightgreen?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-Claude_Code-blueviolet?style=flat-square)
@@ -181,9 +183,9 @@ The current cycle hardens public readiness:
 
 ## Why This Repo?
 
-| | MedSci Skills | Aggregator repos (400-900 skills) |
+| | MedSci Skills | Broad skill aggregators |
 |---|---|---|
-| **Citation quality** | Every reference verified via PubMed / Semantic Scholar / CrossRef API. Zero hallucinated citations. | No verification -- citations generated from model memory |
+| **Citation quality** | Every reference passes reference-verification gates (PubMed / Semantic Scholar / CrossRef) and citation-audit workflows before inclusion. | No verification -- citations generated from model memory |
 | **Pipeline integration** | Skills call each other in defined chains. `design-study` -> `calc-sample-size` -> `write-protocol`. | Standalone stubs with no cross-skill interaction |
 | **End-to-end coverage** | From IRB protocol to journal submission: sample size, data cleaning, analysis, writing, compliance, journal selection, cover letter. | Gaps at every transition -- no protocol, no journal matching, no cover letter |
 | **Battle-tested** | Used on real manuscript submissions by a practicing physician-researcher | Unknown provenance and validation |
@@ -193,7 +195,7 @@ The current cycle hardens public readiness:
 
 ## What This Is NOT
 
-This is **not** a broad scientific-tooling library — for cheminformatics, structural biology, or genomics pipelines, see [K-Dense scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) (135 skills). It is **not** a biomedical-skill aggregator — for the largest curated collection mirroring 12+ source repos, see [OpenClaw Medical Skills](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills) (869 skills).
+This is **not** a broad scientific-tooling library — for cheminformatics, structural biology, or genomics pipelines, see [K-Dense scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills). It is **not** a biomedical-skill aggregator — for a broad curated collection, see [OpenClaw Medical Skills](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills). For how MedSci Skills compares to these catalogs, see [`docs/competitive_positioning.md`](docs/competitive_positioning.md); a cross-agent host-compatibility roadmap is planned.
 
 MedSci Skills is **opinionated and narrow on purpose**: a single physician-researcher's medical-manuscript pipeline, biased toward radiology, diagnostic accuracy, observational EMR studies, and systematic review / meta-analysis. If you write IMRAD manuscripts for clinical journals, audit reporting compliance against EQUATOR guidelines, or run SR/MA workflows end-to-end, this is built for you. For wet-lab protocols, drug discovery, or single-cell genomics, the repos above are better fits.
 

--- a/docs/competitive_positioning.md
+++ b/docs/competitive_positioning.md
@@ -1,0 +1,53 @@
+# Competitive Positioning
+
+> **MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog.**
+> **It competes on clinical submission reliability, not skill count.**
+
+This page explains where MedSci Skills sits relative to broad agent-skill catalogs, and where it deliberately does **not** compete. It is intentionally narrow: one physician-researcher's medical-manuscript pipeline, biased toward radiology, diagnostic accuracy, observational EMR studies, and systematic review / meta-analysis.
+
+## What it is
+
+A connected pipeline from research question to journal submission: topic discovery → literature search → full-text retrieval → study design → sample size → protocol → de-identification → data cleaning → statistics → figures → writing → humanize → reporting compliance → reference verification → journal selection → peer review → revision → submission drift control.
+
+The differentiated strength is **submission reliability**, not breadth:
+
+- **Reference-verification gates and citation-audit workflows.** References pass PubMed / Semantic Scholar / CrossRef verification (including full-author cross-checks) before inclusion, rather than being generated from model memory.
+- **Reporting-guideline compliance.** Item-by-item audits against EQUATOR-network checklists (STROBE, CONSORT, STARD, TRIPOD+AI, PRISMA, and risk-of-bias tools).
+- **Drift guards.** Numerical, reference, and submission-package consistency checks across the manuscript lifecycle.
+- **Cross-skill chaining.** Skills call each other in defined chains (for example, `design-study` → `calc-sample-size` → `write-protocol`), rather than standing alone.
+- **Reproducible demos.** End-to-end demo projects on public datasets with manifest-locked outputs.
+
+## How it differs from broad skill catalogs
+
+Broad catalogs optimize for **coverage** — hundreds of skills spanning many scientific domains. MedSci Skills optimizes for **curation and reliability** within a single clinical-manuscript domain: fewer skills, each with bundled reference material, validators, explicit usage boundaries, and tested behavior on real publication workflows.
+
+Skill count is not the axis of comparison. A larger catalog does not make a manuscript more likely to pass desk review; reference integrity, reporting compliance, and consistency control do.
+
+## Comparable repositories
+
+These are larger-scope catalogs that serve adjacent needs. Skill counts drift; the figures below are point-in-time and should be re-checked at the source.
+
+| Repository | Scope | Skill count (as of 2026-06-03; verify at source) |
+|---|---|---|
+| [K-Dense scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) | Multi-disciplinary science (cheminformatics, structural biology, genomics) | ~140 (verify at source) |
+| [OpenClaw Medical Skills](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills) | Broad biomedical aggregation across many source repos | ~870 (verify at source) |
+| [AIPOCH medical-research-skills](https://github.com/aipoch/medical-research-skills) | Medical research, with a published skill-audit framing | varies (verify at source) |
+| [Orchestra AI Research Skills](https://github.com/Orchestra-Research/AI-Research-SKILLs) | AI/ML research lifecycle | varies (verify at source) |
+
+If you need wet-lab protocols, drug discovery, single-cell genomics, broad bioinformatics, or generic AI/ML engineering, those catalogs are better fits.
+
+## What MedSci Skills does not do
+
+- No skill-count race.
+- No omics / single-cell / broad bioinformatics.
+- No drug discovery or cheminformatics.
+- No generic AI/ML engineering.
+- No hundreds of thin skills.
+
+## Host compatibility
+
+MedSci Skills targets Claude Code today. A cross-agent host-compatibility roadmap (Codex, Cursor, and the generic Agent Skills standard) is planned; host support will be stated only where install and discovery have been verified against official documentation.
+
+---
+
+*Part of [MedSci Skills](../README.md). For the per-skill reference, see [`docs/skills/`](skills/).*


### PR DESCRIPTION
Adds the canonical positioning lines (submission-grade clinical manuscript workflow; competes on reliability, not skill count), removes brittle competitor skill counts from the README body, softens the citation claim to validator-backed language, and adds `docs/competitive_positioning.md`. The 42-count tagline, Skills badge, and Platform badge are untouched.

**Stacked PR 1/6.** Base: `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)