### PR TITLE
feat(authoring): LLM/NLP-extraction design-time gates

### DIFF
--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -110,6 +110,12 @@ Look for:
 - normalization or thresholding performed before data split
 - repeated exams across train/test
 - reader annotations derived from outcome information
+- **input-text contamination for NLP/LLM extraction tasks**: if the model input includes report
+  sections such as clinical history, indication, impression, prior diagnosis, or referral text, confirm
+  that those fields do not literally name or strongly imply the target label. If the target is already
+  present in the supplied text, the task is information retrieval under label leakage, not phenotype
+  inference; redesign the input mask, report a sensitivity analysis excluding leaky fields, or reframe the
+  claim.
 - **construct dependence** (a predictor that is a definitional component of the outcome). Two cases:
   (i) *mathematical definition* — an input that computes the outcome (when the outcome is HOMA-IR =
   f(fasting insulin, fasting glucose), those two inputs are not independent predictors); (ii)
@@ -196,6 +202,10 @@ Ask whether the comparator and endpoint support the stated claim:
 - is the endpoint clinically meaningful?
 - does performance translate to action?
 - **incremental value**: if the study frames the model/marker as adding value *beyond* / *on top of* / *incremental to* an existing tool (a clinical score, a routine test, a baseline model), the design must pre-specify the baseline comparator built from the in-routine-use predictors **and** an incremental-value metric — ΔC-index / ΔAUC (with a paired CI, e.g. DeLong), categorical or continuous NRI, IDI, or decision-curve net benefit. A standalone discrimination number ("our model's AUC was 0.84") does not support a "beyond X" claim; without the nested-model comparison the finding may be real but redundant. Plan this at design time — it cannot be added post hoc without the baseline model.
+- **fine-tuning contribution baseline**: if an NLP/LLM study claims that fine-tuning, LoRA, prompt
+  engineering, or a multi-agent wrapper improves extraction/classification, pre-specify a same-backbone
+  zero-shot or few-shot comparator on the identical input, output schema, and test split. A comparison
+  only against a weaker or unrelated baseline cannot establish that the proposed adaptation adds value.
 - **endpoint↔conclusion scope**: decide up front what *kind* of conclusion the design can support, so the manuscript does not overreach. A cross-sectional / single-visit / prevalence design cannot support a prognostic or surveillance claim (rescreen interval, disease progression) — that needs longitudinal follow-up. A binary surrogate endpoint (present/absent, >0, dichotomized) is risk stratification, not a patient-care directive (defer/withhold/initiate therapy). At review time `/self-review` §D + `check_scope_coherence.py` flag `CROSS_SECTIONAL_PROGNOSTIC` / `SURROGATE_CARE_DIRECTIVE` against the conclusion.
 
 ### Phase 4: Reporting fit
@@ -238,6 +248,8 @@ Recommend one primary guideline:
 - no clear rubric for clinical correctness
 - benchmark labels derived from noisy reports without adjudication
 - unsupported claims about safety or workflow benefit
+- input text contains the target label or diagnosis being predicted
+- no same-backbone zero-shot/few-shot baseline for a fine-tuning or prompt-engineering claim
 
 ### Imaging meta-analysis
 - overlapping cohorts

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -78,6 +78,7 @@ partially, or not at all for the given manuscript type.
 |-------|-----------------|
 | Patient-level splitting | Are train/val/test splits at the patient level? Is this explicitly stated? |
 | Leakage risk | Any postoperative variable used in a preoperative model? Cohort-wide preprocessing before split? |
+| Input-text contamination | For NLP/LLM extraction tasks, does any supplied report text (clinical history, indication, impression, prior diagnosis, referral text) already contain the target label? If yes, mark as Major unless the input was masked or a no-leaky-field sensitivity analysis is reported. |
 | Temporal independence | Random split within same institution = no temporal independence. Acknowledged? |
 | Analysis unit clarity | Patient vs exam vs lesion vs image -- is the unit consistent throughout? |
 | Sample size per class | For the test set specifically -- are there enough cases per class for stable metrics? |
