### PR TITLE
feat: P2 scope/reviewer/leakage gates (endpoint-conclusion coherence, LLM-as-reviewer, time-origin, strata, pool totals, copy divergence)

### DIFF
--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -47,6 +47,7 @@
 - `check_cohort_arithmetic.py`
 - `check_confounding_completeness.py`
 - `check_reviewer_team_consistency.py`
+- `check_scope_coherence.py`
 
 ## Source
 

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -139,6 +139,12 @@ Before running parametric tests, always check and report:
 - Always report both uncorrected and corrected p-values.
 - State the correction method used.
 
+#### Stratified & Ordinal-Trend Reporting
+
+- **Strata disjointness gate (before any ordinal trend test).** Before running a Cochran-Armitage trend test (or any analysis that treats tiers as an ordered partition), assert the strata are mutually exclusive and exhaustive: `sum(n per stratum) == unique N` and `sum(events per stratum) == total events`. A trend test on overlapping or non-exhaustive strata is invalid. Emit the per-stratum N/event table and the reconciliation in the output (this is the analysis-side mirror of `/self-review` `check_cohort_arithmetic.py` `PARTITION_OVERLAP`).
+- **Secondary stratum-HR validation checklist.** Every secondary stratum hazard/odds ratio must be reported with (a) its **reference contrast** (which category is the referent), (b) the **event count** in each stratum, and (c) a **sparse-stratum caveat** when any stratum has a low event count (a rule of thumb: < 10 events makes the estimate unstable). A bare "HR 1.55 in lean participants" without the referent and the events is uninterpretable.
+- **Proportion CI lower-bound clamp.** Clamp every proportion confidence-interval lower bound to `max(0, lower)`; a zero-event Wilson/score interval can emit a negative or absurd tiny-exponent lower bound (e.g., `3.47e-16`) that is a display artifact, not a real bound. Report `0` (or `0.0%`) instead, and prefer an exact (Clopper-Pearson) interval for zero/near-zero cells.
+
 #### Output Manifest
 
 After all analyses complete, save a manifest file `_analysis_outputs.md` in the output directory:

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -185,6 +185,7 @@ Ask whether the comparator and endpoint support the stated claim:
 - is the endpoint clinically meaningful?
 - does performance translate to action?
 - **incremental value**: if the study frames the model/marker as adding value *beyond* / *on top of* / *incremental to* an existing tool (a clinical score, a routine test, a baseline model), the design must pre-specify the baseline comparator built from the in-routine-use predictors **and** an incremental-value metric — ΔC-index / ΔAUC (with a paired CI, e.g. DeLong), categorical or continuous NRI, IDI, or decision-curve net benefit. A standalone discrimination number ("our model's AUC was 0.84") does not support a "beyond X" claim; without the nested-model comparison the finding may be real but redundant. Plan this at design time — it cannot be added post hoc without the baseline model.
+- **endpoint↔conclusion scope**: decide up front what *kind* of conclusion the design can support, so the manuscript does not overreach. A cross-sectional / single-visit / prevalence design cannot support a prognostic or surveillance claim (rescreen interval, disease progression) — that needs longitudinal follow-up. A binary surrogate endpoint (present/absent, >0, dichotomized) is risk stratification, not a patient-care directive (defer/withhold/initiate therapy). At review time `/self-review` §D + `check_scope_coherence.py` flag `CROSS_SECTIONAL_PROGNOSTIC` / `SURROGATE_CARE_DIRECTIVE` against the conclusion.
 
 ### Phase 4: Reporting fit
 

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -118,6 +118,14 @@ Look for:
   part, from the outcome's definition or the same measurement?" If yes, exclude it, or retain it only
   as a labeled calibration probe rather than a reported discovery.
 
+#### F. Time origin & survivorship (incident / transition models)
+
+For any time-to-event or incident/transition design, check before drafting:
+- **Time origin per model.** Each incident model starts its at-risk clock at the correct origin. Watch for **immortal-time bias** (a span in which the event cannot occur, misattributed to one group) and **left-truncation / delayed entry** (subjects entering the risk set after the origin).
+- **Mediator-ascertainment-window survivorship.** A "progressor" / transition label that is conditional on *surviving to* a later ascertainment (a second scan, a follow-up visit) is survivorship-biased; plan a landmark time or an explicit intermediate-state (multistate / illness-death) model.
+- **Primary-analysis-set selection.** If the primary will not be the full cohort (e.g., complete-case while a large fraction is missing), pre-specify the selection justification and a MAR rationale; do not let the complete-case model become primary because it is the significant one (an outcome-dependent choice).
+- A design that cannot yet answer these should say so honestly — but note that at review time a Methods/Limitations admission that the issue was *"not formally assessed"* is escalated to a MAJOR by the survival probe (S1), not waved through as a limitation.
+
 #### C. Reference standard
 
 Check:

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -256,6 +256,14 @@ Downstream gates
   category must match the locked value.
 - Manuscript prose: NEVER re-derive `k included` from extraction TSV at
   manuscript build time. Always reference `final_pool_n` from the lock.
