### PR TITLE
feat(docs): render Quality Cards in docs/skills/, add AUDIT.md, enforce contracts

### DIFF
--- a/docs/skills/AUDIT.md
+++ b/docs/skills/AUDIT.md
@@ -1,0 +1,56 @@
+# How MedSci Skills Are Validated
+
+This page describes what is actually checked in this repository, what is reviewed by hand, and what is deliberately **not** claimed. It is a trust surface grounded in the repo's CI and demos, not a marketing claim. Every check below runs in `.github/workflows/validate.yml` on each push and pull request, or is reproducible locally.
+
+## Static gates (run in CI on every change)
+
+| Gate | What it enforces |
+|---|---|
+| `scripts/validate_skills.sh` | Per-skill structure (required frontmatter, anti-hallucination section), size tiers, and a public-surface PII / precedent scan (personal paths, names, document EXIF). Also runs the contract validator. |
+| `scripts/validate_skill_contracts.py` | Every skill ships a `skill.yml` (v2); schema correctness; the optional v2.1 quality-card fields (non-empty lists, strict `evidence_surface` enum). Missing contract → **FAIL**. |
+| `scripts/validate_catalog_consistency.py` | Catalog counts (skills, reporting guidelines, journal profiles) recomputed from disk and asserted equal across `metadata/catalog_counts.json` and the public docs. |
+| `scripts/validate_routing_assets.py --strict` | Every `${CLAUDE_SKILL_DIR}` asset reference in a `SKILL.md` resolves to a file that exists. |
+| `scripts/gen_skill_docs.py --check` | The generated per-skill pages under `docs/skills/` are in sync with each `SKILL.md` + `skill.yml` (no drift). |
+| `scripts/version_dataset.py verify --strict` | The three demo projects' `manifest.lock.json` (input + output SHA-256) still reproduce. |
+
+## Dynamic evidence (reproducible demos)
+
+Three end-to-end demos exercise the core pipeline on public data, each pinned by a `manifest.lock.json` that CI verifies:
+
+- [`demo/01_wisconsin_bc/`](../../demo/01_wisconsin_bc/) — diagnostic accuracy (STARD 2015).
+- [`demo/02_metafor_bcg/`](../../demo/02_metafor_bcg/) — meta-analysis (PRISMA 2020).
+- [`demo/03_nhanes_obesity/`](../../demo/03_nhanes_obesity/) — survey epidemiology (STROBE).
+
+## Evidence surface (per-skill)
+
+Each skill's Quality Card carries an `evidence_surface` label — the strongest validation it has. Labels are assigned conservatively:
+
+| Label | Meaning |
+|---|---|
+| `ci_validator` | A CI gate exercises the skill's behavior or output. |
+| `demo` | The skill is exercised end-to-end by one of the demos above. |
+| `bundled_script` | The skill ships a deterministic script that produces its output. |
+| `manual_workflow` | LLM/MCP-driven; no standalone automated check (often needs a Claude MCP server). |
+| `not_yet_demonstrated` | No demo or deterministic check yet. |
+
+## Trust boundaries
+
+**What these gates establish:** structural validity, absence of known PII patterns, citation/asset/count integrity, generated-doc sync, and reproducibility of the demo outputs.
+
+**What is reviewed by hand, not automated:** clinical correctness, statistical appropriateness for a given dataset, and writing quality. The skills enforce *process* (verified references, reporting-guideline items, drift checks); they do not certify that a study's design or conclusions are correct. Several skills are `manual_workflow` and depend on a connected Claude MCP server (PubMed, CrossRef, Zotero); off-Claude they degrade to manual steps (see [`host_compatibility.md`](../host_compatibility.md)).
+
+**What is deliberately not claimed:** there is no external security scan, no skill signing, and no third-party audit in this repository at this time. Cross-agent host support is asserted only where install and discovery have been verified against official documentation; OpenClaw and Hermes remain unverified roadmap items.
+
+## Reproduce locally
+
+```bash
+bash scripts/validate_skills.sh
+python3 scripts/validate_skill_contracts.py
+python3 scripts/validate_catalog_consistency.py
+python3 scripts/validate_routing_assets.py --strict
+python3 scripts/gen_skill_docs.py --check
+```
+
+---
+
+*Part of [MedSci Skills](../../README.md). Per-skill pages: [skill reference index](README.md).*

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -2,47 +2,47 @@
 
 # MedSci Skills — Skill Reference
 
-One reference page per skill, generated from each skill's `SKILL.md`. Each page describes what the skill does, when it activates, and its bundled resources, and links to the canonical definition. See the [main README](../../README.md) for installation and live demos.
+One reference page per skill, generated from each skill's `SKILL.md` and `skill.yml`. Each page describes what the skill does, when it activates, its Quality Card (purpose, safety boundaries, known limitations, validation, evidence), and its bundled resources. See the [main README](../../README.md) for installation and live demos, and [AUDIT.md](AUDIT.md) for how these skills are validated. The `evidence` tag below marks the strongest validation each skill carries.
 
