### PR TITLE
feat(contracts): complete skill.yml to 42/42 with v2.1 quality cards

### DIFF
--- a/skills/academic-aio/skill.yml
+++ b/skills/academic-aio/skill.yml
@@ -1,0 +1,36 @@
+schema_version: 2
+name: academic-aio
+layer: C
+owner_domain: manuscript_optimization
+
+when_to_use: "Optimize a medical-AI manuscript's title, abstract, and structured summary boxes for AI search engines and RAG tools, integrating TRIPOD+AI/CLAIM/STARD-AI reporting requirements."
+when_NOT_to_use: "Drafting a manuscript from scratch (use write-paper); removing AI writing tells (use humanize)."
+
+inputs:
+  - "draft manuscript / abstract / title (Markdown)"
+outputs:
+  - "AIO-optimized title, abstract, structured summary boxes"
+  - "visible pass/fail checklist"
+deterministic_scripts:
+  - scripts/validate_schema.py
+  - scripts/batch_metadata_audit.py
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - self-review
+  - check-reporting
+forbidden_actions:
+  - silently_rewrite_without_user_review
+  - fabricate_reporting_guideline_compliance
+
+# v2.1 quality card
+purpose: "Make a medical-AI manuscript discoverable and citable by AI search/RAG tools without sacrificing reporting-guideline compliance."
+safety_boundaries:
+  - "Off by default in autonomous pipelines; rewrites require user review (no silent rewrite)."
+  - "Reporting-guideline claims are checked, never asserted without the underlying item being present."
+known_limitations:
+  - "GEO/AIO heuristics evolve with each engine; recommendations are point-in-time."
+  - "Does not draft new scientific content; optimizes existing approved text only."
+validation_commands:
+  - "python3 scripts/validate_schema.py <summary-box-file>"
+evidence_surface: bundled_script

--- a/skills/add-journal/skill.yml
+++ b/skills/add-journal/skill.yml
@@ -1,0 +1,33 @@
+schema_version: 2
+name: add-journal
+layer: C
+owner_domain: journal_profile_authoring
+
+when_to_use: "Add a new journal to the profile database from its author guidelines, generating both write-paper (detailed) and find-journal (compact) profiles."
+when_NOT_to_use: "Recommending a journal for a manuscript (use find-journal)."
+
+inputs:
+  - "journal author-guidelines URL or pasted text"
+outputs:
+  - "find-journal compact profile"
+  - "write-paper detailed profile"
+side_effects:
+  - writes_journal_profiles
+downstream_consumers:
+  - find-journal
+  - write-paper
+forbidden_actions:
+  - fabricate_journal_policy_or_metrics
+  - record_unverified_guidelines_as_verified
+
+# v2.1 quality card
+purpose: "Turn a journal's official author guidelines into canonical compact + detailed profiles for the recommendation and drafting skills."
+safety_boundaries:
+  - "Policy/scope fields are transcribed from the official source, never inferred; unverifiable items are flagged."
+  - "No cached impact-factor or APC values are asserted; users verify current metrics at the source."
+known_limitations:
+  - "Profiles drift as journals update guidelines; each carries a verification date."
+  - "Quality depends on the guidelines text supplied; gated pages require user-provided content."
+validation_commands:
+  - "python3 scripts/validate_catalog_consistency.py   # profile counts stay in sync"
+evidence_surface: manual_workflow

--- a/skills/analyze-stats/skill.yml
+++ b/skills/analyze-stats/skill.yml
@@ -1,0 +1,38 @@
+schema_version: 2
+name: analyze-stats
+layer: B
+owner_domain: statistical_analysis
+
+when_to_use: "Generate reproducible Python/R analysis code with publication-ready tables and figures for a defined study design."
+when_NOT_to_use: "Sample-size planning (use calc-sample-size); figure-only generation (use make-figures)."
+
+inputs:
+  - "analysis dataset (CSV)"
+  - "analysis plan / variable definitions"
+outputs:
+  - "analysis code (Python/R)"
+  - "result tables"
+  - "analysis figures"
+side_effects:
+  - writes_project_artifacts
+  - executes_analysis_code
+downstream_consumers:
+  - write-paper
+  - make-figures
+  - self-review
+forbidden_actions:
+  - fabricate_or_hand_type_numeric_results
+  - report_estimates_without_ci_or_p
+
+# v2.1 quality card
+purpose: "Produce reproducible statistical code and publication-ready output for a specified design (DTA, agreement, survival, regression, survey, etc.)."
+safety_boundaries:
+  - "All numbers come from executed code on the supplied data; never hand-typed (seed-fixed transforms)."
+  - "Primary estimates report effect size with 95% CI and exact p-values."
+known_limitations:
+  - "Correctness depends on a correct analysis plan and clean data (use design-study / clean-data first)."
+  - "Does not adjudicate clinical validity of the chosen test."
+validation_commands:
+  - "re-run the emitted script and diff results"
+  - "/self-review"
+evidence_surface: demo

--- a/skills/author-strategy/skill.yml
+++ b/skills/author-strategy/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: author-strategy
+layer: D
+owner_domain: author_profile_analysis
+
+when_to_use: "Analyze a PubMed author profile (study-type mix, trends) and produce a strategy report."
+when_NOT_to_use: "Finding meta-analysis topics (use ma-scout); literature search for a manuscript (use search-lit)."
+
+inputs:
+  - "author name / PubMed identifier"
+outputs:
+  - "study-type classification"
+  - "profile visualization"
+  - "strategy report"
+side_effects:
+  - writes_report_artifacts
+  - network_access_pubmed
+downstream_consumers:
+  - ma-scout
+forbidden_actions:
+  - fabricate_publication_records
+  - infer_identity_without_disambiguation
+
+# v2.1 quality card
+purpose: "Summarize an author's PubMed publication profile and surface strategy options from the actual record."
+safety_boundaries:
+  - "Records are fetched from PubMed, not recalled from memory; author disambiguation is explicit."
+  - "Reports describe the public record only; no private or speculative attribution."
+known_limitations:
+  - "Name collisions on PubMed can blur profiles; disambiguation is best-effort."
+  - "No standalone demo; output is an advisory report."
+validation_commands:
+  - "manual review of the fetched record against PubMed"
+evidence_surface: manual_workflow

--- a/skills/batch-cohort/skill.yml
+++ b/skills/batch-cohort/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: batch-cohort
+layer: B
+owner_domain: batch_analysis
+
+when_to_use: "Generate N analysis scripts from one validated methodology template across many exposure/outcome combinations."
+when_NOT_to_use: "A single analysis (use analyze-stats); cross-country comparison (use cross-national)."
+
+inputs:
+  - "methodology template"
+  - "exposure/outcome combination matrix"
+outputs:
+  - "N analysis scripts"
+  - "summary matrix"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - analyze-stats
+  - self-review
+forbidden_actions:
+  - alter_methodology_per_combination_without_disclosure
+  - fabricate_results_matrix
+
+# v2.1 quality card
+purpose: "Scale one validated method across many variable combinations, swapping only exposure/outcome, never the method."
+safety_boundaries:
+  - "The methodology is held constant across all generated scripts; deviations are disclosed."
+  - "Generated scripts run on real data; no results are pre-filled."
+known_limitations:
+  - "Inherits the source template's assumptions; a flawed template propagates."
+  - "No standalone demo; outputs are code to be executed and reviewed."
+validation_commands:
+  - "execute each generated script and reconcile the summary matrix"
+  - "/self-review"
+evidence_surface: manual_workflow