@@ -99,6 +100,7 @@ partially, or not at all for the given manuscript type.
 | Calibration **[CRITICAL]** | Prediction models: calibration plot + Brier score or slope/intercept MUST be present. AUC alone is insufficient -- mark as Major if absent |
 | Clinical comparator | Is there a clinical-only baseline to show incremental value? |
 | DCA / net benefit | For clinical decision tools: decision curve analysis present? |
+| Fine-tuning baseline | For LLM/NLP fine-tuning, LoRA, prompt-engineering, or multi-agent claims, is there a same-backbone zero-shot or few-shot comparator on the same input, schema, and test split? |
 | Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
 | Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
 | Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
@@ -115,7 +117,9 @@ partially, or not at all for the given manuscript type.
 | Terminology precision | Key terms defined? (e.g., "perioperative" = when exactly?) |
 | Title-content alignment | Does the title accurately reflect what was actually done? |
 | Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
+| Substantive novelty differentiation | For AI/LLM extraction papers, does the Introduction name 2-3 close prior papers/systems and state the concrete delta (new task, dataset, workflow, method, validation, or clinical decision point), rather than merely saying the method is novel? |
 | Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
+| Decision impact | Does the manuscript state what decision, workflow step, or downstream action would change if the model is correct? A text-only phenotype that does not alter triage, treatment, surveillance, enrichment, or research operations has weak clinical utility even if accuracy is high. |
 | Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
 | Endpoint↔conclusion scope **[CRITICAL]** | Does the conclusion's *action* exceed what the design or endpoint supports? A cross-sectional / single-visit study cannot license a prognostic or surveillance claim (rescreen interval, disease progression); a binary surrogate endpoint (present/absent, >0) is risk stratification, not a care directive (defer/withhold/initiate therapy). Both are documented anti-patterns. |
 
@@ -965,7 +969,7 @@ After presenting the report, offer to help fix specific issues:
 - Rewrite overclaiming sentences
 - Draft missing limitation statements
 - Suggest statistical additions (e.g., calibration analysis code via `/analyze-stats`)
-- Draft intended use or novelty statements
+- Draft intended use, decision-impact, or novelty-delta statements
 - Check specific tables/figures for consistency
 - Generate missing flow diagrams via `/make-figures`
 

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -51,8 +51,9 @@ Gather essential information from the user before any writing begins.
    - Systematic review: PRISMA 2020
    - Observational study: STROBE
    - Educational study: no standard checklist (use SQUIRE if applicable)
-4. Create or confirm the project scaffold directory.
-5. Check for `--no-llm-disclosure` flag. If absent, LLM disclosure is ON by default.
+4. **AI/LLM design-stage reporting map**: for AI validation, LLM/MLLM, NLP extraction, or report-generation papers, map each required AI-reporting item to a manuscript section before drafting. At minimum record model/version/access date, input fields, prompt or fine-tuning protocol, same-backbone zero-shot/few-shot baseline if an adaptation claim is made, test-data independence/contamination assessment, repeatability/stochasticity handling, and the Methods subsection where each will appear. If any item cannot be placed, halt for design clarification rather than burying it as a Phase 7 limitation.
+5. Create or confirm the project scaffold directory.
+6. Check for `--no-llm-disclosure` flag. If absent, LLM disclosure is ON by default.
    Check for `--autonomous` flag. If present, record autonomous mode as ON.
    Record both flag states for use in Phase 1-7 gate logic.
 
@@ -79,7 +80,7 @@ When paper type is "case report":
 10. For extended case reports with literature review, user can specify `--extended` to raise
     the word limit to 2000-3000 words and add a structured review section.
 
-5. **Identify a backbone article (auto-proposal first, ask only as fallback)**:
+7. **Identify a backbone article (auto-proposal first, ask only as fallback)**:
    a. **Scan first** — if `manuscript/_src/refs.bib` exists, scan it for entries matching the current paper's study design (Phase 0 paper_type), imaging modality, and target journal (or comparable tier). Prefer entries whose Zotero record has a PDF attachment (full text locally available).
    b. **Rank candidates** by: PDF available locally (+2), recency within 5 years (+1), same target journal (+2), same study design + modality (+2).
    c. **Behavior**:
@@ -87,7 +88,7 @@ When paper type is "case report":
       - **Multiple candidates** — present the top 3 ranked list with rationale and ask the user to choose.
       - **No refs.bib, or no candidates** — ask the user to provide a published study (legacy behavior).
    d. Record the chosen citekey in `project.yaml::backbone_article` so Methods, Tables, and Figures phases reuse it without re-asking.
-6. Summarize the setup to the user and confirm before proceeding.
+8. Summarize the setup to the user and confirm before proceeding.
 
 **Output:** Setup summary with journal constraints, paper type, reporting guideline, backbone article, directory path, and LLM disclosure status (ON/OFF).
 
@@ -201,6 +202,15 @@ Write the Methods section first -- it is the most objective and anchors the rest
 5. Statistical Analysis (reference `${CLAUDE_SKILL_DIR}/references/section_templates/methods_statistical.md`)
 6. Ethics statement
 7. AI/LLM disclosure (if `--no-llm-disclosure` was NOT set): insert the Methods disclosure paragraph from the [LLM Disclosure](#llm-writing-disclosure) section
+
+**AI/LLM extraction add-ons (when applicable):**
+- In Dataset / Inputs, state exactly which text fields the model received and whether clinical history,
+  indication, impression, prior diagnosis, or referral text was masked. If a supplied field can contain
+  the target label, Methods must either exclude it or describe a no-leaky-field sensitivity analysis.
+- In AI Model or Statistical Analysis, include a same-backbone zero-shot/few-shot comparator when the
+  claim is that fine-tuning, LoRA, prompt engineering, or a multi-agent wrapper improves performance.
+- In Introduction, state the decision-impact path: what clinical or research workflow step changes if the
+  model works, not only that the extracted label is interesting.
 
 **Process:**
 1. **Writer pass**: Draft the full Methods section following the outline and paper type template.
@@ -1115,7 +1125,7 @@ Severity levels: **ENFORCED** = pipeline halts on failure (cannot proceed to nex
 
 | Phase | Gate | Severity | Trigger | Action on fail |
 |---|---|---|---|---|
-| 0 | Backbone-article auto-proposal (Phase 0 Step 5) | ADVISORY | refs.bib has methodologically similar candidate | Surface to user; user accepts/declines |
+| 0 | Backbone-article auto-proposal (Phase 0 "Identify a backbone article" action) | ADVISORY | refs.bib has methodologically similar candidate | Surface to user; user accepts/declines |
 | 7.0 | Citekey resolution (delegate `/manage-refs scripts/check_citation_keys.py`) | ENFORCED | UNDEFINED keys present | Halt; resolve via `/lit-sync` then re-run |
 | 7.0 | NEW_PLACEHOLDER drain (delegate `/manage-refs`) | ENFORCED at 7.6 entry | `[@NEW:topic]` markers remain | Resolve each before DOCX render |
 | 7.1 | Classical-style QC (manuscript-style-classical 11 items) | ENFORCED | § symbol > 0 OR AI Disclosure paragraph in body OR em-dash > 25 | Auto-fix or HALT for senior MA reviewer prep |

--- a/skills/write-paper/references/paper_types/ai_validation.md
+++ b/skills/write-paper/references/paper_types/ai_validation.md
@@ -51,6 +51,9 @@ Follow the target journal's format. Include:
 - Prior AI approaches for this task (brief, cite key studies).
 - Gaps: limited validation, single-center, no reader comparison, no generalizability data.
 - For LLM studies: current evidence on LLM/MLLM performance in medical domains.
+- For NLP/LLM extraction studies: name 2-3 closest prior extraction or report-mining papers/systems
+  and state the substantive delta (task, dataset, input constraints, method, validation, or workflow),
+  not merely that the new system is "novel."
 
 ### Paragraph 3: Study Objective
 - Precise aim with study design mentioned.
@@ -113,6 +116,11 @@ Follow the target journal's format. Include:
 - Full prompts in supplement (or verbatim in methods if short).
 - If multi-agent: agent roles, interaction protocol, consensus mechanism.
 - Input format: text-only, image+text, structured data.
+- For report-text extraction: list each supplied text field separately (e.g., findings, impression,
+  clinical history, indication, prior diagnosis, referral text). State whether fields that may contain the
+  target label were masked, excluded, or evaluated in a sensitivity analysis.
+- For fine-tuning, LoRA, prompt-engineering, or multi-agent claims: include a same-backbone zero-shot or
+  few-shot comparator using the identical input fields, output schema, and test split.
 
 #### For Pipeline/System Studies
 - End-to-end system description.
@@ -130,6 +138,12 @@ Follow the target journal's format. Include:
 - **Primary metric**: AUC, sensitivity, specificity, accuracy, F1 -- state which and why.
 - **Confidence intervals**: 95% CIs for all primary metrics (bootstrap or exact binomial).
 - **Comparison tests**: DeLong test for AUC comparison, McNemar for sensitivity/specificity.
+- **Adaptation ablation**: when claiming benefit from fine-tuning, LoRA, prompt design, or a wrapper,
+  pre-specify the paired comparison against the same-backbone zero-shot/few-shot baseline and report the
+  uncertainty for the delta, not only the adapted model's standalone performance.
+- **Input-contamination sensitivity**: for NLP/LLM extraction, report the primary analysis with the
+  pre-specified input fields and, when applicable, a sensitivity analysis excluding fields likely to
+  contain the answer.
 - **Calibration**: calibration plot, Brier score, calibration slope/intercept (for prediction models).
 - **Subgroup analyses**: pre-specified subgroups with rationale.
 - **Multiple comparisons**: correction method if applicable.
@@ -201,6 +215,8 @@ Follow the target journal's format. Include:
 ### Paragraph 4: Clinical Deployment Implications
 - Where in the workflow would this fit? (triage, second reader, standalone, quality assurance)
 - What is the intended use case?
+- What decision, workflow step, or downstream action changes if the model is correct? State this before
+  making a clinical-utility claim.
 - Implementation considerations: speed, hardware, integration.
 - Regulatory pathway considerations (if relevant).
 
@@ -249,3 +265,6 @@ For each: (a) what it is, (b) how mitigated, (c) direction of residual bias.
 8. **No intended use**: Not specifying where in the clinical workflow the model would be deployed.
 9. **Cherry-picked operating point**: Choosing the threshold that looks best on the test set.
 10. **Ignoring prevalence**: Reporting PPV/NPV without discussing the study prevalence vs real-world prevalence.
+11. **Input-text contamination**: clinical history, indication, impression, or referral text contains the target diagnosis or label.
+12. **Missing same-backbone baseline**: fine-tuning or prompt-engineering benefit is claimed without a zero-shot/few-shot comparator on the same task.
+13. **Presence-only novelty**: the Introduction says the task is novel but does not position the work against the closest 2-3 prior papers or systems.


### PR DESCRIPTION
**What** — Strengthens `design-study`, `self-review`, and `write-paper` so common reviewer-killing weaknesses in LLM/NLP report-extraction studies surface at design and self-review time instead of at submission:

- **Input-text contamination** — flag when supplied report fields (clinical history, indication, impression, prior diagnosis, referral text) may already contain the target label.
- **Same-backbone baseline** — require a zero-shot/few-shot comparator on identical input/schema/split before any fine-tuning, LoRA, prompt-engineering, or multi-agent "adds value" claim.
- **Substantive novelty differentiation** (name 2-3 closest priors + delta) and an explicit **decision-impact / workflow-change** statement.
- **write-paper Phase 0** AI/LLM design-stage reporting map so MI-CLEAR-LLM-style items are placed into Methods up front.

**Scope** — Post-v3.8.0 improvement. Full validator suite + self-review tests pass. No change to `evaluation/` or `demo/` artifacts.
