### PR TITLE
chore(peer-review): generalize guideline name in skill.yml purpose (PII)

### DIFF
--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -12,7 +12,7 @@
 
 ## Quality Card
 
-**Purpose** — Draft a structured peer-review for a journal-assigned manuscript following the Yoojin Peer-Review Guideline v2.5, with journal-specific formatting.
+**Purpose** — Draft a structured peer-review for a journal-assigned manuscript following the MedSci peer-review guideline (v2.5), with journal-specific formatting.
 
 **Safety boundaries**
 

--- a/skills/peer-review/skill.yml
+++ b/skills/peer-review/skill.yml
@@ -26,7 +26,7 @@ forbidden_actions:
   - generate_references_from_memory
 
 # v2.1 quality card
-purpose: "Draft a structured peer-review for a journal-assigned manuscript following the Yoojin Peer-Review Guideline v2.5, with journal-specific formatting."
+purpose: "Draft a structured peer-review for a journal-assigned manuscript following the MedSci peer-review guideline (v2.5), with journal-specific formatting."
 safety_boundaries:
   - "Reviews assigned external manuscripts only; never edits the user's own manuscript."
   - "References are not generated from memory."


### PR DESCRIPTION
## Summary

Removes a maintainer first name from public skill content. The peer-review skill's Quality Card `purpose` referenced an internally-named guideline that embedded a first name; this generalizes it.

- `skills/peer-review/skill.yml` — `purpose`: "Yoojin Peer-Review Guideline v2.5" → "MedSci peer-review guideline (v2.5)".
- `docs/skills/peer-review.md` — regenerated so the generated Purpose line matches (`gen_skill_docs.py`).

The SKILL.md frontmatter description was already neutral; this `skill.yml` field was the only content site carrying the name. A full repo scan (co-author names, hospital, mentor initials, project codes, manuscript IDs, personal paths) found no other content leaks. Author attribution in `CITATION.cff` / `paper.md` / `.zenodo.json`, and the personal-path detection regex in `validate_skills.sh`, are intentional and left unchanged.

## Validation (all green locally)

- `validate_skills.sh`, `validate_skill_contracts.py`, `validate_catalog_consistency.py`, `validate_routing_assets.py --strict`, `gen_skill_docs.py --check`
- `grep -rni yoojin skills/ docs/skills/` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)