### PR TITLE
feat(self-review,orchestrate): add --panel multi-agent review mode

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 
+      - name: Run self-review panel-mode structural + PII test
+        run: bash skills/self-review/tests/test_panel_mode.sh
+
       - name: Run validate_catalog_consistency.py (doc counts must match disk SSOT)
         run: python3 scripts/validate_catalog_consistency.py
 

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -28,6 +28,7 @@
 
 - `python3 scripts/check_reviewer_team_consistency.py`
 - `python3 scripts/check_domain_probe_sync.py --strict`
+- `bash tests/test_panel_mode.sh`
 - `feed R0-numbered output into /revise`
 
 **Evidence** — `demo`
@@ -37,6 +38,7 @@
 **References** (`skills/self-review/references/`):
 
 - `domain-probes/` (4 files)
+- `panel_review_template.md`
 
 **Scripts** (`skills/self-review/scripts/`):
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -47,7 +47,7 @@ You do NOT do the work yourself. You classify, plan, and delegate.
 | **make-figures** | Visualization | ROC curves, forest plots, flow diagrams (PRISMA/CONSORT/STARD), Kaplan-Meier, Bland-Altman, visual/graphical abstracts |
 | **meta-analysis** | Systematic review | Full MA pipeline: protocol, search, screening, extraction, synthesis, PRISMA-DTA |
 | **write-paper** | Writing | IMRAD manuscript drafting (8-phase pipeline), any section writing |
-| **self-review** | Quality | Pre-submission self-check from reviewer perspective (10 categories) |
+| **self-review** | Quality | Pre-submission self-check with domain probes (Survival / SR-MA / Radiomics / Narrative); optional `--panel` for a high-stakes final QC pass |
 | **check-reporting** | Compliance | Audit against 32 reporting guidelines and risk-of-bias tools |
 | **revise** | Revision | Parse reviewer comments, generate point-by-point response, track changes |
 | **grant-builder** | Funding | Structure grant proposals: significance, innovation, approach, milestones |
@@ -93,6 +93,7 @@ When the user's request arrives, classify it into one of these intents:
 | "I'm doing a meta-analysis" / "Start systematic review" | `/meta-analysis` |
 | "Write the methods section" / "Draft my paper" | `/write-paper` |
 | "Review my manuscript before submission" | `/self-review` |
+| "Brutally / harshly check before submission" / "top-tier journal final check" / "multi-reviewer / panel review" / "review it from stats, clinical, and imaging angles" / "혹독하게 제출 전 점검" | `/self-review --panel --json` |
 | "Check STROBE compliance" / "Run reporting checklist" | `/check-reporting` |
 | "I got reviewer comments" / "Help me respond to reviewers" | `/revise` |
 | "Write a grant proposal" / "Structure my aims page" | `/grant-builder` |
@@ -149,6 +150,8 @@ The **Nodes** column lists decision forks that should be rendered in interactive
 | **Full submission chain** | `write-paper` -> `self-review` -> `check-reporting` -> `find-journal` -> `write-paper` (Phase 8+ cover letter) -> `manage-project checklist` | N4, N8 (if recovery triggered), N9 (on re-entry) |
 | **Post-rejection resubmission** | `find-journal` (exclude rejected journal) -> `write-paper` (Phase 8+ new cover letter) | N4 |
 | **Case report pipeline** | `search-lit` (similar cases) -> `write-paper` (case-report mode) -> `self-review` -> `check-reporting` (CARE) -> `find-journal` | N2 (option 2), N4 |
+
+**Panel mode (`/self-review --panel`) is opt-in, never automatic.** The submission chains above use single-pass `self-review`. Add `--panel` only for a deliberate high-stakes final pass (it spawns several reviewer agents plus an editor, so it costs several times more tokens); do not apply it by default, and do not auto-enable it in `--e2e` unless the user explicitly asks. A panel diagnoses and prioritizes, so keep it separate from the auto-fix loop — do not call `--panel` together with `--fix`.
 
 ### Ambiguous requests (ask before routing)
 