-- [academic-aio](academic-aio.md) — Medical AI paper optimization for AI search engines (Perplexity, ChatGPT web, Elicit, Consensus, SciSpace) and RAG-based literature tools.
-- [add-journal](add-journal.md) — Add a new journal to the MedSci Skills profile database.
-- [analyze-stats](analyze-stats.md) — Statistical analysis for medical research papers.
-- [author-strategy](author-strategy.md) — PubMed author profile analysis.
-- [batch-cohort](batch-cohort.md) — Generate N analysis scripts from a single methodology template × multiple exposure/outcome combinations.
-- [calc-sample-size](calc-sample-size.md) — Interactive sample size calculator for medical research.
-- [check-reporting](check-reporting.md) — Check manuscript compliance with medical research reporting guidelines.
-- [clean-data](clean-data.md) — Interactive data profiling and cleaning assistant for medical research.
-- [cross-national](cross-national.md) — End-to-end cross-national comparison study using KNHANES + NHANES + CHNS (or other parallel surveys).
-- [define-variables](define-variables.md) — Literature-grounded variable operationalization for observational research.
-- [deidentify](deidentify.md) — De-identify clinical research data before LLM-assisted analysis.
-- [design-study](design-study.md) — Study design and validity review for radiology and medical AI research.
-- [fill-icmje-coi](fill-icmje-coi.md) — Batch-generate per-author ICMJE Conflict of Interest Disclosure Forms (`coi_disclosure.docx`) for manuscript submission.
-- [fill-protocol](fill-protocol.md) — Fill institutional Word form templates (.doc/.docx) for IRB protocols, ethics applications, grant proposals, and other structured research documents while preserving the original styles, table layouts…
-- [find-cohort-gap](find-cohort-gap.md) — Research gap finder for longitudinal cohort databases.
-- [find-journal](find-journal.md) — Journal recommendation engine for medical manuscripts.
-- [fulltext-retrieval](fulltext-retrieval.md) — Batch download open-access PDFs by DOI using legitimate OA APIs (Unpaywall, PMC, OpenAlex, Crossref).
-- [generate-codebook](generate-codebook.md) — Generate a citable data dictionary / codebook from a tabular dataset (CSV/TSV/Excel/Parquet/Stata/SAS).
-- [grant-builder](grant-builder.md) — Grant and challenge proposal support for radiology and medical AI projects.
-- [humanize](humanize.md) — Detect and remove AI writing patterns from academic manuscripts and response-to-reviewers letters.
-- [intake-project](intake-project.md) — Intake and normalize a new radiology research project.
-- [lit-sync](lit-sync.md) — Sync research references from .bib files to Zotero library + Obsidian literature notes.
-- [ma-scout](ma-scout.md) — Meta-analysis topic discovery and feasibility assessment.
-- [make-figures](make-figures.md) — Generate publication-ready figures and visual abstracts for medical research papers.
-- [manage-project](manage-project.md) — Research project management for medical manuscripts.
-- [manage-refs](manage-refs.md) — Cross-cutting reference manager for medical manuscripts.
-- [meta-analysis](meta-analysis.md) — Systematic review and meta-analysis pipeline for medical research.
-- [orchestrate](orchestrate.md) — General-purpose research orchestrator.
-- [peer-review](peer-review.md) — Peer review assistant for medical journals.
-- [present-paper](present-paper.md) — Academic presentation preparation — paper-driven (journal club, grand rounds, seminar) and lecture/teaching decks (course material, workshop slides, conference talks).
-- [publish-skill](publish-skill.md) — Convert a personal agent skill into a distributable, open-source-ready skill.
-- [render-pdf-doc](render-pdf-doc.md) — Render Korean academic Markdown documents to publication-quality PDF via pandoc + xelatex.
-- [replicate-study](replicate-study.md) — Replicate an existing cohort study's methodology on a different database.
-- [revise](revise.md) — Parse peer reviewer comments and generate a structured Response to Reviewers document with tracked manuscript changes.
-- [search-lit](search-lit.md) — Literature search and citation management for medical research.
-- [self-review](self-review.md) — Pre-submission self-review for the user's own manuscripts, applying a reviewer perspective.
-- [setup-medsci](setup-medsci.md) — Diagnostic checklist for the MedSci Skills runtime.
-- [sync-submission](sync-submission.md) — Audit SSOT-to-submission drift and create journal submission manifests from canonical manuscript artifacts.
-- [verify-refs](verify-refs.md) — Audit-only verification of manuscript references against PubMed and CrossRef.
-- [version-dataset](version-dataset.md) — Dataset version control for research reproducibility.
-- [write-paper](write-paper.md) — Full-pipeline medical/scientific paper writing.
-- [write-protocol](write-protocol.md) — IRB/ethics committee research protocol generator.
+- [academic-aio](academic-aio.md) — Medical AI paper optimization for AI search engines (Perplexity, ChatGPT web, Elicit, Consensus, SciSpace) and RAG-based literature tools. _(evidence: bundled_script)_
+- [add-journal](add-journal.md) — Add a new journal to the MedSci Skills profile database. _(evidence: manual_workflow)_
+- [analyze-stats](analyze-stats.md) — Statistical analysis for medical research papers. _(evidence: demo)_
+- [author-strategy](author-strategy.md) — PubMed author profile analysis. _(evidence: manual_workflow)_
+- [batch-cohort](batch-cohort.md) — Generate N analysis scripts from a single methodology template × multiple exposure/outcome combinations. _(evidence: manual_workflow)_
+- [calc-sample-size](calc-sample-size.md) — Interactive sample size calculator for medical research. _(evidence: manual_workflow)_
+- [check-reporting](check-reporting.md) — Check manuscript compliance with medical research reporting guidelines. _(evidence: demo)_
+- [clean-data](clean-data.md) — Interactive data profiling and cleaning assistant for medical research. _(evidence: manual_workflow)_
+- [cross-national](cross-national.md) — End-to-end cross-national comparison study using KNHANES + NHANES + CHNS (or other parallel surveys). _(evidence: manual_workflow)_
+- [define-variables](define-variables.md) — Literature-grounded variable operationalization for observational research. _(evidence: manual_workflow)_
+- [deidentify](deidentify.md) — De-identify clinical research data before LLM-assisted analysis. _(evidence: bundled_script)_
+- [design-study](design-study.md) — Study design and validity review for radiology and medical AI research. _(evidence: manual_workflow)_
+- [fill-icmje-coi](fill-icmje-coi.md) — Batch-generate per-author ICMJE Conflict of Interest Disclosure Forms (`coi_disclosure.docx`) for manuscript submission. _(evidence: bundled_script)_
+- [fill-protocol](fill-protocol.md) — Fill institutional Word form templates (.doc/.docx) for IRB protocols, ethics applications, grant proposals, and other structured research documents while preserving the original styles, table layouts… _(evidence: bundled_script)_
+- [find-cohort-gap](find-cohort-gap.md) — Research gap finder for longitudinal cohort databases. _(evidence: manual_workflow)_
+- [find-journal](find-journal.md) — Journal recommendation engine for medical manuscripts. _(evidence: manual_workflow)_
+- [fulltext-retrieval](fulltext-retrieval.md) — Batch download open-access PDFs by DOI using legitimate OA APIs (Unpaywall, PMC, OpenAlex, Crossref). _(evidence: bundled_script)_
+- [generate-codebook](generate-codebook.md) — Generate a citable data dictionary / codebook from a tabular dataset (CSV/TSV/Excel/Parquet/Stata/SAS). _(evidence: bundled_script)_
+- [grant-builder](grant-builder.md) — Grant and challenge proposal support for radiology and medical AI projects. _(evidence: manual_workflow)_
+- [humanize](humanize.md) — Detect and remove AI writing patterns from academic manuscripts and response-to-reviewers letters. _(evidence: manual_workflow)_
+- [intake-project](intake-project.md) — Intake and normalize a new radiology research project. _(evidence: manual_workflow)_
+- [lit-sync](lit-sync.md) — Sync research references from .bib files to Zotero library + Obsidian literature notes. _(evidence: manual_workflow)_
+- [ma-scout](ma-scout.md) — Meta-analysis topic discovery and feasibility assessment. _(evidence: manual_workflow)_
+- [make-figures](make-figures.md) — Generate publication-ready figures and visual abstracts for medical research papers. _(evidence: demo)_
+- [manage-project](manage-project.md) — Research project management for medical manuscripts. _(evidence: manual_workflow)_
+- [manage-refs](manage-refs.md) — Cross-cutting reference manager for medical manuscripts. _(evidence: bundled_script)_
+- [meta-analysis](meta-analysis.md) — Systematic review and meta-analysis pipeline for medical research. _(evidence: demo)_
+- [orchestrate](orchestrate.md) — General-purpose research orchestrator. _(evidence: demo)_
+- [peer-review](peer-review.md) — Peer review assistant for medical journals. _(evidence: manual_workflow)_
+- [present-paper](present-paper.md) — Academic presentation preparation — paper-driven (journal club, grand rounds, seminar) and lecture/teaching decks (course material, workshop slides, conference talks). _(evidence: bundled_script)_
+- [publish-skill](publish-skill.md) — Convert a personal agent skill into a distributable, open-source-ready skill. _(evidence: bundled_script)_
+- [render-pdf-doc](render-pdf-doc.md) — Render Korean academic Markdown documents to publication-quality PDF via pandoc + xelatex. _(evidence: bundled_script)_
+- [replicate-study](replicate-study.md) — Replicate an existing cohort study's methodology on a different database. _(evidence: manual_workflow)_
+- [revise](revise.md) — Parse peer reviewer comments and generate a structured Response to Reviewers document with tracked manuscript changes. _(evidence: manual_workflow)_
+- [search-lit](search-lit.md) — Literature search and citation management for medical research. _(evidence: bundled_script)_
+- [self-review](self-review.md) — Pre-submission self-review for the user's own manuscripts, applying a reviewer perspective. _(evidence: demo)_
+- [setup-medsci](setup-medsci.md) — Diagnostic checklist for the MedSci Skills runtime. _(evidence: manual_workflow)_
+- [sync-submission](sync-submission.md) — Audit SSOT-to-submission drift and create journal submission manifests from canonical manuscript artifacts. _(evidence: bundled_script)_
+- [verify-refs](verify-refs.md) — Audit-only verification of manuscript references against PubMed and CrossRef. _(evidence: bundled_script)_
+- [version-dataset](version-dataset.md) — Dataset version control for research reproducibility. _(evidence: ci_validator)_
+- [write-paper](write-paper.md) — Full-pipeline medical/scientific paper writing. _(evidence: demo)_
+- [write-protocol](write-protocol.md) — IRB/ethics committee research protocol generator. _(evidence: manual_workflow)_

--- a/docs/skills/academic-aio.md
+++ b/docs/skills/academic-aio.md
@@ -10,6 +10,26 @@
 
 `academic-aio` activates on requests such as: AIO, LLMO, GEO, AI search optimization, discoverability, abstract optimization, structured abstract, Key Points, Research in context, plain-language summary, preprint strategy, GitHub README, CITATION.cff, Zenodo DOI, Hugging Face model card, dataset card, Perplexity, Elicit, Consensus, SciSpace, RAG visibility, reporting guideline compliance, TRIPOD-AI, CLAIM, STARD-AI, taxonomy review paper, Radiology Key Points, Lancet Digital Health Research in context, npj Digital Medicine.
 
