### PR TITLE
feat: adoption & impact tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/used-in-research.yml
+++ b/.github/ISSUE_TEMPLATE/used-in-research.yml
@@ -1,0 +1,59 @@
+name: "📄 I used MedSci Skills in my research"
+description: Tell us how you used the toolkit so we can list it and learn what to improve.
+title: "[used-in-research] "
+labels: ["used-in-research"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using MedSci Skills! Sharing how you used it helps other
+        researchers discover the toolkit and helps us understand real-world use.
+        Only fill in what you are comfortable making public — everything here is
+        optional and you control what gets listed.
+  - type: textarea
+    id: how-used
+    attributes:
+      label: How did you use MedSci Skills?
+      description: Which skills, for what kind of study, at what stage (protocol, analysis, writing, submission)?
+      placeholder: "e.g., used /search-lit + /verify-refs for a diagnostic-accuracy review, and /check-reporting (STARD) before submission."
+    validations:
+      required: true
+  - type: input
+    id: work
+    attributes:
+      label: Associated work (optional)
+      description: A paper, preprint, thesis, protocol, registration (PROSPERO/ClinicalTrials), or downstream repository.
+      placeholder: "DOI, URL, or registry ID"
+    validations:
+      required: false
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Stage of the work
+      options:
+        - Planning / protocol
+        - Analysis
+        - Manuscript writing
+        - Submitted / under review
+        - Published
+        - Other
+    validations:
+      required: false
+  - type: dropdown
+    id: list-permission
+    attributes:
+      label: May we list this in docs/citations.md?
+      description: We never list anything without permission, and you can ask us to remove it at any time.
+      options:
+        - "Yes, list it (with the link above)"
+        - "Yes, but anonymously (no name/affiliation)"
+        - "No, this is just feedback"
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What worked well, and what should we improve? (optional)
+      description: Anything that helped, broke, or was missing.
+    validations:
+      required: false

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,75 @@
+name: metrics
+
+# Weekly adoption snapshot. GitHub only retains traffic (views/clones) for 14
+# days and exposes it to repo admins only — without this job that data is lost
+# every day. Appends one row per run to metrics/traffic_log.csv so the growth
+# curve survives as a durable, auditable record.
+#
+# Traffic endpoints (/traffic/views, /traffic/clones) require push access. The
+# default GITHUB_TOKEN may return 403; set a repo secret METRICS_PAT (a fine-
+# grained PAT with "Administration: read" on this repo) to capture them. Public
+# metrics (stars/forks/release downloads/Zenodo) work without any PAT.
+
+on:
+  schedule:
+    - cron: "17 3 * * 1" # every Monday 03:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    # Do not run on forks — only the canonical repo should append to the log.
+    if: github.repository_owner == 'Aperivue'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Capture metrics snapshot
+        env:
+          GH_TOKEN: ${{ secrets.METRICS_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Zenodo concept record id (the number in the concept DOI). Verify it
+          # resolves at https://zenodo.org/api/records/<id> before relying on the
+          # Zenodo columns; left blank-tolerant if the API call fails.
+          ZENODO_RECORD: "20155321"
+        run: |
+          set -uo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+
+          # --- Public repo metrics (always available) ---
+          REPO_JSON=$(gh api "repos/$REPO" 2>/dev/null || echo '{}')
+          STARS=$(echo "$REPO_JSON"  | jq -r '.stargazers_count // ""')
+          FORKS=$(echo "$REPO_JSON"  | jq -r '.forks_count // ""')
+          WATCH=$(echo "$REPO_JSON"  | jq -r '.subscribers_count // ""')
+          DL=$(gh api "repos/$REPO/releases" --paginate 2>/dev/null \
+                 | jq -s 'add // [] | [.[].assets[]?.download_count] | add // 0' || echo "")
+
+          # --- Traffic (needs push access; blank-tolerant on 403) ---
+          VJSON=$(gh api "repos/$REPO/traffic/views"  2>/dev/null || echo '{}')
+          CJSON=$(gh api "repos/$REPO/traffic/clones" 2>/dev/null || echo '{}')
+          VIEWS=$(echo "$VJSON"  | jq -r '.count // ""')
+          UVIEWS=$(echo "$VJSON" | jq -r '.uniques // ""')
+          CLONES=$(echo "$CJSON" | jq -r '.count // ""')
+          UCLONES=$(echo "$CJSON"| jq -r '.uniques // ""')
+
+          # --- Zenodo (public API, blank-tolerant) ---
+          ZJSON=$(curl -fsSL "https://zenodo.org/api/records/$ZENODO_RECORD" 2>/dev/null || echo '{}')
+          ZVIEWS=$(echo "$ZJSON" | jq -r '(.stats.version_views // .stats.views) // ""' 2>/dev/null || echo "")
+          ZDL=$(echo "$ZJSON"    | jq -r '(.stats.version_downloads // .stats.downloads) // ""' 2>/dev/null || echo "")
+
+          mkdir -p metrics
+          if [ ! -f metrics/traffic_log.csv ]; then
+            echo "date,stars,forks,watchers,release_downloads,views_14d,unique_views_14d,clones_14d,unique_clones_14d,zenodo_views,zenodo_downloads" > metrics/traffic_log.csv
+          fi
+          echo "$DATE,$STARS,$FORKS,$WATCH,$DL,$VIEWS,$UVIEWS,$CLONES,$UCLONES,$ZVIEWS,$ZDL" >> metrics/traffic_log.csv
+          echo "Appended: $DATE stars=$STARS forks=$FORKS downloads=$DL views=$VIEWS clones=$CLONES"
+
+      - name: Commit snapshot
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add metrics/traffic_log.csv
+          git diff --staged --quiet || git commit -m "chore(metrics): weekly adoption snapshot [skip ci]"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Adoption & impact tracking** — a public [`IMPACT.md`](IMPACT.md) dashboard, an automated weekly metrics snapshot (`.github/workflows/metrics.yml` → `metrics/traffic_log.csv`, capturing stars/forks/release-downloads/14-day traffic/Zenodo stats that GitHub otherwise discards after 14 days), a [`docs/citations.md`](docs/citations.md) ledger for academic citations and named downstream use, and a "Used in research" issue template (`.github/ISSUE_TEMPLATE/used-in-research.yml`) for collecting user reports. No skill behavior changes; catalog unchanged at 43 skills.
+
 ## [3.6.0] - 2026-06-06
 
 A 13-project panel self-review distilled 158 cross-project traces into 12 recurring defect patterns; this release lands the 18 resulting gates (P1/P2/P3) as deterministic, stdlib-only checks wherever a grep is clean, and as prose/probe guidance where the call needs a human. Six new detectors join the existing trio, each with PII-free synthetic fixtures and a regression test. Catalog unchanged at 43 skills — every addition is a check, probe, or convention inside an existing skill.

--- a/IMPACT.md
+++ b/IMPACT.md
@@ -1,0 +1,79 @@
+# Adoption & Impact
+
+This page tracks how MedSci Skills is used in the wild. It exists because GitHub
+discards traffic data after 14 days and surfaces it to repo admins only — without
+a durable record, the evidence of adoption disappears daily. Numbers here are
+honest snapshots, not marketing. Empty sections mean *not yet observed*, and they
+are expected to fill over time.
+
+How the numbers are captured:
+
+- **Automated**: a weekly workflow ([`.github/workflows/metrics.yml`](.github/workflows/metrics.yml))
+  appends a row to [`metrics/traffic_log.csv`](metrics/traffic_log.csv) — stars,
+  forks, release downloads, 14-day traffic, and Zenodo views/downloads.
+- **Manual**: academic citations and named downstream use are logged in
+  [`docs/citations.md`](docs/citations.md) as they are discovered.
+
+---
+
+## Snapshot
+
+*As of 2026-06-06 (repo created 2026-04-06 — roughly two months old):*
+
+| Signal | Value | Source |
+|---|---|---|
+| GitHub stars | 134 | repo API |
+| GitHub forks | 36 | repo API |
+| Release asset downloads (cumulative) | 220 | releases API |
+| Repo views (trailing 14 days) | 1,636 (560 unique) | traffic API |
+| Repo clones (trailing 14 days) | 8,566 (791 unique) | traffic API |
+| Zenodo archive | DOI [10.5281/zenodo.20155321](https://doi.org/10.5281/zenodo.20155321) | Zenodo |
+
+Trend over time lives in [`metrics/traffic_log.csv`](metrics/traffic_log.csv); a
+star-history chart is available at
+[star-history.com](https://star-history.com/#Aperivue/medsci-skills&Date).
+
+---
+
+## Listings & ecosystem presence
+
+- Conforms to the [Agent Skills](https://agentskills.io) standard (cross-host:
+  Claude Code, Codex, Cursor, GitHub Copilot — see
+  [`docs/host_compatibility.md`](docs/host_compatibility.md)).
+- Indexed in community "awesome" lists for the agent-skills ecosystem.
+- Archived for citation on Zenodo with a concept DOI (always resolves to latest).
+
+*(New listings are added here as they appear.)*
+
+---
+
+## Academic citations
+
+Papers, preprints, theses, or protocols that cite the Zenodo DOI or describe
+using MedSci Skills in their methods are logged in
+[`docs/citations.md`](docs/citations.md).
+
+If you used MedSci Skills in your research, please
+[tell us](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml) —
+it helps other researchers find the toolkit and helps us understand what to
+improve.
+
+---
+
+## Downstream use
+
+- **Forks**: 36 (a fork is the clearest signal that someone is building on or
+  adapting the toolkit).
+- **Named adopters**: collected via the
+  ["Used in research" issue template](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml)
+  and listed in [`docs/citations.md`](docs/citations.md) with permission.
+
+---
+
+## Notes on methodology
+
+- All figures are point-in-time snapshots from public GitHub/Zenodo APIs. Clone
+  counts include automated CI/mirroring traffic and overstate human use; the
+  *unique* columns are the more meaningful adoption signal.
+- This page never claims adoption that has not been observed. A thin section is a
+  truthful section.

--- a/README.md
+++ b/README.md
@@ -486,6 +486,16 @@ Or equivalently: `/write-paper --autonomous` if analysis and figures already exi
 /search-lit            # Find supporting literature with verified citations
 ```
 
+## In the Wild
+
+Adoption is tracked openly in [`IMPACT.md`](IMPACT.md) (stars, forks, traffic,
+release downloads — snapshotted weekly into [`metrics/traffic_log.csv`](metrics/traffic_log.csv))
+and academic use is logged in [`docs/citations.md`](docs/citations.md).
+
+**Used MedSci Skills in your research?** Please
+[let us know](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml).
+It helps other researchers find the toolkit — and we list it (with your permission).
+
 ## Disclaimer
 
 These skills are research productivity tools. They do **not** provide clinical decision support, medical advice, or diagnostic recommendations. All outputs should be reviewed by qualified researchers before use in any publication or clinical context.

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -1,0 +1,61 @@
+# Citations & Downstream Use
+
+A running ledger of academic citations and named downstream use of MedSci Skills.
+This is the manual companion to the automated metrics in
+[`../IMPACT.md`](../IMPACT.md) and [`../metrics/traffic_log.csv`](../metrics/traffic_log.csv).
+
+**How to cite:** see [`../CITATION.cff`](../CITATION.cff) or use the Zenodo DOI
+[10.5281/zenodo.20155321](https://doi.org/10.5281/zenodo.20155321).
+
+**Reporting use:** if you used MedSci Skills in your work, open a
+["Used in research" issue](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml).
+With your permission, it will be added below.
+
+---
+
+## How discoveries are tracked
+
+- **Zenodo** automatically lists works that cite the archived DOI.
+- **Google Scholar alerts** on the DOI, the title "MedSci Skills", and the
+  publisher "Aperivue".
+- **Reverse links**: GitHub "Used by" / dependents, and forks with public
+  activity.
+- **Self-reported**: the "Used in research" issue template.
+
+---
+
+## Peer-reviewed / preprint citations
+
+| Date found | Work (authors, year) | Venue | How it uses MedSci Skills | Link |
+|---|---|---|---|---|
+| _none recorded yet_ | | | | |
+
+---
+
+## Theses, protocols, and registered studies
+
+| Date found | Work | Institution / registry | Use | Link |
+|---|---|---|---|---|
+| _none recorded yet_ | | | | |
+
+---
+
+## Named downstream tools / forks
+
+| Date found | Project | What it builds on | Link |
+|---|---|---|---|
+| _none recorded yet_ | | | | |
+
+---
+
+## Media, talks, and listings
+
+| Date | Item | Type | Link |
+|---|---|---|---|
+| _none recorded yet_ | | | |
+
+---
+
+*Entries are added only when verified against a primary source (the DOI, a
+published paper, a public repo, or an explicit user report). Unverified mentions
+are not listed.*

--- a/metrics/traffic_log.csv
+++ b/metrics/traffic_log.csv
@@ -1,0 +1,2 @@
+date,stars,forks,watchers,release_downloads,views_14d,unique_views_14d,clones_14d,unique_clones_14d,zenodo_views,zenodo_downloads
+2026-06-06,134,36,3,220,1636,560,8566,791,,


### PR DESCRIPTION
## What

Adds a durable **evidence layer** for how MedSci Skills is used in the wild. GitHub discards traffic data after 14 days and exposes it to admins only — without a record, adoption evidence disappears daily. This captures it.

## Files

- **`IMPACT.md`** — public adoption dashboard. Honest point-in-time snapshots; empty sections mean *not yet observed* (a thin section is a truthful section).
- **`.github/workflows/metrics.yml`** — weekly job appending one row to `metrics/traffic_log.csv`: stars, forks, release downloads, 14-day views/clones, Zenodo views/downloads. Public metrics work with `GITHUB_TOKEN`; traffic needs an optional `METRICS_PAT` secret (fine-grained PAT, Administration: read). Fork-guarded; blank-tolerant on missing data.
- **`docs/citations.md`** — manual ledger for academic citations + named downstream use, with discovery method (Zenodo, Scholar alerts, dependents, self-report).
- **`.github/ISSUE_TEMPLATE/used-in-research.yml`** — collect user reports (with explicit list-permission control).
- **README "In the Wild"** section + **CHANGELOG `[Unreleased]`**.

## Baseline (2026-06-06, repo ~2 months old)

134 stars · 36 forks · 220 release downloads · 1,636 views / 8,566 clones (14d).

## Notes

- No skill behavior changes; **catalog unchanged at 43 skills**.
- Local CI parity: `validate_skills.sh` (PII + structure), catalog consistency, `gen_skill_docs --check`, routing assets — all pass.
- **Action needed after merge** (optional): add a `METRICS_PAT` repo secret to enable traffic-column capture; confirm the Zenodo record id (`20155321`) resolves at the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)