@@ -287,7 +290,7 @@ After each skill completes, verify that expected output files exist. If validati
 | `/write-paper` | `manuscript/manuscript.md` (required), `manuscript/manuscript_final.docx` (required in --e2e) | Check file existence and non-empty |
 | `/check-reporting` | `qc/reporting_checklist.md` or inline report | Check file existence |
 | `/verify-refs` | `qc/reference_audit.json` (sole output) | Parse JSON; halt if `submission_safe == false` (i.e., `FABRICATED` / `MISMATCH` count > 0 OR `duplicate_findings[]` nonempty) |
-| `/self-review` | Review report with JSON block (when --json) | Check JSON block is parseable |
+| `/self-review` | Review report with JSON block (when --json) | Check JSON block is parseable. In `--panel` mode each issue may carry an additional optional `consensus` array plus R1/R2/R3 attribution annotations on the `M`/`m` comments — these are additive and backwards-compatible; accept them |
 | `/manage-refs` | `manuscript/manuscript_final.docx`, `qc/xref_audit.json` | DOCX exists and non-empty; xref_audit.json has `submission_safe: true` (no P0 blocker rows) |
 | `/lit-sync` | `manuscript/_src/refs.bib` (mtime updated), `references/zotero_collection.json` | refs.bib mtime newer than collection snapshot; `refs_bib_refreshed: true` in collection JSON |
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -20,6 +20,7 @@ strengthened before reviewers ever see it.
 
 - `--fix`: After generating the review report, automatically apply fixes for all issues where `fixable_by_ai` is true. Edits the manuscript in place, then reports a diff summary. Does NOT fix issues marked `fixable_by_ai: false` (e.g., missing data, design flaws). Maximum 2 fix-and-re-review iterations.
 - `--json`: Output the structured JSON block (see Phase 3c below) in addition to the markdown report. Default when called from `/write-paper` Phase 7.
+- `--panel`: Run the multi-agent panel review (Phase 2.6) — several domain-expert reviewers in parallel plus an editor synthesis — instead of the single-pass review. Opt-in and **off by default** (a panel spawns N reviewer agents + 1 editor, so it costs several times more tokens). Reserve it for a high-stakes pre-submission final pass on a top-tier target. Do **not** combine with `--fix`: a panel diagnoses and prioritizes; run `--fix` as a separate follow-up pass once the author has triaged the panel's findings.
 
 ## Severity Framing
 
@@ -544,6 +545,40 @@ DOCX build has occurred yet (early drafts).
 in the body without re-running the DOCX build will simply move the mismatch.
 Surface as Major Comments and let the user route to `/write-paper` Step 7.6a.
 