--- a/skills/calc-sample-size/skill.yml
+++ b/skills/calc-sample-size/skill.yml
@@ -37,3 +37,15 @@ forbidden_actions:
   - fabricate_effect_size_from_unverified_assumption
   - omit_attrition_or_loss_to_followup
   - silent_protocol_modification  # changes to N must update both justification.md and protocol Methods
+
+# v2.1 quality card
+purpose: "Compute sample size / power with decision-tree test selection and reproducible R/Python code plus IRB-ready justification."
+safety_boundaries:
+  - "Effect-size assumptions are justified and sourced, not fabricated; attrition/loss is accounted for."
+  - "Any change to N updates both the justification and the protocol Methods (no silent change)."
+known_limitations:
+  - "Emits inline R/Python, not a packaged script; the user runs it."
+  - "Output is only as valid as the assumed effect size and design."
+validation_commands:
+  - "re-run the emitted power code and confirm N matches the justification"
+evidence_surface: manual_workflow

--- a/skills/check-reporting/skill.yml
+++ b/skills/check-reporting/skill.yml
@@ -26,3 +26,16 @@ downstream_consumers:
 forbidden_actions:
   - invent_reporting_guideline_items
   - silently_mark_missing_items_present
+
+# v2.1 quality card
+purpose: "Audit a manuscript item-by-item against a chosen reporting guideline (32 supported) with PRESENT/MISSING/PARTIAL status."
+safety_boundaries:
+  - "Checklist items are quoted from the guideline, never invented; missing items are not marked present."
+  - "Fails fast if the requested checklist file is absent rather than generating a guessed checklist."
+known_limitations:
+  - "Item judgements are advisory; a PRESENT mark is a locator, not a quality guarantee."
+  - "Coverage is limited to the bundled checklists."
+validation_commands:
+  - "python3 scripts/check_checklist_exists.py <guideline>"
+  - "python3 scripts/prisma_cascade_check.py"
+evidence_surface: demo

--- a/skills/clean-data/skill.yml
+++ b/skills/clean-data/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: clean-data
+layer: B
+owner_domain: data_preparation
+
+when_to_use: "Profile and clean clinical CSV/Excel data through a three-stage workflow with user approval at each gate."
+when_NOT_to_use: "Removing PHI (use deidentify); statistical analysis (use analyze-stats)."
+
+inputs:
+  - "raw analysis dataset (CSV/Excel)"
+outputs:
+  - "data profile report"
+  - "cleaning code"
+  - "cleaned dataset"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - analyze-stats
+  - version-dataset
+forbidden_actions:
+  - auto_clean_without_user_approval
+  - drop_rows_or_impute_silently
+
+# v2.1 quality card
+purpose: "Profile, flag, and code-generate cleaning steps for clinical tabular data, with a researcher approval gate at every stage."
+safety_boundaries:
+  - "Never auto-cleans; every decision (missing values, outliers, dups, types) requires user confirmation."
+  - "All transforms are emitted as reviewable code, not applied silently."
+known_limitations:
+  - "Heuristic flags need clinical judgement; the skill does not decide what is a true outlier."
+  - "No standalone demo; correctness depends on user approvals."
+validation_commands:
+  - "re-run the emitted cleaning code and re-profile"
+  - "/version-dataset for a manifest"
+evidence_surface: manual_workflow

--- a/skills/cross-national/skill.yml
+++ b/skills/cross-national/skill.yml
@@ -1,0 +1,37 @@
+schema_version: 2
+name: cross-national
+layer: B
+owner_domain: cross_national_comparison
+
+when_to_use: "Run a cross-national comparison (KNHANES + NHANES + CHNS or similar) with harmonized variables and parallel weighted analysis."
+when_NOT_to_use: "Single-cohort analysis (use analyze-stats); replicating one study on one DB (use replicate-study)."
+
+inputs:
+  - "parallel survey datasets"
+  - "variable harmonization plan"
+outputs:
+  - "harmonization table"
+  - "parallel weighted analysis"
+  - "comparison tables"
+side_effects:
+  - writes_project_artifacts
+  - executes_analysis_code
+downstream_consumers:
+  - analyze-stats
+  - self-review
+forbidden_actions:
+  - harmonize_variables_without_documented_mapping
+  - ignore_survey_weights
+
+# v2.1 quality card
+purpose: "Harmonize and analyze parallel national surveys (2- or 3-country) with correct complex-survey weighting."
+safety_boundaries:
+  - "Variable harmonization is documented in an explicit mapping; survey weights are always applied."
+  - "Numbers come from executed weighted analysis on real survey data."
+known_limitations:
+  - "Cross-survey comparability is limited by instrument differences; residual non-comparability remains."
+  - "No standalone demo; depends on a sound harmonization plan."
+validation_commands:
+  - "re-run weighted analysis per country and reconcile"
+  - "/self-review"
+evidence_surface: manual_workflow

--- a/skills/define-variables/skill.yml
+++ b/skills/define-variables/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: define-variables
+layer: C
+owner_domain: variable_operationalization
+
+when_to_use: "Turn a data dictionary + research question into a citation-backed table of exposure/outcome/covariate definitions, cutoffs, and DB variable mappings."
+when_NOT_to_use: "Drafting Methods prose (use write-protocol/write-paper); finding literature (use search-lit)."
+
+inputs:
+  - "data dictionary"
+  - "research question"
+  - "candidate literature"
+outputs:
+  - "variable operationalization table (definitions, cutoffs, DB mappings)"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - write-protocol
+  - analyze-stats
+forbidden_actions:
+  - define_phenotype_without_dictionary_citation
+  - invent_cutoff_without_literature_source
+
+# v2.1 quality card
+purpose: "Produce a literature-grounded, dictionary-cited operationalization table that prevents ad-hoc phenotype definitions."
+safety_boundaries:
+  - "Every DB variable interpretation quotes the data dictionary verbatim (dictionary-first)."
+  - "Cutoffs cite a canonical literature source; unsupported definitions are flagged, not invented."
+known_limitations:
+  - "Quality depends on a complete data dictionary; silent dictionary gaps block definitions."
+  - "No standalone demo; output is reviewed against the dictionary and sources."
+validation_commands:
+  - "cross-check each row's dictionary citation against the source dictionary"
+evidence_surface: manual_workflow

