### PR TITLE
feat(self-review): power-aware null interpretation check (category C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`/self-review` category C — power-aware null interpretation**: a new check that scores non-significant primary results (p > 0.05, 95% CI crossing the null) for whether the analysis is powered to *exclude* a clinically meaningful effect. An underpowered null is flagged as "not yet established" rather than "no effect," and the check watches for bilateral over-correction (a prior overclaim swinging to an equally unsupported negative claim during revision). Undocumented null = Minor; a null driving a clinical recommendation without power/CI-compatibility justification = Major. Backports a panel-only finding into the single-pass review (prose check, no new dependency).
+
 ## [3.4.0] - 2026-06-06
 
 Dual-review consolidation and a multi-agent panel mode for self-review — depth without broadening the catalog (still 43 skills).

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -83,6 +83,7 @@ partially, or not at all for the given manuscript type.
 | Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
 | Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
 | Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
+| Power-aware null interpretation | Scored separately from significance, for any **non-significant primary result** (p > 0.05, 95% CI crossing the null): is the analysis powered to *exclude* a clinically meaningful effect? An underpowered null is "not yet established," not "no effect" -- if the upper CI bound still includes a meaningful effect size, a flat "X was not associated with Y" claim overreads the data. Look for reported observed power or a minimum detectable effect that justifies a negative conclusion, and watch for **bilateral over-correction** (a prior "independently associated" overclaim swinging to an equally unsupported "not associated" claim during revision). Undocumented null = Minor; a null that drives a clinical recommendation or a headline negative conclusion without power/CI-compatibility justification = Major. |
 
 #### D. Clinical Framing & Importance
 


### PR DESCRIPTION
## Summary

Adds a **power-aware null interpretation** check to `/self-review` category C. A non-significant primary result (p > 0.05, 95% CI crossing the null) is scored for whether the analysis is powered to *exclude* a clinically meaningful effect — an underpowered null reads as "not yet established," not "no effect." The check also flags **bilateral over-correction** (a prior overclaim swinging to an equally unsupported negative claim during revision).

- Undocumented null = Minor; a null that drives a clinical recommendation without power/CI-compatibility justification = Major.
- Prose-only — no new dependency or script.

First of a short series that backports findings a `--panel` review caught but the single-pass review missed, into deterministic / prose single-pass guards.

## Verification

`validate_skills.sh`, `gen_skill_docs.py --check`, `check_domain_probe_sync.py --strict`, `validate_routing_assets.py --strict`, `validate_catalog_consistency.py`, and `test_panel_mode.sh` all pass. Catalog unchanged (43 skills).

## Merge order

Base of the self-review stack — the confounding-completeness PR (Phase 2.5e) is stacked on this branch. Merge this first with a **merge commit** (not squash), then retarget the stacked PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
