### PR TITLE
feat(plugin): Claude Code plugin marketplace — 8 medsci-* category plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "medsci-skills",
+  "description": "Physician-built Claude Code skills for the full medical research lifecycle — literature search with anti-hallucination citation verification, study design, statistics, publication-ready figures, IMRAD manuscript drafting, reporting-compliance audits, journal selection, peer review, and revision.",
+  "owner": {
+    "name": "Aperivue"
+  },
+  "plugins": [
+    {
+      "name": "medsci-literature",
+      "description": "Literature search with anti-hallucination citation verification, full-text retrieval, Zotero/Obsidian sync, and reference-integrity audits.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/fulltext-retrieval",
+        "./skills/lit-sync",
+        "./skills/manage-refs",
+        "./skills/search-lit",
+        "./skills/verify-refs"
+      ]
+    },
+    {
+      "name": "medsci-data",
+      "description": "Study design and validity review, literature-grounded variable operationalization, sample-size planning, data cleaning, de-identification, codebook generation, and dataset versioning.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/calc-sample-size",
+        "./skills/clean-data",
+        "./skills/define-variables",
+        "./skills/deidentify",
+        "./skills/design-ai-benchmarking",
+        "./skills/design-study",
+        "./skills/generate-codebook",
+        "./skills/version-dataset"
+      ]
+    },
+    {
+      "name": "medsci-analysis",
+      "description": "Reproducible statistical analysis, publication-ready figures, batch/cross-national/replication analysis, and meta-analysis synthesis.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/analyze-stats",
+        "./skills/batch-cohort",
+        "./skills/cross-national",
+        "./skills/make-figures",
+        "./skills/meta-analysis",
+        "./skills/replicate-study"
+      ]
+    },
+    {
+      "name": "medsci-writing",
+      "description": "IMRAD manuscript and IRB-protocol drafting, AI-pattern removal, AI-search optimization, and reviewer-response letters.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/academic-aio",
+        "./skills/humanize",
+        "./skills/revise",
+        "./skills/write-paper",
+        "./skills/write-protocol"
+      ]
+    },
+    {
+      "name": "medsci-review",
+      "description": "Pre-submission self-review, peer-review drafting, and reporting-guideline compliance audits against EQUATOR checklists.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/check-reporting",
+        "./skills/peer-review",
+        "./skills/self-review"
+      ]
+    },
+    {
+      "name": "medsci-submission",
+      "description": "Submission packaging, journal recommendation and profiling, institutional form filling (ICMJE COI, IRB), and grant proposals.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/add-journal",
+        "./skills/fill-icmje-coi",
+        "./skills/fill-protocol",
+        "./skills/find-journal",
+        "./skills/grant-builder",
+        "./skills/sync-submission"
+      ]
+    },
+    {
+      "name": "medsci-project",
+      "description": "Research orchestration, project intake and management, research-gap and meta-analysis topic discovery, and author-strategy analysis.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/author-strategy",
+        "./skills/find-cohort-gap",
+        "./skills/intake-project",
+        "./skills/ma-scout",
+        "./skills/manage-project",
+        "./skills/orchestrate"
+      ]
+    },
+    {
+      "name": "medsci-presentation",
+      "description": "Academic presentation and PPTX building, PDF/document rendering, environment setup, and skill publishing.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/present-paper",
+        "./skills/publish-skill",
+        "./skills/render-pdf-doc",
+        "./skills/setup-medsci"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Run skills_catalog generator self-test
         run: bash tests/test_skills_catalog_json.sh
 
+      - name: Run gen_marketplace_json.py --check (plugin marketplace SSOT)
+        run: python3 scripts/gen_marketplace_json.py --check
+
+      - name: Run marketplace generator self-test
+        run: bash tests/test_marketplace_json.sh
+
       - name: Run analyze-stats survival template test (A1)
         run: bash skills/analyze-stats/tests/test_survival_template.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Claude Code plugin marketplace (`.claude-plugin/marketplace.json`)** — one-line install via `/plugin marketplace add Aperivue/medsci-skills`, then `/plugin` discovery of eight `medsci-*` category plugins (`medsci-literature`, `-data`, `-analysis`, `-writing`, `-review`, `-submission`, `-project`, `-presentation`) mirroring the storefront categories. Generated from `metadata/skills_catalog.json` by `scripts/gen_marketplace_json.py` (a pure downstream transform — the SSOT chain stays single-source) and CI-gated with `--check` plus `tests/test_marketplace_json.sh` (validated by `claude plugin validate`). The marketplace tracks `main`: no `version` is emitted, so each plugin's version is its git commit SHA. No skills change (still 43).
+
 ## [4.0.0] - 2026-06-10
 
 Theme: extend the project's own deterministic, no-drift SSOT discipline to the public storefront, finish the detector backlog, and roll up the English-canonical i18n migration. Analysis-integrity detectors **21 → 24** (still 43 skills). Frozen `demo/` and `evaluation/runs/canonical` artifacts (pinned to the published methods paper) are unchanged.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,35 @@ cp -r medsci-skills/skills/* ~/.claude/skills/
 
 Restart Claude Code, then start with **`/orchestrate`** — it classifies your request and routes you to the right skill. Full install options (Codex, Cursor, individual skills) are in [Installation](#installation).
 
+### Install as a Claude Code plugin
+
+Prefer plugins? One line adds the marketplace; `/plugin` then lets you browse eight category plugins and enable the ones you want:
+
+```text
+/plugin marketplace add Aperivue/medsci-skills
+/plugin            # browse eight category plugins; enable the ones you want
+```
+
+| Plugin | Covers |
+|--------|--------|
+| `medsci-literature` | Literature search, full-text retrieval, Zotero sync, reference-integrity audits |
+| `medsci-data` | Study design, variable operationalization, sample size, data cleaning, de-identification, codebooks, dataset versioning |
+| `medsci-analysis` | Statistics, figures, batch/cross-national/replication analysis, meta-analysis |
+| `medsci-writing` | IMRAD & protocol drafting, AI-pattern removal, AI-search optimization, reviewer responses |
+| `medsci-review` | Self-review, peer review, reporting-guideline compliance |
+| `medsci-submission` | Submission packaging, journal selection, ICMJE/IRB form filling, grant proposals |
+| `medsci-project` | Orchestration, project intake/management, gap & topic discovery, author strategy |
+| `medsci-presentation` | Presentations/PPTX, PDF/document rendering, environment setup, skill publishing |
+
+Install a single category and invoke its skills under that namespace:
+
+```text
+/plugin install medsci-analysis@medsci-skills
+/medsci-analysis:analyze-stats
+```
+
+All eight plugins share the same repository source, so this groups and enables skills by category — it is not a partial download. The marketplace tracks `main`, so a plugin's version is its git commit.
+
 ---
 
 ## Live Demos: Three Study Types, Three Full Pipelines

--- a/scripts/gen_marketplace_json.py
+++ b/scripts/gen_marketplace_json.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Generate .claude-plugin/marketplace.json — the Claude Code plugin marketplace.
+
+Why: the one-line `/plugin marketplace add Aperivue/medsci-skills` + `/plugin`
+discovery flow is the highest-ROI distribution channel for this repo. Rather than
+one monolithic plugin, the 8 research-lifecycle categories already defined in
+`metadata/skills_catalog.json` become 8 themed `medsci-*` plugins, so a user can
+browse and enable just the categories they want.
+
+This is a PURE DOWNSTREAM TRANSFORM of metadata/skills_catalog.json (it does NOT
+re-scan skills/), keeping the single-source chain intact:
+  skills/<slug>/{SKILL.md,skill.yml}
+    -> metadata/skills_catalog.json   (gen_skills_catalog_json.py, --check-gated)
+    -> .claude-plugin/marketplace.json (this script, --check-gated)
+The only non-SSOT inputs are the two hand-authored tables below (plugin short
+names + public-facing descriptions), mirroring how gen_skills_catalog_json.py
+hand-authors CATEGORY_BY_OWNER_DOMAIN. A catalog category with no plugin mapping
+aborts generation (fail loud) so a new category is deliberately surfaced.
+
+Version semantics: this marketplace serves from `main` HEAD (no release cut), so
+NO `version` is emitted at the marketplace top level or per plugin — each commit
+is a new version via its git SHA. The marketplace top-level `version` does NOT
+control plugin updates (that is each plugin entry's `version`), so emitting one
+would falsely imply control. Consequence: this generator has no version logic and
+no CITATION.cff coupling — marketplace.json is a pure function of the catalog +
+the tables below (deterministic, so `--check` is meaningful).
+
+Stdlib-only, deterministic (sorted, no timestamps).
+
+Usage:
+  python3 scripts/gen_marketplace_json.py          # write .claude-plugin/marketplace.json
+  python3 scripts/gen_marketplace_json.py --check   # verify in sync; exit 1 on drift (CI gate)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "metadata" / "skills_catalog.json"
+OUT = ROOT / ".claude-plugin" / "marketplace.json"
+
+# Editor/validation hint only; runtime ignores it. URL the current Anthropic
+# official repo uses (anthropics/claude-code/.claude-plugin/marketplace.json).
+SCHEMA_URL = "https://json.schemastore.org/claude-code-marketplace.json"
+MARKETPLACE_NAME = "medsci-skills"  # not a reserved name
+MARKETPLACE_DESCRIPTION = (
+    "Physician-built Claude Code skills for the full medical research lifecycle — "
+    "literature search with anti-hallucination citation verification, study design, "
+    "statistics, publication-ready figures, IMRAD manuscript drafting, "
+    "reporting-compliance audits, journal selection, peer review, and revision."
+)
+OWNER = {"name": "Aperivue"}  # public org; no personal email (PII-safe)
+
+# catalog category key -> plugin name (kebab-case, no spaces). Every category in
+# metadata/skills_catalog.json must appear here; an unmapped key fails generation.
+PLUGIN_NAME_BY_CATEGORY: dict[str, str] = {
+    "literature_references": "medsci-literature",
+    "data_study_design": "medsci-data",
+    "analysis_figures": "medsci-analysis",
+    "writing_manuscript": "medsci-writing",
+    "review_compliance": "medsci-review",
+    "submission_journals": "medsci-submission",
+    "project_workflow": "medsci-project",
+    "presentation_tooling": "medsci-presentation",
+}
+
+# catalog category key -> one-sentence public-facing plugin description.
+PLUGIN_DESC_BY_CATEGORY: dict[str, str] = {
+    "literature_references": (
+        "Literature search with anti-hallucination citation verification, full-text "
+        "retrieval, Zotero/Obsidian sync, and reference-integrity audits."
+    ),
+    "data_study_design": (
+        "Study design and validity review, literature-grounded variable "
+        "operationalization, sample-size planning, data cleaning, de-identification, "
+        "codebook generation, and dataset versioning."
+    ),
+    "analysis_figures": (
+        "Reproducible statistical analysis, publication-ready figures, "
+        "batch/cross-national/replication analysis, and meta-analysis synthesis."
+    ),
+    "writing_manuscript": (
+        "IMRAD manuscript and IRB-protocol drafting, AI-pattern removal, "
+        "AI-search optimization, and reviewer-response letters."
+    ),
+    "review_compliance": (
+        "Pre-submission self-review, peer-review drafting, and reporting-guideline "
+        "compliance audits against EQUATOR checklists."
+    ),
+    "submission_journals": (
+        "Submission packaging, journal recommendation and profiling, institutional "
+        "form filling (ICMJE COI, IRB), and grant proposals."
+    ),
+    "project_workflow": (
+        "Research orchestration, project intake and management, research-gap and "
+        "meta-analysis topic discovery, and author-strategy analysis."
+    ),
+    "presentation_tooling": (
+        "Academic presentation and PPTX building, PDF/document rendering, "
+        "environment setup, and skill publishing."
+    ),
+}
+
+
+class MarketplaceError(Exception):
+    """Raised when the catalog cannot be transformed into a valid marketplace."""
+
+
+def build(catalog_path: Path = CATALOG) -> dict:
+    if not catalog_path.is_file():
+        raise MarketplaceError(
+            f"{catalog_path} not found; run scripts/gen_skills_catalog_json.py first"
+        )
+    try:
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise MarketplaceError(f"{catalog_path} is not valid JSON: {e}")
+
+    categories = catalog.get("categories")
+    if not isinstance(categories, list) or not categories:
+        raise MarketplaceError(f"{catalog_path} has no 'categories' array")
+
+    plugins: list[dict] = []
+    for cat in categories:
+        key = cat.get("key")
+        slugs = cat.get("slugs") or []
+        if key not in PLUGIN_NAME_BY_CATEGORY:
+            raise MarketplaceError(
+                f"category '{key}' is not mapped to a plugin name in "
+                "gen_marketplace_json.py (PLUGIN_NAME_BY_CATEGORY). Add it before release."
+            )
+        if key not in PLUGIN_DESC_BY_CATEGORY:
+            raise MarketplaceError(
+                f"category '{key}' is not mapped to a plugin description in "
+                "gen_marketplace_json.py (PLUGIN_DESC_BY_CATEGORY). Add it before release."
+            )
+        if not slugs:
+            raise MarketplaceError(f"category '{key}' has no skills")
+        plugins.append({
+            "name": PLUGIN_NAME_BY_CATEGORY[key],
+            "description": PLUGIN_DESC_BY_CATEGORY[key],
+            "source": "./",
+            "strict": False,
+            "skills": [f"./skills/{slug}" for slug in sorted(slugs)],
+        })
+
+    return {
+        "$schema": SCHEMA_URL,
+        "name": MARKETPLACE_NAME,
+        "description": MARKETPLACE_DESCRIPTION,
+        "owner": OWNER,
+        "plugins": plugins,
+    }
+
+
+def render(marketplace: dict) -> str:
+    return json.dumps(marketplace, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate .claude-plugin/marketplace.json.")
+    ap.add_argument("--check", action="store_true",
+                    help="verify the marketplace is in sync; exit 1 on drift (CI gate)")
+    ap.add_argument("--catalog", type=Path, default=CATALOG,
+                    help="skills_catalog.json to read (default: metadata/skills_catalog.json; for tests)")
+    ap.add_argument("--out", type=Path, default=OUT,
+                    help="output JSON path (default: .claude-plugin/marketplace.json)")
+    args = ap.parse_args()
+
+    try:
+        content = render(build(args.catalog))
+    except MarketplaceError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+
+    out = args.out
+    if args.check:
+        if not out.exists():
+            print(f"MARKETPLACE_DRIFT — MISSING {out}; run "
+                  "`python3 scripts/gen_marketplace_json.py`", file=sys.stderr)
+            return 1
+        if out.read_text(encoding="utf-8") != content:
+            print(f"MARKETPLACE_DRIFT — {out} out of sync; run "
+                  "`python3 scripts/gen_marketplace_json.py`", file=sys.stderr)
+            return 1
+        mk = json.loads(content)
+        print(f"OK: {out} in sync ({len(mk['plugins'])} plugins).")
+        return 0
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(content, encoding="utf-8")
+    mk = json.loads(content)
+    print(f"OK: wrote {out} ({len(mk['plugins'])} plugins).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_marketplace_json.sh
+++ b/tests/test_marketplace_json.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Test scripts/gen_marketplace_json.py — the plugin-marketplace generator/gate.
+# Uses synthetic catalog fixtures via --catalog / --out. Also asserts the committed
+# .claude-plugin/marketplace.json is in sync AND structurally covers every skill.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/gen_marketplace_json.py"
+PASS=0
+FAIL=0
+
+ok()  { echo "  PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 1. happy path: a mapped-category catalog generates + round-trips on --check ---
+cat > "$WORK/cat.json" <<'JSON'
+{
+  "skill_count": 3,
+  "categories": [
+    {"key": "analysis_figures", "label": "Analysis & Figures", "slugs": ["beta", "alpha"]},
+    {"key": "review_compliance", "label": "Review & Compliance", "slugs": ["gamma"]}
+  ],
+  "skills": []
+}
+JSON
+python3 "$SCRIPT" --catalog "$WORK/cat.json" --out "$WORK/mk.json" >/dev/null 2>&1
+if [ $? -eq 0 ] && [ -f "$WORK/mk.json" ]; then ok "generates marketplace for mapped categories"; else bad "generate failed"; fi
+
+python3 "$SCRIPT" --catalog "$WORK/cat.json" --out "$WORK/mk.json" --check >/dev/null 2>&1
+[ $? -eq 0 ] && ok "--check round-trips on fresh output" || bad "--check should pass right after generate"
+
+python3 -c "
+import json,sys
+d=json.load(open('$WORK/mk.json'))
+names=[p['name'] for p in d['plugins']]
+analysis=next((p for p in d['plugins'] if p['name']=='medsci-analysis'), None)
+ok = (d['name']=='medsci-skills'
+      and names==['medsci-analysis','medsci-review']          # catalog order preserved
+      and analysis is not None
+      and analysis['source']=='./' and analysis['strict'] is False
+      and analysis['skills']==['./skills/alpha','./skills/beta']  # slugs sorted
+      and 'version' not in d
+      and all('version' not in p for p in d['plugins']))
+sys.exit(0 if ok else 1)
+" && ok "JSON shape: name + plugin order + source/strict + sorted skills + no version" || bad "JSON shape wrong"
+
+# --- 2. drift: editing the file makes --check fail ---
+printf '{"tampered":true}\n' > "$WORK/mk.json"
+python3 "$SCRIPT" --catalog "$WORK/cat.json" --out "$WORK/mk.json" --check >/dev/null 2>&1
+[ $? -eq 1 ] && ok "--check detects drift (exit 1)" || bad "--check should fail on drift"
+
+# --- 3. fail-loud: an UNMAPPED category aborts generation ---
+cat > "$WORK/cat_bad.json" <<'JSON'
+{
+  "skill_count": 1,
+  "categories": [
+    {"key": "totally_new_category", "label": "New", "slugs": ["delta"]}
+  ],
+  "skills": []
+}
+JSON
+python3 "$SCRIPT" --catalog "$WORK/cat_bad.json" --out "$WORK/mk2.json" >/dev/null 2>&1
+[ $? -eq 1 ] && ok "unmapped category aborts (exit 1)" || bad "unmapped category must fail loud"
+
+# --- 4. the committed marketplace is in sync (the actual CI gate) ---
+python3 "$SCRIPT" --check >/dev/null 2>&1
+[ $? -eq 0 ] && ok "committed .claude-plugin/marketplace.json in sync" || bad "repo marketplace drifted — run the generator"
+
+# --- 5. structural coverage of the committed file vs real skills/ + catalog ---
+python3 -c "
+import json,sys
+from pathlib import Path
+root=Path('$REPO_ROOT')
+mk=json.load(open(root/'.claude-plugin'/'marketplace.json'))
+cat=json.load(open(root/'metadata'/'skills_catalog.json'))
+errs=[]
+# marketplace identity + 8 plugins
+if mk.get('name')!='medsci-skills': errs.append('name != medsci-skills')
+if len(mk['plugins'])!=len(cat['categories']):
+    errs.append('plugin count != category count')
+# plugin names kebab-case + unique
+names=[p['name'] for p in mk['plugins']]
+import re
+for n in names:
+    if not re.fullmatch(r'[a-z0-9]+(?:-[a-z0-9]+)*', n): errs.append(f'name not kebab-case: {n}')
+if len(set(names))!=len(names): errs.append('duplicate plugin names')
+# every skills path is ./skills/<slug> whose dir exists with SKILL.md
+seen=[]
+for p in mk['plugins']:
+    for s in p['skills']:
+        if not s.startswith('./skills/'): errs.append(f'bad path: {s}'); continue
+        slug=s[len('./skills/'):]
+        if not (root/'skills'/slug/'SKILL.md').is_file(): errs.append(f'missing SKILL.md: {slug}')
+        seen.append(slug)
+# union == all catalog slugs, each exactly once
+catalog_slugs=sorted(sk['slug'] for sk in cat['skills'])
+if sorted(seen)!=catalog_slugs: errs.append('skills union != catalog slugs')
+if len(seen)!=len(set(seen)): errs.append('a skill appears in >1 plugin')
+if len(seen)!=cat['skill_count']: errs.append(f'covered {len(seen)} != skill_count {cat[\"skill_count\"]}')
+if errs:
+    print('\n'.join(errs)); sys.exit(1)
+sys.exit(0)
+" && ok "committed file covers every skill exactly once (paths exist)" || bad "structural coverage failed"
+
+echo ""
+echo "test_marketplace_json: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Adds a Claude Code **plugin marketplace** so users can install with one line and discover skills via `/plugin`:

```text
/plugin marketplace add Aperivue/medsci-skills
/plugin            # browse eight category plugins; enable the ones you want
```

The eight `medsci-*` plugins mirror the existing storefront categories: `medsci-literature`, `-data`, `-analysis`, `-writing`, `-review`, `-submission`, `-project`, `-presentation`. Installing one and invoking a skill: `/plugin install medsci-analysis@medsci-skills` → `/medsci-analysis:analyze-stats`.

## How it stays drift-free

`.claude-plugin/marketplace.json` is **generated** by `scripts/gen_marketplace_json.py`, a pure downstream transform of `metadata/skills_catalog.json` — the single-source chain stays intact:

`skills/<slug>/{SKILL.md,skill.yml}` → `metadata/skills_catalog.json` (`--check`-gated) → `.claude-plugin/marketplace.json` (`--check`-gated)

Only two hand-authored tables (plugin short names + descriptions) are non-SSOT, mirroring `gen_skills_catalog_json.py`'s `CATEGORY_BY_OWNER_DOMAIN`. An unmapped category fails generation (fail-loud).

## Version semantics

The marketplace serves from `main` HEAD, so **no `version`** is emitted at the marketplace or plugin level — each plugin's version is its git commit SHA (confirmed in the smoke test: installed version showed the commit SHA). The marketplace top-level `version` does not control plugin updates, so emitting one would be misleading.

## Verification

- `claude plugin validate . --strict` → passes.
- Local smoke test: `claude plugin marketplace add` + `install medsci-analysis@medsci-skills` succeeded; namespace resolved as `/medsci-analysis:analyze-stats`; cleaned up after.
- `tests/test_marketplace_json.sh` → 7/7 (synthetic happy path, drift, fail-loud, committed-in-sync, full skill-coverage: all 43 skills covered exactly once, every path has a real `SKILL.md`).
- CI wired: `gen_marketplace_json.py --check` + self-test in `validate.yml`.
- No regression: `gen_skills_catalog_json.py --check`, `validate_catalog_consistency.py`, `validate_skills.sh` all green.

## Notes

- All 8 plugins share `source: "./"`; this groups/enables skills by category — **not** a partial download. README wording reflects that.
- `$schema` uses `https://json.schemastore.org/claude-code-marketplace.json` (the URL the current Anthropic official repo uses); runtime ignores `$schema` regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)