--- a/skills/deidentify/skill.yml
+++ b/skills/deidentify/skill.yml
@@ -1,0 +1,43 @@
+schema_version: 2
+name: deidentify
+layer: A
+owner_domain: data_preparation
+
+when_to_use: "De-identify clinical CSV/TSV/Excel data locally before any LLM-assisted analysis."
+when_NOT_to_use: "General data cleaning or type fixing (use clean-data). Never to have the agent itself read, paste, or process raw PHI."
+
+inputs:
+  - path: "raw clinical data file (CSV / TSV / XLSX)"
+    schema: csv
+    required: true
+outputs:
+  - path: "de-identified data file"
+  - path: "scan report (column classifications, no raw values)"
+  - path: "audit log (SHA-256 hashes only)"
+
+deterministic_scripts:
+  - deidentify.py
+side_effects:
+  - writes_deidentified_data
+  - runs_locally_no_network
+downstream_consumers:
+  - clean-data
+  - analyze-stats
+forbidden_actions:
+  - read_raw_phi
+  - display_mapping_file
+  - send_phi_to_llm
+
+# v2.1 quality card
+purpose: "Detect and remove PHI from clinical tabular data with a local-only CLI, so downstream LLM analysis never touches raw identifiers."
+safety_boundaries:
+  - "The agent never sees raw PHI; de-identification runs in a standalone local script with no network or AI calls."
+  - "Never reads or displays the re-identification mapping file (it holds original PHI values)."
+  - "Only the scan report (no raw values), the hash-only audit log, and the de-identified output may be read."
+known_limitations:
+  - "Regex and heuristic detection across 10 country locale packs is not a substitute for expert disclosure review or an IRB determination."
+  - "PHI coverage is limited to the bundled locale packs (kr, us, jp, cn, de, uk, fr, ca, au, in)."
+validation_commands:
+  - "python deidentify.py scan <file> --locale <code>   # review column classifications before stripping"
+  - "inspect the SHA-256 audit log after a full run"
+evidence_surface: bundled_script

--- a/skills/design-study/skill.yml
+++ b/skills/design-study/skill.yml
@@ -1,0 +1,33 @@
+schema_version: 2
+name: design-study
+layer: D
+owner_domain: study_design
+
+when_to_use: "Review study design and validity (analysis unit, cohort logic, leakage, comparator, validation, reporting fit) before drafting or submission."
+when_NOT_to_use: "Sample-size math (use calc-sample-size); variable definitions (use define-variables)."
+
+inputs:
+  - "study description / draft protocol"
+outputs:
+  - "design and validity review (decision notes)"
+side_effects:
+  - writes_decision_notes
+downstream_consumers:
+  - calc-sample-size
+  - define-variables
+  - write-protocol
+forbidden_actions:
+  - write_project_artifacts_beyond_decision_notes
+  - approve_design_with_uncorrected_leakage
+
+# v2.1 quality card
+purpose: "Surface design and validity risks (leakage, analysis unit, comparator, validation strategy) before a study is built or written."
+safety_boundaries:
+  - "Advisory only: writes decision notes, not analysis or manuscript artifacts."
+  - "Names validity threats explicitly rather than rubber-stamping a design."
+known_limitations:
+  - "A review reduces but cannot eliminate design risk; it is not a guarantee of validity."
+  - "No standalone demo; recommendations require researcher judgement."
+validation_commands:
+  - "carry findings into write-protocol Methods and re-check with /self-review"
+evidence_surface: manual_workflow

--- a/skills/fill-icmje-coi/skill.yml
+++ b/skills/fill-icmje-coi/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: fill-icmje-coi
+layer: A
+owner_domain: form_filling
+
+when_to_use: "Batch-generate per-author ICMJE COI disclosure forms from a synthetic seed, pre-filled as 'None' with date/name/title replaced."
+when_NOT_to_use: "Filling an IRB or institutional Word form (use fill-protocol)."
+
+inputs:
+  - "author list"
+  - "manuscript title"
+  - "date"
+outputs:
+  - "per-author coi_disclosure.docx files"
+deterministic_scripts:
+  - scripts/fill_icmje_coi.py
+side_effects:
+  - writes_docx_forms
+downstream_consumers:
+  - none
+forbidden_actions:
+  - alter_checkboxes_or_disclosure_items
+  - use_a_seed_containing_real_author_pii
+
+# v2.1 quality card
+purpose: "Clone the ICMJE COI form per author with date/name/title filled, defaulting all 13 items to 'None' for the no-conflict common case."
+safety_boundaries:
+  - "Only date, name, and manuscript title are substituted; the 13 items and certification come from the seed unchanged."
+  - "Ships a synthetic PII-free seed; never commits a seed with real author PII."
+known_limitations:
+  - "Authors with real disclosures must edit their form in Word; the skill cannot infer conflicts."
+  - "A blank ICMJE template cannot be used as the seed (the safety check requires the pre-filled 'None' strings)."
+validation_commands:
+  - "verify each output: 14 checked boxes, 13 'None', no seed-placeholder leakage"
+evidence_surface: bundled_script

--- a/skills/fill-protocol/skill.yml
+++ b/skills/fill-protocol/skill.yml
@@ -1,0 +1,37 @@
+schema_version: 2
+name: fill-protocol
+layer: A
+owner_domain: form_filling
+
+when_to_use: "Fill an institutional Word (.doc/.docx) template (IRB protocol, ethics application, grant form) while preserving styles, tables, fonts, and page geometry."
+when_NOT_to_use: "Drafting the scientific content (use write-protocol); ICMJE COI forms (use fill-icmje-coi)."
+
+inputs:
+  - "institutional Word template"
+  - "content mapping (fill_*.yaml)"
+outputs:
+  - "filled .docx preserving the institutional template"
+deterministic_scripts:
+  - scripts/fill_form.py
+  - scripts/inspect_template.py
+  - scripts/doc_to_docx.py
+side_effects:
+  - writes_docx_forms
+downstream_consumers:
+  - render-pdf-doc
+forbidden_actions:
+  - rebuild_template_from_blank_document
+  - drop_template_styles_or_logos
+
+# v2.1 quality card
+purpose: "Render approved content into an institutional Word template without losing its layout, styles, or page geometry."
+safety_boundaries:
+  - "Operates on the original template (never rebuilds from a blank Document, which strips logos/headers/styles)."
+  - "CJK eastAsia fonts and table cantSplit are enforced for Korean templates."
+known_limitations:
+  - "Requires the institutional template file; cannot invent a missing one."
+  - "Content-controlled (SDT) fields may need manual handling in Word."
+validation_commands:
+  - "confirm [MISS] count is 0 after fill"
+  - "soffice --headless --convert-to pdf for visual check"
+evidence_surface: bundled_script