+## Quality Card
+
+**Purpose** — Make a medical-AI manuscript discoverable and citable by AI search/RAG tools without sacrificing reporting-guideline compliance.
+
+**Safety boundaries**
+
+- Off by default in autonomous pipelines; rewrites require user review (no silent rewrite).
+- Reporting-guideline claims are checked, never asserted without the underlying item being present.
+
+**Known limitations**
+
+- GEO/AIO heuristics evolve with each engine; recommendations are point-in-time.
+- Does not draft new scientific content; optimizes existing approved text only.
+
+**Validation**
+
+- `python3 scripts/validate_schema.py <summary-box-file>`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/academic-aio/references/`):

--- a/docs/skills/add-journal.md
+++ b/docs/skills/add-journal.md
@@ -10,6 +10,26 @@
 
 `add-journal` activates on requests such as: add journal, new journal, create journal profile, journal profile 추가.
 
+## Quality Card
+
+**Purpose** — Turn a journal's official author guidelines into canonical compact + detailed profiles for the recommendation and drafting skills.
+
+**Safety boundaries**
+
+- Policy/scope fields are transcribed from the official source, never inferred; unverifiable items are flagged.
+- No cached impact-factor or APC values are asserted; users verify current metrics at the source.
+
+**Known limitations**
+
+- Profiles drift as journals update guidelines; each carries a verification date.
+- Quality depends on the guidelines text supplied; gated pages require user-provided content.
+
+**Validation**
+
+- `python3 scripts/validate_catalog_consistency.py   # profile counts stay in sync`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/add-journal/SKILL.md`](../../skills/add-journal/SKILL.md)

--- a/docs/skills/analyze-stats.md
+++ b/docs/skills/analyze-stats.md
@@ -10,6 +10,27 @@
 
 `analyze-stats` activates on requests such as: statistics, statistical analysis, analyze data, run stats, table 1, demographics table, ROC curve, agreement analysis, ICC, kappa, survival analysis, Kaplan-Meier, group comparison, logistic regression, linear regression, regression, propensity score, PSM, IPTW, SIPTW, overlap weighting, repeated measures, mixed model, GEE, longitudinal, survey weighted, KNHANES, NHANES, NHIS cohort, complex survey, wOR, weighted odds ratio, claims-based, ICD-10.
 
+## Quality Card
+
+**Purpose** — Produce reproducible statistical code and publication-ready output for a specified design (DTA, agreement, survival, regression, survey, etc.).
+
+**Safety boundaries**
+
+- All numbers come from executed code on the supplied data; never hand-typed (seed-fixed transforms).
+- Primary estimates report effect size with 95% CI and exact p-values.
+
+**Known limitations**
+
+- Correctness depends on a correct analysis plan and clean data (use design-study / clean-data first).
+- Does not adjudicate clinical validity of the chosen test.
+
+**Validation**
+
+- `re-run the emitted script and diff results`
+- `/self-review`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/analyze-stats/references/`):

--- a/docs/skills/author-strategy.md
+++ b/docs/skills/author-strategy.md
@@ -10,6 +10,26 @@
 
 `author-strategy` activates on requests such as: author-strategy, 저자 분석, publication analysis, 다작 분석, 연구 전략 분석, author profile, reverse engineer strategy.
 
+## Quality Card
+
+**Purpose** — Summarize an author's PubMed publication profile and surface strategy options from the actual record.
+
+**Safety boundaries**
+
+- Records are fetched from PubMed, not recalled from memory; author disambiguation is explicit.
+- Reports describe the public record only; no private or speculative attribution.
+
+**Known limitations**
+
+- Name collisions on PubMed can blur profiles; disambiguation is best-effort.
+- No standalone demo; output is an advisory report.
+
+**Validation**
+
+- `manual review of the fetched record against PubMed`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/author-strategy/SKILL.md`](../../skills/author-strategy/SKILL.md)

--- a/docs/skills/batch-cohort.md
+++ b/docs/skills/batch-cohort.md
@@ -10,6 +10,27 @@
 
 `batch-cohort` activates on requests such as: batch cohort, batch analysis, 대량 분석, 변수 교체, variable swap, mass production, 80명 팀, batch generate, 일괄 코드 생성, exposure outcome matrix, combinatorial analysis.
 
+## Quality Card
+
+**Purpose** — Scale one validated method across many variable combinations, swapping only exposure/outcome, never the method.
+
+**Safety boundaries**
+
+- The methodology is held constant across all generated scripts; deviations are disclosed.
+- Generated scripts run on real data; no results are pre-filled.
+
+**Known limitations**
+
+- Inherits the source template's assumptions; a flawed template propagates.
+- No standalone demo; outputs are code to be executed and reviewed.
+
+**Validation**
+
+- `execute each generated script and reconcile the summary matrix`
+- `/self-review`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/batch-cohort/references/`):

--- a/docs/skills/calc-sample-size.md
+++ b/docs/skills/calc-sample-size.md
@@ -10,6 +10,26 @@
 
 `calc-sample-size` activates on requests such as: sample size, power analysis, power calculation, how many patients, how many subjects, IRB sample size.
 
+## Quality Card
+
+**Purpose** — Compute sample size / power with decision-tree test selection and reproducible R/Python code plus IRB-ready justification.
+
+**Safety boundaries**
+
+- Effect-size assumptions are justified and sourced, not fabricated; attrition/loss is accounted for.
+- Any change to N updates both the justification and the protocol Methods (no silent change).
+
+**Known limitations**
+
+- Emits inline R/Python, not a packaged script; the user runs it.
+- Output is only as valid as the assumed effect size and design.
+
+**Validation**
+
+- `re-run the emitted power code and confirm N matches the justification`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/calc-sample-size/references/`):

--- a/docs/skills/check-reporting.md
+++ b/docs/skills/check-reporting.md
@@ -10,6 +10,27 @@
 
 `check-reporting` activates on requests such as: checklist, reporting guideline, STROBE, CONSORT, STARD, STARD-AI, TRIPOD, PRISMA, PRISMA-DTA, PRISMA-P, ARRIVE, CARE, CLAIM, MI-CLEAR-LLM, SPIRIT, QUADAS, QUADAS-C, RoB, ROBINS, ROBINS-E, ROBIS, ROB-ME, PROBAST, NOS, COSMIN, AMSTAR, SWiM, risk of bias, compliance check, LLM accuracy.
 
+## Quality Card
+
+**Purpose** — Audit a manuscript item-by-item against a chosen reporting guideline (32 supported) with PRESENT/MISSING/PARTIAL status.
+
+**Safety boundaries**
+
+- Checklist items are quoted from the guideline, never invented; missing items are not marked present.
+- Fails fast if the requested checklist file is absent rather than generating a guessed checklist.
+
+**Known limitations**
+
+- Item judgements are advisory; a PRESENT mark is a locator, not a quality guarantee.
+- Coverage is limited to the bundled checklists.
+
+**Validation**
+
+- `python3 scripts/check_checklist_exists.py <guideline>`
+- `python3 scripts/prisma_cascade_check.py`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/check-reporting/references/`):

--- a/docs/skills/clean-data.md
+++ b/docs/skills/clean-data.md
@@ -10,6 +10,27 @@
 
 `clean-data` activates on requests such as: clean data, data cleaning, data preprocessing, data profiling, missing values, outliers, check my data, data quality.
 
+## Quality Card
+
+**Purpose** — Profile, flag, and code-generate cleaning steps for clinical tabular data, with a researcher approval gate at every stage.
+
+**Safety boundaries**
+
+- Never auto-cleans; every decision (missing values, outliers, dups, types) requires user confirmation.
+- All transforms are emitted as reviewable code, not applied silently.
+
+**Known limitations**
+
+- Heuristic flags need clinical judgement; the skill does not decide what is a true outlier.
+- No standalone demo; correctness depends on user approvals.
+
+**Validation**
+
+- `re-run the emitted cleaning code and re-profile`
+- `/version-dataset for a manifest`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/clean-data/references/`):

--- a/docs/skills/cross-national.md
+++ b/docs/skills/cross-national.md
@@ -10,6 +10,27 @@
 
 `cross-national` activates on requests such as: cross-national, 한미 비교, Korea US comparison, KNHANES NHANES, 양국 비교, binational, cross-country, 비교연구, 3국 비교, CHNS, 한미중.
 