+### Phase 2.6: Multi-Agent Panel Review (--panel, opt-in)
+
+Run this phase **only when `--panel` is passed**. The default single-pass review (Phases 2–2.5d) stays the fast path; the panel is the high-cost, high-precision option for a pre-submission final pass on a top-tier target. Run it after the numerical audits (Phases 2.5–2.5d) so the reviewers see source-verified numbers, and before the Phase 3 report, which it feeds.
+
+The panel simulates independent peer reviewers who do not see each other's comments, then an editor who consolidates them — the same structure a journal uses. It reuses the vendored domain-probe modules so every reviewer applies the same criteria.
+
+**Step 1 — Compose the reviewer set by research type.** Auto-detect the manuscript type (Phase 1 input + the Research-Type Adaptation table). Each reviewer loads the matching domain-probe module so the panel's criteria are single-sourced.
+
+| Research type | Reviewer set (each is one reviewer) | Domain-probe module each loads |
+|---|---|---|
+| Survival / prognostic cohort | R1 Biostatistics & Study Design · R2 Clinical (domain) · R3 Imaging/Radiology (if an imaging exposure) | `references/domain-probes/survival_prognostic.md` |
+| Systematic review / meta-analysis | R1 Methodology (search/screening/PRISMA) · R2 Clinical · R3 Statistics (pooling/heterogeneity) | `references/domain-probes/sr_ma.md` |
+| Radiomics / feature reproducibility | R1 Imaging physics & acquisition · R2 ML / Statistics · R3 Clinical translation | `references/domain-probes/radiomics.md` |
+| Diagnostic-accuracy / AI model | R1 Study design & leakage · R2 Statistics (DeLong, calibration) · R3 Clinical / reference standard | `references/domain-probes/sr_ma.md` (P1 DTA cells) + categories A–C |
+| Observational (STROBE) | R1 Epidemiology / confounding · R2 Clinical · R3 Statistics | none type-specific; categories A–J + the effect-size / added-value axes |
+| Narrative / review article | R1 Domain-content expert · R2 Methodology / SANRA · R3 Technical accuracy | `references/domain-probes/narrative_review.md` |
+
+If the type is ambiguous, ask the user before composing the set.
+
+**Step 2 — Run the reviewers (portable execution).** When the host provides a parallel subagent / Task capability (Claude Code, or any harness exposing an Agent tool), spawn the reviewer set as independent parallel subagents, each blinded to the others, then run the editor as a final synthesis agent. **Fallback (no subagent capability — e.g. a minimal Codex/Cursor harness):** a single agent role-plays each reviewer sequentially and in isolation — it completes and writes out reviewer R1's full structured review before reading the manuscript "fresh" as R2, so a later reviewer never sees an earlier reviewer's comments. The panel is defined by these instructions; it does **not** depend on the `Workflow` tool or any Claude-Code-only orchestration.
+
+A reusable reviewer schema, a generic harsh-but-fair reviewer prompt skeleton with per-domain focus checklists, and the editor synthesis prompt skeleton live in `${CLAUDE_SKILL_DIR}/references/panel_review_template.md`.
+
+Each reviewer returns: `reviewer_id`, `expertise_area`, an `overall_assessment` (name the single biggest threat to the conclusions), `strengths` (2–3), `major[]` (each with `heading`, `comment`, `location`, `severity`, `suggested_fix`), and `minor[]`. Map `severity` onto this skill's own scale — a conclusion-threatening / design-level finding is **Fatal**, a reporting-level finding is **Fixable** — rather than introducing a separate vocabulary.
+
+**Step 3 — Editor synthesis.** One editor pass (a final agent, or the main agent in the fallback) consolidates the reviews:
+1. **Dedupe** findings by theme across reviewers.
+2. **Flag CONSENSUS** for any theme raised by ≥2 reviewers, with R1/R2/R3 attribution (e.g., `[CONSENSUS: R1+R3]`); single-reviewer findings are attributed to the one reviewer.
+3. **Decide** an internal readiness verdict (this sets the Phase 3c `verdict` / `overall_score`; it is not printed as a journal recommendation).
+4. **Rank** the concrete pre-submission actions the author should complete first.
+5. State a one-line **readiness verdict** (ready for the target tier now / fix specific items first / consider a different tier).
+
+**Step 4 — Feed Phase 3.** The consolidated panel output flows into the Phase 3 report, Phase 3b R0 numbering (**preserved**, so `/revise` still consumes it), and Phase 3c JSON. CONSENSUS flags and reviewer attribution are additive annotations on the existing `M`/`m` comments (and the optional `consensus` JSON field); they do not change the report or JSON structure.
+
 ### Phase 3: Report
 
 Generate a concise report with this structure:
@@ -646,6 +681,7 @@ When `--json` is passed, or when invoked by `/write-paper` Phase 7, append a mac
 - `category`: Letter code from the 10-category system (A-J)
 - `fixable_by_ai`: `true` if the issue can be resolved by editing manuscript text with existing data; `false` if it requires new data, analyses, or human judgment (e.g., design changes, IRB decisions, missing experiments)
 - `suggested_fix`: Specific, actionable instruction. If `fixable_by_ai` is true, this must be concrete enough for the fixer to execute without ambiguity.