--- a/skills/find-cohort-gap/skill.yml
+++ b/skills/find-cohort-gap/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: find-cohort-gap
+layer: D
+owner_domain: research_gap_analysis
+
+when_to_use: "Find research gaps in a longitudinal cohort DB by profiling its strengths, matching PI expertise, and scanning literature saturation."
+when_NOT_to_use: "Finding meta-analysis topics (use ma-scout); designing a chosen study (use design-study)."
+
+inputs:
+  - "cohort profile / data dictionary"
+  - "PI expertise"
+  - "literature landscape"
+outputs:
+  - "ranked topic proposals with gap evidence"
+side_effects:
+  - writes_report_artifacts
+  - network_access_literature
+downstream_consumers:
+  - design-study
+  - define-variables
+forbidden_actions:
+  - claim_a_gap_without_literature_evidence
+  - fabricate_saturation_counts
+
+# v2.1 quality card
+purpose: "Rank under-studied topics for a specific cohort, each backed by literature-saturation evidence and feasibility."
+safety_boundaries:
+  - "Each proposed gap cites the literature scan that supports it; saturation counts come from real searches."
+  - "Advisory report only; does not design or execute studies."
+known_limitations:
+  - "Literature scans are point-in-time; a gap can close between scan and submission."
+  - "No standalone demo; proposals require domain judgement."
+validation_commands:
+  - "re-run the saturation search before committing to a topic"
+evidence_surface: manual_workflow

--- a/skills/find-journal/skill.yml
+++ b/skills/find-journal/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: find-journal
+layer: D
+owner_domain: journal_recommendation
+
+when_to_use: "Recommend journals for a manuscript via two-pass matching against the public profile library plus any user-local private profiles."
+when_NOT_to_use: "Adding a journal to the database (use add-journal); building the submission package (use sync-submission)."
+
+inputs:
+  - "manuscript abstract / scope"
+  - "study type"
+outputs:
+  - "ranked journal recommendations with scope rationale and AI-policy notes"
+side_effects:
+  - reads_journal_profiles
+downstream_consumers:
+  - add-journal
+  - write-paper
+  - sync-submission
+forbidden_actions:
+  - fabricate_impact_factor_or_apc
+  - recommend_journals_outside_the_profile_library
+
+# v2.1 quality card
+purpose: "Rank candidate journals by scope fit from the curated profile library, with AI-disclosure policy and homepage links."
+safety_boundaries:
+  - "No cached impact-factor/APC values are asserted; users verify current metrics at journal sites."
+  - "Recommendations are drawn from the curated profile library, not invented venues."
+known_limitations:
+  - "Coverage is limited to profiled journals; an unprofiled fit may be missed (add via add-journal)."
+  - "Scope-fit ranking is advisory, not an acceptance prediction."
+validation_commands:
+  - "verify shortlisted journals' current scope and metrics at their official sites"
+evidence_surface: manual_workflow

--- a/skills/fulltext-retrieval/skill.yml
+++ b/skills/fulltext-retrieval/skill.yml
@@ -1,0 +1,41 @@
+schema_version: 2
+name: fulltext-retrieval
+layer: A
+owner_domain: literature_discovery
+
+when_to_use: "Batch-download open-access full-text PDFs from a DOI list; optionally convert them to Markdown for token-efficient analysis."
+when_NOT_to_use: "Finding or verifying citations (use search-lit / verify-refs). Retrieving paywalled or non-open-access content."
+
+inputs:
+  - path: "DOI list (.txt, one per line, or .tsv with a DOI column)"
+    schema: csv
+    required: true
+outputs:
+  - path: "downloaded open-access PDFs (pdfs/)"
+  - path: "optional PDF-to-Markdown conversions"
+
+deterministic_scripts:
+  - fetch_oa.py
+  - pdf_to_md.py
+side_effects:
+  - downloads_files
+  - network_access_oa_apis
+downstream_consumers:
+  - meta-analysis
+  - obsidian-paper-vault
+forbidden_actions:
+  - download_paywalled_content
+  - bypass_publisher_access_controls
+
+# v2.1 quality card
+purpose: "Resolve a DOI list to open-access full-text PDFs via legitimate OA APIs, with optional Markdown conversion."
+safety_boundaries:
+  - "Uses legitimate open-access sources only (Unpaywall, PMC / Europe PMC, OpenAlex, Crossref); never circumvents paywalls or access controls."
+  - "Validates each download (>=10 KB and a %PDF- header) before accepting it."
+known_limitations:
+  - "Only open-access content is retrievable; non-OA DOIs fail by design rather than fetching from unauthorized sources."
+  - "PDF-to-Markdown conversion requires the optional pymupdf4llm dependency (AGPL-3.0 or commercial license)."
+validation_commands:
+  - "python fetch_oa.py dois.txt -o pdfs/ -e <email> --verbose   # per-DOI source trace"
+  - "verify each output begins with %PDF- and is at least 10 KB"
+evidence_surface: bundled_script

--- a/skills/generate-codebook/skill.yml
+++ b/skills/generate-codebook/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: generate-codebook
+layer: A
+owner_domain: data_documentation
+
+when_to_use: "Generate a data dictionary and codebook from a dataset."
+when_NOT_to_use: "Cleaning the data (use clean-data); versioning the dataset (use version-dataset)."
+
+inputs:
+  - "analysis dataset (CSV/Excel)"
+outputs:
+  - "data dictionary"
+  - "codebook"
+deterministic_scripts:
+  - scripts/generate_codebook.py
+side_effects:
+  - writes_codebook_artifacts
+downstream_consumers:
+  - define-variables
+  - version-dataset
+forbidden_actions:
+  - fabricate_variable_descriptions
+  - infer_units_not_present_in_data
+
+# v2.1 quality card
+purpose: "Derive a structured codebook (variables, types, ranges, missingness) directly from a dataset."
+safety_boundaries:
+  - "Descriptive statistics are computed from the data by the bundled script, not asserted."
+  - "Variable semantics not present in the data are left blank for the researcher, not invented."
+known_limitations:
+  - "Computes structure and distributions; does not supply clinical meaning of variables."
+  - "Free-text/semantic descriptions require researcher input."
+validation_commands:
+  - "python3 scripts/generate_codebook.py <dataset>"
+evidence_surface: bundled_script

--- a/skills/grant-builder/skill.yml
+++ b/skills/grant-builder/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: grant-builder
+layer: C
+owner_domain: grant_proposal
+
+when_to_use: "Support grant and challenge proposals (significance, innovation, approach, milestones, consortium roles) with evidence-based, executable claims."
+when_NOT_to_use: "IRB protocol content (use write-protocol); manuscript drafting (use write-paper)."
+
+inputs:
+  - "funding call / RFP"
+  - "project concept"
+  - "team/consortium"
+outputs:
+  - "proposal sections (significance, innovation, approach, milestones)"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - write-protocol
+forbidden_actions:
+  - fabricate_preliminary_data_or_citations
+  - promise_unexecutable_milestones
+
+# v2.1 quality card
+purpose: "Structure a fundable, executable proposal whose claims are evidence-based and whose milestones are realistic."
+safety_boundaries:
+  - "Claims are tied to evidence the user supplies; preliminary data and citations are not invented."
+  - "Milestones are scoped to be executable, not aspirational."
+known_limitations:
+  - "Does not guarantee funding; tailoring to a specific reviewer panel is the user's responsibility."
+  - "No standalone demo; content requires PI review."
+validation_commands:
+  - "/verify-refs --strict on any cited work"
+  - "/self-review for internal consistency"
+evidence_surface: manual_workflow