+## Quality Card
+
+**Purpose** — Harmonize and analyze parallel national surveys (2- or 3-country) with correct complex-survey weighting.
+
+**Safety boundaries**
+
+- Variable harmonization is documented in an explicit mapping; survey weights are always applied.
+- Numbers come from executed weighted analysis on real survey data.
+
+**Known limitations**
+
+- Cross-survey comparability is limited by instrument differences; residual non-comparability remains.
+- No standalone demo; depends on a sound harmonization plan.
+
+**Validation**
+
+- `re-run weighted analysis per country and reconcile`
+- `/self-review`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/cross-national/SKILL.md`](../../skills/cross-national/SKILL.md)

--- a/docs/skills/define-variables.md
+++ b/docs/skills/define-variables.md
@@ -10,6 +10,26 @@
 
 `define-variables` activates on requests such as: variable definition, phenotype definition, operationalization, cutoff justification, inclusion criteria, case definition, grouping criteria, literature-grounded definition, canonical definition, 변수 정의, 정의 근거.
 
+## Quality Card
+
+**Purpose** — Produce a literature-grounded, dictionary-cited operationalization table that prevents ad-hoc phenotype definitions.
+
+**Safety boundaries**
+
+- Every DB variable interpretation quotes the data dictionary verbatim (dictionary-first).
+- Cutoffs cite a canonical literature source; unsupported definitions are flagged, not invented.
+
+**Known limitations**
+
+- Quality depends on a complete data dictionary; silent dictionary gaps block definitions.
+- No standalone demo; output is reviewed against the dictionary and sources.
+
+**Validation**
+
+- `cross-check each row's dictionary citation against the source dictionary`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/define-variables/references/`):

--- a/docs/skills/deidentify.md
+++ b/docs/skills/deidentify.md
@@ -10,6 +10,28 @@
 
 `deidentify` activates on requests such as: deidentify, de-identify, anonymize, 비식별화, 익명화, remove PHI, remove PII, strip patient info.
 
+## Quality Card
+
+**Purpose** — Detect and remove PHI from clinical tabular data with a local-only CLI, so downstream LLM analysis never touches raw identifiers.
+
+**Safety boundaries**
+
+- The agent never sees raw PHI; de-identification runs in a standalone local script with no network or AI calls.
+- Never reads or displays the re-identification mapping file (it holds original PHI values).
+- Only the scan report (no raw values), the hash-only audit log, and the de-identified output may be read.
+
+**Known limitations**
+
+- Regex and heuristic detection across 10 country locale packs is not a substitute for expert disclosure review or an IRB determination.
+- PHI coverage is limited to the bundled locale packs (kr, us, jp, cn, de, uk, fr, ca, au, in).
+
+**Validation**
+
+- `python deidentify.py scan <file> --locale <code>   # review column classifications before stripping`
+- `inspect the SHA-256 audit log after a full run`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/deidentify/references/`):

--- a/docs/skills/design-study.md
+++ b/docs/skills/design-study.md
@@ -10,6 +10,26 @@
 
 `design-study` activates on requests such as: study design, leakage check, cohort design, analysis plan, validation strategy, comparator design, bias check.
 
+## Quality Card
+
+**Purpose** — Surface design and validity risks (leakage, analysis unit, comparator, validation strategy) before a study is built or written.
+
+**Safety boundaries**
+
+- Advisory only: writes decision notes, not analysis or manuscript artifacts.
+- Names validity threats explicitly rather than rubber-stamping a design.
+
+**Known limitations**
+
+- A review reduces but cannot eliminate design risk; it is not a guarantee of validity.
+- No standalone demo; recommendations require researcher judgement.
+
+**Validation**
+
+- `carry findings into write-protocol Methods and re-check with /self-review`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/design-study/SKILL.md`](../../skills/design-study/SKILL.md)

--- a/docs/skills/fill-icmje-coi.md
+++ b/docs/skills/fill-icmje-coi.md
@@ -10,6 +10,26 @@
 
 `fill-icmje-coi` activates on requests such as: ICMJE, COI form, conflict of interest form, disclosure form, coi_disclosure.docx, 이해상충, 이해상충 폼, icmje 폼, 저자 동의서, submission forms.
 
+## Quality Card
+
+**Purpose** — Clone the ICMJE COI form per author with date/name/title filled, defaulting all 13 items to 'None' for the no-conflict common case.
+
+**Safety boundaries**
+
+- Only date, name, and manuscript title are substituted; the 13 items and certification come from the seed unchanged.
+- Ships a synthetic PII-free seed; never commits a seed with real author PII.
+
+**Known limitations**
+
+- Authors with real disclosures must edit their form in Word; the skill cannot infer conflicts.
+- A blank ICMJE template cannot be used as the seed (the safety check requires the pre-filled 'None' strings).
+
+**Validation**
+
+- `verify each output: 14 checked boxes, 13 'None', no seed-placeholder leakage`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **Scripts** (`skills/fill-icmje-coi/scripts/`):

--- a/docs/skills/fill-protocol.md
+++ b/docs/skills/fill-protocol.md
@@ -10,6 +10,27 @@
 
 `fill-protocol` activates on requests such as: fill protocol, fill template, fill IRB form, IRB template, ethics template, grant template, 양식 채우기, 연구계획서 작성, 신청서 작성, 정부 양식, 병원 양식, 워드 템플릿.
 
+## Quality Card
+
+**Purpose** — Render approved content into an institutional Word template without losing its layout, styles, or page geometry.
+
+**Safety boundaries**
+
+- Operates on the original template (never rebuilds from a blank Document, which strips logos/headers/styles).
+- CJK eastAsia fonts and table cantSplit are enforced for Korean templates.
+
+**Known limitations**
+
+- Requires the institutional template file; cannot invent a missing one.
+- Content-controlled (SDT) fields may need manual handling in Word.
+
+**Validation**
+
+- `confirm [MISS] count is 0 after fill`
+- `soffice --headless --convert-to pdf for visual check`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/fill-protocol/references/`):

--- a/docs/skills/find-cohort-gap.md
+++ b/docs/skills/find-cohort-gap.md
@@ -10,6 +10,26 @@
 
 `find-cohort-gap` activates on requests such as: cohort gap, research topic, DB 주제, 코호트 갭, gap analysis, 연구주제 찾기, find research gap, 주제 발굴.
 
+## Quality Card
+
+**Purpose** — Rank under-studied topics for a specific cohort, each backed by literature-saturation evidence and feasibility.
+
+**Safety boundaries**
+
+- Each proposed gap cites the literature scan that supports it; saturation counts come from real searches.
+- Advisory report only; does not design or execute studies.
+
+**Known limitations**
+
+- Literature scans are point-in-time; a gap can close between scan and submission.
+- No standalone demo; proposals require domain judgement.
+
+**Validation**
+
+- `re-run the saturation search before committing to a topic`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/find-cohort-gap/references/`):

--- a/docs/skills/find-journal.md
+++ b/docs/skills/find-journal.md
@@ -10,6 +10,26 @@
 
 `find-journal` activates on requests such as: find journal, recommend journal, where to submit, which journal, journal selection, target journal, journal match.
 
+## Quality Card
+
+**Purpose** — Rank candidate journals by scope fit from the curated profile library, with AI-disclosure policy and homepage links.
+
+**Safety boundaries**
+
+- No cached impact-factor/APC values are asserted; users verify current metrics at journal sites.
+- Recommendations are drawn from the curated profile library, not invented venues.
+
+**Known limitations**
+
+- Coverage is limited to profiled journals; an unprofiled fit may be missed (add via add-journal).
+- Scope-fit ranking is advisory, not an acceptance prediction.
+
+**Validation**
+
+- `verify shortlisted journals' current scope and metrics at their official sites`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/find-journal/references/`):

--- a/docs/skills/fulltext-retrieval.md
+++ b/docs/skills/fulltext-retrieval.md
@@ -10,6 +10,27 @@
 
 `fulltext-retrieval` activates on requests such as: PDF download, fulltext retrieval, open access PDF, batch download papers, meta-analysis PDF, PDF to markdown, convert PDF.
 
+## Quality Card
+
+**Purpose** — Resolve a DOI list to open-access full-text PDFs via legitimate OA APIs, with optional Markdown conversion.
+
+**Safety boundaries**
+
+- Uses legitimate open-access sources only (Unpaywall, PMC / Europe PMC, OpenAlex, Crossref); never circumvents paywalls or access controls.
+- Validates each download (>=10 KB and a %PDF- header) before accepting it.
+
+**Known limitations**
+
+- Only open-access content is retrievable; non-OA DOIs fail by design rather than fetching from unauthorized sources.
+- PDF-to-Markdown conversion requires the optional pymupdf4llm dependency (AGPL-3.0 or commercial license).
+
+**Validation**
+
+- `python fetch_oa.py dois.txt -o pdfs/ -e <email> --verbose   # per-DOI source trace`
+- `verify each output begins with %PDF- and is at least 10 KB`
+
+**Evidence** — `bundled_script`
+
 ## Source
 
 Canonical definition: [`skills/fulltext-retrieval/SKILL.md`](../../skills/fulltext-retrieval/SKILL.md)

