### PR TITLE
chore(i18n): English-canonical Language Policy + locale-inventory gate (PR1)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 
+      - name: Run check_locale_inventory.py (Korean-bearing files must be inventory-justified)
+        run: python3 scripts/check_locale_inventory.py
+
+      - name: Run check_locale_inventory.py self-test
+        run: bash tests/test_locale_inventory.sh
+
       - name: Run self-review panel-mode structural + PII test
         run: bash skills/self-review/tests/test_panel_mode.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Language Policy + locale-inventory gate** — MedSci Skills is now explicitly English-canonical: skill mechanics and prose are English, and non-English (currently Korean) text is allowed only as a labeled locale feature, a locale-jurisdiction mode (e.g. `grant-builder`'s Korean Government Grant Mode), a bilingual `triggers:` alias, or an opt-in `*_ko` variant. A new [`docs/locale_inventory.md`](docs/locale_inventory.md) lists every Korean-bearing file under `skills/` with a one-line justification, and a new stdlib detector `scripts/check_locale_inventory.py` (wired into CI + `tests/test_locale_inventory.sh`) fails if any Korean-bearing file is missing from that inventory — the authoritative allowlist, complementing the WARN-only Korean-prose check in `validate_skills.sh`. CONTRIBUTING gains a Language Policy section + PR-checklist item. This is the policy/scaffold step (PR1); incidental-prose translation (PR2) and English-default-with-Korean-opt-in redesign (PR3) follow. Catalog unchanged at 43 skills.
+
 ## [3.8.0] - 2026-06-07
 
 An `evaluation/` harness suite that validates the instrument itself, plus a reconcile of the README Live-Demos numbers with the v3.7.0 clean-room demo artifacts. Catalog unchanged at 43 skills, 21 detectors — this release adds tooling and tracked evidence, not skills.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Per-skill documentation under `docs/skills/` is **generated** from each `skills/
 
 - [ ] `bash scripts/validate_skills.sh`
 - [ ] `python3 scripts/validate_skill_contracts.py`
+- [ ] `python3 scripts/check_locale_inventory.py` (any new non-English text is justified in `docs/locale_inventory.md`).
 - [ ] No private project identifiers, manuscript IDs, collaborator names, patient-level examples, or institution-specific hidden context.
 - [ ] No personal absolute paths.
 - [ ] New scripts have a short usage example and deterministic expected behavior.
@@ -43,6 +44,33 @@ MedSci Skills is public. Do not include:
 - Private emails, home-directory paths, or local institution-only paths.
 
 The validator blocklist is intentionally conservative. If it catches a false positive, explain the case in the pull request rather than bypassing the check silently.
+
+## Language Policy
+
+MedSci Skills is **English-canonical**. Write skill mechanics and prose in English so that any
+international reader or contributor can understand and adapt them:
+
+- `SKILL.md` body prose, `skill.yml`, code comments, and general reference/template files: **English**.
+- Default user-facing prompts and default output templates: **English**, with Korean (or any other
+  language) offered as an opt-in `*_ko` variant or via a "communicate in the user's preferred
+  language" instruction — not hardcoded as the default.
+
+Non-English text is allowed **only** when it is functional, and then it must be **labeled and
+justified**. Permitted categories:
+
+- **Locale data / features** — e.g. the Korean PHI pack in `deidentify`, KNHANES variable labels,
+  Korean-PDF rendering references, Korean PII-detection patterns.
+- **Locale-jurisdiction modes** — e.g. `grant-builder`'s "Korean Government Grant Mode", where the
+  prose is English but real Korean program/artifact terms are preserved.
+- **Bilingual `triggers:`** — additive recognition aliases in SKILL.md frontmatter.
+- **Opt-in `*_ko` variants** — a Korean sibling of an English-default file.
+
+Every file containing non-English text must appear in
+[`docs/locale_inventory.md`](docs/locale_inventory.md) with a one-line reason. The deterministic
+gate `python3 scripts/check_locale_inventory.py` (run in CI) fails if a Korean-bearing file under
+`skills/` is missing from that inventory. Note that `validate_skills.sh`'s Korean-prose check is
+WARN-only and scans only SKILL.md (skipping code blocks, tables, and blockquotes), so the inventory
+— not that warning — is the authoritative allowlist.
 
 ## Code Style
 

--- a/docs/locale_inventory.md
+++ b/docs/locale_inventory.md
@@ -1,0 +1,120 @@
+# Locale Inventory
+
+This file is the **auditable allowlist** for non-English (currently Korean) text under `skills/`.
+
+Policy: skill mechanics and prose are English-canonical. Non-English is allowed **only** as a
+labeled locale feature, a locale-jurisdiction mode, a bilingual trigger, or an opt-in `*_ko`
+variant — and every such file must appear in the table below with a reason. See
+[CONTRIBUTING.md](../CONTRIBUTING.md#language-policy) for the principle.
+
+**Enforcement:** `scripts/check_locale_inventory.py` asserts that every file matched by
+`grep -rl '[가-힣]' skills/` is listed here. A Korean-bearing file that is *missing* from this
+table fails the check (CI). As translation/redesign PRs land, their rows are removed (the file no
+longer contains Korean); the steady state is only the **KEEP** rows.
+
+Buckets:
+- **A** — locale feature: Korean is functional (locale data, language-specific parsing/examples, Korean PII detection). KEEP.
+- **A2** — locale-jurisdiction mode: a Korean-domain workflow with English wrapper prose + preserved Korean artifact terms. KEEP.
+- **B** — incidental prose: translate to English (PR2). Transitional row, removed when translated.
+- **C** — Korean-default behavior/output: redesign to English-default + Korean opt-in `*_ko` variant (PR3). Transitional row.
+- **D** — bilingual `triggers:` field (frontmatter): additive recognition aliases. KEEP.
+
+> Note: several SKILL.md files carry both a **D** trigger line and **A** locale content; they are
+> listed once under their KEEP rationale. Mixed B+C files are handled wholly in one PR (PR3) to
+> avoid a single file straddling two PRs.
+
+---
+
+## KEEP — locale features (Bucket A)
+
+| Path | Bucket | Why retained |
+|---|---|---|
+| `skills/deidentify/locales/kr.json` | A | Korean PHI locale data (RRN/phone/address patterns) — the feature. |
+| `skills/deidentify/references/korean_phi_patterns.md` | A | Korean PHI pattern reference. |
+| `skills/deidentify/references/hipaa_18_identifiers.md` | A | HIPAA ↔ Korean identifier mapping (성명/주민등록번호/개인정보보호법). |
+| `skills/deidentify/references/date_shift_guide.md` | A | Korean date-format examples (차트번호, `2024년 3월 15일`) for date-shift logic. |
+| `skills/deidentify/tests/test_phi_korean.csv` | A | Korean PHI test fixtures. |
+| `skills/deidentify/tests/test_edge_cases.csv` | A | Korean edge-case test fixtures. |
+| `skills/deidentify/tests/README.md` | A | Documents the Korean placeholder test names (김철수 etc., synthetic). |
+| `skills/deidentify/deidentify.py` | A | Korean date parsing (년/월/일) + bilingual `Select country / 국가 선택` prompt. |
+| `skills/deidentify/SKILL.md` | A/D | Locale-pack description (kr: 주민번호 …) + bilingual trigger. |
+| `skills/publish-skill/SKILL.md` | A | Language-hardcoding **detection** patterns (`한국어로`, `<한글이름> 교수님`) — the feature. |
+| `skills/publish-skill/scripts/audit_skill.sh` | A | Korean PII/name detection regex. |
+| `skills/publish-skill/references/pii-patterns.md` | A | Korean PII pattern examples for the auditor. |
+| `skills/present-paper/scripts/inject_pronunciation_notes.py` | A | Korean pronunciation dictionary for Korean-presenter speaker notes. |
+| `skills/present-paper/SKILL.md` | A/D | `[ 발음 ]` pronunciation-section header example + bilingual trigger. |
+| `skills/fill-protocol/SKILL.md` | A/D | Korean institutional-form fill examples + `맑은 고딕` font + bilingual trigger. |
+| `skills/fill-protocol/scripts/fill_form.py` | A | `맑은 고딕` default CJK font for Korean .docx forms. |
+| `skills/fill-protocol/examples/example_irb_template.yaml` | A | Korean IRB template example (`국문`, `맑은 고딕`). |
+| `skills/sync-submission/scripts/blind_sweep.py` | A | `성명` shown as a native-script (hangul) example. |
+| `skills/sync-submission/scripts/author_registry_example.yaml` | A | `성명` as a hangul `native_names` example comment. |
+| `skills/replicate-study/references/harmonization_knhanes_nhanes.csv` | A | KNHANES authoritative Korean variable labels (`개인아이디`, `조사연도`). Notes already English. |
+| `skills/replicate-study/references/harmonization_3country.csv` | A | KNHANES authoritative Korean variable labels. |
+| `skills/define-variables/SKILL.md` | A/D | KNHANES-style dictionary sheet/row example (`5-1.복부초음파 r12`) + bilingual trigger. |
+| `skills/find-journal/SKILL.md` | A | Bilingual section-heading recognition patterns (`## 추가 필요` / `## Missing`). |
+| `skills/render-pdf-doc/references/pandoc_korean_cheatsheet.md` | A | Korean-PDF rendering reference (the skill renders Korean academic PDFs). +label in PR3. |
+| `skills/render-pdf-doc/references/known_pitfalls.md` | A | Korean-PDF rendering failure-mode demonstrations. +label in PR3. |
+
+## KEEP — Korean-domain mode (Bucket A2)
+
+| Path | Bucket | Why retained |
+|---|---|---|
+| `skills/grant-builder/SKILL.md` | A2 | "Korean Government Grant Mode" — English prose already wraps preserved KR program terms (첨부1/2/3, 산학과제). PR4 adds the locale label + this row. |
+
+## KEEP — bilingual triggers only (Bucket D)
+
+| Path | Bucket | Why retained |
+|---|---|---|
+| `skills/add-journal/SKILL.md` | D | Korean only in `triggers:` (`저널 프로필 추가`). |
+| `skills/batch-cohort/SKILL.md` | D | Korean only in `triggers:`. |
+| `skills/cross-national/SKILL.md` | D | Korean only in `triggers:` (한미 비교 …). |
+| `skills/find-cohort-gap/SKILL.md` | D | Korean only in `triggers:`. |
+| `skills/humanize/SKILL.md` | D | Korean only in `triggers:`. |
+| `skills/peer-review/SKILL.md` | D | Korean only in `triggers:`. |
+| `skills/replicate-study/SKILL.md` | D | Korean only in `triggers:`. |
+| `skills/setup-medsci/SKILL.md` | D | Korean only in `triggers:`. |
+
+---
+
+## TRANSLATE — incidental prose (Bucket B → PR2, transitional)
+
+| Path | Bucket | Disposition |
+|---|---|---|
+| `skills/humanize/references/ai_patterns.md` | B | Translate prose to English (preserve the §/AI-tell rationale). |
+| `skills/meta-analysis/references/data_integrity_checklist.md` | B | Translate prose. |
+| `skills/meta-analysis/references/post_submission_release_ops.md` | B | Translate prose. |
+| `skills/meta-analysis/references/review_orchestration.md` | B | Translate prose. |
+| `skills/meta-analysis/references/submission_package_drift.md` | B | Translate prose. |
+| `skills/meta-analysis/SKILL.md` | B | Translate `참고용` prose (line ~322). |
+| `skills/ma-scout/SKILL.md` | B | Translate internal table headers/prose (영역/대표 키워드 …). |
+| `skills/fill-protocol/references/best_practices.md` | B | Translate prose. |
+| `skills/define-variables/templates/variable_operationalization.md` | B | Translate prose. |
+| `skills/define-variables/references/common_definitions.md` | B | Translate the KCDC standard-drink note. |
+| `skills/check-reporting/references/step4d_prisma_figure_audit.md` | B | Translate the one Korean line. |
+| `skills/write-paper/references/section_guides/step7_1_classical_qc.md` | B | Translate prose (separate file from write-paper SKILL.md). |
+| `skills/author-strategy/SKILL.md` | B | Translate the Korean example query (line ~66); keep the trigger. |
+| `skills/orchestrate/references/dialogue_nodes.md` | B | Translate the one Korean line. |
+| `skills/peer-review/references/reviewer_profiles/RYAI.md` | B/A | MIXED: translate explanatory prose; **keep** the ScholarOne Korean field labels (file stays inventoried for those after PR2). |
+
+## REDESIGN — English-default + Korean opt-in (Bucket C → PR3, transitional)
+
+| Path | Bucket | Disposition |
+|---|---|---|
+| `skills/lit-sync/SKILL.md` | C | English-default folders/headings; honor existing Korean vault if present; Korean layout → `references/locale/ko/note_templates.md`. |
+| `skills/write-paper/SKILL.md` | C | English-default Q1–Q5 + Discussion-review prompts + QC-table prose (whole file in PR3); Korean → `references/locale/ko/planning_prompts.md`. |
+| `skills/present-paper/templates/build_pptx_nature_lancet.py` | C | Docstrings: notes language = user preference (English default); keep `FONT_KR`. |
+| `skills/present-paper/references/generate_pptx_templates.py` | C | Docstring/comment de-Koreanize (English default). |
+| `skills/present-paper/references/slide_visual_styles/nature_lancet.md` | C | Translate Korean-notes/font directives to English. |
+| `skills/present-paper/references/medical_presentation_templates.md` | C | Translate the Korean speaker-notes directive. |
+| `skills/orchestrate/SKILL.md` | C | English-default PHI prompts (lines ~402/408) + translate §-name `Tier-3 차단 항목`; keep bilingual routing phrases (whole file in PR3). |
+| `skills/orchestrate/references/report_template.md` | C | English-default template + add `report_template_ko.md`. |
+| `skills/ma-scout/references/project_readme_template.md` | C | English-default (English structure kept) + add `_ko` variant. |
+| `skills/render-pdf-doc/SKILL.md` | C | Translate body prose (Boundary table, design notes). |
+| `skills/render-pdf-doc/skill.yml` | C | Translate `quality_gates` Korean (lines 42-44). |
+| `skills/render-pdf-doc/templates/proposal-cover.md` | C | English-default starter + add `_ko` variant. |
+| `skills/render-pdf-doc/templates/briefing-handout.md` | C | English-default starter + add `_ko` variant. |
+| `skills/render-pdf-doc/templates/anchor-doc.md` | C | English-default starter + add `_ko` variant. |
+| `skills/render-pdf-doc/templates/reference-table.md` | C | English-default starter + add `_ko` variant. |
+| `skills/fill-icmje-coi/SKILL.md` | C | English-default co-author email template (lines ~135-138) + `_ko` variant. |
+| `skills/analyze-stats/SKILL.md` | C | English-default PHI prompt (lines ~21-22, currently in blockquote — validator-invisible). |
+| `skills/make-figures/SKILL.md` | C | English-default PHI prompt (lines ~36-37, blockquote — validator-invisible). |

--- a/scripts/check_locale_inventory.py
+++ b/scripts/check_locale_inventory.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Locale-inventory coverage gate for medsci-skills.
+
+medsci-skills is English-canonical: skill mechanics and prose are English, and
+non-English (currently Korean) text is allowed only as a labeled locale feature,
+a locale-jurisdiction mode, a bilingual trigger, or an opt-in `*_ko` variant.
+Every such file must be justified in `docs/locale_inventory.md`.
+
+This is the auditable allowlist gate (the real anti-drift guard), independent of
+the WARN-only Korean-prose check in validate_skills.sh (which scans only SKILL.md
+and skips code/tables/blockquotes). It enforces the invariant:
+
+  every file matched by `grep -rl '[가-힣]' skills/` MUST appear as a row in
+  docs/locale_inventory.md.
+
+A Korean-bearing file that is *missing* from the inventory fails the check (a leak
+slipped past review). An inventory row whose file no longer contains Korean is
+*stale* (a translated/redesigned file whose row should be removed) — reported as a
+warning by default, and as a failure under --strict.
+
+Exit 0 when coverage is clean. Exit 1 on findings (missing always; stale under
+--strict). Exit 2 on operational error. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Same Hangul range as validate_skills.sh check #9 (syllables + isolated jamo).
+HANGUL = re.compile(r"[가-힣ㄱ-ㆎ]")
+# Any skills/-relative path token mentioned in the inventory prose/tables.
+SKILLS_PATH = re.compile(r"skills/[A-Za-z0-9_./\-]+")
+# Files we never scan for content (binary-ish); kept small and explicit.
+SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".pdf", ".docx", ".xlsx", ".zip", ".pptx"}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def korean_files(skills_dir: Path, base: Path) -> set[str]:
+    """Posix paths (relative to `base`, i.e. `skills/...`) of files under skills/ containing Hangul."""
+    found: set[str] = set()
+    for p in sorted(skills_dir.rglob("*")):
+        if not p.is_file() or p.suffix.lower() in SKIP_SUFFIXES:
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, ValueError):
+            continue
+        if HANGUL.search(text):
+            found.add(p.relative_to(base).as_posix())
+    return found
+
+
+def inventory_paths(inventory: Path, base: Path) -> set[str]:
+    """`skills/...` path tokens listed in the inventory that resolve to real files under `base`."""
+    text = inventory.read_text(encoding="utf-8", errors="ignore")
+    listed: set[str] = set()
+    for tok in SKILLS_PATH.findall(text):
+        if (base / tok).is_file():
+            listed.add(tok)
+    return listed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--skills-dir", default=None, help="skills/ directory (default: <repo>/skills)")
+    ap.add_argument("--inventory", default=None, help="inventory file (default: <repo>/docs/locale_inventory.md)")
+    ap.add_argument("--strict", action="store_true", help="treat stale inventory rows as failures too")
+    ap.add_argument("--quiet", action="store_true", help="suppress the per-file listing")
+    ap.add_argument("--json", action="store_true", help="emit a JSON summary instead of text")
+    args = ap.parse_args()
+
+    root = repo_root()
+    skills_dir = Path(args.skills_dir).resolve() if args.skills_dir else root / "skills"
+    inventory = Path(args.inventory).resolve() if args.inventory else root / "docs" / "locale_inventory.md"
+
+    if not skills_dir.is_dir():
+        print(f"ERROR: skills dir not found: {skills_dir}", file=sys.stderr)
+        return 2
+    if not inventory.is_file():
+        print(f"ERROR: inventory not found: {inventory}", file=sys.stderr)
+        return 2
+
+    base = skills_dir.parent  # so file paths read as "skills/..." regardless of --skills-dir
+    korean = korean_files(skills_dir, base)
+    listed = inventory_paths(inventory, base)
+
+    missing = sorted(korean - listed)   # Korean files not in the inventory -> leak (FAIL)
+    stale = sorted(listed - korean)     # inventoried files no longer Korean -> remove row (WARN/strict-FAIL)
+
+    summary = {
+        "korean_files": len(korean),
+        "inventoried_files": len(listed),
+        "missing": missing,
+        "stale": stale,
+        "strict": args.strict,
+        "ok": not missing and (not stale or not args.strict),
+    }
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        print(f"Locale inventory: {len(korean)} Korean-bearing file(s) under skills/; "
+              f"{len(listed)} inventoried.")
+        if missing:
+            print(f"\nMISSING from docs/locale_inventory.md ({len(missing)}) — leak, FAIL:")
+            if not args.quiet:
+                for m in missing:
+                    print(f"  - {m}")
+        if stale:
+            tag = "FAIL (--strict)" if args.strict else "warning"
+            print(f"\nSTALE inventory rows ({len(stale)}) — file no longer contains Korean, remove row [{tag}]:")
+            if not args.quiet:
+                for s in stale:
+                    print(f"  - {s}")
+        if summary["ok"]:
+            print("\nOK: every Korean-bearing file is inventory-justified.")
+
+    if missing:
+        return 1
+    if stale and args.strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_locale_inventory.sh
+++ b/tests/test_locale_inventory.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Test scripts/check_locale_inventory.py — the locale-inventory coverage gate.
+# Uses synthetic, PII-free fixtures via --skills-dir / --inventory. No repo files touched.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check_locale_inventory.py"
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Synthetic skills tree: one Korean-bearing file, one English-only file.
+mkdir -p "$WORK/skills/alpha" "$WORK/skills/beta"
+printf 'description: sample\n비식별화 샘플 텍스트\n' > "$WORK/skills/alpha/SKILL.md"   # Hangul -> matched
+printf 'description: english only\nno korean here\n'   > "$WORK/skills/beta/SKILL.md"    # not matched
+
+run() { python3 "$SCRIPT" --skills-dir "$WORK/skills" --inventory "$1" "${@:2}"; }
+
+# 1. Korean file listed -> OK (exit 0)
+cat > "$WORK/inv_ok.md" <<'EOF'
+# Inventory
+| skills/alpha/SKILL.md | A | locale sample |
+EOF
+run "$WORK/inv_ok.md" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "listed Korean file -> exit 0" || bad "listed Korean file should pass"
+
+# 2. Korean file NOT listed -> missing -> FAIL (exit 1)
+cat > "$WORK/inv_missing.md" <<'EOF'
+# Inventory
+(no rows)
+EOF
+run "$WORK/inv_missing.md" >/dev/null 2>&1
+[ $? -eq 1 ] && ok "missing Korean file -> exit 1" || bad "missing Korean file should fail"
+
+# 3. Stale row (lists an English-only file that has no Korean) -> warn, exit 0 by default
+cat > "$WORK/inv_stale.md" <<'EOF'
+# Inventory
+| skills/alpha/SKILL.md | A | locale sample |
+| skills/beta/SKILL.md | B | stale row (beta has no Korean) |
+EOF
+run "$WORK/inv_stale.md" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "stale row -> warn, exit 0 (default)" || bad "stale row should not fail by default"
+
+# 4. Stale row under --strict -> FAIL (exit 1)
+run "$WORK/inv_stale.md" --strict >/dev/null 2>&1
+[ $? -eq 1 ] && ok "stale row --strict -> exit 1" || bad "stale row should fail under --strict"
+
+# 5. JSON output is valid and reports the missing file
+cat > "$WORK/inv_missing2.md" <<'EOF'
+# Inventory
+EOF
+out="$(run "$WORK/inv_missing2.md" --json 2>/dev/null)"
+echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d['missing']==['skills/alpha/SKILL.md'] and d['ok'] is False else 1)" \
+  && ok "JSON reports missing file + ok:false" || bad "JSON summary incorrect"
+
+echo ""
+echo "test_locale_inventory: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

