### PR TITLE
feat: reference adequacy gates across write-paper/search-lit/self-review

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run self-review panel-mode structural + PII test
         run: bash skills/self-review/tests/test_panel_mode.sh
 
+      - name: Run self-review reference-adequacy gate test
+        run: bash skills/self-review/tests/test_reference_adequacy.sh
+
       - name: Run validate_catalog_consistency.py (doc counts must match disk SSOT)
         run: python3 scripts/validate_catalog_consistency.py
 

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -29,6 +29,7 @@
 - `python3 scripts/check_reviewer_team_consistency.py`
 - `python3 scripts/check_domain_probe_sync.py --strict`
 - `bash tests/test_panel_mode.sh`
+- `bash tests/test_reference_adequacy.sh`
 - `feed R0-numbered output into /revise`
 
 **Evidence** — `demo`
@@ -48,6 +49,7 @@
 - `check_cohort_arithmetic.py`
 - `check_confounding_completeness.py`
 - `check_panel_diversity.py`
+- `check_reference_adequacy.py`
 - `check_reviewer_team_consistency.py`
 - `check_scope_coherence.py`
 

--- a/skills/search-lit/SKILL.md
+++ b/skills/search-lit/SKILL.md
@@ -328,6 +328,39 @@ When called during manuscript writing (especially by `/write-paper` Phase 7):
 
 ## Specialized Search Modes
 
+### Mode: Manuscript Paper Reference Pool
+
+For supplying a manuscript's reference pool — typically invoked by `/write-paper` Step 7.3c (or
+`/self-review` Phase 2.5c-2) when the **reference adequacy** gate finds the draft under target or a
+named method uncited, but usable directly when building out an original-research bibliography.
+
+This mode is deliberately **broad**: for an original-research article, return **25–40** verified
+candidates, not the ~10 a quick search settles on. Do not stop early unless the field is genuinely
+sparse — and if it is, say so explicitly rather than returning a thin list silently. Respect a
+narrower journal reference cap or user scope when one is given.
+
+Structure the pool across **six candidate categories** so the gaps the adequacy gate cares about
+are all covered:
+
+1. **Background / disease burden / clinical context** — establishes why the question matters.
+2. **Gap-defining prior studies** — the work the manuscript extends or contradicts.
+3. **Comparator / comparable-design cohorts** — studies the Results will be measured against.
+4. **Methods / statistical canonical sources** — the originating reference for every named method,
+   model, score, equation, or diagnostic criterion (e.g. competing-risk model, multiple
+   imputation, E-value, eGFR equation, concordance statistic). This is the category that clears
+   Methods named-method gaps.
+5. **Reporting-guideline sources** — STROBE, TRIPOD(+AI), CONSORT, PRISMA(-DTA), STARD, etc.
+6. **Interpretation / mechanism / limitation support** — grounds Discussion claims.
+
+For each candidate, report: **PMID/DOI**, **verification status**, **candidate category**, the
+**target manuscript section** it belongs in, and a one-line **why it is needed**.
+
+Boundary (unchanged): every entry is API-verified before inclusion, and BibTeX is appended **only**
+to `references/library.bib` — the candidate pool for `/lit-sync` to import into Zotero. **Never**
+write to `manuscript/_src/refs.bib`; that SSOT belongs to `/lit-sync`. This mode produces
+candidates; it does not decide inclusion (the user does) and it does not insert references into the
+manuscript bib.
+
 ### Mode: Systematic Search
 
 For systematic reviews or comprehensive literature sections:

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -554,6 +554,40 @@ Numerical audits (2.5/2.5a/2.5b) cover in-text numbers; they do **not** cover re
 
 **Do NOT fabricate replacement references** if any entry fails. Fix-forward belongs to `/search-lit` and `/lit-sync`, not to this skill. Self-review only reports the failure and blocks submission.
 