--- a/docs/skills/generate-codebook.md
+++ b/docs/skills/generate-codebook.md
@@ -10,6 +10,26 @@
 
 `generate-codebook` activates on requests such as: generate codebook, data dictionary, codebook, profile variables, variable dictionary, describe dataset, what variables, column dictionary, build codebook.
 
+## Quality Card
+
+**Purpose** — Derive a structured codebook (variables, types, ranges, missingness) directly from a dataset.
+
+**Safety boundaries**
+
+- Descriptive statistics are computed from the data by the bundled script, not asserted.
+- Variable semantics not present in the data are left blank for the researcher, not invented.
+
+**Known limitations**
+
+- Computes structure and distributions; does not supply clinical meaning of variables.
+- Free-text/semantic descriptions require researcher input.
+
+**Validation**
+
+- `python3 scripts/generate_codebook.py <dataset>`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/generate-codebook/references/`):

--- a/docs/skills/grant-builder.md
+++ b/docs/skills/grant-builder.md
@@ -10,6 +10,27 @@
 
 `grant-builder` activates on requests such as: grant, proposal, aims page, grant proposal, significance, innovation, approach, milestones, 산학과제, 산학협력, 과제계획서, 연구계획서, 연구비 신청, 첨부3.
 
+## Quality Card
+
+**Purpose** — Structure a fundable, executable proposal whose claims are evidence-based and whose milestones are realistic.
+
+**Safety boundaries**
+
+- Claims are tied to evidence the user supplies; preliminary data and citations are not invented.
+- Milestones are scoped to be executable, not aspirational.
+
+**Known limitations**
+
+- Does not guarantee funding; tailoring to a specific reviewer panel is the user's responsibility.
+- No standalone demo; content requires PI review.
+
+**Validation**
+
+- `/verify-refs --strict on any cited work`
+- `/self-review for internal consistency`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/grant-builder/SKILL.md`](../../skills/grant-builder/SKILL.md)

--- a/docs/skills/humanize.md
+++ b/docs/skills/humanize.md
@@ -10,6 +10,27 @@
 
 `humanize` activates on requests such as: humanize, AI patterns, AI 문체, remove AI writing, make it sound natural, 자연스럽게, de-AI.
 
+## Quality Card
+
+**Purpose** — Rewrite flagged passages to read as naturally human-written without changing facts, numbers, or citations.
+
+**Safety boundaries**
+
+- Edits style only; never alters numeric values, citations, or scientific meaning.
+- Preserves the manuscript's technical claims while removing AI tells.
+
+**Known limitations**
+
+- Pattern detection is heuristic; subtle tells may remain and need a human pass.
+- No standalone demo; judgement is required on borderline phrasings.
+
+**Validation**
+
+- `diff against the source to confirm only style changed`
+- `/self-review`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/humanize/references/`):

--- a/docs/skills/intake-project.md
+++ b/docs/skills/intake-project.md
@@ -10,6 +10,26 @@
 
 `intake-project` activates on requests such as: new project, intake project, project intake, classify project, organize project, what is this project.
 
+## Quality Card
+
+**Purpose** — Normalize a new or messy project into a classified, summarized starting point with scaffolded memory.
+
+**Safety boundaries**
+
+- Scaffolds new lightweight files; does not overwrite existing project artifacts.
+- Flags missing inputs rather than inventing them.
+
+**Known limitations**
+
+- Classification is heuristic and may need correction on unusual projects.
+- No standalone demo; a setup step, not an analysis.
+
+**Validation**
+
+- `review the scaffolded files and correct the classification if needed`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/intake-project/SKILL.md`](../../skills/intake-project/SKILL.md)

--- a/docs/skills/lit-sync.md
+++ b/docs/skills/lit-sync.md
@@ -10,6 +10,27 @@
 
 `lit-sync` activates on requests such as: lit-sync, 문헌 동기화, 레퍼런스 정리, 개념 노트 추출, lit sync, Zotero 동기화, reference sync, 참고문헌 옵시디언.
 
+## Quality Card
+
+**Purpose** — Sync verified references from .bib into Zotero and Obsidian literature notes, extracting cross-cutting concept notes when enough literature accumulates.
+
+**Safety boundaries**
+
+- Bibliographic metadata is never fabricated; only Better BibTeX may write refs.bib.
+- Existing literature notes are not overwritten.
+
+**Known limitations**
+
+- Depends on a connected Zotero MCP + Better BibTeX auto-export; degrades to manual without them.
+- No standalone demo; effects are in the user's Zotero/Obsidian.
+
+**Validation**
+
+- `confirm refs.bib mtime refreshed via Better BibTeX`
+- `zotero_find_duplicates after sync`
+
+**Evidence** — `manual_workflow`
+
 ## Source
 
 Canonical definition: [`skills/lit-sync/SKILL.md`](../../skills/lit-sync/SKILL.md)

--- a/docs/skills/ma-scout.md
+++ b/docs/skills/ma-scout.md
@@ -10,6 +10,26 @@
 
 `ma-scout` activates on requests such as: ma-scout, MA 주제 찾기, professor MA, 메타분석 주제, MA gap, topic-first MA, 트렌드 MA, meta-analysis topic, 교수님 분석, 연구 분석.
 
+## Quality Card
+
+**Purpose** — Find feasible meta-analysis gaps (professor-first or topic-first) backed by literature evidence.
+
+**Safety boundaries**
+
+- Gap claims rest on real literature scans; candidate study counts are not fabricated.
+- Advisory report; does not perform screening or synthesis.
+
+**Known limitations**
+
+- Feasibility is an estimate; the true includable pool is established only by meta-analysis screening.
+- No standalone demo; topic selection needs domain judgement.
+
+**Validation**
+
+- `confirm feasibility by running meta-analysis screening on the shortlist`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/ma-scout/references/`):

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -10,6 +10,27 @@
 
 `make-figures` activates on requests such as: figure, plot, graph, diagram, ROC curve, forest plot, flow diagram, CONSORT diagram, PRISMA flow, visualization, chart, visual abstract, graphical abstract, key message, figure design, figure planning, effective figure, cognitive load.
 
+## Quality Card
+
+**Purpose** — Generate publication-ready figures and visual/graphical abstracts (ROC, forest, CONSORT/STARD/PRISMA flow, KM, Bland-Altman, etc.).
+
+**Safety boundaries**
+
+- Figure numbers are not fabricated; flow diagrams are built from real source counts.
+- Honors journal AI-image policies; no AI images for prohibited targets.
+
+**Known limitations**
+
+- Figure correctness depends on correct input data/counts supplied by upstream skills.
+- PPTX visual abstracts need the Mac-compatibility check before sharing.
+
+**Validation**
+
+- `Rscript scripts/generate_flow_diagram.R`
+- `python3 scripts/validate_pptx_mac_compat.py <file>`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/make-figures/references/`):

--- a/docs/skills/manage-project.md
+++ b/docs/skills/manage-project.md
@@ -10,6 +10,26 @@
 
 `manage-project` activates on requests such as: manage project, project init, project status, submission checklist, project scaffold, create project, new paper project.
 
+## Quality Card
+
+**Purpose** — Track and scaffold a manuscript project across phases with checklists and timelines from real project state.
+
+**Safety boundaries**
+
+- Reads/writes project state and scaffolding; never edits canonical manuscript artifacts.
+- Status and timelines reflect actual project files, not invented progress.
+
+**Known limitations**
+
+- Timelines are planning aids, not commitments; depend on user-maintained state.
+- No standalone demo; an orchestration/tracking utility.
+
+**Validation**
+
+- `reconcile reported phase against the project's SSOT/artifacts`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/manage-project/references/`):

--- a/docs/skills/manage-refs.md
+++ b/docs/skills/manage-refs.md
@@ -10,6 +10,27 @@
 
 `manage-refs` activates on requests such as: manage-refs, references, citation, citation keys, pandoc citeproc, journal CSL, CSL swap, cascade rejection re-render, cross-reference QC, [@bibkey], Zotero CWYW, ADDIN ZOTERO_ITEM, marker conversion, [N] to [@key], reference manager, render manuscript, check_citation_keys, check_xref.
 
+## Quality Card
+
+**Purpose** — Manage the reference lifecycle: citekey validation, CSL rendering (pandoc citeproc), Zotero CWYW injection, marker conversion, and cross-reference QC.
+
+**Safety boundaries**
+
+- References are never hand-typed; only Better BibTeX / citeproc / CWYW produce the list.
+- Citekeys are validated against the .bib; unmapped markers are not guessed; CWYW docx is not regex-patched.
+
+**Known limitations**
+
+- Pandoc/Zotero must be installed; rendering is deterministic but environment-dependent.
+- Phase 3 CWYW field safety depends on a correct Zotero library.
+
+**Validation**
+
+- `python3 scripts/check_citation_keys.py manuscript.md refs.bib`
+- `python3 scripts/check_xref.py --md manuscript.md --docx out.docx --strict`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/manage-refs/references/`):

