### PR TITLE
feat: P3 style/method gates (classical-style lint, survival IC/PH/CIF, PROSPERO ID, k<4 subgroup, construct concordance)

### DIFF
--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -44,6 +44,7 @@
 
 - `check_artifact_coverage.py`
 - `check_claim_artifact.py`
+- `check_classical_style.py`
 - `check_cohort_arithmetic.py`
 - `check_confounding_completeness.py`
 - `check_reviewer_team_consistency.py`

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -425,6 +425,8 @@ tbl %>% as_flex_table() %>% flextable::save_as_docx(path = "table.docx")
 - Cox proportional hazards: report HR (95% CI)
 - **Events-per-variable (EPV) gate**: check `events / n_covariates >= 10` before fitting Cox (mirror of the logistic EPV rule). Warn if violated and fall back to a Firth/penalized Cox or profile-likelihood CIs; do not report Wald CIs from a sparse-event model as if stable
 - Check proportional hazards assumption (Schoenfeld residuals)
+- **PH violation → do not report a single time-averaged HR.** If the Schoenfeld global test is significant (or a covariate's residual trends with time), a single Cox HR averages a changing effect and is misleading. Report a piecewise / time-stratified HR (split follow-up at a clinically sensible cut, or `tt()` time-transform), or switch to RMST difference at a fixed horizon, and state the violation explicitly
+- **Horizon vs follow-up.** Do not read a KM/CIF estimate at a horizon beyond the data: if a reported time point (e.g., a 15-year cumulative incidence) exceeds the reverse-KM median follow-up, either restrict the horizon to where the risk set is non-trivial or report the number-at-risk at that horizon so the reader can judge the extrapolation
 - Report median survival with 95% CI
 - **Warranty period / quantile estimands (T25 etc.)**: Time to a fixed cumulative incidence. Use `quantile()` from the KM/`survfit` object and **always emit the 95% CI** (the lower/upper from `quantile(km, conf.int=TRUE)`, or a log-transformed / bootstrap CI) alongside the events/n that define it. A quantile point estimate reported without its CI is incomplete. If the event rate is below the target quantile, report "not reached" and consider Weibull parametric extrapolation (also with an interval)
 
@@ -437,6 +439,8 @@ When exact event times are unknown (e.g., health screening cohorts where status 
 - **Parametric IC models**: Weibull or log-logistic via `icenReg::ic_par()`. Report shape/scale parameters and compare AIC across distributions
 - **Mid-point imputation**: Simple approximation — event time = midpoint of (last negative, first positive). Acceptable as sensitivity analysis but NOT as primary method
 - **When to use**: Serial measurement cohorts (e.g., health screening databases), cancer screening intervals, repeated biomarker assessments
+- **Auto-trigger**: if the event date is defined by a periodic visit / scheduled re-examination (the event is detected *at* a visit, not observed exactly), interval-censoring is not optional — make an IC model the **primary** analysis, or at minimum a mandatory pre-specified sensitivity analysis, and do not present a right-censored Cox `coxph()` on visit-dated events as if the times were exact
+- **Multistate / transition models**: for repeated transitions (e.g., `msm`), account for subject-level clustering with a subject random effect or a sandwich (robust) variance, and check the time-homogeneity assumption (constant transition intensities) before trusting a single rate
 - **Reporting**: State the interval-censored nature of the data explicitly in Methods. Report both standard KM (for comparability with prior literature) and IC estimates (as primary or sensitivity)
 
 ### Competing Risks
@@ -448,7 +452,7 @@ When death or other events preclude the outcome of interest, standard KM overest
 - **Fine-Gray subdistribution hazard**: `cmprsk::crr()` or `tidycmprsk::crr()` — reports subdistribution HR (sHR) with 95% CI. Interpretable as effect on CIF directly. **Check the subdistribution-PH assumption** the same way you check it for Cox (a time-interaction term on the subdistribution scale, or inspection of scaled-residual analogues); a constant sHR is an assumption, not a given. Report the cause-specific HR alongside it so the etiologic and prognostic readings are both visible
 - **Cause-specific Cox**: Standard Cox censoring competing events — reports cause-specific HR. Better for etiology; Fine-Gray better for prognosis/prediction
 - **When to use**: Mortality studies with multiple causes of death, cardiovascular events when non-CV death is frequent, any outcome where competing events are common (>5% of total events)
-- **Reporting**: Present CIF plots (NOT 1-KM) when competing risks exist. Report both cause-specific HR and subdistribution HR when the research question is etiologic. State which competing events were defined
+- **Reporting**: Present CIF plots (NOT 1-KM) when competing risks exist. Report both cause-specific HR and subdistribution HR when the research question is etiologic. State which competing events were defined. When a CIF is quoted at a horizon beyond the median follow-up, report the number-at-risk at that horizon (or restrict the horizon) — a CIF extrapolated past the data is not a stable estimate
 
 ### Group Comparison
 

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -188,6 +188,12 @@ Methods and the registry record (PROSPERO PDF, ClinicalTrials.gov export) — si
 discrepancy is a finding; (5) retrospective-registration disclosure paragraph when
 evidence suggests post-extraction filing.
 
+**Registration-ID format gate:** a PROSPERO ID is `CRD42` + 9 digits = 14 characters
+(`^CRD42\d{9}$`, e.g. `CRD42024500001`). Run `grep -oE 'CRD42[0-9]+' manuscript.md` and
+assert each match is 14 characters long; a 15-character ID (a stray inserted digit) is a
+transcription error logged as `[REGISTRATION-TIMING]` (`fixable_by_ai: false` — verify against
+the live PROSPERO record, do not guess the correct digit).
+
 **Flagging:** any failure is logged in Part C Action Items with label
 `[REGISTRATION-TIMING]`. `fixable_by_ai: false` when reconciliation requires an external
 amendment filing; `true` only when the fix is a Methods-text insertion of a date already

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -133,6 +133,9 @@ Check:
 - when it was established
 - whether blinding was possible
 - whether only a subset had gold standard verification
+- **Construct ↔ nominal-definition match.** Does the exposure/finding *construct* stay inside its stated definition, or does it quietly exceed it? An "incidentaloma" defined as an *indeterminate* finding must not include frank malignancy reads; a label that overshoots its definition inflates the apparent cohort and breaks the κ. For each construct, restate the nominal definition and confirm every included case satisfies it.
+- **Per-flag reference-standard concordance.** When the index finding is flagged against a reference standard, report the concordance *per flag category* (not just overall). A construct where a large fraction of flags do not match the reference standard (e.g., ~86% non-match) is measuring something other than the named construct.
+- **Manuscript definition ↔ `variable_operationalization.md`.** The variable definitions written in Methods must match the operationalization table verbatim (dictionary-first). A blinded re-classification form must quote the analytic protocol's definition verbatim — paraphrase / "common-sense extension" in the form (but not the Methods) is the documented cause of a low κ that is a *definition mismatch*, not real disagreement. Cross-check with `/define-variables` output before drafting.
 
 #### D. Validation
 

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -396,6 +396,8 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/dta_extraction_qc.py" \
 
 Any `FLAG_SWAP` or `FLAG_MISMATCH` row requires third-reviewer adjudication before Phase 6 statistical synthesis.
 
+**Flag → form-edit forced transition.** A confirmed flag is not resolved until the extraction form itself is edited. Track each flag through `confirmed → acted`: after the adjudicator confirms a `FLAG_SWAP`/`FLAG_MISMATCH`/unit-of-analysis violation, the extraction CSV row MUST be corrected and the QC re-run to clear it. A flag that is "confirmed" but whose form row is unchanged (the correction lived only in a review note) silently re-enters synthesis. Verify the form's mtime advanced and the re-run QC shows zero open flags before locking.
+
 **2. Cohort Overlap Check** -- `scripts/cohort_overlap_check.py`:
 
 Clusters included studies by (a) shared public ICU/EHR database (MIMIC-IV, eICU, MIMIC-III, KNHIS, UK Biobank, Optum, MarketScan, TriNetX, IBM), (b) same institution + overlapping enrollment period, (c) shared first-author surname + ±2y year proximity. Flags HIGH / MEDIUM overlap confidence.
@@ -662,15 +664,19 @@ Synthesized from recent SR-MA peer-review cycles. Drives the Phase 4 extraction 
 
 3. **Diagnostic subset N transparency** in mixed DTA + prognostic MAs: report `sample_n_dta_pool` separately from `sample_n_prognostic_pool` with explicit prevalence. Aggregate N in Abstract misleads readers about diagnostic-subset power.
 
-4. **k=1 subgroups are not robust**: any subgroup p-value driven by a single included study must be reframed as exploratory or removed from formal subgroup test. Post-hoc subgroups require PROSPERO amendment with visible record.
+4. **Small-k subgroups are not robust (k < 4)**: a subgroup test driven by a single study (k=1) is descriptive-only, and the same caution extends to k=2–3 — heterogeneity and the trend are not estimable from so few strata. Any subgroup with k < 4 must be labelled descriptive / exploratory rather than entered into a formal subgroup interaction test. Post-hoc subgroups require a PROSPERO amendment with a visible record.
 
 5. **Supplementary 8-file package** is the minimum bar for high-impact journals: PRISMA checklist, PROSPERO PDF, full search strategy, full-text exclusion list with reasons, per-study extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication-bias analyses. See `templates/supplementary_8file_checklist.md`.
 
-6. **PROSPERO 13-char ID format** (`CRD42` + YYYY + 6-digit sequential); pre-2020 IDs may be 12 chars. Non-numeric tails or >13 chars are format anomalies. Request live registration URL in cover letter for protocol cross-check.
+6. **PROSPERO 14-char ID format** (`^CRD42\d{9}$` = `CRD42` + 4-digit year + 5-digit sequence, e.g. `CRD42024500001`). A 15-character ID is a stray-digit transcription error; pre-2020 IDs may be shorter. Validate with `grep -oE 'CRD42[0-9]+'` + length assert, and request the live registration URL in the cover letter for protocol cross-check.
 
 7. **AI Disclosure presence** for SR-MA submissions to RYAI / Radiology / RSNA / Lancet / JAMA / BMJ / Nature families. Absence triggers MINOR-to-MAJOR finding at peer review.
 
 8. **Sensitivity analyses are recomputed, not copied** (Phase 6b rule 5). Leave-one-out / erosion / alternative-model effect sizes identical to the primary analysis to 2 decimals across ≥4 values means the recomputation did not run. Re-derive from the modified dataset; the inputs (means/SDs/counts) change even when the effect size is close.
+
+9. **Outcome harmonization before pooling.** Studies that report the same-named outcome under different definitions (an imaging-detected event vs a clinically diagnosed one; different thresholds) must not be presented as a single pooled range or pooled estimate. Split by ascertainment method (or pool only the harmonizable subset) and state the definition per stratum — a "6.9–46%" range that silently mixes imaging-detected and clinical events is a heterogeneity artifact, not a finding.
+
+10. **Heterogeneous RoB instruments → no single pooled κ.** When studies are assessed with different risk-of-bias tools (QUADAS-2 for DTA + NOS for cohorts, etc.), do not report one pooled inter-rater κ across the mixed set. Report agreement per instrument, and use an ordinal weighted κ when the domain judgments are ordered (low/some/high). A single κ over a heterogeneous instrument set is uninterpretable.
 
 9. **Prognostic / survival-outcome MAs carry survival-specific concerns** beyond the DTA pitfalls: censoring handling, competing risks (cause-specific vs Fine-Gray), cutoff-derivation optimism, comparator time-horizon alignment, C-index variant transparency (Harrell vs Uno vs IPCW), and calibration beyond discrimination. When pooling prognostic models, pre-specify these in the protocol and report them per study; for the reviewing counterpart see the survival/prognostic 7-probe in `/peer-review`.
 

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -101,6 +101,8 @@ Auto-detect type from the research question or accept user specification.
    - Read `${CLAUDE_SKILL_DIR}/references/PROSPERO_template.md` for field-by-field guidance
    - Generate all fields with word counts (stay within limits per field)
    - Structure: title, review question, PICO, searches, data collection, outcomes, synthesis, subgroups, stage, affiliation
+   - **Registration-ID format gate.** A PROSPERO ID is `CRD42` + 9 digits (14 characters total), e.g. `CRD42024500001`. Validate any ID that appears in the manuscript or registration doc with `grep -oE 'CRD42[0-9]+'` and assert a 14-character length / `^CRD42\d{9}$` — a 15-character ID (a stray digit) is a transcription error a reviewer will check against the live record.
+   - **Review-type selection.** Pick the *least-wrong* portal review type for the actual design and state any portal constraint in the protocol. A descriptive single-arm proportion synthesis is not an "Intervention review"; choosing "Intervention review" only to satisfy a portal field contradicts a later GRADE / effect-certainty statement. Whatever certainty language the protocol commits to (GRADE vs "evidence statements only") must match the manuscript verbatim — a guideline-style "we recommend" is not licensed by a descriptive review type.
    - For mixed designs (comparative + single-arm): explicitly address comparator for both arms
    - For RoB: map tool to study design (NOS for comparative, JBI for case series → select "Other" in form)
    - Output: Markdown + DOCX (via pandoc) for copy-paste into PROSPERO web form

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -198,6 +198,16 @@ before submission for item-level assessment."
 | Model provenance | Is it clear where the model came from? (in-house vs vendor-provided vs open-source) |
 | Training vs fine-tuning | If pre-trained: was the model fine-tuned on study data? If vendor-provided: any access to training data composition? |
 | Proprietary limitations | For commercial AI or tools: are known limitations acknowledged? Can results be independently reproduced? |
+| Classical-style body conventions | Does the body carry an AI tell or a policy violation a senior reviewer flags on sight — a `§` symbol, an in-body AI-disclosure paragraph, eligibility criteria as prose, mixed OR/HR decimal places, or em-dash overuse? |
+
+Run the deterministic classical-style lint (these are all greps, so they belong in a gate, not eyeballing):
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_classical_style.py" \
+  --manuscript manuscript.md --out qc/classical_style.json --strict
+```
+
+`SECTION_SYMBOL` and `INBODY_AI_DISCLOSURE` are Major (the `§` count must be 0; the AI-disclosure paragraph belongs on the title page for a classical / senior-MA target, not the body). `ELIGIBILITY_PROSE`, `DECIMAL_INCONSISTENCY`, and `EM_DASH_OVERUSE` are Minor. This is the self-review-side mirror of `/write-paper` Step 7.1's classical QC (manuscript-style-classical §5/§6/§7/§8).
 
 #### K. Reviewer-team consistency (SR/MA-only; fabrication-grade)
 

--- a/skills/self-review/scripts/check_classical_style.py
+++ b/skills/self-review/scripts/check_classical_style.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Classical-style body lint (self-review §J / write-paper Phase 7.1).
+
+A senior meta-analysis reviewer reads several surface signals as "AI wrote this"
+or as a policy violation. They are all deterministic greps, so they belong in a
+gate rather than a prose checklist (manuscript-style-classical.md §5/§6/§7/§8):
+
+  SECTION_SYMBOL        (Major) the § symbol anywhere in the body — the canonical
+                        AI tell; also catches "see Methods §2" self-references.
+  INBODY_AI_DISCLOSURE  (Major) an AI/LLM-use disclosure paragraph in the body
+                        ("Generative AI was not used", "During the preparation of
+                        this manuscript the authors used …"). For a classical /
+                        senior-MA target this belongs on the title page, not the body.
+  ELIGIBILITY_PROSE     (Minor) eligibility/inclusion criteria written as a prose
+                        sentence rather than a numbered list.
+  DECIMAL_INCONSISTENCY (Minor) OR/HR/RR reported with mixed decimal places (some
+                        2 dp, some 3 dp) in the same manuscript.
+  EM_DASH_OVERUSE       (Minor) more than 25 em-dashes — a generation tell.
+
+INPUTS
+  --manuscript   manuscript markdown/text (required).
+  --em-dash-max  em-dash threshold (default 25).
+
+OUTPUT
+  A reconciliation table (stdout) and, with --out, a JSON artifact:
+    {manuscript, claims[{verdict, severity, detail, where}], summary}
+  Exit 1 (with --strict) when any Major-severity claim exists (§ symbol or in-body
+  AI disclosure).
+
+Stdlib-only (json / re / argparse / pathlib). Exit codes: 0 clean (or report-only),
+1 Major claim(s) found (with --strict), 2 input/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+INBODY_AI_DISCLOSURE = re.compile(
+    r"generative ai was not used|artificial intelligence disclosure|"
+    r"during the preparation of (?:this|the) (?:manuscript|work|study)[^.]{0,120}?"
+    r"(?:used|use[d]?|employed)[^.]{0,60}?(?:ai|gpt|chatgpt|claude|copilot|gemini|language model)",
+    re.IGNORECASE)
+
+ELIGIBILITY_LEAD = re.compile(
+    r"(?:studies|articles|records|participants|patients|trials)\s+were\s+eligible\s+if|"
+    r"eligibility criteria were|inclusion criteria (?:were|included)|"
+    r"(?:studies|articles) were included if",
+    re.IGNORECASE)
+NUMBERED_MARKER = re.compile(r"\(\s*1\s*\)|\(\s*i\s*\)|(?:^|\s)1\.\s")
+
+EFFECT_DECIMAL = re.compile(
+    r"(?:\b(?:a?OR|a?HR|RR|sHR)\b|\bodds ratio\b|\bhazard ratio\b|\brisk ratio\b)"
+    r"\s*(?:of|was|were|=|:|,)?\s*(\d+\.(\d+))", re.IGNORECASE)
+
+
+def check(text: str, em_dash_max: int) -> list[dict]:
+    claims = []
+
+    # SECTION_SYMBOL (Major)
+    if "§" in text:
+        n = text.count("§")
+        first = text.find("§")
+        claims.append({
+            "verdict": "SECTION_SYMBOL",
+            "severity": "Major",
+            "detail": f"the § symbol appears {n} time(s) — a senior-reviewer AI tell; "
+                      f"replace with the section name (manuscript-style-classical §6)",
+            "where": text[max(0, first - 30):first + 20].replace("\n", " ").strip()[:120],
+        })
+
+    # INBODY_AI_DISCLOSURE (Major)
+    m = INBODY_AI_DISCLOSURE.search(text)
+    if m:
+        claims.append({
+            "verdict": "INBODY_AI_DISCLOSURE",
+            "severity": "Major",
+            "detail": "an AI/LLM-use disclosure paragraph is in the body; for a classical / "
+                      "senior-MA target it belongs on the title page (manuscript-style-classical §7)",
+            "where": m.group(0)[:120],
+        })
+
+    # ELIGIBILITY_PROSE (Minor)
+    em = ELIGIBILITY_LEAD.search(text)
+    if em and not NUMBERED_MARKER.search(text[em.start():em.start() + 320]):
+        claims.append({
+            "verdict": "ELIGIBILITY_PROSE",
+            "severity": "Minor",
+            "detail": "eligibility/inclusion criteria are written as prose; senior reviewers "
+                      "expect a numbered list (1)…(2)…(3) (manuscript-style-classical §5)",
+            "where": em.group(0)[:120],
+        })
+
+    # DECIMAL_INCONSISTENCY (Minor)
+    dps = {len(mm.group(2)) for mm in EFFECT_DECIMAL.finditer(text)}
+    if len(dps) > 1:
+        claims.append({
+            "verdict": "DECIMAL_INCONSISTENCY",
+            "severity": "Minor",
+            "detail": f"OR/HR/RR reported with mixed decimal places ({sorted(dps)}); "
+                      f"standardize (OR/HR to 2 dp)",
+            "where": "effect-size decimals",
+        })
+
+    # EM_DASH_OVERUSE (Minor)
+    n_dash = text.count("—")
+    if n_dash > em_dash_max:
+        claims.append({
+            "verdict": "EM_DASH_OVERUSE",
+            "severity": "Minor",
+            "detail": f"{n_dash} em-dashes (> {em_dash_max}); a generation tell — "
+                      f"replace some with commas/colons or split sentences",
+            "where": f"{n_dash} em-dashes",
+        })
+
+    return claims
+
+
+def analyze(manuscript: str, em_dash_max: int) -> dict:
+    p = Path(manuscript)
+    if not p.is_file():
+        sys.stderr.write(f"ERROR: manuscript not found: {manuscript}\n")
+        sys.exit(2)
+    claims = check(p.read_text(encoding="utf-8"), em_dash_max)
+    n_major = sum(1 for c in claims if c["severity"] == "Major")
+    return {
+        "manuscript": str(p),
+        "claims": claims,
+        "summary": {
+            "n_claims": len(claims),
+            "n_major": n_major,
+            "n_flag": len(claims) - n_major,
+            "verdict": "MAJOR_CANDIDATE" if n_major else ("FLAG" if claims else "OK"),
+        },
+    }
+
+
+def render(result: dict) -> str:
+    lines = ["| Check | Severity | Detail |", "|---|---|---|"]
+    for c in result["claims"]:
+        lines.append(f"| {c['verdict']} | {c['severity']} | {c['detail']} |")
+    if len(lines) == 2:
+        lines.append("| (none) | — | classical-style body conventions satisfied |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Classical-style body lint (§J).")
+    ap.add_argument("--manuscript", required=True, help="manuscript markdown/text")
+    ap.add_argument("--em-dash-max", type=int, default=25, help="em-dash threshold (default 25)")
+    ap.add_argument("--out", help="write JSON artifact to this path")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any Major claim exists")
+    ap.add_argument("--quiet", action="store_true", help="suppress stdout table")
+    args = ap.parse_args()
+
+    result = analyze(args.manuscript, args.em_dash_max)
+
+    if not args.quiet:
+        print("=" * 41)
+        print(" Classical-Style Body Lint (§J)")
+        print("=" * 41)
+        print(render(result))
+        print()
+        s = result["summary"]
+        if s["n_major"]:
+            print(f"MAJOR candidate: {s['n_major']} policy/AI-tell violation(s).")
+        elif s["n_flag"]:
+            print(f"FLAG: {s['n_flag']} style inconsistency(ies).")
+        else:
+            print("OK: classical-style body conventions satisfied.")
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(f"\nwrote {args.out}")
+
+    return 1 if (args.strict and result["summary"]["n_major"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/self-review/tests/fixtures/style_bad.md
+++ b/skills/self-review/tests/fixtures/style_bad.md
@@ -1,0 +1,13 @@
+# **METHODS**
+
+Studies were eligible if they reported a diagnostic accuracy estimate and enrolled
+adult participants with the target condition.
+
+Outcome definitions are given in Methods §2.
+
+The adjusted odds ratio was 1.25 and the hazard ratio was 2.305.
+
+# **DISCUSSION**
+
+During the preparation of this manuscript, the authors used a generative AI tool to
+assist with language editing. Generative AI was not used to create any figures.

--- a/skills/self-review/tests/fixtures/style_clean.md
+++ b/skills/self-review/tests/fixtures/style_clean.md
@@ -1,0 +1,11 @@
+# **METHODS**
+
+Studies were eligible if they met the following criteria: (1) reported a diagnostic
+accuracy estimate; (2) enrolled adult participants; (3) used an acceptable reference
+standard.
+
+The adjusted odds ratio was 1.25 and the hazard ratio was 2.30.
+
+# **DISCUSSION**
+
+These findings extend prior work on the target condition and support further study.

--- a/skills/self-review/tests/test_classical_style.sh
+++ b/skills/self-review/tests/test_classical_style.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression test for the classical-style body lint (self-review §J).
+# Synthetic, PII-free fixtures reproduce: a § symbol self-reference + an in-body
+# AI-disclosure paragraph (both Major), eligibility prose, and mixed OR/HR decimals
+# (Minor). The clean fixture uses a numbered eligibility list, consistent decimals,
+# no § symbol, and no in-body disclosure.
+# Stdlib-only (python3).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_classical_style.py"
+BAD="$HERE/fixtures/style_bad.md"
+CLEAN="$HERE/fixtures/style_clean.md"
+OUT="$(mktemp -t style_XXXX).json"
+trap 'rm -f "$OUT"' EXIT
+
+fail=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+has_verdict() { python3 -c "
+import json,sys
+d=json.load(open('$OUT'))
+assert any(c['verdict']=='$1' for c in d['claims']), '$1 not found'
+"; }
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+# (1) bad manuscript: Major (§ + in-body disclosure) -> exit 1
+python3 "$SCRIPT" --manuscript "$BAD" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 under --strict (Major present)" test "$?" -eq 1
+check "JSON artifact written" test -s "$OUT"
+check "SECTION_SYMBOL detected"        has_verdict SECTION_SYMBOL
+check "INBODY_AI_DISCLOSURE detected"  has_verdict INBODY_AI_DISCLOSURE
+check "ELIGIBILITY_PROSE detected"     has_verdict ELIGIBILITY_PROSE
+check "DECIMAL_INCONSISTENCY detected" has_verdict DECIMAL_INCONSISTENCY
+
+# (2) clean manuscript: numbered eligibility, consistent decimals, no §/disclosure -> exit 0
+python3 "$SCRIPT" --manuscript "$CLEAN" --strict --quiet >/dev/null 2>&1
+check "exit 0 on clean manuscript" test "$?" -eq 0
+
+echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -362,6 +362,7 @@ Scan for and remove AI writing patterns (see AI Pattern Avoidance below). Edit `
 | Trigger | Action |
 |---------|--------|
 | Manuscript 유형 = MA, systematic review, 또는 senior co-author review가 예정됨 | `references/section_guides/step7_1_classical_qc.md` 로드 → 7개 grep 점검 (§ 기호, AI Disclosure 단락, heading style, eligibility numbered list, Funding placeholder, PROSPERO chronology, em-dash 남용) 일괄 실행 |
+| 결정론 lint으로 한 번에 검증 | `python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_classical_style.py" --manuscript manuscript/manuscript.md --strict` — `SECTION_SYMBOL`/`INBODY_AI_DISCLOSURE`(Major) + `ELIGIBILITY_PROSE`/`DECIMAL_INCONSISTENCY`/`EM_DASH_OVERUSE`(Minor). 7-grep checklist과 같은 conventions의 machine-checkable subset. |
 | 글로벌 룰 cross-reference | `~/.claude/rules/manuscript-style-classical.md` (11항목 motivation) |
 | Pattern 19–21 본문 rewrite | `/humanize` (§, self-reference, AI Disclosure boilerplate) |
 


### PR DESCRIPTION
## What

Lands **P3 (5 gates)** — the final tier from the cross-project panel review (after P1 #83, P2 #84). These are the lower-frequency / judgment-weighted items, implemented deterministically where a grep is clean and as prose/probe where the call needs a human.

## Gates

| Item | Skill(s) | Change |
|---|---|---|
| **P3-B** | self-review, write-paper | New `check_classical_style.py`: `SECTION_SYMBOL` + `INBODY_AI_DISCLOSURE` (Major), `ELIGIBILITY_PROSE` / `DECIMAL_INCONSISTENCY` / `EM_DASH_OVERUSE` (Minor). §J + Step 7.1 wire it as the machine-checkable subset of the classical-QC checklist. |
| **P3-A** | analyze-stats | IC auto-trigger for visit-dated events; PH violation → piecewise/time-stratified HR (not a single averaged HR); CIF/KM horizon beyond median follow-up → number-at-risk or restrict; msm clustering + time-homogeneity. |
| **P3-C** | check-reporting, meta-analysis | PROSPERO ID format gate `^CRD42\d{9}$` (14 chars; a 15-char ID is a stray digit); review-type decision (least-wrong portal type; certainty language must match verbatim). |
| **P3-D** | meta-analysis | Lesson #4 extended to k<4 subgroups (descriptive-only); #6 PROSPERO length corrected to 14; new #9 outcome harmonization + #10 heterogeneous-RoB κ; Phase 4c flag→form-edit forced transition. |
| **P3-E** | design-study | Phase 2C: construct↔nominal-definition match, per-flag reference-standard concordance, manuscript-definition ↔ `variable_operationalization.md` (dictionary-first). |

## Verification

Full CI mirror green + **26/26** skill tests (1 new: classical-style; all P1/P2 regressions hold). Domain-probe byte-identity preserved. No catalog/skill-count change.

This completes the P1+P2+P3 improvement cycle (18/18 panel-derived items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