+- **Aggregate patient/lesion totals are locked too, not just study counts.**
+  The Abstract/Results aggregate denominators ("a total of 483 patients /
+  531 lesions") are derived from the lock, never hand-carried. Lock them as
+  explicit fields and distinguish **arm-separable** from **both-arm** rows:
+  a study contributing one arm to a comparison must not have its full-cohort
+  patient count folded into a pooled total. A hand-carried headline total that
+  does not re-derive from the locked per-study values is a P0 (the analysis-side
+  mirror of `/self-review` `check_cohort_arithmetic.py` partition checks).
 
 If a late post-freeze decision changes the pool, treat it as a formal
 PROSPERO amendment: file the amendment, re-freeze the lock as a new
@@ -501,6 +509,16 @@ publication-bias test power, sensitivity-analysis menu, and error-handling rules
    - Precedent: a revision-era sensitivity analysis (1-voxel erosion) reported 8 effect-size values
      (Cohen's dz + f across 4 VOIs) byte-identical to the primary tables while the means/SDs
      differed — the erosion analysis had not actually been recomputed. Caught only by external QC.
+
+6. **A "fixed" / "resolved" audit note requires re-run evidence, not a claim.**
+   - When a prior audit note records a number as `fixed`, `resolved`, or `corrected`, that status is
+     only valid if it carries the re-run evidence: a timestamp and the relevant stdout / output-file
+     line showing the corrected value, or the commit that changed it. A bare "fixed in v10" with no
+     re-run artifact does NOT clear the finding — re-run the script and attach the output.
+   - The forward pipeline can echo a stale value through every artifact while an audit note claims it
+     was fixed (e.g., a major-comparison N still reading the old total after a "fixed" note). The
+     outcome-denominator cross-check (`/self-review` Phase 2.5b, the cohort-arithmetic / pool-lock
+     assertions) must pass against the *current* outputs before any "fixed" status is accepted.
 
 **When this phase triggers:** every time Phase 6 outputs change (first draft, revision, reviewer-
 requested re-analysis). Not optional on "minor" re-runs — the precedent reversal above

--- a/skills/peer-review/references/domain-probes/survival_prognostic.md
+++ b/skills/peer-review/references/domain-probes/survival_prognostic.md
@@ -15,6 +15,8 @@ An 8-probe checklist for time-to-event outcomes and prognostic model development
 - Inputs include post-decision variables (resection margin status, adjuvant chemo/radiotherapy, transplant status) that are unknown at the claimed decision point?
 - Non-treatment comparator or causal framework present?
 - Conditioning gap → MAJOR candidate. Recommend retrain without leaky variables / add non-treatment arm / reframe intended use.
+- **Time origin & survivorship** (incident / transition models): is the at-risk clock started at the correct origin for each incident model, with immortal time (a span in which the event cannot occur, misattributed to one group) and left-truncation / delayed entry handled? Is a "progressor" / transition label conditioned on *surviving to* a later ascertainment (a second scan, a follow-up visit) — a survivorship that needs a landmark time or an explicit intermediate-state model? If the primary analysis is **not** the full cohort (e.g., complete-case while a large fraction is missing) and the complete-case model is the significant one, that selection needs a stated justification and a MAR rationale — an outcome-dependent choice of the analysis set is the S8 concern. Any of these unhandled → MAJOR.
+- **Self-confession escalation**: a Methods or Limitations admission that a time-origin, immortal-time, return-conditioning, or selection issue was *"not formally assessed"* (or equivalent) is itself a MAJOR — it names a known bias that was left unaddressed, not a mitigated limitation.
 
 **S2 — Censoring handling in training loss**:
 - Cox partial-likelihood loss or DeepSurv-style loss specified? How is censoring handled (right-censoring, interval-censoring, informative censoring by death)?

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -98,6 +98,16 @@ partially, or not at all for the given manuscript type.
 | Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
 | Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
 | Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
+| Endpoint↔conclusion scope **[CRITICAL]** | Does the conclusion's *action* exceed what the design or endpoint supports? A cross-sectional / single-visit study cannot license a prognostic or surveillance claim (rescreen interval, disease progression); a binary surrogate endpoint (present/absent, >0) is risk stratification, not a care directive (defer/withhold/initiate therapy). Both are documented anti-patterns. |
+
+Run the deterministic scope gate:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_scope_coherence.py" \
+  --manuscript manuscript.md --out qc/scope_coherence.json --strict
+```
+
+`CROSS_SECTIONAL_PROGNOSTIC` and `SURROGATE_CARE_DIRECTIVE` are Anticipated Major Comments (category: D. Clinical Framing). The gate is conservative — it fires only when a design/endpoint signal and a conclusion-region action verb co-occur.
 
 #### E. Reproducibility
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -44,6 +44,25 @@ Most issues are Fixable. Reserve Fatal for true design-level problems.
    - Anything they're already worried about?
    - **Review depth?** The default is a single-pass review. For a high-stakes pre-submission final pass, a multi-agent **panel** (`--panel`, Phase 2.6) is available — several domain-expert reviewers run independently, then an editor consolidates them (more thorough, but it spawns several agents so it costs several times more tokens). On an interactive run, surface this option **once** in one line and offer it; then proceed with the single-pass review unless the user opts in. Do **not** surface or auto-apply the panel when invoked with `--json` or from `/write-paper` — those stay single-pass.
 3. Read the full manuscript.
+4. **SSOT gate — confirm there is one manuscript, not several.** Self-review reads a single
+   input file, so a divergence between a legacy working copy and the live submission copy is
+   structurally invisible to it. Before a `--panel` run (or any pre-submission pass), check for
+   multiple copies and reconcile first:
+
+   ```bash
+   find . \( -path '*manuscript*' -o -path '*main_document*' \) -name '*.md' | grep -v node_modules
+   ```
+
+   If more than one manuscript-like file exists, confirm which is the SSOT and run
+   `/sync-submission`'s divergence gate before reviewing — a `STALE_COPY` (an SSOT numeric claim
+   or heading that did not propagate to the other copy) is a P0 that must clear first:
+
+   ```bash
+   python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/sync-submission/scripts/detect_copy_divergence.py" \
+     --ssot <ssot>.md --copy <other-copy>.md
+   ```
+
+   Review the SSOT copy; do not review a stale copy and pass it.
 
 ### Phase 2: Systematic Check
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -175,18 +175,25 @@ before submission for item-level assessment."
 | Check | What to look for |
 |-------|-----------------|
 | DUAL vs SINGLE conjunction **[CRITICAL]** | Methods or PROSPERO claims dual independent reviewers AND Discussion/Limitations admits single primary reviewer + 20% sample (or "deferred to before submission")? Mark as **MAJOR**, fabrication-grade. |
+| LLM-as-reviewer **[CRITICAL]** | A per-study extraction JSON whose `reviewer`/`screener`/`extractor` field is an LLM (Claude, GPT-4, Gemini, "LLM")? An LLM is a tool, not an independent reviewer — listing it as one misrepresents the team. **Fatal**, regardless of the prose. |
+| Deferred mitigation | A future-tense mitigation promise — "a 20% sample **will be completed before submission**" — unmet at circulation? The future tense is the tell that the work is not done. **MAJOR**. |
 
-Run the deterministic check at Phase 2 entry:
+Run the deterministic check at Phase 2 entry (pass the extraction JSON — a file or
+a directory of per-study JSONs — so the prose↔JSON↔confession 3-way is covered):
 
 ```bash
 python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
     --manuscript manuscript.md \
     --prospero prospero/record.md \
+    --extraction-json extraction/ \
     --out _audit_self/reviewer_team_consistency.md
 ```
 
-Exit 1 = MAJOR red flag. Either claim alone is fine; the conjunction is
-read by reviewers as fabrication. Resolution path:
+Exit 1 = MAJOR red flag. The JSON sidecar carries `dual_hits`, `single_hits`,
+`llm_reviewer_hits`, and `deferred_mitigation_hits`. Any of the DUAL+SINGLE
+conjunction, an LLM reviewer field, or a deferred mitigation trips it. Either of
+the dual/single claims alone is fine; the conjunction is read by reviewers as
+fabrication. Resolution path:
 1. Honest Methods/PROSPERO update (single-reviewer execution disclosed), OR
 2. Limitations confession rewritten if dual review was actually completed.
 

--- a/skills/self-review/references/domain-probes/survival_prognostic.md
+++ b/skills/self-review/references/domain-probes/survival_prognostic.md
@@ -15,6 +15,8 @@ An 8-probe checklist for time-to-event outcomes and prognostic model development
 - Inputs include post-decision variables (resection margin status, adjuvant chemo/radiotherapy, transplant status) that are unknown at the claimed decision point?
 - Non-treatment comparator or causal framework present?
 - Conditioning gap → MAJOR candidate. Recommend retrain without leaky variables / add non-treatment arm / reframe intended use.
+- **Time origin & survivorship** (incident / transition models): is the at-risk clock started at the correct origin for each incident model, with immortal time (a span in which the event cannot occur, misattributed to one group) and left-truncation / delayed entry handled? Is a "progressor" / transition label conditioned on *surviving to* a later ascertainment (a second scan, a follow-up visit) — a survivorship that needs a landmark time or an explicit intermediate-state model? If the primary analysis is **not** the full cohort (e.g., complete-case while a large fraction is missing) and the complete-case model is the significant one, that selection needs a stated justification and a MAR rationale — an outcome-dependent choice of the analysis set is the S8 concern. Any of these unhandled → MAJOR.
+- **Self-confession escalation**: a Methods or Limitations admission that a time-origin, immortal-time, return-conditioning, or selection issue was *"not formally assessed"* (or equivalent) is itself a MAJOR — it names a known bias that was left unaddressed, not a mitigated limitation.
 
 **S2 — Censoring handling in training loss**:
 - Cox partial-likelihood loss or DeepSurv-style loss specified? How is censoring handled (right-censoring, interval-censoring, informative censoring by death)?

--- a/skills/self-review/scripts/check_reviewer_team_consistency.py
+++ b/skills/self-review/scripts/check_reviewer_team_consistency.py
@@ -33,6 +33,16 @@ Section-aware grep for two regex families:
 
 Both present → MAJOR self-review red flag.
 
+Two further fabrication-grade axes (the prose↔JSON↔confession 3-way):
+- LLM-AS-REVIEWER (fatal): a per-study extraction JSON whose reviewer /
+  screener / extractor / rater field is an LLM ("Claude", "GPT-4", "LLM",
+  "Gemini"). An LLM is a tool, not an independent reviewer; listing it as
+  one misrepresents the screening team regardless of the prose. Pass the
+  extraction JSON (file or directory) via --extraction-json.
+- DEFERRED-MITIGATION (MAJOR): a future-tense mitigation promise — "a 20%
+  sample will be completed before submission" — that is unmet at the time
+  the manuscript circulates. The promise is evidence the work is not done.
+
 Usage
 =====
 
@@ -114,6 +124,22 @@ SINGLE_PATTERNS = [
 ]
 
 
+# An LLM named where an independent reviewer should be (fatal). Bare "ai" is too
+# broad (matches names), so it is excluded; explicit model families + "LLM" only.
+LLM_NAME_RE = re.compile(
+    r"\b(?:claude|chatgpt|gpt-?\d|gpt|llm|large language model|gemini|copilot|bard|"
+    r"ai model|an ai\b)\b", re.IGNORECASE)
+REVIEWER_KEY_RE = re.compile(
+    r"reviewer|screener|extractor|rater|annotator|adjudicator|coder", re.IGNORECASE)
+
+# A future-tense mitigation promised but not yet executed at circulation.
+DEFERRED_MITIGATION_RE = re.compile(
+    r"(?:will be|to be|is to be|are to be)\s+"
+    r"(?:completed|performed|conducted|done|undertaken|carried out|finalized|finalised)\b"
+    r"[^.]{0,80}?(?:before|prior to|ahead of)\s+(?:final\s+)?submission",
+    re.IGNORECASE)
+
+
 SECTION_HEADERS = {
     "Methods": re.compile(
         r"^#{1,3}\s*\*{0,2}(?:METHODS?|Method[s]?|Materials and Methods)\*{0,2}\s*$",
@@ -142,6 +168,8 @@ class Report:
     submission_safe: bool
     dual_hits: list[dict] = field(default_factory=list)
     single_hits: list[dict] = field(default_factory=list)
+    llm_reviewer_hits: list[dict] = field(default_factory=list)
+    deferred_mitigation_hits: list[dict] = field(default_factory=list)
 
 
 def split_sections(text: str) -> dict[str, str]:
@@ -179,7 +207,50 @@ def hit_to_dict(h: Hit, source: str) -> dict:
     }
 
 
-def build_report(manuscript: str, prospero: str | None) -> Report:
+def _iter_extraction_files(path: Path):
+    if path.is_dir():
+        yield from sorted(path.rglob("*.json"))
+    elif path.is_file():
+        yield path
+
+
+def _walk_reviewer_fields(obj, source: str, hits: list[dict], keypath: str = "") -> None:
+    """Recursively find reviewer-role fields whose value names an LLM."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            kp = f"{keypath}.{k}" if keypath else str(k)
+            if isinstance(v, str) and REVIEWER_KEY_RE.search(str(k)) and LLM_NAME_RE.search(v):
+                hits.append({"source": source, "field": kp, "value": v[:120]})
+            _walk_reviewer_fields(v, source, hits, kp)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            _walk_reviewer_fields(v, source, hits, f"{keypath}[{i}]")
+
+
+def scan_llm_reviewers(extraction: Path | None) -> list[dict]:
+    hits: list[dict] = []
+    if extraction is None:
+        return hits
+    for f in _iter_extraction_files(extraction):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        _walk_reviewer_fields(data, f.name, hits)
+    return hits
+
+
+def scan_deferred_mitigation(manuscript: str) -> list[dict]:
+    hits: list[dict] = []
+    for lineno, line in enumerate(manuscript.splitlines(), start=1):
+        m = DEFERRED_MITIGATION_RE.search(line)
+        if m:
+            hits.append({"source": "manuscript", "line": lineno, "context": m.group(0).strip()[:160]})
+    return hits
+
+
+def build_report(manuscript: str, prospero: str | None,
+                 extraction: Path | None = None) -> Report:
     sections = split_sections(manuscript)
 
     dual_hits: list[dict] = []
@@ -199,12 +270,36 @@ def build_report(manuscript: str, prospero: str | None) -> Report:
         for h in scan_text(sections.get(region, ""), SINGLE_PATTERNS):
             single_hits.append(hit_to_dict(h, f"manuscript:{region}"))
 
-    submission_safe = not (dual_hits and single_hits)
+    llm_reviewer_hits = scan_llm_reviewers(extraction)
+    deferred_hits = scan_deferred_mitigation(manuscript)
+
+    submission_safe = not (
+        (dual_hits and single_hits) or llm_reviewer_hits or deferred_hits
+    )
     return Report(
         submission_safe=submission_safe,
         dual_hits=dual_hits,
         single_hits=single_hits,
+        llm_reviewer_hits=llm_reviewer_hits,
+        deferred_mitigation_hits=deferred_hits,
     )
+
+
+def _render_extra(lines: list[str], report: Report) -> None:
+    if report.llm_reviewer_hits:
+        lines.append("")
+        lines.append("## LLM-AS-REVIEWER (fatal)")
+        lines.append("An LLM is named where an independent reviewer is required:")
+        for h in report.llm_reviewer_hits:
+            lines.append(f"- `{h['source']}` field `{h['field']}` = {h['value']}")
+        lines.append("Fix: list a human reviewer; an LLM is a tool, not a member of the review team.")
+    if report.deferred_mitigation_hits:
+        lines.append("")
+        lines.append("## DEFERRED-MITIGATION (MAJOR)")
+        lines.append("A mitigation is promised in the future tense but not yet executed:")
+        for h in report.deferred_mitigation_hits:
+            lines.append(f"- line {h['line']}: {h['context']}")
+        lines.append("Fix: execute and report the mitigation before circulation, or remove the claim.")
 
 
 def render_markdown(report: Report) -> str:
@@ -224,21 +319,28 @@ def render_markdown(report: Report) -> str:
             for h in report.single_hits:
                 lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}` — {h['context']}")
     else:
-        lines.append("Status: **MAJOR red flag** — DUAL claim and SINGLE confession both present.")
+        triggers = []
+        if report.dual_hits and report.single_hits:
+            triggers.append("DUAL claim + SINGLE confession")
+        if report.llm_reviewer_hits:
+            triggers.append("LLM-as-reviewer")
+        if report.deferred_mitigation_hits:
+            triggers.append("deferred mitigation")
+        lines.append(f"Status: **MAJOR red flag** — {', '.join(triggers)}.")
         lines.append("")
-        lines.append("Reviewers will read this as fabrication-grade. Fix one of:")
-        lines.append("1. Methods / PROSPERO honestly states single-reviewer execution.")
-        lines.append("2. The Limitations admission is rewritten if dual review was actually done.")
-        lines.append("")
-        lines.append("## DUAL claims (Methods / PROSPERO)")
-        for h in report.dual_hits:
-            lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
-            lines.append(f"  > {h['context']}")
-        lines.append("")
-        lines.append("## SINGLE confessions (Discussion / Limitations)")
-        for h in report.single_hits:
-            lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
-            lines.append(f"  > {h['context']}")
+        lines.append("Reviewers will read this as fabrication-grade.")
+        if report.dual_hits and report.single_hits:
+            lines.append("")
+            lines.append("## DUAL claims (Methods / PROSPERO)")
+            for h in report.dual_hits:
+                lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
+                lines.append(f"  > {h['context']}")
+            lines.append("")
+            lines.append("## SINGLE confessions (Discussion / Limitations)")
+            for h in report.single_hits:
+                lines.append(f"- `{h['source']}` line {h['line']}: `{h['pattern']}`")
+                lines.append(f"  > {h['context']}")
+        _render_extra(lines, report)
     return "\n".join(lines) + "\n"
 
 
@@ -248,6 +350,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--manuscript", type=Path, required=True)
     parser.add_argument("--prospero", type=Path, default=None)
+    parser.add_argument(
+        "--extraction-json", type=Path, default=None,
+        help="per-study extraction JSON file or directory (reviewer-field LLM scan)",
+    )
     parser.add_argument(
         "--out",
         type=Path,
@@ -265,9 +371,12 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: prospero not found: {args.prospero}", file=sys.stderr)
             return 2
         prospero_text = args.prospero.read_text(encoding="utf-8")
+    if args.extraction_json is not None and not args.extraction_json.exists():
+        print(f"ERROR: extraction-json not found: {args.extraction_json}", file=sys.stderr)
+        return 2
 
     text = args.manuscript.read_text(encoding="utf-8")
-    report = build_report(text, prospero_text)
+    report = build_report(text, prospero_text, args.extraction_json)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(render_markdown(report), encoding="utf-8")
@@ -278,6 +387,8 @@ def main(argv: list[str] | None = None) -> int:
                 "submission_safe": report.submission_safe,
                 "dual_hits": report.dual_hits,
                 "single_hits": report.single_hits,
+                "llm_reviewer_hits": report.llm_reviewer_hits,
+                "deferred_mitigation_hits": report.deferred_mitigation_hits,
             },
             indent=2,
         ),
@@ -285,16 +396,13 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if not args.quiet:
+        counts = (f"DUAL={len(report.dual_hits)} SINGLE={len(report.single_hits)} "
+                  f"LLM={len(report.llm_reviewer_hits)} "
+                  f"DEFERRED={len(report.deferred_mitigation_hits)}")
         if report.submission_safe:
-            print(
-                f"PASS: no conjunction. DUAL={len(report.dual_hits)} "
-                f"SINGLE={len(report.single_hits)}"
-            )
+            print(f"PASS: no fabrication-grade conflict. {counts}")
         else:
-            print(
-                f"FAIL: MAJOR red flag. DUAL={len(report.dual_hits)} "
-                f"SINGLE={len(report.single_hits)}"
-            )
+            print(f"FAIL: MAJOR red flag. {counts}")
             print(f"See {args.out}")
 
     return 0 if report.submission_safe else 1

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Endpoint↔conclusion scope-coherence gate (self-review §D).
+
+Two overclaim patterns where the conclusion's action exceeds what the design or
+endpoint can support. Both are deterministic when a design/endpoint signal and a
+conclusion action verb co-occur, and both are documented anti-patterns
+(scope-coherence-gate.md):
+
+  CROSS_SECTIONAL_PROGNOSTIC  the design is cross-sectional / single-visit /
+                              prevalence, yet the conclusion makes a prognostic or
+                              surveillance claim (rescreen interval, surveillance,
+                              disease progression, predicting future risk). A single
+                              time point cannot license a longitudinal conclusion.
+  SURROGATE_CARE_DIRECTIVE    a binary surrogate endpoint (present/absent, >0,
+                              dichotomized) drives a patient-care directive (defer,
+                              withhold, initiate/discontinue therapy, statin). A
+                              risk-stratification marker is not a management trigger.
+
+The gate is conservative: it fires only when both a signal and a conclusion-region
+verb are present, to keep false positives low on a widely-used skill.
+
+INPUTS
+  --manuscript  manuscript markdown/text (required).
+
+OUTPUT
+  A reconciliation table (stdout) and, with --out, a JSON artifact:
+    {manuscript, claims[{verdict, severity, detail, where}], summary}
+  Both verdicts are Major. Exit 1 (with --strict) when any Major claim exists.
+
+Stdlib-only (json / re / argparse / pathlib). Exit codes: 0 clean (or report-only),
+1 Major claim(s) found (with --strict), 2 input/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DESIGN_CROSS_SECTIONAL = re.compile(
+    r"cross[-\s]?sectional|single[-\s](?:time[-\s]?point|visit|examination|measurement)|"
+    r"at (?:a |one )?(?:single |one )?time[-\s]?point|point[-\s]prevalence|"
+    r"prevalence (?:study|survey|design)", re.IGNORECASE)
+
+PROGNOSTIC_VERB = re.compile(
+    r"surveillance|re[-\s]?screen|screening interval|rescreening|"
+    r"monitor(?:ed|ing)?\s+over\s+time|disease progression|progress(?:es|ion)\s+to|"
+    r"prognost|predict(?:s|ing|ed)?\s+(?:incident|future|long[-\s]?term|the risk of developing)|"
+    r"longitudinal (?:follow|risk|trajector)", re.IGNORECASE)
+
+DIRECTIVE_VERB = re.compile(
+    r"\bdefer(?:ral|red|ring)?\b|\bwithhold\b|\bforgo\b|\binitiat(?:e|ed|ion)\b|"
+    r"\bdiscontinu(?:e|ed|ation)\b|start(?:ing)?\s+(?:statin|therapy|treatment|pharmacotherapy)|"
+    r"(?:statin|treatment|therapy|pharmacotherapy)\s+(?:can|should|may)\s+be\s+(?:deferred|withheld|started|initiated)|"
+    r"recommend(?:ed)?\s+(?:statin|treatment|therapy|initiation|against treatment)|"
+    r"guide\s+(?:treatment|management|therapy)", re.IGNORECASE)
+
+SURROGATE_SIGNAL = re.compile(
+    r"binary (?:surrogate|endpoint|outcome|marker)|dichotom(?:ous|ised|ized)|surrogate (?:endpoint|marker|outcome)|"
+    r"presence (?:or absence )?of|present (?:vs\.?|versus|or) absent|positive (?:vs\.?|versus|or) negative|"
+    r"categor(?:ised|ized) as (?:positive|present|absent)|>\s?0\b", re.IGNORECASE)
+
+CONCLUSION_HEADINGS = re.compile(
+    r"^#{1,4}\s*\*{0,2}(?:CONCLUSIONS?|Conclusions?|DISCUSSION|Discussion|"
+    r"Clinical Implications?|Interpretation)\*{0,2}\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def conclusion_region(text: str) -> str:
+    """Text under Conclusion/Discussion/Implications headings, plus any inline
+    'Conclusion:' clause (abstract). Fallback: the last 25% of the document."""
+    spans = []
+    starts = [m.end() for m in CONCLUSION_HEADINGS.finditer(text)]
+    # heading-delimited regions: from each heading to the next top-level heading
+    all_headings = [m.start() for m in re.finditer(r"^#{1,4}\s", text, re.MULTILINE)]
+    for s in starts:
+        nxt = next((h for h in all_headings if h > s), len(text))
+        spans.append(text[s:nxt])
+    for m in re.finditer(r"(?:^|\n)\s*\*{0,2}Conclusions?\*{0,2}\s*[:.]\s*(.+?)(?:\n\n|$)",
+                         text, re.IGNORECASE | re.DOTALL):
+        spans.append(m.group(1))
+    if not spans:
+        spans.append(text[int(len(text) * 0.75):])
+    return "\n".join(spans)
+
+
+def check(text: str) -> list[dict]:
+    claims = []
+    concl = conclusion_region(text)
+
+    if DESIGN_CROSS_SECTIONAL.search(text):
+        pm = PROGNOSTIC_VERB.search(concl)
+        if pm:
+            claims.append({
+                "verdict": "CROSS_SECTIONAL_PROGNOSTIC",
+                "severity": "Major",
+                "detail": (f"cross-sectional/single-visit design, but the conclusion makes a "
+                           f"prognostic/surveillance claim ('{pm.group(0).strip()}')"),
+                "where": concl[max(0, pm.start() - 40):pm.end() + 40].strip()[:160],
+            })
+
+    dm = DIRECTIVE_VERB.search(concl)
+    sm = SURROGATE_SIGNAL.search(concl)
+    if dm and sm:
+        claims.append({
+            "verdict": "SURROGATE_CARE_DIRECTIVE",
+            "severity": "Major",
+            "detail": (f"a binary surrogate endpoint ('{sm.group(0).strip()}') drives a "
+                       f"patient-care directive ('{dm.group(0).strip()}') in the conclusion"),
+            "where": concl[max(0, dm.start() - 40):dm.end() + 40].strip()[:160],
+        })
+
+    return claims
+
+
+def analyze(manuscript: str) -> dict:
+    p = Path(manuscript)
+    if not p.is_file():
+        sys.stderr.write(f"ERROR: manuscript not found: {manuscript}\n")
+        sys.exit(2)
+    claims = check(p.read_text(encoding="utf-8"))
+    n_major = sum(1 for c in claims if c["severity"] == "Major")
+    return {
+        "manuscript": str(p),
+        "claims": claims,
+        "summary": {
+            "n_claims": len(claims),
+            "n_major": n_major,
+            "n_flag": len(claims) - n_major,
+            "verdict": "MAJOR_CANDIDATE" if n_major else "OK",
+        },
+    }
+
+
+def render(result: dict) -> str:
+    lines = ["| Check | Severity | Detail |", "|---|---|---|"]
+    for c in result["claims"]:
+        lines.append(f"| {c['verdict']} | {c['severity']} | {c['detail']} |")
+    if len(lines) == 2:
+        lines.append("| (none) | — | conclusion scope matches the design/endpoint |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Endpoint↔conclusion scope-coherence gate (§D).")
+    ap.add_argument("--manuscript", required=True, help="manuscript markdown/text")
+    ap.add_argument("--out", help="write JSON artifact to this path")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any Major claim exists")
+    ap.add_argument("--quiet", action="store_true", help="suppress stdout table")
+    args = ap.parse_args()
+
+    result = analyze(args.manuscript)
+
+    if not args.quiet:
+        print("=" * 41)
+        print(" Scope Coherence (§D)")
+        print("=" * 41)
+        print(render(result))
+        print()
+        s = result["summary"]
+        if s["n_major"]:
+            print(f"MAJOR candidate: {s['n_major']} endpoint↔conclusion scope mismatch(es).")
+        else:
+            print("OK: conclusion scope matches the design/endpoint.")
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(f"\nwrote {args.out}")
+
+    return 1 if (args.strict and result["summary"]["n_major"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/self-review/tests/fixtures/scope_bad.md
+++ b/skills/self-review/tests/fixtures/scope_bad.md
@@ -1,0 +1,9 @@
+# Methods
+
+This was a cross-sectional study of health-screening participants assessed at a
+single visit.
+
+# Conclusion
+
+Individuals with a negative scan may safely extend their screening interval, and
+routine surveillance can be deferred.

--- a/skills/self-review/tests/fixtures/scope_clean.md
+++ b/skills/self-review/tests/fixtures/scope_clean.md
@@ -1,0 +1,8 @@
+# Methods
+
+This was a longitudinal cohort followed prospectively for ten years.
+
+# Conclusion
+
+Higher coronary calcium scores were associated with incident cardiovascular
+events over the follow-up period.

--- a/skills/self-review/tests/fixtures/scope_surrogate.md
+++ b/skills/self-review/tests/fixtures/scope_surrogate.md
@@ -1,0 +1,8 @@
+# Methods
+
+The primary endpoint was a longitudinal cohort outcome over ten years.
+
+# Conclusion
+
+Because coronary calcium was categorized as present versus absent, a binary
+surrogate, statin therapy can be deferred in calcium-negative individuals.

--- a/skills/self-review/tests/test_reviewer_team_consistency.sh
+++ b/skills/self-review/tests/test_reviewer_team_consistency.sh
@@ -92,6 +92,47 @@ python3 "$SCRIPT" --manuscript "$TMP/c4.md" \
     --out "$TMP/c4.md.audit" --quiet
 assert_exit "case 4: single confession only (PASS)" 0 $?
 
+# --------------------------------------------------------------------------
+# Case 5: extraction JSON names an LLM as a reviewer => fatal FAIL.
+# --------------------------------------------------------------------------
+cat > "$TMP/c5.md" <<'EOF'
+## **METHODS**
+Records were screened against pre-specified eligibility criteria.
+EOF
+cat > "$TMP/c5_extract.json" <<'EOF'
+{"study": "Example 2024", "reviewer_1": "Claude", "reviewer_2": "Jane Doe"}
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c5.md" --extraction-json "$TMP/c5_extract.json" \
+    --out "$TMP/c5.md.audit" --quiet
+assert_exit "case 5: LLM-as-reviewer in extraction JSON (FAIL)" 1 $?
+grep -q "LLM-AS-REVIEWER" "$TMP/c5.md.audit" || { echo "  FAIL c5 markdown body"; fail=$((fail + 1)); }
+
+# --------------------------------------------------------------------------
+# Case 6: future-tense deferred mitigation => MAJOR FAIL.
+# --------------------------------------------------------------------------
+cat > "$TMP/c6.md" <<'EOF'
+## **METHODS**
+Records were screened by the primary reviewer.
+
+## **DISCUSSION**
+### Limitations
+A duplicate-screening check will be completed before submission.
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c6.md" \
+    --out "$TMP/c6.md.audit" --quiet
+assert_exit "case 6: deferred mitigation (FAIL)" 1 $?
+grep -q "DEFERRED-MITIGATION" "$TMP/c6.md.audit" || { echo "  FAIL c6 markdown body"; fail=$((fail + 1)); }
+
+# --------------------------------------------------------------------------
+# Case 7: clean extraction JSON (human reviewers) => PASS (backward compat).
+# --------------------------------------------------------------------------
+cat > "$TMP/c7_extract.json" <<'EOF'
+{"study": "Example 2024", "reviewer_1": "Jane Doe", "reviewer_2": "John Roe"}
+EOF
+python3 "$SCRIPT" --manuscript "$TMP/c1.md" --extraction-json "$TMP/c7_extract.json" \
+    --out "$TMP/c7.md.audit" --quiet
+assert_exit "case 7: human reviewers in extraction JSON (PASS)" 0 $?
+
 echo ""
 echo "ran=$ran fail=$fail"
 [[ $fail -eq 0 ]]

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression test for the scope-coherence gate (self-review §D).
+# Synthetic, PII-free fixtures reproduce: (a) a cross-sectional design with a
+# prognostic/surveillance conclusion (CROSS_SECTIONAL_PROGNOSTIC), (b) a binary
+# surrogate endpoint driving a care directive (SURROGATE_CARE_DIRECTIVE). The clean
+# fixture is a longitudinal cohort with an association conclusion.
+# Stdlib-only (python3).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_scope_coherence.py"
+BAD="$HERE/fixtures/scope_bad.md"
+SURR="$HERE/fixtures/scope_surrogate.md"
+CLEAN="$HERE/fixtures/scope_clean.md"
+OUT="$(mktemp -t scope_XXXX).json"
+trap 'rm -f "$OUT"' EXIT
+
+fail=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+has_verdict() { python3 -c "
+import json,sys
+d=json.load(open('$OUT'))
+assert any(c['verdict']=='$1' for c in d['claims']), '$1 not found'
+"; }
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+# (1) cross-sectional + prognostic conclusion -> CROSS_SECTIONAL_PROGNOSTIC, exit 1
+python3 "$SCRIPT" --manuscript "$BAD" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 (cross-sectional prognostic)" test "$?" -eq 1
+check "CROSS_SECTIONAL_PROGNOSTIC detected" has_verdict CROSS_SECTIONAL_PROGNOSTIC
+
+# (2) binary surrogate + care directive -> SURROGATE_CARE_DIRECTIVE, exit 1
+python3 "$SCRIPT" --manuscript "$SURR" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 (surrogate care directive)" test "$?" -eq 1
+check "SURROGATE_CARE_DIRECTIVE detected" has_verdict SURROGATE_CARE_DIRECTIVE
+
+# (3) longitudinal cohort + association conclusion -> exit 0
+python3 "$SCRIPT" --manuscript "$CLEAN" --strict --quiet >/dev/null 2>&1
+check "exit 0 on clean manuscript" test "$?" -eq 0
+
+echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -77,6 +77,13 @@ The registry is a project-local YAML mapping author identifiers (full names, nat
 - Gate 9 (Phase 6 intra-manuscript scope drift): run `scripts/scope_drift_check.py` against the manuscript (and optionally the PROSPERO record). Numeric anchors (AUC, OR/HR/RR, sensitivity/specificity) appearing in Limitations / Discussion but absent from Methods + Results are P0 SCOPE_DRIFT. PROSPERO ↔ Methods synthesis-method disagreement is a P0 PROSPERO_DRIFT.
 - Gate 10 (Phase 7 v_(N+1) docx regeneration): when building a new submission from a frozen prior version, run `scripts/verify_package_integrity.py --assert-vN-docx-changed --vN-docx <prev>.docx --new-docx <next>.docx`. Identical MD5 = unmodified seed copy = block submission. Defense-in-depth — required even when the upstream pipeline appears to have regenerated the docx.
 - Gate 11 (Phase 8 multi-copy divergence): when the project hand-maintains more than one manuscript copy (working SSOT, circulation, portal), run `scripts/detect_copy_divergence.py --ssot <ssot>.md --copy <copy>.md ...` before freeze or circulation. Any `STALE_COPY` (an SSOT numeric claim or heading that did not propagate to a copy) is a P0 drift. See "Phase 8 — Multi-copy manuscript divergence" below.
+- Gate 12 (target-journal metadata drift): on `build` / retarget, cross-check the target the manuscript is written *for* against the target the project is being submitted *to*. Compare `project.yaml` `target` (and any in-manuscript header/footer "for submission to X" string) against the journal the package is built for, and check the structural metadata the target dictates — abstract heading structure (4- vs 5-heading), body word limit, citation style (Vancouver / AMA), required elements (Highlights / Central Illustration / Key Points). A mismatch (e.g., a header still reading the previous journal after a cascade retarget, or a 4-heading abstract for a 5-heading target) is a target-restructure trigger — branch to v_(N+1) per `manuscript-versioning.md` §2 and sync every sidecar (cover letter, title page, ICMJE COI list) — not a silent build.
+
+  ```bash
+  # header target vs project.yaml target
+  TGT=$(python3 -c "import yaml;print(yaml.safe_load(open('project.yaml')).get('target',''))" 2>/dev/null)
+  grep -niE 'for submission to|submitted to|prepared for' manuscript/manuscript.md   # compare against "$TGT"
+  ```
 
 ## Phase 4 — Cover-letter free-text drift
 

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -307,6 +307,7 @@ Write the Discussion using the inverted funnel structure:
 **Rules:**
 - Do not introduce new data not presented in Results.
 - Avoid overclaiming: language must match evidence level.
+- **Endpoint↔conclusion scope.** The Clinical-implications and Conclusion sentences must not exceed what the design and endpoint support. A cross-sectional / single-visit / prevalence study cannot license a prognostic or surveillance claim (a rescreen interval, disease progression, predicting future risk) — that requires longitudinal follow-up. A binary surrogate endpoint (present/absent, >0, dichotomized) is risk stratification, not a patient-care directive (defer/withhold/initiate therapy). `/self-review` §D (`check_scope_coherence.py`) flags `CROSS_SECTIONAL_PROGNOSTIC` / `SURROGATE_CARE_DIRECTIVE`; keep the conclusion verb inside the design's reach.
 - Acknowledge alternative explanations for key findings.
 - Each comparison with prior work must cite the specific study.
 - NO "interestingly," "notably," "it is worth noting" — state the point directly.


### PR DESCRIPTION
## What

Lands **P2 (6 gates)** from the same cross-project panel review, building on the P1 gates (#83). Continues the pattern: deterministic where the signal is clean, prose/probe where the call is judgmental.

## Gates

| Item | Skill(s) | Change |
|---|---|---|
| **P2-C** | self-review | `check_reviewer_team_consistency.py` extended to the prose↔JSON↔confession 3-way: **LLM-as-reviewer** (an extraction-JSON reviewer field naming Claude/GPT/Gemini → fatal) and **deferred mitigation** ("will be completed before submission" → Major). New `--extraction-json`; existing dual/single contract preserved. |
| **P2-A** | self-review, design-study, write-paper | New `check_scope_coherence.py`: **CROSS_SECTIONAL_PROGNOSTIC** + **SURROGATE_CARE_DIRECTIVE** (fires only when a design/endpoint signal and a conclusion action verb co-occur). |
| **P2-B** | design-study, survival probe | Time-origin & survivorship (immortal-time, left-truncation, mediator-window survivorship, complete-case primary selection); S1 probe gains a "not formally assessed" self-confession escalation. Probe edited canonically + vendored byte-identical. |
| **P2-D** | analyze-stats | Strata disjointness gate before Cochran-Armitage; secondary stratum-HR checklist (referent + events + sparse caveat); proportion CI lower-bound clamp to `max(0,.)`. |
| **P2-E** | meta-analysis | FINAL_POOL_LOCK extends to patient/lesion aggregate totals (arm-separable vs both-arm); a "fixed"/"resolved" audit note requires re-run evidence. |
| **P2-F** | self-review, sync-submission | self-review Phase 1 SSOT multi-copy gate (run `detect_copy_divergence.py` before a single-file review); sync-submission Gate 12 target-journal metadata drift. |

## Verification

Full CI mirror green + **24/24** skill tests (3 new/extended: scope-coherence, reviewer-team 3-way, cohort/coverage regression; plus meta-analysis + sync-submission regression). Domain-probe byte-identity preserved. No catalog/skill-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