--- a/docs/skills/meta-analysis.md
+++ b/docs/skills/meta-analysis.md
@@ -10,6 +10,27 @@
 
 `meta-analysis` activates on requests such as: meta-analysis, systematic review, PROSPERO, forest plot, funnel plot, PRISMA, QUADAS, ROBINS, HSROC, bivariate model, pooled sensitivity, pooled specificity, search strategy, study selection, data extraction form.
 
+## Quality Card
+
+**Purpose** — Run the SR/MA pipeline: PROSPERO registration, search, screening, extraction, risk of bias, synthesis (bivariate/HSROC or random-effects), and PRISMA reporting.
+
+**Safety boundaries**
+
+- Study counts are never reported without ID-level receipts; halts on a P0 reconciliation mismatch.
+- Pool composition is locked to a single source of truth; downstream counts are re-derived, not copied.
+
+**Known limitations**
+
+- Synthesis validity depends on correct extraction; the skill enforces process, not clinical correctness.
+- DTA pooling assumes adequate per-study 2x2 / threshold data.
+
+**Validation**
+
+- `python3 scripts/screening_reconcile.py`
+- `python3 scripts/check_pool_consistency.py`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/meta-analysis/references/`):

--- a/docs/skills/orchestrate.md
+++ b/docs/skills/orchestrate.md
@@ -10,6 +10,27 @@
 
 `orchestrate` activates on requests such as: orchestrate, research help, what should I do next, where do I start, help me with my paper, run the pipeline, which skill, end-to-end, e2e.
 
+## Quality Card
+
+**Purpose** — Single entry point for the bundle: classify a request and route to the right skill, or chain skills for multi-step and end-to-end (--e2e) workflows.
+
+**Safety boundaries**
+
+- Never generates worker-skill outputs directly; routes to and invokes the owning skill.
+- Does not bypass per-skill artifact validation in the chain.
+
+**Known limitations**
+
+- Routing is heuristic; an ambiguous request may need explicit skill selection.
+- --e2e halts on missing expected outputs rather than proceeding with gaps.
+
+**Validation**
+
+- `python3 scripts/validate_skill_contracts.py`
+- `python3 scripts/validate_project_contract.py`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/orchestrate/references/`):

--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -10,6 +10,26 @@
 
 `peer-review` activates on requests such as: peer review, manuscript review, review paper, reviewer comments, 리뷰, 논문 리뷰, review invitation, journal review.
 
+## Quality Card
+
+**Purpose** — Draft a structured peer-review for a journal-assigned manuscript following the Yoojin Peer-Review Guideline v2.5, with journal-specific formatting.
+
+**Safety boundaries**
+
+- Reviews assigned external manuscripts only; never edits the user's own manuscript.
+- References are not generated from memory.
+
+**Known limitations**
+
+- A review is one reviewer's judgement, not an editorial decision.
+- No standalone demo; quality depends on the manuscript supplied.
+
+**Validation**
+
+- `confirm the draft addresses each section against the guideline rubric`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/peer-review/references/`):

--- a/docs/skills/present-paper.md
+++ b/docs/skills/present-paper.md
@@ -10,6 +10,27 @@
 
 `present-paper` activates on requests such as: present paper, paper presentation, journal club, seminar presentation, grand rounds, academic presentation, presentation prep, lecture, lecture material, teaching slides, course slides, 강의자료, 발표자료, 슬라이드, pptx.
 
+## Quality Card
+
+**Purpose** — Turn source papers into an audience-adapted deck with speaker notes, Mac-compatible PPTX, and a sharing-stripped variant.
+
+**Safety boundaries**
+
+- Slide claims trace to the source material; findings are not invented for narrative effect.
+- A notes-stripped variant is produced for sharing so private speaker notes never leak.
+
+**Known limitations**
+
+- Figure cropping and notes parsing are heuristic; verify the built PPTX in PowerPoint.
+- Mac OOXML quirks require the bundled compatibility checks; not every host renders identically.
+
+**Validation**
+
+- `unzip the .pptx and confirm 0 markdown-raw notes / 0 TIFF / app.xml counts synced`
+- `python3 scripts/strip_notes_for_sharing.py before sharing`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/present-paper/references/`):

--- a/docs/skills/publish-skill.md
+++ b/docs/skills/publish-skill.md
@@ -10,6 +10,27 @@
 
 `publish-skill` activates on requests such as: publish skill, distribute skill, open-source skill, package skill, universalize skill.
 
+## Quality Card
+
+**Purpose** — Harden a personal skill for open-source release through a PII audit, generalization, and license/portability checks.
+
+**Safety boundaries**
+
+- Publication is gated on a passing PII audit; the blocklist is conservative and not weakened to pass.
+- Personal paths, names, and document metadata are scrubbed before release.
+
+**Known limitations**
+
+- The audit catches known PII patterns; novel identifiers still need human review.
+- Generalization preserves behavior but a maintainer should re-read the result.
+
+**Validation**
+
+- `bash scripts/audit_skill.sh <skill-dir>`
+- `bash scripts/validate_skills.sh`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/publish-skill/references/`):

--- a/docs/skills/render-pdf-doc.md
+++ b/docs/skills/render-pdf-doc.md
@@ -10,6 +10,27 @@
 
 `render-pdf-doc` activates on requests such as: render PDF, PDF 렌더, korean PDF, 한글 PDF, anchor doc PDF, briefing PDF, proposal PDF, 연구계획서 PDF, 표 정렬 PDF, 표 폭 자동, tbl-colwidths, 학술 PDF.
 
+## Quality Card
+
+**Purpose** — Render a Markdown manuscript to a styled DOCX/PDF (tables, column widths, dependencies checked).
+
+**Safety boundaries**
+
+- Delegates bibliography rendering to manage-refs and figures/PPTX to make-figures/present-paper; does not modify citation keys.
+- Does not hand-type CSV data into tables (numerical-safety).
+
+**Known limitations**
+
+- Output fidelity depends on installed render dependencies (checked by check_deps.sh).
+- Institutional Word forms are out of scope (use fill-protocol).
+
+**Validation**
+
+- `bash scripts/check_deps.sh`
+- `bash scripts/render_pdf.sh <manuscript.md>`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/render-pdf-doc/references/`):

--- a/docs/skills/replicate-study.md
+++ b/docs/skills/replicate-study.md
@@ -10,6 +10,27 @@
 
 `replicate-study` activates on requests such as: replicate study, replicate paper, 논문 복제, 방법론 복제, reproduce study, replication, 다른 DB로, swap database, 데이터 교체.
 
+## Quality Card
+
+**Purpose** — Re-run a published study's method on a new DB and report exactly where target-DB constraints forced deviations.
+
+**Safety boundaries**
+
+- Method deviations forced by the target DB are documented in a difference report, not hidden.
+- Results come from executed code on the target data.
+
+**Known limitations**
+
+- Perfect replication is rarely possible; residual method differences remain and are disclosed.
+- No standalone demo; depends on a faithful variable mapping.
+
+**Validation**
+
+- `execute the replication code and review the difference report`
+- `/self-review`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/replicate-study/references/`):

--- a/docs/skills/revise.md
+++ b/docs/skills/revise.md
@@ -10,6 +10,27 @@
 
 `revise` activates on requests such as: revise paper, respond to reviewers, revision letter, reviewer comments, major revision, minor revision, resubmit, R1 revision, revision round, response letter, point-by-point response.
 
+## Quality Card
+
+**Purpose** — Parse reviewer comments and generate a structured Response to Reviewers with tracked manuscript changes and an editor cover letter.
+
+**Safety boundaries**
+
+- Valid reviewer points are not argued away as rebuttal without user approval.
+- Does not reference original page/line numbers after the manuscript has been revised.
+
+**Known limitations**
+
+- Coordinates new analyses/figures via other skills but does not itself produce statistics.
+- No standalone demo; depends on the actual reviewer comments supplied.
+
+**Validation**
+
+- `confirm every reviewer comment maps to a point-by-point response`
+- `/verify-refs --strict on new citations`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/revise/references/`):