--- a/skills/humanize/skill.yml
+++ b/skills/humanize/skill.yml
@@ -1,0 +1,33 @@
+schema_version: 2
+name: humanize
+layer: C
+owner_domain: ai_pattern_removal
+
+when_to_use: "Detect and remove the 18 common AI-writing patterns from an academic manuscript while preserving technical accuracy."
+when_NOT_to_use: "Drafting content (use write-paper); AI-search optimization (use academic-aio)."
+
+inputs:
+  - "manuscript / section text (Markdown)"
+outputs:
+  - "revised text with AI patterns removed"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - self-review
+  - write-paper
+forbidden_actions:
+  - alter_numeric_values_or_citations
+  - change_scientific_meaning
+
+# v2.1 quality card
+purpose: "Rewrite flagged passages to read as naturally human-written without changing facts, numbers, or citations."
+safety_boundaries:
+  - "Edits style only; never alters numeric values, citations, or scientific meaning."
+  - "Preserves the manuscript's technical claims while removing AI tells."
+known_limitations:
+  - "Pattern detection is heuristic; subtle tells may remain and need a human pass."
+  - "No standalone demo; judgement is required on borderline phrasings."
+validation_commands:
+  - "diff against the source to confirm only style changed"
+  - "/self-review"
+evidence_surface: manual_workflow

--- a/skills/intake-project/skill.yml
+++ b/skills/intake-project/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: intake-project
+layer: D
+owner_domain: project_intake
+
+when_to_use: "Intake and normalize a new research project: classify type, summarize state, flag missing inputs, recommend next steps, and scaffold lightweight memory files."
+when_NOT_to_use: "Ongoing project tracking (use manage-project)."
+
+inputs:
+  - "raw project description / existing files"
+outputs:
+  - "project classification"
+  - "state summary"
+  - "scaffolded memory files"
+side_effects:
+  - scaffolds_project_files
+downstream_consumers:
+  - manage-project
+  - design-study
+forbidden_actions:
+  - overwrite_existing_project_artifacts
+  - fabricate_missing_inputs
+
+# v2.1 quality card
+purpose: "Normalize a new or messy project into a classified, summarized starting point with scaffolded memory."
+safety_boundaries:
+  - "Scaffolds new lightweight files; does not overwrite existing project artifacts."
+  - "Flags missing inputs rather than inventing them."
+known_limitations:
+  - "Classification is heuristic and may need correction on unusual projects."
+  - "No standalone demo; a setup step, not an analysis."
+validation_commands:
+  - "review the scaffolded files and correct the classification if needed"
+evidence_surface: manual_workflow

--- a/skills/lit-sync/skill.yml
+++ b/skills/lit-sync/skill.yml
@@ -37,3 +37,16 @@ forbidden_actions:
   - fabricate_bibliographic_metadata
   - overwrite_existing_literature_notes
   - hand_edit_manuscript_refs_bib  # only Better BibTeX may write
+
+# v2.1 quality card
+purpose: "Sync verified references from .bib into Zotero and Obsidian literature notes, extracting cross-cutting concept notes when enough literature accumulates."
+safety_boundaries:
+  - "Bibliographic metadata is never fabricated; only Better BibTeX may write refs.bib."
+  - "Existing literature notes are not overwritten."
+known_limitations:
+  - "Depends on a connected Zotero MCP + Better BibTeX auto-export; degrades to manual without them."
+  - "No standalone demo; effects are in the user's Zotero/Obsidian."
+validation_commands:
+  - "confirm refs.bib mtime refreshed via Better BibTeX"
+  - "zotero_find_duplicates after sync"
+evidence_surface: manual_workflow

--- a/skills/ma-scout/skill.yml
+++ b/skills/ma-scout/skill.yml
@@ -1,0 +1,33 @@
+schema_version: 2
+name: ma-scout
+layer: D
+owner_domain: ma_topic_discovery
+
+when_to_use: "Discover and assess meta-analysis topics, either from a professor's publication profile or from a clinical question/trend."
+when_NOT_to_use: "Running the meta-analysis (use meta-analysis); single-author profiling (use author-strategy)."
+
+inputs:
+  - "professor profile or clinical question/trend"
+outputs:
+  - "ranked MA topic proposals with feasibility and gap evidence"
+side_effects:
+  - writes_report_artifacts
+  - network_access_literature
+downstream_consumers:
+  - meta-analysis
+  - search-lit
+forbidden_actions:
+  - claim_an_ma_gap_without_search_evidence
+  - fabricate_study_counts
+
+# v2.1 quality card
+purpose: "Find feasible meta-analysis gaps (professor-first or topic-first) backed by literature evidence."
+safety_boundaries:
+  - "Gap claims rest on real literature scans; candidate study counts are not fabricated."
+  - "Advisory report; does not perform screening or synthesis."
+known_limitations:
+  - "Feasibility is an estimate; the true includable pool is established only by meta-analysis screening."
+  - "No standalone demo; topic selection needs domain judgement."
+validation_commands:
+  - "confirm feasibility by running meta-analysis screening on the shortlist"
+evidence_surface: manual_workflow

--- a/skills/make-figures/skill.yml
+++ b/skills/make-figures/skill.yml
@@ -37,3 +37,16 @@ forbidden_actions:
   - fabricate_figure_numbers
   - create_flow_diagrams_without_source_counts
   - generate_AI_images_for_prohibited_targets
+
+# v2.1 quality card
+purpose: "Generate publication-ready figures and visual/graphical abstracts (ROC, forest, CONSORT/STARD/PRISMA flow, KM, Bland-Altman, etc.)."
+safety_boundaries:
+  - "Figure numbers are not fabricated; flow diagrams are built from real source counts."
+  - "Honors journal AI-image policies; no AI images for prohibited targets."
+known_limitations:
+  - "Figure correctness depends on correct input data/counts supplied by upstream skills."
+  - "PPTX visual abstracts need the Mac-compatibility check before sharing."
+validation_commands:
+  - "Rscript scripts/generate_flow_diagram.R"
+  - "python3 scripts/validate_pptx_mac_compat.py <file>"
+evidence_surface: demo

--- a/skills/manage-project/skill.yml
+++ b/skills/manage-project/skill.yml
@@ -1,0 +1,36 @@
+schema_version: 2
+name: manage-project
+layer: D
+owner_domain: project_management
+
+when_to_use: "Manage a manuscript project: scaffold structure, track writing progress across phases, maintain memory, and generate checklists and backwards timelines."
+when_NOT_to_use: "First-time intake of a messy project (use intake-project)."
+
+inputs:
+  - "project.yaml / SSOT"
+  - "current phase state"
+outputs:
+  - "progress status"
+  - "submission checklist"
+  - "backwards timeline"
+side_effects:
+  - writes_project_state
+  - scaffolds_project_files
+downstream_consumers:
+  - sync-submission
+  - self-review
+forbidden_actions:
+  - fabricate_progress_or_deadlines
+  - overwrite_canonical_manuscript_artifacts
+
+# v2.1 quality card
+purpose: "Track and scaffold a manuscript project across phases with checklists and timelines from real project state."
+safety_boundaries:
+  - "Reads/writes project state and scaffolding; never edits canonical manuscript artifacts."
+  - "Status and timelines reflect actual project files, not invented progress."
+known_limitations:
+  - "Timelines are planning aids, not commitments; depend on user-maintained state."
+  - "No standalone demo; an orchestration/tracking utility."
+validation_commands:
+  - "reconcile reported phase against the project's SSOT/artifacts"
+evidence_surface: manual_workflow