+- `consensus` *(optional, panel mode only)*: array of reviewer ids that raised the issue, e.g. `["R1","R3"]`. Additive and backwards-compatible — present only when Phase 2.6 ran; parsers that do not expect it must ignore it.
 
 ### Phase 4: Fix Support
 

--- a/skills/self-review/references/panel_review_template.md
+++ b/skills/self-review/references/panel_review_template.md
@@ -1,0 +1,148 @@
+# Panel Review Template (Phase 2.6)
+
+Reusable scaffolding for the multi-agent panel: a reviewer output schema, a
+generic reviewer prompt skeleton with per-domain focus checklists, and an
+editor synthesis prompt skeleton. This is a template, not a runtime program —
+it carries no manuscript-specific content. Fill the `{...}` placeholders from
+the manuscript under review and from the reviewer-set mapping in Phase 2.6.
+
+The per-domain focus checklists below name *categories of concern*; the precise
+probes (and their output templates) live in the vendored domain-probe modules
+(`references/domain-probes/*.md`), which each reviewer should load.
+
+---
+
+## Reviewer output schema
+
+Each reviewer returns one object with these fields:
+
+```json
+{
+  "reviewer_id": "R1",
+  "expertise_area": "Biostatistics & Study Design",
+  "overall_assessment": "3-5 sentences. State explicitly whether a fatal flaw exists and name the single biggest threat to the conclusions.",
+  "strengths": ["...", "..."],
+  "major": [
+    {
+      "number": 1,
+      "heading": "Short title of the issue",
+      "comment": "Detailed critique. Quote the manuscript where relevant. Explain why it threatens validity.",
+      "location": "section / table / figure / specific claim",
+      "severity": "Fatal | Fixable",
+      "suggested_fix": "What the authors should do to address it"
+    }
+  ],
+  "minor": [
+    { "number": 1, "comment": "...", "location": "..." }
+  ]
+}
+```
+
+`severity` uses this skill's own scale: **Fatal** for a conclusion-threatening /
+design-level finding, **Fixable** for a reporting-level finding.
+
+---
+
+## Reviewer prompt skeleton
+
+> You are an expert peer reviewer for a competitive journal in {field}, performing a
+> blinded pre-submission review of the author's own manuscript. Read the full
+> manuscript (and any supplement) first.
+>
+> TONE: rigorous and skeptical, but fair and constructive. Hunt for the issues that
+> threaten the manuscript's conclusions. Keep strengths to 2–3 genuine items. Every
+> major comment must threaten an actual conclusion or a reporting requirement; quote
+> the manuscript when you criticize a specific claim, and cite the location.
+>
+> Stay strictly within YOUR assigned area of expertise: {expertise_area}. Do not
+> stray into the other reviewers' domains. Load and apply the probes in
+> {domain_probe_module} where it applies. Produce 4–8 major comments and 4–10 minor
+> comments, and return them in the reviewer output schema above. Set `reviewer_id`
+> to "{reviewer_id}" and `expertise_area` to "{expertise_area}".
+>
+> YOUR FOCUS:
+> {focus_checklist}
+
+### Per-domain focus checklists (generic)
+
+**Biostatistics & Study Design**
+- Model specification: is the primary model pre-specified, or chosen post hoc in a results-favorable direction? Over-adjustment / conditioning on mediators on the causal pathway?
+- Assumption checks appropriate to the model (e.g., proportional hazards for Cox), and adequacy of any corrections.
+- Missing data: extent, plausibility of the missingness mechanism, whether the headline estimate survives a principled imputation, and whether imputation is primary or relegated to sensitivity.
+- Competing risks / informative censoring where multiple event types exist.
+- Sparse events: events-per-variable, penalization adequacy, CI stability.
+- Multiplicity across multiple outcomes, subgroups, and exploratory analyses.
+- Sensitivity / bias analyses (e.g., E-value) computed and interpreted correctly.
+- Time-zero / immortal-time / left-truncation; power for any null finding.
+
+**Clinical (domain)**
+- Clinical actionability: do the stated recommendations follow from the actual (possibly attenuated) results, or do they overreach?
+- Residual confounding by the dominant clinical driver of the outcome; can the exposure be disentangled from it?
+- Screening vs symptomatic population framing; external validity to the target readership.
+- Plausibility of the pattern of findings (e.g., a selective association without an expected concomitant one) — biology vs confounding vs chance.
+- Whether the findings would change management for a real patient.
+- Missing clinical variables and their interpretive cost.
+
+**Imaging / Radiology**
+- Exposure / measurement validity: how the imaging variable was defined and measured; visual/binary vs quantitative; threshold dependence.
+- Interobserver reliability measured in THIS cohort vs cited from the literature; defensibility of any non-differential-misclassification "bias toward the null" claim.
+- Protocol heterogeneity over time (scanner generation, slice thickness, reconstruction, dose) and its effect on the measurement.
+- Unavailable / non-retrievable images and selection implications.
+- Subtype/severity collapsed into a binary; loss of dose-response.
+- Reliability of routine clinical reports used as a research-grade variable.
+
+**Methodology (SR/MA)**
+- Search comprehensiveness and reproducibility; screening reviewer count.
+- Extraction fidelity vs source; comparator existence and consistent definition.
+- Non-independence (overlapping cohorts / shared public benchmarks).
+- Risk-of-bias instrument and per-study application; supplementary completeness.
+- Registration (PROSPERO) format and amendment discipline.
+
+**ML / Statistics (radiomics, AI)**
+- Design-grid circularity: is an outcome predicted from the very axes used to construct the dataset?
+- Construct validity: reliability ≠ predictiveness; orthogonality of proxy and target.
+- Transportability: cross-domain failure framed as success; negative R² read as a weak metric.
+- Multiplicity across model × threshold / cohort grids; small-cohort bootstrap intervals.
+- Leakage (patient-level vs image-level splits); calibration beyond discrimination.
+
+**Clinical translation / reference standard**
+- Reference-standard validity and verification bias.
+- Whether reported performance reflects the intended-use population and decision point.
+- Incremental value over the comparator already in routine use.
+
+**Methodology / SANRA (narrative review)**
+- Novelty / value-add against recent reviews; scope and aims clarity.
+- Evidence-gathering transparency (suggestion-level; not PRISMA).
+- Taxonomy / synthesis coherence; balance, currency, citation accuracy.
+- Load-bearing figures/tables; proportionate gap-filling ("consider adding", never "must cite").
+
+**Technical accuracy (narrative review)**
+- Engineering and domain correctness of specific claims; itemize errors with location.
+- Verify-your-own-criticism: cross-check each asserted inaccuracy against a current authoritative source before raising it.
+
+---
+
+## Editor synthesis prompt skeleton
+
+> You are the handling editor. {N} expert reviewers (areas: {areas}) have returned
+> independent blinded reviews of this pre-submission manuscript. Here are their
+> structured reviews as JSON:
+>
+> {reviews_json}
+>
+> Read enough of the manuscript to adjudicate conflicts and weigh severity yourself.
+> Then:
+> 1. Reach an internal readiness decision and state the rationale honestly. (This sets
+>    the Phase 3c verdict / score; it is not a journal recommendation to print.)
+> 2. De-duplicate and consolidate the major comments by theme. For each consolidated
+>    point, flag CONSENSUS (raised by ≥2 reviewers) or single-reviewer, and attribute
+>    (R1/R2/R3).
+> 3. List the top priority pre-submission actions, ranked and concrete.
+> 4. Give an honest readiness verdict: ready for the target tier now, fix specific
+>    items first, or consider a different tier.
+>
+> Map every finding onto the self-review framing (Fatal / Fixable, category letters
+> A–K) and emit it through the Phase 3 report, Phase 3b R0 numbering, and Phase 3c
+> JSON, adding the optional `consensus` field where ≥2 reviewers agreed. Follow the
+> manuscript-style rules: no "§" symbols, minimal em-dashes, full prose, cite specific
+> locations.

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -7,6 +7,7 @@ when_to_use:
   - Generating Anticipated Major / Minor Comments before sending to senior co-authors
   - Phase 2.5a numerical source-fidelity audit (CSV ↔ analysis ↔ manuscript ↔ primary paper)
   - Producing R0-numbered comments that flow into /revise for the response document