--- a/docs/skills/search-lit.md
+++ b/docs/skills/search-lit.md
@@ -10,6 +10,27 @@
 
 `search-lit` activates on requests such as: literature search, find papers, citation, references, bibliography, PubMed search, related work.
 
+## Quality Card
+
+**Purpose** — Search PubMed, Semantic Scholar, and bioRxiv/medRxiv and generate API-verified BibTeX (anti-hallucination: every reference verified before inclusion).
+
+**Safety boundaries**
+
+- Never generates references from memory; unverified references are not silently included.
+- Does not write to the manuscript refs.bib (that SSOT belongs to lit-sync).
+
+**Known limitations**
+
+- Depends on PubMed/Semantic Scholar availability; rate limits/outages reduce recall.
+- Verification confirms existence/metadata, not topical relevance.
+
+**Validation**
+
+- `bash references/pubmed_eutils.sh <query>`
+- `/verify-refs --strict`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/search-lit/references/`):

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -10,6 +10,27 @@
 
 `self-review` activates on requests such as: self-review, pre-submission check, check my paper, reviewer perspective, manuscript self-check.
 
+## Quality Card
+
+**Purpose** — Pre-submission self-review of the user's own manuscript from a reviewer's perspective across 10 categories, with severity-framed anticipated comments.
+
+**Safety boundaries**
+
+- Reviews the user's own manuscript only; not for reviewing external (journal-assigned) manuscripts.
+- Does not silently fix non-AI-fixable issues; it flags them for the author.
+
+**Known limitations**
+
+- Anticipates likely reviewer comments; cannot predict a specific reviewer's focus.
+- Advisory; produces recommendations, not manuscript edits.
+
+**Validation**
+
+- `python3 scripts/check_reviewer_team_consistency.py`
+- `feed R0-numbered output into /revise`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **Scripts** (`skills/self-review/scripts/`):

--- a/docs/skills/setup-medsci.md
+++ b/docs/skills/setup-medsci.md
@@ -10,6 +10,26 @@
 
 `setup-medsci` activates on requests such as: setup, install, environment, diagnostic, check setup, why doesn't this work, missing python, missing R, MCP not connected, 환경 설정, 설치 점검.
 
+## Quality Card
+
+**Purpose** — Check and prepare the local toolchain (Python/R/CLI deps) needed to run the skills.
+
+**Safety boundaries**
+
+- Confirms before destructive or system-wide changes; surfaces what is missing.
+- Operates locally; does not transmit machine state.
+
+**Known limitations**
+
+- Environment coverage is best-effort across OSes; some hosts need manual steps.
+- No standalone demo; an operational utility.
+
+**Validation**
+
+- `re-run the setup check and confirm all dependencies report present`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/setup-medsci/references/`):

--- a/docs/skills/sync-submission.md
+++ b/docs/skills/sync-submission.md
@@ -10,6 +10,27 @@
 
 `sync-submission` activates on requests such as: sync submission, build submission, submission drift, SSOT sync, journal package, retarget journal, freeze submission.
 
+## Quality Card
+
+**Purpose** — Audit SSOT-to-submission drift and build journal submission manifests from canonical manuscript artifacts.
+
+**Safety boundaries**
+
+- Never silently edits the canonical manuscript; a drifted submission is not frozen until reconciled.
+- Submission packages are derived from canonical sources, not hand-assembled.
+
+**Known limitations**
+
+- Detects drift it is configured to scan (counts, cover-letter fields, scope); portal free-text fields still need a human check.
+- A clean audit is necessary, not sufficient, for acceptance.
+
+**Validation**
+
+- `python3 scripts/sync_submission.py`
+- `python3 scripts/cross_document_n_check.py`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **Scripts** (`skills/sync-submission/scripts/`):

--- a/docs/skills/verify-refs.md
+++ b/docs/skills/verify-refs.md
@@ -10,6 +10,27 @@
 
 `verify-refs` activates on requests such as: verify refs, verify references, citation audit, reference hallucination, fabricated references, bibliography check, PMID check, DOI check.
 
+## Quality Card
+
+**Purpose** — Audit-only verification of manuscript references against PubMed and CrossRef (full-author cross-check); writes qc/reference_audit.json. Does not modify references.
+
+**Safety boundaries**
+
+- Audit-only: never edits references/ or refs.bib; never generates references from memory.
+- Unverified references are flagged, not silently included.
+
+**Known limitations**
+
+- Confirms DOI/PMID and author identity, not topical appropriateness of the citation.
+- CrossRef given-name errors are possible; PubMed efetch is treated as authoritative.
+
+**Validation**
+
+- `bash scripts/verify_cli.sh <refs.bib>`
+- `confirm qc/reference_audit.json submission_safe: true`
+
+**Evidence** — `bundled_script`
+
 ## Bundled resources
 
 **References** (`skills/verify-refs/references/`):

--- a/docs/skills/version-dataset.md
+++ b/docs/skills/version-dataset.md
@@ -10,6 +10,26 @@
 
 `version-dataset` activates on requests such as: version dataset, dataset version, data manifest, data hash, dataset drift, reproducibility lock, verify dataset, data provenance, did my data change, manifest.lock.
 
+## Quality Card
+
+**Purpose** — Pin a dataset's contents with SHA-256 manifests so analyses are reproducible and drift is detectable.
+
+**Safety boundaries**
+
+- Hashes are computed from the actual files; a manifest is never edited to force a pass.
+- Verification is deterministic and re-runnable in CI.
+
+**Known limitations**
+
+- Detects byte-level drift, not semantic correctness of the data.
+- A manifest is only as trustworthy as the moment it was locked.
+
+**Validation**
+
+- `python3 scripts/version_dataset.py verify --manifest <lock> --strict`
+
+**Evidence** — `ci_validator`
+
 ## Bundled resources
 
 **References** (`skills/version-dataset/references/`):

--- a/docs/skills/write-paper.md
+++ b/docs/skills/write-paper.md
@@ -10,6 +10,28 @@
 
 `write-paper` activates on requests such as: write paper, manuscript, draft paper, start writing, write methods, write results, write discussion, write introduction.
 
+## Quality Card
+
+**Purpose** — Draft a submission-ready IMRAD manuscript or section from approved project inputs (8-phase workflow).
+
+**Safety boundaries**
+
+- Never generates references from memory; citations come from search-lit and are checked by verify-refs.
+- Never silently edits a frozen submission; branches to v_(N+1) instead.
+- Numerical claims are audited against approved tables before submission (Step 7.3a).
+
+**Known limitations**
+
+- Reference integrity depends on verify-refs (PubMed/CrossRef); offline runs degrade to manual checking.
+- Drafts the user's own manuscript only; not for self-critique (self-review), reviewer response (revise), or external review (peer-review).
+
+**Validation**
+
+- `/verify-refs --strict`
+- `/self-review`
+
+**Evidence** — `demo`
+
 ## Bundled resources
 
 **References** (`skills/write-paper/references/`):

--- a/docs/skills/write-protocol.md
+++ b/docs/skills/write-protocol.md
@@ -10,6 +10,27 @@
 
 `write-protocol` activates on requests such as: write protocol, IRB protocol, ethics protocol, research protocol, IRB submission, ethics submission, protocol draft.
 
+## Quality Card
+
+**Purpose** — Draft the scientific core of an IRB protocol and leave institution-specific sections as explicit TODO skeletons.
+
+**Safety boundaries**
+
+- Institution-specific content is left as TODO markers, never fabricated.
+- Citations come from search-lit; references are not generated from memory.
+
+**Known limitations**
+
+- Core sections need design-study/calc-sample-size inputs to be sound.
+- Skeleton sections require the researcher's institutional knowledge to complete.
+
+**Validation**
+
+- `/verify-refs --strict on cited work`
+- `hand off to fill-protocol for the institutional template`
+
+**Evidence** — `manual_workflow`
+
 ## Bundled resources
 
 **References** (`skills/write-protocol/references/`):

--- a/scripts/gen_skill_docs.py
+++ b/scripts/gen_skill_docs.py
@@ -35,6 +35,14 @@ REQUIRED = ("name", "description", "triggers", "tools", "model")
 RESOURCE_DIRS = ("references", "scripts", "templates")
 RESOURCE_LABELS = {"references": "References", "scripts": "Scripts", "templates": "Templates"}
 
+# Hand-maintained pages under docs/skills/ that are NOT generated and must not be
+# treated as stale (and so never deleted or flagged EXTRA by --check).
+HAND_MAINTAINED = ("AUDIT.md",)
+
+# Optional v2.1 quality-card fields surfaced from skills/<name>/skill.yml.
+CARD_SCALARS = ("purpose", "evidence_surface")
+CARD_LISTS = ("safety_boundaries", "known_limitations", "validation_commands")
+
 KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):(.*)$")
 BLOCK_INDICATORS = {">", "|", ">-", "|-", ">+", "|+"}
 