--- a/skills/manage-refs/skill.yml
+++ b/skills/manage-refs/skill.yml
@@ -55,3 +55,16 @@ quality_gates:
   - check_xref.py --strict: hard exit on MISSING_DOCX / MISSING_BODY / MISMATCH
   - verify-refs hand-off: required before sign-off
   - cwyw_first_build_user_step: Add/Edit Bibliography in Word
+
+# v2.1 quality card
+purpose: "Manage the reference lifecycle: citekey validation, CSL rendering (pandoc citeproc), Zotero CWYW injection, marker conversion, and cross-reference QC."
+safety_boundaries:
+  - "References are never hand-typed; only Better BibTeX / citeproc / CWYW produce the list."
+  - "Citekeys are validated against the .bib; unmapped markers are not guessed; CWYW docx is not regex-patched."
+known_limitations:
+  - "Pandoc/Zotero must be installed; rendering is deterministic but environment-dependent."
+  - "Phase 3 CWYW field safety depends on a correct Zotero library."
+validation_commands:
+  - "python3 scripts/check_citation_keys.py manuscript.md refs.bib"
+  - "python3 scripts/check_xref.py --md manuscript.md --docx out.docx --strict"
+evidence_surface: bundled_script

--- a/skills/meta-analysis/skill.yml
+++ b/skills/meta-analysis/skill.yml
@@ -32,3 +32,16 @@ downstream_consumers:
 forbidden_actions:
   - report_counts_without_id_receipts
   - continue_after_p0_reconciliation_mismatch
+
+# v2.1 quality card
+purpose: "Run the SR/MA pipeline: PROSPERO registration, search, screening, extraction, risk of bias, synthesis (bivariate/HSROC or random-effects), and PRISMA reporting."
+safety_boundaries:
+  - "Study counts are never reported without ID-level receipts; halts on a P0 reconciliation mismatch."
+  - "Pool composition is locked to a single source of truth; downstream counts are re-derived, not copied."
+known_limitations:
+  - "Synthesis validity depends on correct extraction; the skill enforces process, not clinical correctness."
+  - "DTA pooling assumes adequate per-study 2x2 / threshold data."
+validation_commands:
+  - "python3 scripts/screening_reconcile.py"
+  - "python3 scripts/check_pool_consistency.py"
+evidence_surface: demo

--- a/skills/orchestrate/skill.yml
+++ b/skills/orchestrate/skill.yml
@@ -29,3 +29,16 @@ downstream_consumers:
 forbidden_actions:
   - generate_worker_outputs_directly
   - bypass_artifact_validation
+
+# v2.1 quality card
+purpose: "Single entry point for the bundle: classify a request and route to the right skill, or chain skills for multi-step and end-to-end (--e2e) workflows."
+safety_boundaries:
+  - "Never generates worker-skill outputs directly; routes to and invokes the owning skill."
+  - "Does not bypass per-skill artifact validation in the chain."
+known_limitations:
+  - "Routing is heuristic; an ambiguous request may need explicit skill selection."
+  - "--e2e halts on missing expected outputs rather than proceeding with gaps."
+validation_commands:
+  - "python3 scripts/validate_skill_contracts.py"
+  - "python3 scripts/validate_project_contract.py"
+evidence_surface: demo

--- a/skills/peer-review/skill.yml
+++ b/skills/peer-review/skill.yml
@@ -24,3 +24,15 @@ downstream_consumers:
 forbidden_actions:
   - edit_users_own_manuscript
   - generate_references_from_memory
+
+# v2.1 quality card
+purpose: "Draft a structured peer-review for a journal-assigned manuscript following the Yoojin Peer-Review Guideline v2.5, with journal-specific formatting."
+safety_boundaries:
+  - "Reviews assigned external manuscripts only; never edits the user's own manuscript."
+  - "References are not generated from memory."
+known_limitations:
+  - "A review is one reviewer's judgement, not an editorial decision."
+  - "No standalone demo; quality depends on the manuscript supplied."
+validation_commands:
+  - "confirm the draft addresses each section against the guideline rubric"
+evidence_surface: manual_workflow

--- a/skills/present-paper/skill.yml
+++ b/skills/present-paper/skill.yml
@@ -1,0 +1,41 @@
+schema_version: 2
+name: present-paper
+layer: C
+owner_domain: presentation
+
+when_to_use: "Prepare academic presentations (journal club, grand rounds, seminar, lecture/teaching decks): analyze source, find references, draft audience-adapted scripts, and generate/augment PPTX with speaker notes."
+when_NOT_to_use: "Drafting a manuscript (use write-paper); building figures for a paper (use make-figures)."
+
+inputs:
+  - "source paper(s) / topic"
+  - "audience and format"
+outputs:
+  - "PPTX deck"
+  - "speaker notes"
+  - "Q&A prep"
+deterministic_scripts:
+  - scripts/inject_speaker_notes.py
+  - scripts/trim_caption.py
+  - scripts/extract_pdf_figures.py
+  - scripts/inject_pronunciation_notes.py
+  - scripts/strip_notes_for_sharing.py
+side_effects:
+  - writes_pptx_artifacts
+downstream_consumers:
+  - none
+forbidden_actions:
+  - fabricate_findings_not_in_source
+  - leave_speaker_notes_in_shared_deck
+
+# v2.1 quality card
+purpose: "Turn source papers into an audience-adapted deck with speaker notes, Mac-compatible PPTX, and a sharing-stripped variant."
+safety_boundaries:
+  - "Slide claims trace to the source material; findings are not invented for narrative effect."
+  - "A notes-stripped variant is produced for sharing so private speaker notes never leak."
+known_limitations:
+  - "Figure cropping and notes parsing are heuristic; verify the built PPTX in PowerPoint."
+  - "Mac OOXML quirks require the bundled compatibility checks; not every host renders identically."
+validation_commands:
+  - "unzip the .pptx and confirm 0 markdown-raw notes / 0 TIFF / app.xml counts synced"
+  - "python3 scripts/strip_notes_for_sharing.py before sharing"
+evidence_surface: bundled_script