medsci-skills functions in English environments, but ~67 files under `skills/` still contain Korean — confusing for an international reader/contributor inspecting the repo. This is **PR1 of a 4-PR effort** to make the repo English-canonical while preserving Korean where it is functional.

PR1 lands **policy + the auditable allowlist infrastructure only** — no skill behavior changes, no translations yet.

## Changes

- **`docs/locale_inventory.md`** (new) — classifies all 67 Korean-bearing files into buckets, each with a one-line justification:
  - **A** locale feature / **A2** locale-jurisdiction mode / **D** bilingual triggers → KEEP
  - **B** incidental prose → translate (PR2)
  - **C** Korean-default behavior/output → English-default + Korean opt-in `*_ko` (PR3)
- **`scripts/check_locale_inventory.py`** (new) — deterministic coverage gate (stdlib-only; `--json/--strict/--quiet`, exit 0/1/2). Fails if any Korean-bearing file under `skills/` is missing from the inventory. The inventory is the authoritative allowlist, complementing the WARN-only Korean-prose check in `validate_skills.sh` (which scans only SKILL.md and skips code/tables/blockquotes).
- **`tests/test_locale_inventory.sh`** (new) — 5 synthetic, PII-free fixture cases.
- **`CONTRIBUTING.md`** — adds a **Language Policy** section + PR-checklist item.
- **`.github/workflows/validate.yml`** — wires the gate + self-test into CI.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Policy

English-canonical for SKILL.md prose, `skill.yml`, code comments, and general references. Non-English allowed **only** as labeled locale data, locale-jurisdiction modes, bilingual `triggers:`, or opt-in `*_ko` variants — each justified in `docs/locale_inventory.md`.

## Verification

All CI-equivalent checks pass locally: `validate_skills.sh`, `validate_routing_assets.py --strict`, `validate_catalog_consistency.py` (43 skills, 21 detectors — unchanged), `gen_skill_docs.py --check`, `check_domain_probe_sync.py --strict`, `check_locale_inventory.py` (67/67 inventoried), `tests/test_locale_inventory.sh` (5/5).

## Follow-ups
- PR2: translate Bucket B incidental prose.
- PR3: English-default + Korean opt-in redesign (Bucket C; lit-sync, write-paper, present-paper, orchestrate, ma-scout, render-pdf-doc, fill-icmje-coi).
- PR4: locale labels on KEEP files + finalize coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)