+### Phase 2.5c-2: Reference Adequacy Scan
+
+Phase 2.5c covers reference **integrity** — are the cited references real (fabricated / unverified / duplicate / placeholder)? It does **not** ask whether there are *enough* references, in the right sections, grounding every named method. That is reference **adequacy**, and it is the failure mode behind a draft with thirteen references where the Statistical Analysis subsection names a competing-risk model, multiple imputation, the E-value, and an eGFR equation with zero citations. Keep the two strictly separate: an integrity failure blocks because a citation is *wrong*; an adequacy failure flags because a citation is *missing*.
+
+**When to run:** every manuscript at self-review, after the integrity scan. The two share the manuscript and the resolved bib path.
+
+**Procedure:**
+
+1. **Run the deterministic checker.** Resolve the article type from `project.yaml` (passed verbatim; the script's alias map handles repo paper-type names) and the journal cap from the target journal profile when known:
+
+   ```bash
+   python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_reference_adequacy.py" \
+     --manuscript manuscript/manuscript.md --bib "$BIB" \
+     --article-type "$TYPE" ${CAP:+--journal-cap "$CAP"} \
+     --out qc/reference_adequacy.json --strict
+   ```
+
+   It reports the cited-reference count vs the article-type target, the section distribution (Introduction / Methods / Results / Discussion), every named method found in the Methods/Statistical-Analysis block, which of them lack a citation in their paragraph, and a `methods_zero_citations` flag.
+
+2. **Fold `findings[]` into the review.** Each finding becomes a standard `issues[]` entry (so `/revise` and downstream consumers ingest adequacy and other comments uniformly), **additively** carrying the machine-readable `issue_type` + `subtype` alongside the usual fields, under `category: "F" / category_name: "Reporting Completeness"`:
+
+   ```json
+   {"id":"M2","severity":"major","category":"F","category_name":"Reporting Completeness",
+    "issue_type":"reference_adequacy","subtype":"methods_named_method_uncited",
+    "location":"Methods - Statistical Analysis",
+    "description":"Fine-Gray competing-risk model is named without a canonical citation.",
+    "fixable_by_ai":false,
+    "suggested_fix":"Run /search-lit for the canonical Fine-Gray competing-risk source, sync via /lit-sync, then rerun /verify-refs --strict."}
+   ```
+
+   **Severity:** `methods_zero_citations` (original / AI-validation / meta-analysis) and each uncited statistical method → **Major** (a P0 candidate before submission when the method is central to the primary or a sensitivity analysis); each uncited reporting/diagnostic standard → **Minor**; a total count below the article-type target → **Major** when far below (under half the floor), otherwise **Minor**, scaled also by stage (escalate at a submission/circulation gate).
+
+3. **Fix-forward, not fabricate.** As in Phase 2.5c, this skill never writes replacement references. Every adequacy finding carries `fixable_by_ai: false`; the remedy is `/search-lit` (Manuscript Paper Reference Pool mode) → `/lit-sync` → `/verify-refs --strict`, which the author runs.
+
 ### Phase 2.5d: Cross-Reference QC (Manuscript ↔ rendered DOCX)
 
 Reference-list integrity (Phase 2.5c) does **not** cover Table/Figure

--- a/skills/self-review/scripts/check_reference_adequacy.py
+++ b/skills/self-review/scripts/check_reference_adequacy.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Reference adequacy gate for self-review Phase 2.5c-2 / write-paper Step 7.3c.
+
+Reference INTEGRITY (are the cited references real and metadata-valid?) is the
+job of verify-refs. This is the complementary REFERENCE ADEQUACY check: are
+there enough relevant references, in the right sections, and does every named
+statistical method or reporting guideline carry a citation? The highest-value,
+most-deterministic instance is Methods named-method citation coverage -- an
+autonomous draft can name a competing-risk model, multiple imputation, the
+E-value, and an eGFR equation in its Statistical Analysis subsection with zero
+citations and still read as internally consistent.
+
+This gate NEVER proposes reference text. It diagnoses gaps (fixable_by_ai=false);
+fix-forward belongs to /search-lit -> /lit-sync -> /verify-refs.
+
+INPUTS
+  --manuscript    manuscript markdown/qmd (required).
+  --bib           optional refs.bib; reports the bib entry count for cross-check.
+  --article-type  repo paper-type name or target bucket (see ALIASES); default
+                  original_article.
+  --journal-cap   optional journal reference cap (int).
+
+OUTPUT  (--out path)
+  {article_type, article_bucket, journal_cap, cited_reference_count,
+   bib_entry_count, effective_target, section_distribution,
+   named_methods_found, uncited_named_methods, methods_zero_citations,
+   reference_count_verdict, adequacy_safe,
+   findings[{issue_type, subtype, severity, location, description,
+             fixable_by_ai, suggested_fix}], summary{major, minor, notes}}
+
+Stdlib-only (re / json / argparse / pathlib). Exit codes: 0 clean (or
+report-only), 1 a Major adequacy finding exists (with --strict), 2 input/usage
+error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Article-type targets and aliases (single SSOT for the named-method registry  #
+# and the reference-count ranges; write-paper Step 7.3c calls this script      #
+# directly rather than mirroring these constants).                             #
+# --------------------------------------------------------------------------- #
+
+# bucket -> (min, max) recommended reference count
+TARGETS = {
+    "original_research": (25, 45),
+    "ai_validation": (25, 45),
+    "meta_analysis": (40, 80),   # also systematic_review
+    "review": (50, 100),         # narrative / review
+    "technical_note": (10, 20),
+    "case_report": (10, 20),
+    "editorial": (5, 15),
+    "letter": (0, 10),
+}
+
+# repo paper-type filename (skills/write-paper/references/paper_types/) -> bucket
+ALIASES = {
+    "original_article": "original_research",
+    "original_research": "original_research",
+    "nhis_cohort": "original_research",
+    "cross_national": "original_research",
+    "animal_study": "original_research",
+    "ai_validation": "ai_validation",
+    "meta_analysis": "meta_analysis",
+    "systematic_review": "meta_analysis",
+    "review": "review",
+    "narrative": "review",
+    "narrative_review": "review",
+    "technical_note": "technical_note",
+    "brief": "technical_note",
+    "case_report": "case_report",
+    "editorial": "editorial",
+    "commentary": "editorial",
+    "letter": "letter",
+}
+
+# Buckets where a Methods/Statistical-Analysis section is expected to carry
+# citations; methods_zero_citations escalates to Major only for these.
+METHODS_SECTION_EXPECTED = {"original_research", "ai_validation", "meta_analysis"}
+
+# Named methods whose mention without a citation is a Major adequacy gap.
+STATISTICAL = [
+    "Cox proportional hazards", "Cox",
+    "Fine-Gray", "competing risk", "subdistribution hazard",
+    "multiple imputation", "MICE", "White-Royston",
+    "E-value", "Benjamini-Hochberg", "FDR", "bootstrap", "Schoenfeld",
+    "CKD-EPI", "Harrell C-index", "DeLong", "calibration", "Brier",
+    "decision curve", "net benefit", "propensity score",
+    "inverse probability weighting",
+]
+# Reporting/diagnostic standards whose mention without a citation is Minor.
+GUIDELINE_REPORTING = [
+    "GOLD", "FEV1/FVC", "STROBE", "TRIPOD", "CONSORT", "PRISMA", "STARD",
+]
+
+# --------------------------------------------------------------------------- #
+# Citation-marker detection (union of pandoc, numbered, author-year,           #
+# superscript). Paragraph-level clustering keeps the check conservative.       #
+# --------------------------------------------------------------------------- #
+
+_SUP = {"⁰": "0", "¹": "1", "²": "2", "³": "3", "⁴": "4",
+        "⁵": "5", "⁶": "6", "⁷": "7", "⁸": "8", "⁹": "9"}
+_SUP_CLASS = r"[⁰¹²³⁴-⁹]+"
+# A name token allows internal apostrophes/hyphens (O'Brien, Smith-Jones).
+_NAME = r"[A-Z][A-Za-z'’\-]+"
+
+CITE_RE = re.compile(
+    r"\[@[^\]]+\]"                                                  # pandoc [@key] / [@a; @b]
+    r"|\[\d+(?:[–—-]\d+)?(?:,\s*\d+(?:[–—-]\d+)?)*\]"  # [12] [1-3] [1,2,5]
+    r"|\((?:" + _NAME + r")(?:\s+(?:et al\.?|and|&)\s+" + _NAME + r")?,?\s*(?:19|20)\d{2}[a-z]?\)"  # (Author, 2020)
+    r"|" + _SUP_CLASS,                                              # superscript ¹²
+    re.UNICODE,
+)
+
+
+def normalize(text: str) -> str:
+    """Fold non-breaking/figure hyphens to ASCII so 'E-value' matches."""
+    return text.replace("‑", "-").replace("‐", "-")
+
+
+def distinct_refs(body: str) -> set[str]:
+    """Distinct reference identifiers cited in `body` (keys/numbers/author-year)."""
+    keys: set[str] = set()
+    for m in re.finditer(r"\[@([^\]]+)\]", body):
+        for k in re.split(r"[;,]\s*@?", m.group(1)):
+            k = k.strip().lstrip("@")
+            if k:
+                keys.add("@" + k)
+    for m in re.finditer(r"\[(\d+(?:[–—-]\d+)?(?:,\s*\d+(?:[–—-]\d+)?)*)\]", body):
+        for part in m.group(1).split(","):
+            part = part.strip()
+            rng = re.match(r"(\d+)[–—-](\d+)$", part)
+            if rng:
+                a, b = int(rng.group(1)), int(rng.group(2))
+                if 0 < b - a < 500:
+                    keys.update("#" + str(n) for n in range(a, b + 1))
+            elif part.isdigit():
+                keys.add("#" + part)
+    for m in re.finditer(r"\((" + _NAME + r")(?:\s+(?:et al\.?|and|&)\s+" + _NAME +
+                         r")?,?\s*((?:19|20)\d{2}[a-z]?)\)", body):
+        keys.add("AY:" + m.group(1) + m.group(2))
+    for m in re.finditer(_SUP_CLASS, body):
+        num = "".join(_SUP.get(c, "") for c in m.group(0))
+        if num:
+            keys.add("^" + num)
+    return keys
+
+
+# --------------------------------------------------------------------------- #
+# Section parsing                                                              #
+# --------------------------------------------------------------------------- #
+
+SEC_PATTERNS = {
+    "introduction": re.compile(r"^(introduction|background)\b", re.I),
+    "methods": re.compile(r"^(materials and methods|methods and materials|methods|"
+                          r"statistical analysis|statistical methods)\b", re.I),
+    "results": re.compile(r"^(results|findings)\b", re.I),
+    "discussion": re.compile(r"^(discussion|comment)\b", re.I),
+}
+
+
+def top_sections(md: str) -> list[tuple[str, int, str]]:
+    """Return (clean_title, level, body) for every header (any level)."""
+    lines = md.split("\n")
+    heads = []
+    for i, line in enumerate(lines):
+        m = re.match(r"(#{1,6})\s+(.*)$", line)
+        if m:
+            title = re.sub(r"[*_`]", "", m.group(2)).strip()
+            heads.append((i, len(m.group(1)), title))
+    out = []
+    for idx, (li, lvl, title) in enumerate(heads):
+        end = len(lines)
+        for lj, lvl2, _ in heads[idx + 1:]:
+            if lvl2 <= lvl:
+                end = lj
+                break
+        out.append((title, lvl, "\n".join(lines[li + 1:end])))
+    return out
+
+
+def section_text(sections, key: str) -> str:
+    """Concatenate top-level (h1/h2) section bodies matching a canonical key."""
+    pat = SEC_PATTERNS[key]
+    return "\n\n".join(body for title, lvl, body in sections
+                       if lvl <= 2 and pat.match(title))
+
+
+# --------------------------------------------------------------------------- #
+# Named-method coverage                                                        #
+# --------------------------------------------------------------------------- #
+
+def scan_named_methods(methods_body: str) -> dict[str, dict]:
+    """term -> {cited: bool, tier: 'stat'|'guide'} for every registry term found.
+
+    A term is 'cited' if any paragraph containing it also carries a citation
+    marker. Longest term first so 'Cox proportional hazards' claims its span
+    before the bare 'Cox' can double-count it.
+    """
+    terms = [(t, "stat") for t in STATISTICAL] + [(t, "guide") for t in GUIDELINE_REPORTING]
+    terms.sort(key=lambda x: -len(x[0]))
+    compiled = [(t, tier, re.compile(r"(?<![A-Za-z0-9])" + re.escape(t) + r"(?![A-Za-z0-9])", re.I))
+                for t, tier in terms]
+    found: dict[str, dict] = {}
+    for para in re.split(r"\n\s*\n", methods_body):
+        has_cite = bool(CITE_RE.search(para))
+        covered: list[tuple[int, int]] = []
+        for term, tier, pat in compiled:
+            for m in pat.finditer(para):
+                span = (m.start(), m.end())
+                if any(span[0] >= c[0] and span[1] <= c[1] for c in covered):
+                    continue
+                covered.append(span)
+                rec = found.setdefault(term, {"cited": False, "tier": tier})
+                rec["cited"] = rec["cited"] or has_cite
+                break
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Main                                                                         #
+# --------------------------------------------------------------------------- #
+
+def _finding(subtype, severity, location, description, fix):
+    return {"issue_type": "reference_adequacy", "subtype": subtype,
+            "severity": severity, "location": location, "description": description,
+            "fixable_by_ai": False, "suggested_fix": fix}
+
+
+def assess(manuscript: str, article_type: str, journal_cap, bib_entry_count) -> dict:
+    notes = []
+    key = article_type.strip().lower().replace(" ", "_").replace("-", "_")
+    bucket = ALIASES.get(key)
+    if bucket is None:
+        bucket = "original_research"
+        notes.append(f"unknown article-type '{article_type}'; defaulted to original_research")
+
+    sections = top_sections(manuscript)
+    methods_body = section_text(sections, "methods")
+    distribution = {k: len(distinct_refs(section_text(sections, k))) for k in SEC_PATTERNS}
+    cited_count = len(distinct_refs(manuscript))
+
+    found = scan_named_methods(methods_body)
+    methods_has_citation = bool(CITE_RE.search(methods_body))
+    methods_zero_citations = bool(methods_body.strip()) and not methods_has_citation
+
+    named_methods_found = sorted(found)
+    uncited = sorted(t for t, r in found.items() if not r["cited"])
+
+    amin, amax = TARGETS[bucket]
+    if journal_cap is not None and journal_cap < amin:
+        eff_min, eff_max = journal_cap, journal_cap
+        notes.append(f"journal cap {journal_cap} below article-type floor {amin}; "
+                     f"effective target lowered to the cap")
+    else:
+        eff_min, eff_max = amin, amax
+
+    findings = []
+
+    if methods_zero_citations and bucket in METHODS_SECTION_EXPECTED:
+        listed = ", ".join(named_methods_found) if named_methods_found else "named methods/scores"
+        findings.append(_finding(
+            "methods_zero_citations", "major", "Methods - Statistical Analysis",
+            f"The Methods/Statistical Analysis section contains no citations; every named "
+            f"method, score, guideline, and diagnostic criterion needs a canonical source "
+            f"(found uncited: {listed}).",
+            "Run /search-lit (paper mode) for canonical methodology sources, sync via "
+            "/lit-sync, then rerun /verify-refs --strict."))
+    else:
+        for term in uncited:
+            if found[term]["tier"] == "stat":
+                findings.append(_finding(
+                    "methods_named_method_uncited", "major", "Methods - Statistical Analysis",
+                    f"{term} is named in the Statistical Analysis subsection without a citation "
+                    f"in its paragraph.",
+                    f"Run /search-lit (paper mode) for the canonical {term} source, sync via "
+                    f"/lit-sync, then rerun /verify-refs --strict."))
+            else:
+                findings.append(_finding(
+                    "reporting_guideline_uncited", "minor", "Methods",
+                    f"The {term} standard is named without a citation in its paragraph.",
+                    f"Run /search-lit for the {term} reference, sync via /lit-sync, then rerun "
+                    f"/verify-refs --strict."))
+
+    verdict = "ADEQUATE" if cited_count >= eff_min else "BELOW_TARGET"
+    if verdict == "BELOW_TARGET":
+        sev = "major" if cited_count < 0.5 * eff_min else "minor"
+        findings.append(_finding(
+            "below_article_type_target", sev, "Whole manuscript",
+            f"Cited references ({cited_count}) are below the {bucket} target "
+            f"({eff_min}-{eff_max}).",
+            "Run /search-lit (paper mode) to retrieve verified candidates across the six "
+            "categories, sync via /lit-sync, then rerun /verify-refs --strict."))
+
+    n_major = sum(1 for f in findings if f["severity"] == "major")
+    n_minor = sum(1 for f in findings if f["severity"] == "minor")
+
+    return {
+        "article_type": article_type,
+        "article_bucket": bucket,
+        "journal_cap": journal_cap,
+        "cited_reference_count": cited_count,
+        "bib_entry_count": bib_entry_count,
+        "effective_target": [eff_min, eff_max],
+        "section_distribution": distribution,
+        "named_methods_found": named_methods_found,
+        "uncited_named_methods": uncited,
+        "methods_zero_citations": methods_zero_citations,
+        "reference_count_verdict": verdict,
+        "adequacy_safe": n_major == 0,
+        "findings": findings,
+        "summary": {"major": n_major, "minor": n_minor, "notes": notes},
+    }
+
+
+def count_bib_entries(bib_path: Path) -> int:
+    try:
+        text = bib_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return -1
+    return len(re.findall(r"^\s*@\w+\s*\{", text, re.M))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Reference adequacy gate (count + section + named-method coverage).")
+    ap.add_argument("--manuscript", required=True, help="manuscript markdown/qmd")
+    ap.add_argument("--bib", help="optional refs.bib (reports entry count)")
+    ap.add_argument("--article-type", default="original_article",
+                    help="repo paper-type name or target bucket (see ALIASES)")
+    ap.add_argument("--journal-cap", type=int, help="optional journal reference cap")
+    ap.add_argument("--out", help="write JSON artifact to this path")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any Major adequacy finding")
+    ap.add_argument("--quiet", action="store_true", help="suppress the stdout table")
+    args = ap.parse_args()
+
+    mp = Path(args.manuscript)
+    if not mp.is_file():
+        sys.stderr.write(f"ERROR: manuscript not found: {args.manuscript}\n")
+        return 2
+    manuscript = normalize(mp.read_text(encoding="utf-8"))
+
+    bib_entry_count = None
+    if args.bib:
+        bp = Path(args.bib)
+        if bp.is_file():
+            bib_entry_count = count_bib_entries(bp)
+        else:
+            sys.stderr.write(f"WARN: bib not found: {args.bib} (bib entry count skipped)\n")
+
+    result = assess(manuscript, args.article_type, args.journal_cap, bib_entry_count)
+
+    if not args.quiet:
+        s = result
+        print("=" * 46)
+        print(" Reference Adequacy Gate (count + named methods)")
+        print("=" * 46)
+        print(f" Article type   : {s['article_type']} -> {s['article_bucket']}")
+        print(f" Cited refs     : {s['cited_reference_count']}  "
+              f"(target {s['effective_target'][0]}-{s['effective_target'][1]}"
+              f"{', cap ' + str(s['journal_cap']) if s['journal_cap'] is not None else ''})")
+        d = s["section_distribution"]
+        print(f" Distribution   : Intro {d['introduction']} / Methods {d['methods']} / "
+              f"Results {d['results']} / Discussion {d['discussion']}")
+        print(f" Methods 0-cite : {s['methods_zero_citations']}")
+        if s["uncited_named_methods"]:
+            print(f" Uncited methods: {', '.join(s['uncited_named_methods'])}")
+        for f in s["findings"]:
+            mark = "✗" if f["severity"] == "major" else "△"
+            print(f" {mark} [{f['severity']}] {f['subtype']}: {f['description']}")
+        print(f"\n Verdict: {s['reference_count_verdict']}  |  "
+              f"{s['summary']['major']} major, {s['summary']['minor']} minor  |  "
+              f"adequacy_safe={s['adequacy_safe']}")
+        for note in s["summary"]["notes"]:
+            print(f"   note: {note}")
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(f" wrote {args.out}")
+
+    return 1 if (args.strict and result["summary"]["major"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -18,8 +18,9 @@ inputs:
 outputs:
   - qc/self_review.md
   - qc/self_review.json
+  - qc/reference_adequacy.json
 deterministic_scripts:
-  - none_required
+  - scripts/check_reference_adequacy.py
 side_effects:
   - may_edit_manuscript_when_fix_flag_set
 downstream_consumers:
@@ -41,5 +42,6 @@ validation_commands:
   - "python3 scripts/check_reviewer_team_consistency.py"
   - "python3 scripts/check_domain_probe_sync.py --strict"
   - "bash tests/test_panel_mode.sh"
+  - "bash tests/test_reference_adequacy.sh"
   - "feed R0-numbered output into /revise"
 evidence_surface: demo

--- a/skills/self-review/tests/fixtures/refadeq_letter.md
+++ b/skills/self-review/tests/fixtures/refadeq_letter.md
@@ -1,0 +1,13 @@
+# Synthetic letter to the editor
+
+We read with interest the recent analysis of the index biomarker [@smith2019]
+and offer three observations. First, the reported effect direction is
+consistent with two prior cohorts [@jones2020; @lee2021], strengthening the
+external plausibility of the finding. Second, the authors' interpretation of the
+subgroup pattern echoes an earlier commentary [@kim2018] but appears to
+understate the confidence-interval width reported in the original registry
+[@park2022]. Third, the clinical implication should be read against the
+guideline statement [@choi2017], which cautions against acting on a single
+cross-sectional measurement [@brown2015]. We commend the authors for releasing
+their analytic code [@white2016], which permits the kind of scrutiny that
+strengthens the literature.

--- a/skills/self-review/tests/fixtures/refadeq_original_fixed.md
+++ b/skills/self-review/tests/fixtures/refadeq_original_fixed.md
@@ -1,0 +1,42 @@
+# Synthetic original-research draft (Methods named methods now cited)
+
+## Introduction
+
+Chronic disease burden continues to rise worldwide [@smith2019]. Risk
+stratification tools have proliferated over the last decade [@jones2020], yet
+external validation remains uneven [@lee2021]. Prior cohorts established the
+prognostic value of the index biomarker [@kim2018], and registry analyses
+extended this to older adults [@park2022]. The evidence base nonetheless lacks
+competing-risk-aware modeling [@choi2017].
+
+## Methods
+
+### Study population
+
+We assembled a retrospective single-center cohort of adults meeting the
+eligibility criteria below. The analytic dataset was frozen before any modeling.
+
+### Statistical analysis
+
+We fitted a Fine-Gray subdistribution hazard model for the competing risk of
+non-event mortality [@finegray1999]. Missing covariate data were addressed with
+multiple imputation (MICE) under the fully conditional specification
+[@white2011]. The robustness of the primary association to unmeasured
+confounding was quantified with the E-value [@vanderweele2017]. Estimated
+glomerular filtration rate was computed with the CKD-EPI 2021 equation
+[@inker2021]. Discrimination was summarized with the concordance statistic
+[@harrell1996].
+
+## Results
+
+The cohort comprised consecutive patients over the study window. The primary
+model reproduced the previously reported direction of effect [@smith2019].
+
+## Discussion
+
+Our findings align with earlier prognostic work [@brown2015] and extend it to a
+competing-risk framework [@white2016]. The magnitude is consistent with two
+external cohorts [@green2018; @black2019]. Mechanistically, the association is
+plausible [@gray2020], although residual confounding cannot be excluded
+[@adams2021]. Generalizability is limited by the single-center design
+[@baker2014].

--- a/skills/self-review/tests/fixtures/refadeq_original_uncited.md
+++ b/skills/self-review/tests/fixtures/refadeq_original_uncited.md
@@ -1,0 +1,40 @@
+# Synthetic original-research draft (Methods names methods with zero citations)
+
+## Introduction
+
+Chronic disease burden continues to rise worldwide [@smith2019]. Risk
+stratification tools have proliferated over the last decade [@jones2020], yet
+external validation remains uneven [@lee2021]. Prior cohorts established the
+prognostic value of the index biomarker [@kim2018], and registry analyses
+extended this to older adults [@park2022]. The evidence base nonetheless lacks
+competing-risk-aware modeling [@choi2017].
+
+## Methods
+
+### Study population
+
+We assembled a retrospective single-center cohort of adults meeting the
+eligibility criteria below. The analytic dataset was frozen before any modeling.
+
+### Statistical analysis
+
+We fitted a Fine-Gray subdistribution hazard model for the competing risk of
+non-event mortality. Missing covariate data were addressed with multiple
+imputation (MICE), generating twenty imputed datasets. The robustness of the
+primary association to unmeasured confounding was quantified with the E-value.
+Estimated glomerular filtration rate was computed with the CKD-EPI 2021
+equation. Discrimination was summarized with the concordance statistic.
+
+## Results
+
+The cohort comprised consecutive patients over the study window. The primary
+model reproduced the previously reported direction of effect [@smith2019].
+
+## Discussion
+
+Our findings align with earlier prognostic work [@brown2015] and extend it to a
+competing-risk framework [@white2016]. The magnitude is consistent with two
+external cohorts [@green2018; @black2019]. Mechanistically, the association is
+plausible [@gray2020], although residual confounding cannot be excluded
+[@adams2021]. Generalizability is limited by the single-center design
+[@baker2014].

--- a/skills/self-review/tests/test_reference_adequacy.sh
+++ b/skills/self-review/tests/test_reference_adequacy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression test for the reference-adequacy gate (self-review Phase 2.5c-2 /
+# write-paper Step 7.3c). Synthetic fixtures reproduce:
+#   1. an original-research draft whose Statistical Analysis subsection names a
+#      competing-risk model, multiple imputation, the E-value, and an eGFR
+#      equation with ZERO citations (the highest-value failure mode);
+#   2. the same draft with a citation added in each named-method paragraph;
+#   3. a letter whose lower reference target must not false-fail.
+# Stdlib-only (python3).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_reference_adequacy.py"
+FIX="$HERE/fixtures"
+OUT="$(mktemp -t ra_XXXX).json"
+trap 'rm -f "$OUT"' EXIT
+
+fail=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+# assert a python boolean expression over the JSON at $OUT; `d` is the parsed dict.
+# (No assertion message: the expression embeds single quotes — the check() label
+# already names the case on FAIL.)
+jassert() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert ($1)
+"; }
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing: $SCRIPT" >&2; exit 2; }
+
+echo "== Fixture 1: original research, Methods names methods with 0 citations =="
+python3 "$SCRIPT" --manuscript "$FIX/refadeq_original_uncited.md" \
+    --article-type original_article --out "$OUT" --strict >/dev/null 2>&1
+check "exit 1 under --strict (Major present)"      test "$?" -eq 1
+check "JSON artifact written"                       test -s "$OUT"
+check "methods_zero_citations is true"              jassert "d['methods_zero_citations'] is True"
+check "uncited_named_methods is non-empty"          jassert "len(d['uncited_named_methods']) > 0"
+check "Fine-Gray flagged uncited"                   jassert "'Fine-Gray' in d['uncited_named_methods']"
+check "reference_count_verdict BELOW_TARGET"        jassert "d['reference_count_verdict'] == 'BELOW_TARGET'"
+check "a methods_zero_citations Major finding"      jassert "any(f['subtype']=='methods_zero_citations' and f['severity']=='major' for f in d['findings'])"
+check "all findings fixable_by_ai=false"            jassert "all(f['fixable_by_ai'] is False for f in d['findings'])"
+
+echo "== Fixture 2: same draft, each named method now cited =="
+python3 "$SCRIPT" --manuscript "$FIX/refadeq_original_fixed.md" \
+    --article-type original_article --out "$OUT" --strict >/dev/null 2>&1
+check "exit 0 (no Major; Methods gap cleared)"      test "$?" -eq 0
+check "methods_zero_citations is false"             jassert "d['methods_zero_citations'] is False"
+check "no methods_named_method_uncited finding"     jassert "not any(f['subtype']=='methods_named_method_uncited' for f in d['findings'])"
+check "adequacy_safe is true"                        jassert "d['adequacy_safe'] is True"
+
+echo "== Fixture 3: letter (lower target must not false-fail) =="
+python3 "$SCRIPT" --manuscript "$FIX/refadeq_letter.md" \
+    --article-type letter --out "$OUT" --strict >/dev/null 2>&1
+check "exit 0 (letter target met)"                  test "$?" -eq 0
+check "verdict ADEQUATE for letter"                 jassert "d['reference_count_verdict'] == 'ADEQUATE'"
+check "no adequacy findings"                         jassert "len(d['findings']) == 0"
+
+echo "== Alias map: nhis_cohort routes to original_research target =="
+python3 "$SCRIPT" --manuscript "$FIX/refadeq_original_uncited.md" \
+    --article-type nhis_cohort --out "$OUT" --quiet >/dev/null 2>&1
+check "nhis_cohort -> original_research bucket"      jassert "d['article_bucket'] == 'original_research'"
+check "original_research target is [25,45]"         jassert "d['effective_target'] == [25,45]"
+
+echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -561,6 +561,61 @@ analyses (interaction, subgroup, sensitivity, multiple imputation). Skip for cas
 This step composes with `/self-review` Phase 2.5f; run it here for pipeline completeness even
 when `/self-review` is also invoked.
 
+#### Step 7.3c: Reference Adequacy Gate
+
+Step 7.3/7.3a/7.3b verify reference **integrity** — that the cited references are real and the
+numbers/estimands trace to their artifacts. This step is the complementary **reference adequacy**
+check: are there *enough* relevant references, in the right sections, and does **every named
+statistical method or reporting guideline carry a citation**? The dominant failure mode in an
+autonomous draft is a Statistical Analysis subsection that names a competing-risk model, multiple
+imputation, the E-value, and an eGFR equation with **zero citations** — internally consistent
+prose that no integrity check flags.
+
+Delegate the detection to the self-review checker (same cross-skill pattern Step 7.3b uses for
+`check_artifact_coverage.py`). Resolve the manuscript path with the fallback chain
+`SSOT.yaml::truth.manuscript_md` → `manuscript/manuscript.md` → `manuscript/index.qmd`; pass the
+`project.yaml` paper type verbatim (the script's alias map handles repo names); pass the journal
+reference cap from the chosen `references/journal_profiles/<journal>.md` when known.
+
+```bash
+python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_reference_adequacy.py" \
+  --manuscript "$MANUSCRIPT" --bib "$BIB" \
+  --article-type "$TYPE" ${CAP:+--journal-cap "$CAP"} \
+  --out qc/reference_adequacy.json   # no --strict: write-paper decides the action from the JSON
+```
+
+Parse `qc/reference_adequacy.json` and act:
+
+1. **Methods citation completeness (blocking).** Any `methods_zero_citations: true` (for an
+   original/AI-validation/meta-analysis paper) **or** any `methods_named_method_uncited`
+   (statistical tier) finding is a reference-acquisition blocker. **Interactive:** loop
+   `/search-lit` (Manuscript Paper Reference Pool mode) → `/lit-sync` → `/verify-refs --strict`,
+   then re-run this gate until the named-method gap clears. **`--autonomous` mode** (where
+   `/lit-sync` needs the Zotero GUI and cannot run unattended): do **not** infinite-loop — record
+   `SEARCH_LIT_REQUIRED` plus the uncited-method list in `qc/_pipeline_log.md`, surface it to the
+   owner, and continue producing the draft (the same deferral Phase 0 applies to unresolved
+   `[@NEW:]` placeholders).
+2. **Total count (loop, then warn).** `reference_count_verdict: "BELOW_TARGET"` triggers one
+   `/search-lit` acquisition round; if the field is genuinely sparse and the count stays low,
+   downgrade to a logged WARN rather than blocking. **Never fabricate references to hit a target.**
+
+All additions flow `/search-lit` → `/lit-sync` → `/verify-refs --strict` only; this skill never
+writes references from memory, and the checker emits `fixable_by_ai: false` (it diagnoses gaps, it
+does not write citations). Append the result to `qc/_pipeline_log.md`:
+
+```md
+## Reference Adequacy Gate (Phase 7.3c)
+- Article type / Journal cap: {type} / {cap|unknown}
+- Cited references: {N}   Effective target: {min}-{max}
+- Section distribution: Intro {N} / Methods {N} / Results {N} / Discussion {N}
+- Named methods checked: {N}   Uncited: {list}
+- Action: PASS | SEARCH_LIT_REQUIRED | HALT_UNVERIFIED_REFS
+```
+
+This step composes with `/self-review` Phase 2.5c-2, which re-runs the same checker with `--strict`
+and folds its findings into the review JSON; run it here so a reference-acquisition loop precedes
+the prose self-review in Step 7.4.
+
 #### Step 7.4: Self-Review + Fix Loop
 
 Call `/self-review --json --fix` on the current `manuscript/manuscript.md`.


### PR DESCRIPTION
## Problem

The skills enforce reference **integrity** (are cited references real? — `/verify-refs`) but have no notion of reference **adequacy** (are there *enough*, in the right sections, grounding every named method?). In an autonomous `/write-paper` draft, a Statistical Analysis subsection can name a competing-risk model, multiple imputation, the E-value, and an eGFR equation with **zero citations** — internally consistent prose that no integrity check flags. Reference lists also stall well below article-type norms.

## What this adds

A reference **adequacy** layer across three skills, with Methods named-method citation coverage as the highest-value, most-deterministic check.

- **self-review** — new stdlib checker `scripts/check_reference_adequacy.py`:
  - article-type **alias map** (repo paper-type names → target buckets) + count targets (Original 25–45, MA 40–80, Review 50–100, Technical note 10–20, Letter ≤10, …)
  - two-tier **named-method registry** (statistical → Major, reporting/guideline → Minor) with conservative paragraph-level citation clustering
  - `methods_zero_citations` flag, section distribution, JSON output, exit 0/1/2
  - **Phase 2.5c-2** folds findings into the existing `issues[]` array additively (`issue_type`/`subtype`, category F), keeping integrity vs adequacy strictly separate
- **write-paper** — **Step 7.3c** invokes the same checker via the `${MEDSCI_SKILLS_ROOT}` cross-skill pattern Step 7.3b already uses (no registry duplication). Blocks and loops `/search-lit → /lit-sync → /verify-refs` on a Methods gap; `log+continue` under `--autonomous` (where `/lit-sync` needs the GUI); appends a `qc/_pipeline_log.md` block.
- **search-lit** — new **Manuscript Paper Reference Pool** mode: 25–40 verified candidates across six categories (background, gap-defining, comparator, methods/statistical canonical, reporting-guideline, interpretation). Appends to `references/library.bib` only.

## Anti-hallucination preserved

- Every adequacy finding is `fixable_by_ai: false` — the checker **diagnoses gaps, it never writes references**.
- `/search-lit` writes only `references/library.bib`; `/lit-sync` remains sole writer of `manuscript/_src/refs.bib`; `/verify-refs --strict` stays the final integrity gate.

## Tests

`skills/self-review/tests/test_reference_adequacy.sh` + 3 synthetic fixtures (Methods-zero-citations → fails `--strict`; corrected draft → gap cleared; letter → no false-fail; alias routing), wired into CI. Full local validation suite (`validate_skills.sh`, routing/contract/catalog validators, `gen_skill_docs --check`, panel-mode test, demo manifest verify) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)