--- a/skills/publish-skill/skill.yml
+++ b/skills/publish-skill/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: publish-skill
+layer: B
+owner_domain: skill_publishing
+
+when_to_use: "Convert a personal agent skill into a distributable, OSS-ready skill: PII audit, generalization, license check, cross-platform review, packaging."
+when_NOT_to_use: "Authoring a brand-new skill from scratch (out of scope; this hardens an existing one)."
+
+inputs:
+  - "a personal skill directory"
+outputs:
+  - "PII audit report"
+  - "generalized OSS-ready skill"
+deterministic_scripts:
+  - scripts/audit_skill.sh
+side_effects:
+  - writes_skill_artifacts
+downstream_consumers:
+  - none
+forbidden_actions:
+  - publish_skill_with_unresolved_pii
+  - weaken_the_pii_blocklist_to_pass
+
+# v2.1 quality card
+purpose: "Harden a personal skill for open-source release through a PII audit, generalization, and license/portability checks."
+safety_boundaries:
+  - "Publication is gated on a passing PII audit; the blocklist is conservative and not weakened to pass."
+  - "Personal paths, names, and document metadata are scrubbed before release."
+known_limitations:
+  - "The audit catches known PII patterns; novel identifiers still need human review."
+  - "Generalization preserves behavior but a maintainer should re-read the result."
+validation_commands:
+  - "bash scripts/audit_skill.sh <skill-dir>"
+  - "bash scripts/validate_skills.sh"
+evidence_surface: bundled_script

--- a/skills/render-pdf-doc/skill.yml
+++ b/skills/render-pdf-doc/skill.yml
@@ -42,3 +42,16 @@ quality_gates:
   - check_deps.sh: pandoc + xelatex + CJK font 의존성 미설치 시 hard exit
   - infer_colwidths.py: 균등 분할 (--equal) 옵션 명시 안 한 경우 content-proportional dash 강제
   - circulation_redaction: 회람용 PDF 출력 시 frontmatter `redact_internal: true` 또는 변경이력/버전번호/PI attribution 본문 미노출 강제
+
+# v2.1 quality card
+purpose: "Render a Markdown manuscript to a styled DOCX/PDF (tables, column widths, dependencies checked)."
+safety_boundaries:
+  - "Delegates bibliography rendering to manage-refs and figures/PPTX to make-figures/present-paper; does not modify citation keys."
+  - "Does not hand-type CSV data into tables (numerical-safety)."
+known_limitations:
+  - "Output fidelity depends on installed render dependencies (checked by check_deps.sh)."
+  - "Institutional Word forms are out of scope (use fill-protocol)."
+validation_commands:
+  - "bash scripts/check_deps.sh"
+  - "bash scripts/render_pdf.sh <manuscript.md>"
+evidence_surface: bundled_script

--- a/skills/replicate-study/skill.yml
+++ b/skills/replicate-study/skill.yml
@@ -1,0 +1,37 @@
+schema_version: 2
+name: replicate-study
+layer: B
+owner_domain: study_replication
+
+when_to_use: "Replicate an existing cohort study's methodology on a different database via a variable harmonization table and a replication difference report."
+when_NOT_to_use: "Comparing countries in parallel (use cross-national); a fresh single analysis (use analyze-stats)."
+
+inputs:
+  - "source study paper"
+  - "target database"
+  - "variable mapping"
+outputs:
+  - "replication analysis code"
+  - "replication difference report"
+side_effects:
+  - writes_project_artifacts
+  - executes_analysis_code
+downstream_consumers:
+  - analyze-stats
+  - self-review
+forbidden_actions:
+  - misrepresent_method_deviations_as_identical
+  - fabricate_replication_results
+
+# v2.1 quality card
+purpose: "Re-run a published study's method on a new DB and report exactly where target-DB constraints forced deviations."
+safety_boundaries:
+  - "Method deviations forced by the target DB are documented in a difference report, not hidden."
+  - "Results come from executed code on the target data."
+known_limitations:
+  - "Perfect replication is rarely possible; residual method differences remain and are disclosed."
+  - "No standalone demo; depends on a faithful variable mapping."
+validation_commands:
+  - "execute the replication code and review the difference report"
+  - "/self-review"
+evidence_surface: manual_workflow

--- a/skills/revise/skill.yml
+++ b/skills/revise/skill.yml
@@ -28,3 +28,16 @@ downstream_consumers:
 forbidden_actions:
   - argue_valid_reviewer_points_as_rebuttal_without_approval
   - reference_original_page_lines_after_revision
+
+# v2.1 quality card
+purpose: "Parse reviewer comments and generate a structured Response to Reviewers with tracked manuscript changes and an editor cover letter."
+safety_boundaries:
+  - "Valid reviewer points are not argued away as rebuttal without user approval."
+  - "Does not reference original page/line numbers after the manuscript has been revised."
+known_limitations:
+  - "Coordinates new analyses/figures via other skills but does not itself produce statistics."
+  - "No standalone demo; depends on the actual reviewer comments supplied."
+validation_commands:
+  - "confirm every reviewer comment maps to a point-by-point response"
+  - "/verify-refs --strict on new citations"
+evidence_surface: manual_workflow

--- a/skills/search-lit/skill.yml
+++ b/skills/search-lit/skill.yml
@@ -31,3 +31,16 @@ forbidden_actions:
   - generate_references_from_memory
   - silently_include_unverified_references
   - write_to_manuscript_refs_bib  # SSOT owner is /lit-sync
+
+# v2.1 quality card
+purpose: "Search PubMed, Semantic Scholar, and bioRxiv/medRxiv and generate API-verified BibTeX (anti-hallucination: every reference verified before inclusion)."
+safety_boundaries:
+  - "Never generates references from memory; unverified references are not silently included."
+  - "Does not write to the manuscript refs.bib (that SSOT belongs to lit-sync)."
+known_limitations:
+  - "Depends on PubMed/Semantic Scholar availability; rate limits/outages reduce recall."
+  - "Verification confirms existence/metadata, not topical relevance."
+validation_commands:
+  - "bash references/pubmed_eutils.sh <query>"
+  - "/verify-refs --strict"
+evidence_surface: bundled_script

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -27,3 +27,16 @@ downstream_consumers:
 forbidden_actions:
   - review_external_manuscripts_as_peer_reviewer
   - silently_fix_non_ai_fixable_issues
+
+# v2.1 quality card
+purpose: "Pre-submission self-review of the user's own manuscript from a reviewer's perspective across 10 categories, with severity-framed anticipated comments."
+safety_boundaries:
+  - "Reviews the user's own manuscript only; not for reviewing external (journal-assigned) manuscripts."
+  - "Does not silently fix non-AI-fixable issues; it flags them for the author."
+known_limitations:
+  - "Anticipates likely reviewer comments; cannot predict a specific reviewer's focus."
+  - "Advisory; produces recommendations, not manuscript edits."
+validation_commands:
+  - "python3 scripts/check_reviewer_team_consistency.py"
+  - "feed R0-numbered output into /revise"
+evidence_surface: demo

