### PR TITLE
feat: reader/expert-elicitation + AI-benchmark design lessons (4 skills, +1 new)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # MedSci Skills
 
-**42 skills that actually work.** Built by a physician-researcher, tested on real publications.
+**43 skills that actually work.** Built by a physician-researcher, tested on real publications.
 
 *MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog. It competes on clinical submission reliability, not skill count.*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Aperivue/medsci-skills?style=flat-square&color=blue)](https://github.com/Aperivue/medsci-skills/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/Aperivue/medsci-skills/validate.yml?branch=main&style=flat-square&label=CI)](https://github.com/Aperivue/medsci-skills/actions/workflows/validate.yml)
-![Skills](https://img.shields.io/badge/Skills-42-brightgreen?style=flat-square)
+![Skills](https://img.shields.io/badge/Skills-43-brightgreen?style=flat-square)
 
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-standard-blue?style=flat-square)](https://agentskills.io)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-supported-success?style=flat-square)](docs/host_compatibility.md)
@@ -183,7 +183,7 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 **v3.3.0** sharpens packaging, portability, and trust without broadening scope:
 
-- **Per-skill Quality Cards** — every skill now ships a contract (`skill.yml`, 42/42), surfaced on its [`docs/skills/`](docs/skills/) page: purpose, safety boundaries, known limitations, validation commands, and an evidence label (demo / CI-validated / bundled-script / manual). A missing contract now fails CI.
+- **Per-skill Quality Cards** — every skill now ships a contract (`skill.yml`, 43/43), surfaced on its [`docs/skills/`](docs/skills/) page: purpose, safety boundaries, known limitations, validation commands, and an evidence label (demo / CI-validated / bundled-script / manual). A missing contract now fails CI.
 - **Verified cross-agent support** — [`docs/host_compatibility.md`](docs/host_compatibility.md) documents install and discovery on Claude Code, Codex, Cursor, and GitHub Copilot, each with a sourced path. The two install targets (`~/.claude/skills`, `~/.agents/skills`) already cover all four; OpenClaw/Hermes remain unverified roadmap items.
 - **An auditable validation story** — [`docs/skills/AUDIT.md`](docs/skills/AUDIT.md) maps the CI gates and three reproducible demos to explicit trust boundaries (what is automated, what is reviewed by hand, what is not claimed).
 - **Sharper positioning** — a submission-grade clinical manuscript workflow, not a generic catalog; see [`docs/competitive_positioning.md`](docs/competitive_positioning.md).
@@ -277,6 +277,7 @@ ma-scout -> search-lit -> fulltext-retrieval -> design-study ──> write-proto
 | **meta-analysis** | Full systematic review and meta-analysis pipeline (8 phases). DTA (bivariate/HSROC) and intervention meta-analysis. Protocol to submission-ready manuscript with PRISMA-DTA compliance. |
 | **make-figures** | Publication-ready figures and visual abstracts: ROC curves, forest plots, PRISMA/CONSORT/STARD flow diagrams, Kaplan-Meier curves, Bland-Altman plots, confusion matrices, and journal-specific visual/graphical abstracts (python-pptx template-based). Communication-first design principles (Nat Hum Behav 2026 — key message, audience, cognitive load, figure-vs-table decision) and five flow-diagram production lessons (official-template fidelity, VML fallback PDF export, docx XML escape, sequential placeholder mapping, version freeze); critic rubric Section G adds 5 communication-first checks. `--study-type` auto-generates the full required figure set; structured `_figure_manifest.md` output for downstream pipeline consumption; D2 enforced as default for flow diagrams. |
 | **design-study** | Study design review: identifies analysis unit, cohort logic, data leakage risks, comparator design, validation strategy, and reporting guideline fit. |
+| **design-ai-benchmarking** | Design and validity review for benchmarking AI system(s) against a human-expert panel: evaluation-question and arm definition, decoupled multi-dimensional rubrics with anchors, planted calibration probes (positive-control / known-bad / instability / mechanism-contradiction), reviewer-panel construction with per-reviewer randomization, inter-rater reliability targets with separate control-item reliability, LLM-as-judge vs human-as-judge adjudication, construct-independence guards, and a structured JSON rating-export schema. Locks the rubric before data collection. |
 | **intake-project** | Classifies new research projects, summarizes current state, identifies missing inputs, and recommends next steps. |
 | **grant-builder** | Structures grant proposals: significance, innovation, approach, milestones, and consortium roles. |
 | **present-paper** | Academic presentation preparation: paper analysis, supporting research, speaker scripts, slide note injection, and Q&A prep. |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -15,6 +15,7 @@ One reference page per skill, generated from each skill's `SKILL.md` and `skill.
 - [cross-national](cross-national.md) — End-to-end cross-national comparison study using KNHANES + NHANES + CHNS (or other parallel surveys). _(evidence: manual_workflow)_
 - [define-variables](define-variables.md) — Literature-grounded variable operationalization for observational research. _(evidence: manual_workflow)_
 - [deidentify](deidentify.md) — De-identify clinical research data before LLM-assisted analysis. _(evidence: bundled_script)_
+- [design-ai-benchmarking](design-ai-benchmarking.md) — Design and validity review for studies that benchmark one or more AI systems against a human-expert panel as the reference. _(evidence: manual_workflow)_
 - [design-study](design-study.md) — Study design and validity review for radiology and medical AI research. _(evidence: manual_workflow)_
 - [fill-icmje-coi](fill-icmje-coi.md) — Batch-generate per-author ICMJE Conflict of Interest Disclosure Forms (`coi_disclosure.docx`) for manuscript submission. _(evidence: bundled_script)_
 - [fill-protocol](fill-protocol.md) — Fill institutional Word form templates (.doc/.docx) for IRB protocols, ethics applications, grant proposals, and other structured research documents while preserving the original styles, table layouts… _(evidence: bundled_script)_

--- a/docs/skills/design-ai-benchmarking.md
+++ b/docs/skills/design-ai-benchmarking.md
@@ -1,0 +1,46 @@
+<!-- AUTO-GENERATED from skills/design-ai-benchmarking/SKILL.md by scripts/gen_skill_docs.py. Do not edit by hand. -->
+
+# design-ai-benchmarking
+
+> Design and validity review for studies that benchmark one or more AI systems against a human-expert panel as the reference. Covers the evaluation question and arm definition, decoupled multi-dimensional rubrics with anchors, planted calibration probes, reviewer-panel construction, inter-rater reliability targets, LLM-as-judge versus human-as-judge adjudication, construct-independence guards, and a structured rating-export schema. Use before data collection on an AI-vs-expert evaluation.
+
+**Invoke:** `/design-ai-benchmarking` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
+
+## When to use
+
+`design-ai-benchmarking` activates on requests such as: AI benchmarking, AI vs human expert, reader study design, expert panel evaluation, LLM-as-judge, AI evaluation rubric, model benchmark design, human baseline comparison, AI-output rating, evaluation rubric design.
+
+## Quality Card
+
+**Purpose** — Surface design and validity risks specific to AI-vs-human-expert benchmarks (rubric coupling, scale calibration, rater independence, judge choice) before data collection begins.
+
+**Safety boundaries**
+
+- Advisory only: writes decision notes plus rubric/schema artifacts, never ratings or analysis results.
+- Calibration probes and reference labels are planted or adjudicated, never fabricated to fit a hypothesis.
+
+**Known limitations**
+
+- A design review reduces but cannot eliminate evaluation bias; it does not guarantee a valid benchmark.
+- No standalone demo; rubric and panel decisions require domain-expert judgement.
+
+**Validation**
+
+- `carry the rubric and export schema into analyze-stats for ICC/agreement, then check-reporting (STARD-AI / CLAIM / TRIPOD+AI)`
+
+**Evidence** — `manual_workflow`
+
+## Bundled resources
+
+**References** (`skills/design-ai-benchmarking/references/`):
+
+- `benchmark_export_schema.json`
+- `elicitation_rubric_template.md`
+
+## Source
+
+Canonical definition: [`skills/design-ai-benchmarking/SKILL.md`](../../skills/design-ai-benchmarking/SKILL.md)
+
+---
+
+*Part of [MedSci Skills](../../README.md) — Claude Code skills for the medical research lifecycle. This page is generated from the skill's `SKILL.md`; edit that file and re-run `scripts/gen_skill_docs.py`.*

--- a/metadata/catalog_counts.json
+++ b/metadata/catalog_counts.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Single source of truth for catalog counts cited in public docs (README, orchestrate, check-reporting). scripts/validate_catalog_consistency.py recomputes every value from disk, asserts this file matches, and asserts the doc claims match. Do not hand-edit a value without running that script — CI fails on drift.",
-  "skills": 42,
+  "skills": 43,
   "reporting_guidelines": 32,
   "journal_profiles_find": 67,
   "journal_profiles_write": 54

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -201,6 +201,46 @@ These rules apply to ALL analyses without exception:
    in the manuscript with no script that reproduces it is the failure mode `/self-review`
    Phase 2.5a-2 is built to catch.
 
+### Effect-Size Real-World Translation
+
+Whenever a primary result is a correlation, a standardized coefficient, a regression slope, an
+OR/HR/RR, or a Cohen's d, also report it as a **plain-language unit shift** a non-statistician can
+act on. The coefficient answers "is there an association"; the translation answers "how much, in
+units I use". This complements rule 3 above (report effect sizes) — it does not replace it.
+
+**When to apply**
+- Any continuous-exposure to continuous-outcome association reported as Spearman's rho, Pearson's r,
+  or a standardized slope.
+- Any OR/HR/RR where the audience needs an absolute-risk feel.
+- Reader / expert-elicitation studies, clinical-utility framing, abstracts, and figure captions.
+
+**Procedure**
+1. **Pick an anchored contrast on the exposure**, not a 1-unit step. Default: 25th to 75th percentile
+   (IQR). State both endpoints in native units.
+2. **Translate to the outcome scale.**
+   - For a rank/standardized association (Spearman's rho or a per-SD slope) under an approximately
+     monotonic-linear assumption:
+     `delta_outcome ~= ((x_p75 - x_p25) / SD_x) * |rho| * SD_outcome`.
+     Report as: "going from {x_p25} to {x_p75} {units} is associated with about {delta_outcome}
+     {outcome units} on average."
+   - For a regression slope b: `delta_outcome = b * (x_p75 - x_p25)` (cleaner; no monotonicity caveat).
+   - State the assumption explicitly; the IQR translation is a more defensible verbal guide than an
+     SD-scaled one.
+3. **For OR/HR/RR**, accompany the relative measure with an absolute one at a stated baseline risk:
+   the absolute risk difference, and NNT = 1 / ARR (or NNH = 1 / ARI). Always state the baseline risk used.
+4. **Bound the claim**: report the contrast, the assumption, and a CI on the coefficient; do not imply
+   causation from a crude or unadjusted estimate.
+
+**Worked example (synthetic)**
+rho = 0.39 between a fasting marker (IQR 0.6 to 3.5 units, SD 3.05) and an index (SD 2.13):
+`((3.5 - 0.6) / 3.05) * 0.39 * 2.13 ~= 0.8` -> "Going from the 25th to the 75th percentile of the
+marker is associated with about 0.8 index units higher on average (monotonic-linear approximation;
+crude, unadjusted)."
+
+**Output contract**: add a "Real-world translation" line beneath each primary effect size in the
+results table or its footnote. For OR/HR/RR primary outcomes, add an NNT/NNH line with the baseline
+risk stated.
+
 ## Error Handling
 
 - If a script fails to execute, report the error in one line, diagnose the likely cause

--- a/skills/design-ai-benchmarking/SKILL.md
+++ b/skills/design-ai-benchmarking/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: design-ai-benchmarking
+description: >
+  Design and validity review for studies that benchmark one or more AI systems against a human-expert
+  panel as the reference. Covers the evaluation question and arm definition, decoupled multi-dimensional
+  rubrics with anchors, planted calibration probes, reviewer-panel construction, inter-rater reliability
+  targets, LLM-as-judge versus human-as-judge adjudication, construct-independence guards, and a
+  structured rating-export schema. Use before data collection on an AI-vs-expert evaluation.
+triggers: AI benchmarking, AI vs human expert, reader study design, expert panel evaluation, LLM-as-judge, AI evaluation rubric, model benchmark design, human baseline comparison, AI-output rating, evaluation rubric design
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+# Design-AI-Benchmarking Skill
+
+## Purpose
+
+This skill pressure-tests an AI-vs-human-expert benchmark **before any ratings are collected**, so that
+the comparison is fair, the rubric measures distinct constructs, the scale is calibrated, and the
+reported reliability is interpretable. It is the AI-evaluation specialization of `/design-study`: where
+`/design-study` reviews a study in general, this skill owns the specific machinery of comparing AI
+system(s) to a panel of human experts (or to each other) on rated outputs.
+
+Use it when:
+- one or more AI systems will be scored against a human-expert reference (reader study, annotation
+  panel, AI-output evaluation, model-vs-model bench)
+- a rubric and rating protocol must be locked before reviewers begin
+- a benchmark feels vulnerable to "the highest score is just the most tautological item" or
+  "low agreement, but we cannot tell why" criticism
+- a reviewer or editor asks how the evaluation controlled for rater drift, leakage, or judge bias
+
+Do **not** use it for: general study/validity review (use `/design-study`); statistical execution such
+as ICC or DeLong (use `/analyze-stats`); reporting-guideline item audits (use `/check-reporting`);
+or reviewing an already-written manuscript (use `/peer-review` or `/self-review`).
+
+---
+
+## Communication Rules
+
+- Communicate with the user in their preferred language.
+- Use English for statistical, machine-learning, and reporting-guideline terminology.
+- Be direct about evaluation-validity risks, but always propose the smallest feasible fix first.
+- Never invent reviewer ratings, reference labels, or agreement statistics; those come from collected
+  data only.
+
+---
+
+## Standard Output
+
+```text
+## AI-Benchmark Design Review
+Evaluation question: ...
+Arms / systems compared: ...
+Reference (human-expert panel): ...
+Unit of rating: (item / case / output)
+
+### Rubric (decoupled dimensions)
+- dimension -> construct -> anchors (1..k)
+
+### Calibration probes (blinded, randomized)
+- positive-control / known-bad / instability / mechanism-contradiction
+
+### Reviewer panel
+- n reviewers, metadata captured, per-reviewer randomized order
+
+### Reliability plan
+- overall IRR target + control-item IRR (reported separately)
+
+### Judge strategy
+- human-as-judge / LLM-as-judge / both + adjudication rule
+
+### Validity risks
+1. ...
+
+### Minimal fixes
+- ...
+
+### Decision
+- Ready to collect / Needs rubric revision / Needs arm or judge redesign
+```
+
+---
+
+## Workflow
+
+### Phase 1: Define the evaluation question and arms
+
+Pin down, in writing:
+- the exact claim the benchmark must support (e.g., "system A's outputs are perceptually
+  indistinguishable from expert outputs", not "system A is deployment-ready")
+- every arm/system being compared, and what each arm receives as input (same items, same information
+  access, same output format) so no arm has a hidden advantage
+- the human-expert reference: who they are, and whether they set ground truth, provide a comparison
+  arm, or both
+- the unit of rating (item, case, output) and how many units each reviewer sees
+
+**Gate:** Present the reconstructed evaluation question, arms, and reference to the user and confirm
+before designing the rubric. A wrong reconstruction misdirects the entire benchmark.
+
+### Phase 2: Design a decoupled multi-dimensional rubric
+
+- **Decouple the axes.** Each rated dimension measures one construct. Keep "is the output valid/correct"
+  separate from "is it novel", "is it feasible/measurable", "does it add value over current tools", and
+  "would it change action". A candidate can be high-validity yet low-added-value ("real but redundant");
+  a single blended score hides this divergence.
+- **Anchor every scale point** with a short verbal descriptor; pilot the anchors with at least one
+  reviewer before locking.
+- **Pre-specify discriminant validity**: hypothesize which dimensions should correlate vs be orthogonal,
+  then report the full inter-dimension correlation matrix to confirm the rubric measures distinct
+  constructs.
+- A worked rubric template lives in `${CLAUDE_SKILL_DIR}/references/elicitation_rubric_template.md`.
+
+### Phase 3: Insert and randomize calibration probes
+
+Plant a small number of deliberate control items, blinded and randomized across raters (record who
+received which via a `probe_arm` flag), to (i) anchor the scale, (ii) measure rater drift/fatigue, and
+(iii) audit the rubric and pipeline itself. Four useful flavors:
+- **Positive control / "too-good" item** — a known-strong or near-tautological item; tests whether
+  raters equate "largest effect" with "best", and whether the construct-independence gate (Phase 7) works.
+- **Known-bad negative control** — an engineered defect (fabricated reference, missing key statistic);
+  expected to score low.
+- **Instability item** — an estimate that reverses or fails to replicate on a holdout; tests
+  caveat-handling.
+- **Mechanism-contradiction item** — an empirical direction that opposes the proposed mechanism.
+
+Probes are *planted or adjudicated*, never fabricated to fit a hypothesis.
+
+### Phase 4: Construct the reviewer panel
+
+- Recruit reviewers spanning the intended expertise gradient; pre-specify any expertise stratification.
+- Capture reviewer metadata (years of experience, prior AI-evaluation experience, subspecialty) for
+  descriptive reporting and stratified analysis.
+- Randomize item order **per reviewer** (not one global seed) and record the order; plan to analyze
+  order and fatigue effects.
+- Require each item to be judged standalone; discourage cross-item references in free-text, which signal
+  non-independent rating.
+
+**Gate:** Present the panel composition, stratification, and randomization plan for user review before
+recruitment is finalized.
+
+### Phase 5: Set inter-rater reliability targets
+
+- Pre-specify the agreement statistic (e.g., ICC for continuous ratings, weighted kappa for ordinal)
+  and a target with justification.
+- **Report reliability on the planted control items separately** as primary evidence of rubric and
+  scale validity. A low overall ICC is interpretable only if raters at least converge on the controls;
+  surfacing both numbers prevents "low agreement => bad rubric" or "bad raters" misreads.
+- Plan the minimum ratings-per-item needed for a stable agreement estimate (delegate the math to
+  `/analyze-stats`).
+
+### Phase 6: Choose the judge strategy and adjudication
+
+- Decide human-as-judge, LLM-as-judge, or both. If an LLM is used as a judge, treat it as one more arm
+  whose ratings must themselves be validated against the human panel on the control items.
+- Pre-specify the **adjudication rule** for disagreement (e.g., majority, a third senior reviewer,
+  consensus discussion) and who adjudicates.
+- Blind judges to arm identity wherever feasible; record any unavoidable unblinding.
+
+### Phase 7: Construct-independence and leakage guards
+
+- Exclude any predictor or input that is a definitional component of the outcome (mathematical
+  definition), and flag near-tautological composites built from the outcome's defining components — they
+  produce an inflated, near-circular result and belong as labeled probes, not discoveries.
+- Verify no arm sees post-decision or outcome-derived information the others do not.
+- Confirm the reference labels were not derived from the same model output being evaluated.
+
+### Phase 8: Lock a structured export schema
+
+Define the machine-readable rating record up front: per-item ratings across every rubric dimension,
+free-text justifications, follow-up flags, the `probe_arm` flag, reviewer id and metadata, item order,
+and timing. A synthetic schema lives in `${CLAUDE_SKILL_DIR}/references/benchmark_export_schema.json`.
+
+**Gate:** Present the final rubric, probe set, panel plan, judge strategy, and export schema together;
+collect explicit user approval before any rating begins. Locking these before data collection is the
+whole point — changes afterward compromise the comparison.
+
+---
+
+## Handoff Rules
+
+- route to `/analyze-stats` for ICC / weighted kappa / DeLong, agreement sample size, and effect-size
+  real-world translation of the benchmark results
+- route to `/check-reporting` for STARD-AI, CLAIM, or TRIPOD+AI item-level reporting once the design is locked
+- route to `/design-study` when the broader study around the benchmark (cohort logic, analysis unit,
+  comparator) also needs review
+- route to `/peer-review` or `/self-review` only after ratings exist and a manuscript is being assessed
+
+---
+
+## What This Skill Does NOT Do
+
+- It does not compute agreement statistics or run analyses directly (that is `/analyze-stats`).
+- It does not collect or fabricate ratings, reference labels, or probe outcomes.
+- It does not draft manuscript prose or run a reporting-guideline audit.
+- It does not replace a full peer review of a finished manuscript.
+
+## Anti-Hallucination
+
+- **Never fabricate references.** All citations must be verified via `/search-lit` with a confirmed DOI
+  or PMID. Mark unverified references as `[UNVERIFIED - NEEDS MANUAL CHECK]`.
+- **Never invent reviewer ratings, agreement statistics, reference labels, or probe outcomes** — these
+  come from collected data only. A reported ICC, kappa, or score with no underlying rating record is the
+  failure mode this skill exists to prevent.
+- **Never invent clinical definitions, diagnostic criteria, or guideline recommendations.** If uncertain,
+  flag with `[VERIFY]` and ask the user.
+- If a reporting-guideline item, journal policy, or evaluation standard is uncertain, state the
+  uncertainty rather than guessing.
+
+## Reference Files
+
+- `${CLAUDE_SKILL_DIR}/references/elicitation_rubric_template.md` -- a synthetic, decoupled
+  multi-dimension rating rubric with anchors and a planted-probe column.
+- `${CLAUDE_SKILL_DIR}/references/benchmark_export_schema.json` -- a synthetic JSON schema for the
+  per-item rating export (ratings, justifications, probe_arm, reviewer metadata, order, timing).

--- a/skills/design-ai-benchmarking/references/benchmark_export_schema.json
+++ b/skills/design-ai-benchmarking/references/benchmark_export_schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AI-vs-expert benchmark rating export (synthetic template)",
+  "description": "One record per (reviewer, item) rating. Lock this schema before collecting ratings. All example values are illustrative placeholders, not real data.",
+  "type": "object",
+  "required": ["reviewer_id", "item_id", "arm", "probe_arm", "order_index", "ratings", "justification"],
+  "properties": {
+    "reviewer_id": {
+      "type": "string",
+      "description": "Stable pseudonymous id for the reviewer (no personal identifiers).",
+      "examples": ["R01"]
+    },
+    "reviewer_metadata": {
+      "type": "object",
+      "description": "Captured once per reviewer; repeated here for convenience.",
+      "properties": {
+        "years_experience": {"type": "integer", "minimum": 0},
+        "prior_ai_evaluation": {"type": "boolean"},
+        "subspecialty": {"type": "string"}
+      }
+    },
+    "item_id": {"type": "string", "examples": ["item_0042"]},
+    "arm": {
+      "type": "string",
+      "description": "Which system produced the rated output, or the human-expert reference arm.",
+      "examples": ["system_a", "system_b", "expert_reference"]
+    },
+    "probe_arm": {
+      "type": ["string", "null"],
+      "description": "Non-null when this is a planted control item.",
+      "enum": ["pos_control", "neg_control", "instability", "mechanism_contra", null]
+    },
+    "order_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Position in this reviewer's randomized item order (for fatigue analysis)."
+    },
+    "ratings": {
+      "type": "object",
+      "description": "One score per decoupled rubric dimension.",
+      "required": ["validity", "novelty", "feasibility", "added_value", "actionability"],
+      "properties": {
+        "validity": {"type": "integer", "minimum": 1, "maximum": 5},
+        "novelty": {"type": "integer", "minimum": 1, "maximum": 5},
+        "feasibility": {"type": "integer", "minimum": 1, "maximum": 5},
+        "added_value": {"type": "integer", "minimum": 1, "maximum": 5},
+        "actionability": {"type": "integer", "minimum": 1, "maximum": 5}
+      }
+    },
+    "justification": {
+      "type": "string",
+      "description": "Free text, judged standalone; no cross-item references."
+    },
+    "follow_up": {
+      "type": ["string", "null"],
+      "description": "What additional evidence would change the rating."
+    },
+    "judge_type": {
+      "type": "string",
+      "enum": ["human", "llm"],
+      "description": "Whether the rater is a human expert or an LLM-as-judge arm."
+    },
+    "timing_seconds": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "description": "Time spent on this item, for fatigue/drift analysis."
+    }
+  }
+}

--- a/skills/design-ai-benchmarking/references/elicitation_rubric_template.md
+++ b/skills/design-ai-benchmarking/references/elicitation_rubric_template.md
@@ -1,0 +1,37 @@
+# Decoupled Elicitation Rubric Template (synthetic)
+
+A starting rubric for an AI-vs-human-expert benchmark. Every dimension measures one construct, so a
+candidate can score high on validity yet low on added value ("real but redundant"). All values below
+are illustrative placeholders, not real data — replace them for your own evaluation.
+
+## Per-item rating dimensions
+
+| Dimension | Construct (one only) | Anchor 1 (low) | Anchor 3 (mid) | Anchor 5 (high) |
+|-----------|----------------------|----------------|----------------|-----------------|
+| Validity | Is the output correct against the reference? | Contradicted by reference | Partially supported | Fully supported |
+| Novelty | Is it new vs prior work? | Restates known result | Incremental extension | Genuinely new |
+| Feasibility | Can it be measured/obtained in practice? | Not measurable | Measurable with effort | Routinely measurable |
+| Added value | Does it add over a measure already in use? | Redundant with a routine measure | Marginal gain | Clear gain over current tools |
+| Actionability | Would a clinician act on it for an individual? | Would not change action | Might change action | Would change action |
+
+Notes:
+- Pilot the anchors with at least one reviewer before locking the scale.
+- Pre-specify which dimensions are expected to correlate (e.g., validity and actionability) vs be
+  orthogonal (e.g., novelty and feasibility); report the inter-dimension correlation matrix afterward.
+
+## Planted calibration probes
+
+`probe_arm` marks a control item; it is randomized across reviewers and excluded from the primary
+estimate but reported separately for scale validity.
+
+| probe_arm | Flavor | What it tests | Expected behavior |
+|-----------|--------|---------------|-------------------|
+| pos_control | Positive / "too-good" (near-tautological) | Whether raters equate "largest effect" with "best"; whether the construct-independence gate fires | High validity, low added value |
+| neg_control | Known-bad (engineered defect) | Whether obvious defects are caught | Low validity |
+| instability | Reverses on holdout | Caveat-handling for unstable estimates | Lower confidence ratings |
+| mechanism_contra | Direction opposes mechanism | Whether raters notice mechanism conflict | Flagged in free-text |
+
+## Per-item free-text fields
+
+- justification (required): one or two sentences, judged standalone (no cross-item references)
+- follow_up (optional): what additional evidence would change the rating

--- a/skills/design-ai-benchmarking/skill.yml
+++ b/skills/design-ai-benchmarking/skill.yml
@@ -1,0 +1,38 @@
+schema_version: 2
+name: design-ai-benchmarking
+layer: D
+owner_domain: study_design
+
+when_to_use: "Design or review a study that benchmarks one or more AI systems against a human-expert panel: arm definition, decoupled rubric, calibration probes, reviewer panel, IRR targets, judge adjudication, and a structured export schema, before ratings are collected."
+when_NOT_to_use: "General study/validity review (use design-study); statistical execution such as ICC/DeLong (use analyze-stats); reporting-guideline item audits (use check-reporting); reviewing a finished manuscript (use peer-review or self-review)."
+
+inputs:
+  - "evaluation question and the AI system(s) / arms to compare"
+  - "candidate outputs or items to be rated"
+  - "available human-expert reviewers and their metadata"
+outputs:
+  - "benchmark design and validity review (decision notes)"
+  - "decoupled rating rubric with anchors and planted calibration probes"
+  - "structured rating-export schema (JSON)"
+side_effects:
+  - writes_decision_notes
+downstream_consumers:
+  - analyze-stats
+  - check-reporting
+  - design-study
+forbidden_actions:
+  - fabricate_reviewer_ratings_or_reference_labels
+  - approve_benchmark_with_unblinded_or_leaky_rubric
+  - report_irr_without_separate_control_item_reliability
+
+# v2.1 quality card
+purpose: "Surface design and validity risks specific to AI-vs-human-expert benchmarks (rubric coupling, scale calibration, rater independence, judge choice) before data collection begins."
+safety_boundaries:
+  - "Advisory only: writes decision notes plus rubric/schema artifacts, never ratings or analysis results."
+  - "Calibration probes and reference labels are planted or adjudicated, never fabricated to fit a hypothesis."
+known_limitations:
+  - "A design review reduces but cannot eliminate evaluation bias; it does not guarantee a valid benchmark."
+  - "No standalone demo; rubric and panel decisions require domain-expert judgement."
+validation_commands:
+  - "carry the rubric and export schema into analyze-stats for ICC/agreement, then check-reporting (STARD-AI / CLAIM / TRIPOD+AI)"
+evidence_surface: manual_workflow

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -110,6 +110,13 @@ Look for:
 - normalization or thresholding performed before data split
 - repeated exams across train/test
 - reader annotations derived from outcome information
+- **construct dependence** (a predictor that is a definitional component of the outcome). Two cases:
+  (i) *mathematical definition* — an input that computes the outcome (when the outcome is HOMA-IR =
+  f(fasting insulin, fasting glucose), those two inputs are not independent predictors); (ii)
+  *near-tautological composite* — a ratio or score built from the outcome's defining components, which
+  shows an inflated, near-circular association. Test: "could this predictor be derived, in whole or
+  part, from the outcome's definition or the same measurement?" If yes, exclude it, or retain it only
+  as a labeled calibration probe rather than a reported discovery.
 
 #### C. Reference standard
 
@@ -128,6 +135,48 @@ Classify:
 - temporal validation
 - external validation
 - multi-center external validation
+
+#### E. Reader / Expert-Elicitation Study Design
+
+When the study elicits expert ratings (reader study, annotation panel, AI-output evaluation), check
+the following before data collection.
+
+**Rubric design**
+- **Decouple the axes.** Each rated dimension should measure one construct. Keep "is the finding
+  valid/correct" separate from "is it novel", "is it feasible to measure", "does it add value over
+  current tools", and "would it change action". A candidate can be high-validity yet low-added-value
+  ("real but redundant"); a single blended score hides this.
+- **Anchor every Likert point** with a short verbal descriptor; pilot the anchors with at least one
+  reviewer before locking.
+- **Pre-specify discriminant validity**: hypothesize which dimensions should correlate vs be
+  orthogonal, then report the full inter-dimension correlation matrix to confirm the rubric measures
+  distinct constructs.
+
+**Calibration probes (planted control items)**
+Insert a small number of deliberate control items, blinded and randomized across raters (record who
+received which, e.g. a `probe_arm` flag), to (i) anchor the scale, (ii) measure rater drift and
+fatigue, and (iii) audit the rubric and pipeline itself. Four useful flavors:
+- **Positive control / "too-good" item** — a known-strong or near-tautological item; tests whether
+  raters equate "largest effect" with "best", and whether an upstream construct-independence gate works.
+- **Known-bad negative control** — an engineered defect (fabricated reference, missing key statistic);
+  expected to score low.
+- **Instability item** — an estimate that reverses or fails to replicate on holdout; tests caveat handling.
+- **Mechanism-contradiction item** — an empirical direction that opposes the proposed mechanism.
+
+Report inter-rater reliability **on the control items separately** as primary evidence of rubric and
+scale validity; a low overall ICC is interpretable only if raters at least converge on the controls.
+
+**Operational rigor**
+- Randomize item order **per reviewer** (not one global seed); analyze order and fatigue effects.
+- Collect reviewer metadata (years of experience, prior AI-evaluation experience, subspecialty) for
+  descriptive reporting.
+- Define a structured export schema (per-item ratings, free-text justifications, follow-ups, timing) up front.
+- Require each item to be judged standalone; discourage cross-item references in free-text, which
+  signal non-independent rating.
+
+For an AI-system-versus-human-expert benchmark specifically, route to `/design-ai-benchmarking`, which
+extends this subsection with arm definition, LLM-as-judge versus human-as-judge adjudication, and a
+structured export schema.
 
 ### Phase 3: Clinical framing
 

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -54,6 +54,18 @@ methodology and study design.
    - Overclaiming relative to evidence level
    - Sample size adequacy
    - Statistical methodology appropriateness
+   - Effect-size clinical meaningfulness (scored separately from the validation / CI / calibration axis
+     above): translate the headline effect to a real-world unit shift (see `/analyze-stats` "Effect-Size
+     Real-World Translation") and compare it to a known minimal clinically important difference. Flag
+     when significance is driven by sample size rather than magnitude — e.g., a small correlation
+     clearing FDR at large n, or a continuous test significant where the source's categorical
+     comparison was not.
+   - Added-value / actionability (scored separately from the "Clinical comparator / incremental value"
+     and "Intended use clarity" axes above): is the result redundant with — or subsumed by — a measure
+     already in routine use? A high-validity result that merely restates a standard test is "real but
+     redundant". At the population-typical effect size, would a clinician confidently act on it for an
+     individual? The point is to let these axes diverge from validity (e.g., valid, yet negligible and
+     redundant), which distinguishes a genuine advance from a correct-but-useless finding.
 5. **Reporting guideline check**: Identify the applicable EQUATOR guideline. Flag MISSING items as candidate comments. If `/check-reporting` is available, delegate.
 6. **Prioritize**: Rank issues by impact on validity. Select top 3-5 for Major, 3-4 for Minor. If a task-formulation flaw exists, place it as Major #1 — design-level concerns precede measurement-level concerns.
 7. **Gate**: Present findings to user — "Here are the key issues I found — do you agree with this prioritization?"

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -80,6 +80,7 @@ partially, or not at all for the given manuscript type.
 | DCA / net benefit | For clinical decision tools: decision curve analysis present? |
 | Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
 | Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
+| Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
 
 #### D. Clinical Framing & Importance
 
@@ -91,6 +92,7 @@ partially, or not at all for the given manuscript type.
 | Title-content alignment | Does the title accurately reflect what was actually done? |
 | Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
 | Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
+| Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
 
 #### E. Reproducibility
 


### PR DESCRIPTION
## Summary

Four reusable design lessons from a clinician reader study, applied across the design/review skills, plus one new skill. Single PR, 4 commits.

1. **analyze-stats** — new *Effect-Size Real-World Translation* subsection under Statistical Reporting Rules: anchored IQR contrast, per-SD/slope translation, OR/HR/RR → absolute risk + NNT, a synthetic worked example, and an output contract. Complements (does not replace) the existing effect-size reporting rule.
2. **design-study** — Phase 2 gains a *Reader / Expert-Elicitation Study Design* subsection (rubric axis decoupling, anchored Likert points, discriminant validity, planted calibration probes, per-reviewer randomized order, structured export) and a *construct-independence* bullet under Leakage (predictors that mathematically define, or near-tautologically compose, the outcome).
3. **peer-review + self-review** — decouple and strengthen existing axes: *effect-size clinical meaningfulness* scored separately from the validation/CI/calibration axis, and *added-value/actionability* scored separately from the clinical-comparator and intended-use axes. Surfaces a "valid but negligible and redundant" result instead of folding it into validity.
4. **design-ai-benchmarking** (new — 43rd skill) — Layer-D advisory skill for designing AI-vs-human-expert benchmarks before ratings are collected. Eight phases: arm definition → decoupled rubric → calibration probes → reviewer panel → IRR targets with separately reported control-item reliability → LLM-as-judge vs human-as-judge adjudication → construct-independence guards → locked JSON export schema. Cross-links design-study, analyze-stats, and check-reporting. Ships `skill.yml` (schema v2 + Quality Card) and two synthetic references.

## Catalog sync

`catalog_counts.json` 42→43, README headline/badge/table, generated `docs/skills/` page + index.

## Validation (all green locally)

- `validate_skills.sh` — ALL CHECKS PASSED (43/43)
- `validate_skill_contracts.py` — 43 v2 contracts, 0 failures
- `validate_catalog_consistency.py`
- `validate_routing_assets.py --strict`
- `gen_skill_docs.py --check`

Examples are synthetic; no PII in changed files or this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)