### PR TITLE
docs(self-review,write-paper): surface --panel for discoverability

### DIFF
--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -42,6 +42,7 @@ Most issues are Fixable. Reserve Fatal for true design-level problems.
    - Target journal? (affects reporting standards and scope expectations)
    - Manuscript type? (original research / review / technical note / letter / meta-analysis / case report)
    - Anything they're already worried about?
+   - **Review depth?** The default is a single-pass review. For a high-stakes pre-submission final pass, a multi-agent **panel** (`--panel`, Phase 2.6) is available — several domain-expert reviewers run independently, then an editor consolidates them (more thorough, but it spawns several agents so it costs several times more tokens). On an interactive run, surface this option **once** in one line and offer it; then proceed with the single-pass review unless the user opts in. Do **not** surface or auto-apply the panel when invoked with `--json` or from `/write-paper` — those stay single-pass.
 3. Read the full manuscript.
 
 ### Phase 2: Systematic Check

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -495,6 +495,8 @@ This delegates the entire fix loop to the self-review skill, which:
 3. If `verdict` is `"PASS"` after any iteration: stops early.
 4. Returns the final JSON report with updated scores.
 
+**High-stakes manual pass (optional):** this autonomous loop deliberately uses the single-pass review — a multi-agent panel is *not* auto-applied in the pipeline (it spawns several reviewer agents plus an editor, multiplying token cost). For a top-tier or otherwise high-stakes manuscript, run `/self-review --panel` once manually as a final pre-submission pass (it diagnoses and prioritizes but does not auto-fix, so triage its findings yourself).
+
 After `/self-review --json --fix` completes:
 - Parse the final JSON output block.
 - Log the final `overall_score`, `verdict`, fix iteration count, and any remaining issues to `qc/_pipeline_log.md`.


### PR DESCRIPTION
## Why

The opt-in `/self-review --panel` mode (shipped in v3.4.0) is easy to miss. This makes it discoverable **without** silently forcing its higher (multi-agent) token cost.

## What

- **self-review** Phase 1 Intake now surfaces the panel option once, in one line, on **interactive** runs and offers it — then proceeds single-pass unless the user opts in. Suppressed for `--json` / `/write-paper` calls, so pipelines stay single-pass.
- **write-paper** Step 7.4 notes the autonomous fix loop stays single-pass (a panel is never auto-applied in the pipeline) and that `--panel` can be run manually as a high-stakes final pre-submission pass.

Body-only edits; generated `docs/skills/*.md` unchanged. No version bump.

## Verification

`validate_skills.sh`, `validate_routing_assets.py --strict`, `check_domain_probe_sync.py --strict`, `gen_skill_docs.py --check`, `test_panel_mode.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)