### PR TITLE
chore(release): v4.0.0 — README cleanup, version bump, release-notes fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,13 @@ jobs:
         id: notes
         run: |
           TAG="${GITHUB_REF_NAME}"
-          # Extract the section for this tag from CHANGELOG.md (between this version header and the next version header)
+          # Tags are "vX.Y.Z" but CHANGELOG headers are "## [X.Y.Z]" (no leading v).
+          # Strip the v so the section is actually found (else notes fall back).
+          VER="${TAG#v}"
+          # Extract the section for this version from CHANGELOG.md (between this version header and the next version header)
           if [ -f CHANGELOG.md ]; then
-            awk -v tag="$TAG" '
-              $0 ~ "^## \\[?"tag"\\]?" { found=1; next }
+            awk -v ver="$VER" '
+              $0 ~ "^## \\[?"ver"\\]?" { found=1; next }
               found && /^## / { exit }
               found { print }
             ' CHANGELOG.md > /tmp/release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [4.0.0] - 2026-06-10
+
+Theme: extend the project's own deterministic, no-drift SSOT discipline to the public storefront, finish the detector backlog, and roll up the English-canonical i18n migration. Analysis-integrity detectors **21 → 24** (still 43 skills). Frozen `demo/` and `evaluation/runs/canonical` artifacts (pinned to the published methods paper) are unchanged.
 
 ### Added
 