--- a/skills/setup-medsci/skill.yml
+++ b/skills/setup-medsci/skill.yml
@@ -1,0 +1,30 @@
+schema_version: 2
+name: setup-medsci
+layer: A
+owner_domain: environment_setup
+
+when_to_use: "Set up the local environment for MedSci Skills (dependencies, tooling checks)."
+when_NOT_to_use: "Installing the skills themselves (use installers/install.py)."
+
+inputs:
+  - "local machine state"
+outputs:
+  - "verified environment / dependency report"
+side_effects:
+  - runs_setup_commands
+downstream_consumers:
+  - none
+forbidden_actions:
+  - install_without_user_consent_for_destructive_actions
+
+# v2.1 quality card
+purpose: "Check and prepare the local toolchain (Python/R/CLI deps) needed to run the skills."
+safety_boundaries:
+  - "Confirms before destructive or system-wide changes; surfaces what is missing."
+  - "Operates locally; does not transmit machine state."
+known_limitations:
+  - "Environment coverage is best-effort across OSes; some hosts need manual steps."
+  - "No standalone demo; an operational utility."
+validation_commands:
+  - "re-run the setup check and confirm all dependencies report present"
+evidence_surface: manual_workflow

--- a/skills/sync-submission/skill.yml
+++ b/skills/sync-submission/skill.yml
@@ -28,3 +28,16 @@ downstream_consumers:
 forbidden_actions:
   - silently_edit_canonical_manuscript
   - freeze_drifted_submission
+
+# v2.1 quality card
+purpose: "Audit SSOT-to-submission drift and build journal submission manifests from canonical manuscript artifacts."
+safety_boundaries:
+  - "Never silently edits the canonical manuscript; a drifted submission is not frozen until reconciled."
+  - "Submission packages are derived from canonical sources, not hand-assembled."
+known_limitations:
+  - "Detects drift it is configured to scan (counts, cover-letter fields, scope); portal free-text fields still need a human check."
+  - "A clean audit is necessary, not sufficient, for acceptance."
+validation_commands:
+  - "python3 scripts/sync_submission.py"
+  - "python3 scripts/cross_document_n_check.py"
+evidence_surface: bundled_script

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -29,3 +29,16 @@ downstream_consumers:
 forbidden_actions:
   - generate_references_from_memory
   - silently_include_unverified_references
+
+# v2.1 quality card
+purpose: "Audit-only verification of manuscript references against PubMed and CrossRef (full-author cross-check); writes qc/reference_audit.json. Does not modify references."
+safety_boundaries:
+  - "Audit-only: never edits references/ or refs.bib; never generates references from memory."
+  - "Unverified references are flagged, not silently included."
+known_limitations:
+  - "Confirms DOI/PMID and author identity, not topical appropriateness of the citation."
+  - "CrossRef given-name errors are possible; PubMed efetch is treated as authoritative."
+validation_commands:
+  - "bash scripts/verify_cli.sh <refs.bib>"
+  - "confirm qc/reference_audit.json submission_safe: true"
+evidence_surface: bundled_script

--- a/skills/version-dataset/skill.yml
+++ b/skills/version-dataset/skill.yml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: version-dataset
+layer: A
+owner_domain: dataset_versioning
+
+when_to_use: "Version-control a dataset with SHA-256 manifests for reproducibility."
+when_NOT_to_use: "Cleaning the data (use clean-data); documenting variables (use generate-codebook)."
+
+inputs:
+  - "analysis dataset"
+  - "prior manifest (optional)"
+outputs:
+  - "dataset manifest.lock with SHA-256 hashes"
+deterministic_scripts:
+  - scripts/version_dataset.py
+side_effects:
+  - writes_manifest_artifacts
+downstream_consumers:
+  - analyze-stats
+  - self-review
+forbidden_actions:
+  - alter_data_to_match_a_manifest
+  - report_verification_pass_without_running_verify
+
+# v2.1 quality card
+purpose: "Pin a dataset's contents with SHA-256 manifests so analyses are reproducible and drift is detectable."
+safety_boundaries:
+  - "Hashes are computed from the actual files; a manifest is never edited to force a pass."
+  - "Verification is deterministic and re-runnable in CI."
+known_limitations:
+  - "Detects byte-level drift, not semantic correctness of the data."
+  - "A manifest is only as trustworthy as the moment it was locked."
+validation_commands:
+  - "python3 scripts/version_dataset.py verify --manifest <lock> --strict"
+evidence_surface: ci_validator

--- a/skills/write-paper/skill.yml
+++ b/skills/write-paper/skill.yml
@@ -32,3 +32,17 @@ downstream_consumers:
 forbidden_actions:
   - generate_references_from_memory
   - silently_edit_frozen_submission
+
+# v2.1 quality card
+purpose: "Draft a submission-ready IMRAD manuscript or section from approved project inputs (8-phase workflow)."
+safety_boundaries:
+  - "Never generates references from memory; citations come from search-lit and are checked by verify-refs."
+  - "Never silently edits a frozen submission; branches to v_(N+1) instead."
+  - "Numerical claims are audited against approved tables before submission (Step 7.3a)."
+known_limitations:
+  - "Reference integrity depends on verify-refs (PubMed/CrossRef); offline runs degrade to manual checking."
+  - "Drafts the user's own manuscript only; not for self-critique (self-review), reviewer response (revise), or external review (peer-review)."
+validation_commands:
+  - "/verify-refs --strict"
+  - "/self-review"
+evidence_surface: demo

--- a/skills/write-protocol/skill.yml
+++ b/skills/write-protocol/skill.yml
@@ -1,0 +1,34 @@
+schema_version: 2
+name: write-protocol
+layer: C
+owner_domain: protocol_drafting
+
+when_to_use: "Generate an IRB/ethics research protocol: 4 full prose core sections (Background, Design, Sample Size, Statistical Plan) plus 6 skeleton sections with TODO markers."
+when_NOT_to_use: "Filling an institutional Word form (use fill-protocol); manuscript drafting (use write-paper)."
+
+inputs:
+  - "design-study output"
+  - "calc-sample-size output"
+  - "search-lit output"
+outputs:
+  - "protocol.md (4 core sections + 6 TODO skeletons)"
+side_effects:
+  - writes_project_artifacts
+downstream_consumers:
+  - fill-protocol
+forbidden_actions:
+  - generate_references_from_memory
+  - fill_institution_specific_sections_with_invented_content
+
+# v2.1 quality card
+purpose: "Draft the scientific core of an IRB protocol and leave institution-specific sections as explicit TODO skeletons."
+safety_boundaries:
+  - "Institution-specific content is left as TODO markers, never fabricated."
+  - "Citations come from search-lit; references are not generated from memory."
+known_limitations:
+  - "Core sections need design-study/calc-sample-size inputs to be sound."
+  - "Skeleton sections require the researcher's institutional knowledge to complete."
+validation_commands:
+  - "/verify-refs --strict on cited work"
+  - "hand off to fill-protocol for the institutional template"
+evidence_surface: manual_workflow


### PR DESCRIPTION
Authors 27 new v2 contracts and appends quality cards to the 15 existing ones, reaching 42/42 coverage (contract WARNs 27→0). Evidence labels are grounded in repo reality (demo / ci_validator / bundled_script / manual_workflow); validation_commands and deterministic_scripts reference real files.

**Stacked PR 5/6.** Base: `feat/skill-quality-cards-schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)