+  - Multi-agent panel review (--panel) — parallel domain-expert reviewers + editor synthesis for a high-stakes pre-submission final pass
 when_NOT_to_use:
   - Reviewing external (assigned) manuscripts (use /peer-review)
   - Drafting the user's manuscript (use /write-paper)
@@ -39,5 +40,6 @@ known_limitations:
 validation_commands:
   - "python3 scripts/check_reviewer_team_consistency.py"
   - "python3 scripts/check_domain_probe_sync.py --strict"
+  - "bash tests/test_panel_mode.sh"
   - "feed R0-numbered output into /revise"
 evidence_surface: demo

--- a/skills/self-review/tests/test_panel_mode.sh
+++ b/skills/self-review/tests/test_panel_mode.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Structural + PII regression tests for self-review --panel mode (Phase 2.6).
+# Pure file checks — no agent invocation. Run from anywhere.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SKILL="$REPO_ROOT/skills/self-review/SKILL.md"
+TEMPLATE="$REPO_ROOT/skills/self-review/references/panel_review_template.md"
+PROBE_DIR="$REPO_ROOT/skills/self-review/references/domain-probes"
+
+fail=0
+ran=0
+check() {
+    local label="$1"; shift
+    ran=$((ran + 1))
+    if "$@" >/dev/null 2>&1; then
+        printf '  PASS  %s\n' "$label"
+    else
+        printf '  FAIL  %s\n' "$label"
+        fail=$((fail + 1))
+    fi
+}
+
+[[ -f "$SKILL" ]] || { echo "ENV-ERR: SKILL.md missing" >&2; exit 2; }
+
+# 1. Panel section + flag present.
+check "Phase 2.6 panel section present"       grep -qE '^### Phase 2\.6: Multi-Agent Panel Review' "$SKILL"
+check "--panel flag documented in Optional Flags" grep -qE '^- `--panel`:' "$SKILL"
+check "default stays single-pass (off by default)" grep -qi 'off by default' "$SKILL"
+check "--fix x --panel guard documented"       grep -qi 'Do \*\*not\*\* combine with `--fix`' "$SKILL"
+
+# 2. Reviewer-set mapping names all four domain-probe modules.
+for m in survival_prognostic sr_ma radiomics narrative_review; do
+    check "reviewer-set table references $m module" grep -qE "domain-probes/$m\.md" "$SKILL"
+done
+
+# 3. Template exists and carries the schema fields + skeletons.
+check "panel_review_template.md exists"         test -f "$TEMPLATE"
+check "template references skill-dir path in SKILL.md" grep -qE 'references/panel_review_template\.md' "$SKILL"
+check "template has reviewer schema fields"     grep -qE '"severity": "Fatal \| Fixable"' "$TEMPLATE"
+check "template has editor synthesis skeleton"  grep -qi 'Editor synthesis prompt skeleton' "$TEMPLATE"
+
+# 4. Vendored probe modules each reviewer loads exist.
+for m in survival_prognostic sr_ma radiomics narrative_review; do
+    check "vendored module present: $m.md"      test -f "$PROBE_DIR/$m.md"
+done
+
+# 5. PoC-content-leak scan on the PoC-derived template.
+#    The authoritative PII gate for names / mentors / institutions / project
+#    codes is scripts/check_precedent.py (SHA-256 hashed, run repo-wide by
+#    validate_skills.sh). Do NOT duplicate those identifiers in cleartext here —
+#    that would re-introduce the very PII as a public string (self-doxxing,
+#    oss-publication-pii-guard §5). This check is belt-and-suspenders for the
+#    non-identifying content markers of the source PoC manuscript (a personal
+#    path, the study disease term, the cohort N) that would signal the template
+#    was not fully generalized. POSIX-safe (no \b).
+POC_MARKERS='/Users/|/home/|emphysema|41,?291'
+ran=$((ran + 1))
+if grep -nEi "$POC_MARKERS" "$TEMPLATE"; then
+    printf '  FAIL  PoC-content-leak scan (panel_review_template.md)\n'
+    fail=$((fail + 1))
+else
+    printf '  PASS  PoC-content-leak scan (panel_review_template.md)\n'
+fi
+
+echo ""
+echo "ran=$ran fail=$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Why