+- **Storefront catalog SSOT (`metadata/skills_catalog.json`)** — a generated, machine-readable catalog (slug + research-lifecycle category + one-line description for all 43 skills, derived from each `SKILL.md` + `skill.yml` `owner_domain`) via `scripts/gen_skills_catalog_json.py`, CI-gated with `--check`. The aperivue.com storefront vendors this file behind an offline sync gate so the public site can never silently drift behind the repo (it had shown 40 skills while the repo shipped 43).
+- **Asset/figure anonymization gate** — `skills/sync-submission/scripts/check_asset_anonymization.py` scans figure-generating scripts, figure-PDF rendered text, and docx/PDF metadata authors (`dc:creator`, `/Author`) for the institution/author leaks a body-text scan misses. Generic English+Korean institution patterns + a local-only `--names-file`; degrades gracefully when poppler is absent.
+- **Cross-artifact staleness gate** — `check_cross_artifact_stale.py` flags supplement values that disagree with the corrected body (reconciliation-prone labels) and reporting checklists built against an older manuscript version. `/check-reporting` now emits a `target_manuscript` / `target_version` / `source_sha256` contract (report `check_reporting_version` 1.1) verified by `check_checklist_version.py`.
+- **Survival reporting hardening** — `/analyze-stats`'s survival template now reports median survival with its 95% CI, a Cox events-per-variable gate, and cluster-robust (cluster-sandwich) SE for nested observation units (`--cluster`); the cluster-robust rule extends to logistic/linear regression.
 - **Language Policy + locale-inventory gate** — MedSci Skills is now explicitly English-canonical: skill mechanics and prose are English, and non-English (currently Korean) text is allowed only as a labeled locale feature, a locale-jurisdiction mode (e.g. `grant-builder`'s Korean Government Grant Mode), a bilingual `triggers:` alias, or an opt-in `*_ko` variant. A new [`docs/locale_inventory.md`](docs/locale_inventory.md) lists every Korean-bearing file under `skills/` with a one-line justification, and a new stdlib detector `scripts/check_locale_inventory.py` (wired into CI + `tests/test_locale_inventory.sh`) fails if any Korean-bearing file is missing from that inventory — the authoritative allowlist, complementing the WARN-only Korean-prose check in `validate_skills.sh`. CONTRIBUTING gains a Language Policy section + PR-checklist item. This is the policy/scaffold step (PR1); incidental-prose translation (PR2) and English-default-with-Korean-opt-in redesign (PR3) follow. Catalog unchanged at 43 skills.
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "3.8.0"
-date-released: "2026-06-07"
+version: "4.0.0"
+date-released: "2026-06-10"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 ## What's New
 
+**v4.0** extends the project's own deterministic, no-drift SSOT discipline to the public storefront and finishes the detector backlog — bringing the analysis-integrity detector count in `skills/` to **24** (still 43 skills):
+
+- **SSOT to the storefront** — a generated, machine-readable `metadata/skills_catalog.json` (slug + research-lifecycle category + one-line description per skill) is now the source the [aperivue.com](https://aperivue.com/en/skills) storefront vendors, gated offline so the public site can never silently drift behind the repo (`gen_skills_catalog_json.py --check`).
+- **Asset/figure anonymization** — `/sync-submission` scans figure-generating scripts, figure-PDF rendered text, and docx/PDF metadata authors for the institution/author leaks a body-text scan misses (`check_asset_anonymization.py`).
+- **Cross-artifact staleness** — flags supplement values that disagree with the corrected body, and reporting checklists built against an older manuscript version (`check_cross_artifact_stale.py`; `check_checklist_version.py` with a `target_manuscript`/`source_sha256` checklist contract).
+- **Survival reporting** — `/analyze-stats` emits median survival with its 95% CI, a Cox events-per-variable gate, and cluster-robust SE for nested observation units.
+
 **v3.8.0** adds an `evaluation/` harness suite that validates the instrument itself — deterministic detector recall on programmatically seeded defects (E1), fresh-clone manifest reproducibility (E4), claim audit-trail completeness (E5), host-portability and metadata-drift checks (E6/E7/E8), and a cost/time table (E3) — each writing a self-describing, reproducible run package. An LLM-comparator (E2) and a self-review convergence harness (E9) ship runnable but are NOT executed in this release. This release also reconciles the README Live-Demos numbers with the v3.7.0 clean-room demo artifacts. Catalog unchanged (still 43 skills, 21 detectors).
 
 **v3.7.0** adds three deterministic, stdlib-only detectors on top of the v3.6.0 panel-derived gates — bringing the analysis-integrity detector count in `skills/` to **21** — without broadening the catalog (still 43 skills):
@@ -377,12 +384,16 @@ See [docs/classroom_distribution_plan.md](docs/classroom_distribution_plan.md) a
 
 ## Key Features
 
-### Autonomous E2E Pipeline`orchestrate --e2e` or `write-paper --autonomous` runs the full pipeline from data to submission-ready DOCX with bounded validation. Skills pass outputs via structured manifests (`_analysis_outputs.md`, `_figure_manifest.md`) and project artifacts (`project.yaml`, `artifact_manifest.json`, `qc/status.json`). If a skill fails to produce expected outputs, the pipeline halts rather than proceeding with missing data. Phase 7 enforces a strict QC chain: AI pattern removal → reporting compliance check → `/verify-refs` citation audit → numerical claim audit → self-review with auto-fix (max 2 iterations) → DOCX/submission build.
+### Autonomous E2E Pipeline
+
+`orchestrate --e2e` or `write-paper --autonomous` runs the full pipeline from data to submission-ready DOCX with bounded validation. Skills pass outputs via structured manifests (`_analysis_outputs.md`, `_figure_manifest.md`) and project artifacts (`project.yaml`, `artifact_manifest.json`, `qc/status.json`). If a skill fails to produce expected outputs, the pipeline halts rather than proceeding with missing data. Phase 7 enforces a strict QC chain: AI pattern removal → reporting compliance check → `/verify-refs` citation audit → numerical claim audit → self-review with auto-fix (max 2 iterations) → DOCX/submission build.
 
 ### Anti-Hallucination Citations
 Every reference produced by `search-lit` is verified against PubMed, Semantic Scholar, or CrossRef APIs. Existing manuscripts should then run `/verify-refs`, which writes a visible reference audit and blocks fabricated references before submission. No citation is ever generated from memory alone. API errors are batched silently -- no token waste from repeated failure messages.
 
-### Anti-Hallucination Numerical Claims`/meta-analysis` Phase 6b, `/self-review` Phase 2.5a, `/revise` Step 2.5, and `/write-paper`
+### Anti-Hallucination Numerical Claims
+
+`/meta-analysis` Phase 6b, `/self-review` Phase 2.5a, `/revise` Step 2.5, and `/write-paper`
 Step 7.3a enforce a common 3-layer audit (CSV ↔ analysis script ↔ manuscript) with primary-
 source back-checking for pooled estimates and revision-era numbers. Hand-typed numerical
 matrices without CSV-coordinate comments are flagged as structural risks even when the values

--- a/capabilities.yml
+++ b/capabilities.yml
@@ -82,6 +82,9 @@ umbrellas:
 
 # Deprecation: skills and agents scheduled for removal.
 # Follows D-3 (agent archive), D-4 (project-specific skill deprecation).
+# NOTE: sunset_date is advisory — there is no CI gate that enforces it. It
+# signals intent and is announced in CHANGELOG at removal; nothing here blocks a
+# build. Treat it as a planning marker, not an automated cutoff.
 deprecation:
   agents_archived:
     sunset_date: "2026-10-24"


### PR DESCRIPTION
## Summary

Final v4.0 PR: presentation polish + version metadata + a release-workflow bug fix. No skill behavior change; counts unchanged (43 skills / 24 detectors, set by the detector PR).

- **README** — fix two **malformed run-on headings** (`### Autonomous E2E Pipeline\`orchestrate…`, `### Anti-Hallucination Numerical Claims\`/meta-analysis…` — heading text was glued to the body); add a **v4.0 What's New** entry (storefront SSOT + asset/cross-artifact/survival detectors).
- **CITATION.cff** → `4.0.0` (2026-06-10).
- **CHANGELOG** — roll `[Unreleased]` into `[4.0.0]` + add the v4.0 entries.
- **release.yml** — strip the leading `v` from the tag before matching the CHANGELOG `## [X.Y.Z]` header. The extractor matched `^## \[?v4.0.0\]?` against `## [4.0.0]` and never found the section, silently falling back to "See CHANGELOG.md". Verified by dry-run that `VER=4.0.0` now extracts the section.
- **capabilities.yml** — note that `sunset_date` is advisory (no CI gate).

## Verification
- `validate_catalog_consistency.py` → OK (43 skills, 24 detectors, README badge/tagline/guideline counts agree)
- README malformed-heading grep → 0
- release.yml awk dry-run (`VER=4.0.0`) → extracts the `## [4.0.0]` section
- frozen `demo/` + `evaluation/runs/canonical` → unchanged
- PII grep over diff → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)