@@ -141,6 +149,60 @@ def list_resources(skill_dir: Path) -> dict[str, list[str]]:
     return out
 
 
+def _unquote(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        s = s[1:-1]
+    return s
+
+
+def parse_skill_yml(skill_dir: Path) -> dict | None:
+    """Minimal stdlib parser for the optional v2.1 quality-card fields. Returns a dict
+    with the scalar (purpose, evidence_surface) and list (safety_boundaries,
+    known_limitations, validation_commands) fields, or None if skill.yml is absent.
+    Deliberately narrow: only the card fields are read, so a normal skill.yml that
+    omits them simply yields empty values (no card section is rendered)."""
+    p = skill_dir / "skill.yml"
+    if not p.is_file():
+        return None
+    out: dict[str, object] = {k: "" for k in CARD_SCALARS}
+    out.update({k: [] for k in CARD_LISTS})
+    lines = p.read_text(encoding="utf-8").splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$", line)
+        if not m or line[:1].isspace():
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if key in CARD_SCALARS and val and not val.startswith("#"):
+            out[key] = _unquote(val)
+            i += 1
+            continue
+        if key in CARD_LISTS and (val == "" or val.startswith("#")):
+            items: list[str] = []
+            j = i + 1
+            while j < n:
+                nl = lines[j]
+                if nl.strip() == "":
+                    j += 1
+                    continue
+                lm = re.match(r"^\s+-\s+(.*)$", nl)
+                if lm:
+                    items.append(_unquote(lm.group(1)))
+                    j += 1
+                    continue
+                if not nl[:1].isspace():
+                    break
+                j += 1
+            out[key] = items
+            i = j
+            continue
+        i += 1
+    return out
+
+
 def short_desc(desc: str, cap: int = 200) -> str:
     end = len(desc)
     p = desc.find(". ")
@@ -153,7 +215,40 @@ def short_desc(desc: str, cap: int = 200) -> str:
     return s
 
 
-def render_page(name: str, fm: dict[str, str], resources: dict[str, list[str]]) -> str:
+def render_quality_card(card: dict | None) -> list[str]:
+    """Render the optional v2.1 Quality Card. Empty if skill.yml has no card fields."""
+    if not card:
+        return []
+    has_any = card.get("purpose") or card.get("evidence_surface") or any(
+        card.get(k) for k in CARD_LISTS
+    )
+    if not has_any:
+        return []
+    out = ["## Quality Card", ""]
+    if card.get("purpose"):
+        out += [f"**Purpose** — {card['purpose']}", ""]
+    for label, key in (
+        ("Safety boundaries", "safety_boundaries"),
+        ("Known limitations", "known_limitations"),
+        ("Validation", "validation_commands"),
+    ):
+        items = card.get(key) or []
+        if items:
+            out += [f"**{label}**", ""]
+            # validation_commands often contain <placeholders>; render as inline code so
+            # GitHub markdown does not strip them as unknown HTML tags.
+            if key == "validation_commands":
+                out += [f"- `{it}`" for it in items]
+            else:
+                out += [f"- {it}" for it in items]
+            out += [""]
+    if card.get("evidence_surface"):
+        out += [f"**Evidence** — `{card['evidence_surface']}`", ""]
+    return out
+
+
+def render_page(name: str, fm: dict[str, str], resources: dict[str, list[str]],
+                card: dict | None = None) -> str:
     triggers = ", ".join(t.strip() for t in fm["triggers"].split(",") if t.strip())
     out = [
         f"<!-- AUTO-GENERATED from skills/{name}/SKILL.md by scripts/gen_skill_docs.py. Do not edit by hand. -->",
@@ -169,6 +264,7 @@ def render_page(name: str, fm: dict[str, str], resources: dict[str, list[str]]) 
         f"`{name}` activates on requests such as: {triggers}.",
         "",
     ]
+    out += render_quality_card(card)
     if resources:
         out += ["## Bundled resources", ""]
         for cat in RESOURCE_DIRS:
@@ -192,19 +288,26 @@ def render_page(name: str, fm: dict[str, str], resources: dict[str, list[str]]) 
     return "\n".join(out)
 
 
-def render_index(skills: list[tuple[str, dict[str, str]]]) -> str:
+def render_index(skills: list[tuple[str, dict[str, str], str]]) -> str:
     out = [
         "<!-- AUTO-GENERATED by scripts/gen_skill_docs.py. Do not edit by hand. -->",
         "",
         "# MedSci Skills — Skill Reference",
         "",
-        "One reference page per skill, generated from each skill's `SKILL.md`. Each page "
-        "describes what the skill does, when it activates, and its bundled resources, and "
-        "links to the canonical definition. See the [main README](../../README.md) for "
-        "installation and live demos.",
+        "One reference page per skill, generated from each skill's `SKILL.md` and "
+        "`skill.yml`. Each page describes what the skill does, when it activates, its "
+        "Quality Card (purpose, safety boundaries, known limitations, validation, "
+        "evidence), and its bundled resources. See the [main README](../../README.md) "
+        "for installation and live demos, and [AUDIT.md](AUDIT.md) for how these skills "
+        "are validated. The `evidence` tag below marks the strongest validation each "
+        "skill carries.",
         "",
     ]
-    out += [f"- [{name}]({name}.md) — {short_desc(fm['description'])}" for name, fm in skills]
+    out += [
+        f"- [{name}]({name}.md) — {short_desc(fm['description'])}"
+        + (f" _(evidence: {ev})_" if ev else "")
+        for name, fm, ev in skills
+    ]
     out.append("")
     return "\n".join(out)
 
@@ -219,11 +322,12 @@ def build() -> dict[Path, str]:
     if not skill_dirs:
         raise SkillError("no skills with a SKILL.md found")
     expected: dict[Path, str] = {}
-    loaded: list[tuple[str, dict[str, str]]] = []
+    loaded: list[tuple[str, dict[str, str], str]] = []
     for sd in skill_dirs:
         fm = load_skill(sd)
-        expected[DOCS_DIR / f"{sd.name}.md"] = render_page(sd.name, fm, list_resources(sd))
-        loaded.append((sd.name, fm))
+        card = parse_skill_yml(sd)
+        expected[DOCS_DIR / f"{sd.name}.md"] = render_page(sd.name, fm, list_resources(sd), card)
+        loaded.append((sd.name, fm, (card or {}).get("evidence_surface", "")))
     expected[DOCS_DIR / "README.md"] = render_index(loaded)
     return expected
 
@@ -241,7 +345,8 @@ def main() -> int:
         return 1
 
     existing = set(DOCS_DIR.glob("*.md")) if DOCS_DIR.is_dir() else set()
-    stale = sorted(existing - set(expected))
+    keep = {DOCS_DIR / name for name in HAND_MAINTAINED}
+    stale = sorted(existing - set(expected) - keep)
 
     if args.check:
         problems: list[str] = []

--- a/scripts/validate_skill_contracts.py
+++ b/scripts/validate_skill_contracts.py
@@ -15,7 +15,7 @@ Schema v2.1 quality-card extension (optional, additive, backwards-compatible):
   of the strict labels below. None of these are required yet; missing skill.yml
   stays a WARN until every skill ships one.
 
-Missing skill.yml -> WARN (migration in progress).
+Missing skill.yml -> FAIL (every skill must ship a contract; migration complete 2026-06-03).
 Malformed skill.yml -> FAIL.
 """
 
@@ -203,8 +203,8 @@ def main() -> int:
             continue
         contract = skill_dir / "skill.yml"
         if not contract.exists():
-            warnings += 1
-            print(f"WARN {skill_dir.name}: skill.yml missing (migration warning)")
+            failures += 1
+            print(f"FAIL {skill_dir.name}: skill.yml missing (required — every skill must ship a contract)")
             continue
 
         text = contract.read_text(encoding="utf-8")


### PR DESCRIPTION
Renders a per-page Quality Card from `skill.yml` (stdlib parser; validation commands as inline code; index gains evidence tags + AUDIT link), adds hand-maintained `docs/skills/AUDIT.md` (validation story grounded in real CI + demos), and flips missing-skill.yml WARN→FAIL now that all 42 ship a contract.

**Stacked PR 6/6.** Base: `feat/skill-quality-cards-content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)