PR2 of the dual-review refactor. PR1 (#72) consolidated the four domain probe modules; this PR gives self-review an opt-in **`--panel`** mode that consumes them: several domain-expert reviewers run independently (blinded), then an editor consolidates their findings — the structure a journal uses — for a high-stakes pre-submission final pass. The default single-pass review stays the fast path.

> **Stacked on #72.** Base is `feat/dual-review-domain-probes`, so this diff shows only the incremental change. Merge **#72 first**, then retarget this PR to `main`. Per the repo's stacked-PR guidance, use a **merge commit** (not squash + delete-branch), which would cascade-close this PR and break ancestry.

## What

**self-review**
- New **Phase 2.6** (runs only with `--panel`, after the numerical audits, before the Phase 3 report). Research-type → reviewer-set mapping; each reviewer loads the matching vendored domain-probe module so the panel's criteria are single-sourced (this is the survival/SR-MA/radiomics/narrative coverage from PR1, now driving a panel).
- **Portable execution:** parallel subagents when the host provides them, with an explicit **sequential blinded fallback** for harnesses without a subagent capability. No dependency on the `Workflow` tool; **no shipped `.js`**.
- Reviewer severity maps onto the existing **Fatal/Fixable** scale. Panel output feeds Phase 3 / 3b (**R0 numbering preserved** → `/revise`) / 3c, with CONSENSUS (≥2 reviewers) + R1/R2/R3 attribution as **additive** annotations and an optional `consensus` JSON field.
- New `references/panel_review_template.md`: generalized reviewer schema + prompt skeletons + per-domain focus checklists, derived from a working PoC but **scrubbed of all manuscript-specific content**.
- `--panel` and `--fix` must not be combined (panel diagnoses; `--fix` is a separate pass).

**orchestrate**
- Available Skills row updated; a single-skill routing row sends harsh / top-tier / multi-reviewer / "stats+clinical+imaging angles" requests to `/self-review --panel --json`, while the generic "review my manuscript" request stays single-pass.
- `--panel` is opt-in and **never auto-applied** in chains or `--e2e` unless the user asks; Post-Skill Validation accepts the optional `consensus` field. Router boundary unchanged.

**CI / tests**
- New `tests/test_panel_mode.sh` (17 structural checks + a PoC-content-leak scan), wired into `validate.yml` after the PR1 sync gate, before catalog.
- The leak scan checks **non-identifying content markers only** (a personal path, the study disease term, the cohort N). Names / mentors / institutions / project codes stay with the hashed `check_precedent.py` gate rather than being re-introduced as cleartext in a public test (oss-publication-pii-guard §5).

## Scope notes

- **Catalog count unchanged (43)** — `--panel` is a mode of an existing skill.
- orchestrate changes are SKILL.md body-only, so `docs/skills/orchestrate.md` does not regenerate; `docs/skills/self-review.md` does (skill.yml `validation_commands` + `when_to_use`).

## Verification

```
bash scripts/validate_skills.sh                       # ALL CHECKS PASSED
python3 scripts/validate_routing_assets.py --strict   # 164 asset refs OK (incl. panel template)
python3 scripts/check_domain_probe_sync.py --strict   # 4 modules byte-identical
python3 scripts/validate_catalog_consistency.py       # 43
python3 scripts/gen_skill_docs.py --check             # in sync
python3 scripts/validate_skill_contracts.py           # 43 v2, 0 failures
bash skills/self-review/tests/test_panel_mode.sh      # ran=17 fail=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)