### PR TITLE
feat(dist): npm/npx distribution baseline (PR0)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,3 +102,15 @@ jobs:
             python3 skills/version-dataset/scripts/version_dataset.py verify \
               --manifest "$d/manifest.lock.json" --base "$d" --strict
           done
+
+      # --- npm/npx distribution baseline (runs last so packaging failures are easy to isolate) ---
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: npm package self-test (CLI shim + exec bit + version sync + pack audit)
+        run: bash tests/test_npm_package.sh
+
+      - name: npm pack content audit (real pack, package/ prefix normalized)
+        run: python3 scripts/check_npm_package_contents.py --real

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![Citation](https://img.shields.io/badge/Cite-CITATION.cff-blue?style=flat-square)](CITATION.cff)
 ![Built by](https://img.shields.io/badge/Built_by-Physician--Researcher-blue?style=flat-square)
 
-![MedSci Skills](assets/social-preview.png)
+![MedSci Skills](https://raw.githubusercontent.com/Aperivue/medsci-skills/main/assets/social-preview.png)
 
 *Topic Discovery &rarr; Literature Search &rarr; Full-Text Retrieval &rarr; Study Design &rarr; Sample Size &rarr; Protocol &rarr; De-identification &rarr; Data Cleaning &rarr; Statistics &rarr; Figures &rarr; Writing &rarr; Humanize &rarr; Compliance &rarr; Journal Selection &rarr; Peer Review &rarr; Revision &rarr; Presentation*
 
@@ -413,6 +413,21 @@ cp -r medsci-skills/skills/* ~/.claude/skills/
 git clone https://github.com/Aperivue/medsci-skills.git
 cp -r medsci-skills/skills/check-reporting ~/.claude/skills/
 ```
+
+### Option 4: npm / npx (terminal-friendly shortcut)
+
+A convenience wrapper for terminal users — it copies the same skills via the
+dependency-free Python installer. The canonical install paths remain the plugin
+marketplace (Option 1's sibling above) and the git clone above; npm is just a shortcut.
+
+```bash
+npx @aperivue/medsci-skills install            # all hosts (Claude, Codex, Cursor)
+npx @aperivue/medsci-skills install --target claude
+npx @aperivue/medsci-skills list               # list bundled skills
+npx @aperivue/medsci-skills doctor             # quick Node/Python/skill-folder check
+```
+
+Requires Node 18+ and (for `install`/`doctor`) `python3` on your PATH.
 
 ### Platform notes
 

--- a/bin/medsci-skills.js
+++ b/bin/medsci-skills.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/*
+ * medsci-skills — terminal-friendly installer shortcut for the MedSci Skills suite.
+ *
+ * Zero-dependency Node shim. The actual install logic lives in the dependency-free
+ * Python installer (installers/install.py); this CLI only wraps it and adds a light
+ * `doctor` diagnostic. For deep environment diagnostics use the in-agent `setup-medsci`
+ * skill — this `doctor` is intentionally a thin npm-level check, not a replacement.
+ *
+ * Canonical distribution stays the GitHub repo + Claude Code plugin marketplace;
+ * this package is a convenience shortcut for terminal users.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+const INSTALLER = path.join(PKG_ROOT, 'installers', 'install.py');
+const CATALOG = path.join(PKG_ROOT, 'metadata', 'skills_catalog.json');
+
+function readPkg() {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8'));
+  } catch (e) {
+    return { name: 'medsci-skills', version: 'unknown' };
+  }
+}
+
+function pythonCmd() {
+  // Require a Python 3 interpreter — installers/install.py is Python 3 only.
+  // 'python' is accepted only if it reports Python 3.x (some systems alias it to 2.7).
+  for (const cmd of ['python3', 'python']) {
+    const r = spawnSync(cmd, ['--version'], { encoding: 'utf8' });
+    if (r.status === 0) {
+      const out = (r.stdout || '') + (r.stderr || ''); // Py2 prints version to stderr
+      if (/Python 3\./.test(out)) return cmd;
+    }
+  }
+  return null;
+}
+
+function printHelp() {
+  const pkg = readPkg();
+  process.stdout.write(
+`${pkg.name} v${pkg.version}
+MedSci Skills — medical/scientific research skill suite for AI coding agents.
+
+Usage:
+  npx @aperivue/medsci-skills <command> [options]
+  medsci-skills <command> [options]      (after a global install)
+
+Commands:
+  install [--target all|claude|codex|cursor] [--cursor-project <dir>] [--dry-run]
+                       Copy the skills into your agent's skill folder.
+                       Delegates to the dependency-free Python installer and
+                       passes every flag through (including Cursor rule install).
+  list                 List the bundled skills, grouped by category.
+  doctor               Quick environment check (Node, Python, skill folders).
+                       For a full check, run the in-agent 'setup-medsci' skill.
+  --version, -v        Print the package version.
+  --help, -h           Show this help.
+
+Notes:
+  - npm/npx is a terminal-friendly shortcut. The canonical install paths are the
+    Claude Code plugin marketplace and the GitHub repo (see the project README).
+  - 'install'/'doctor' require python3 on PATH (the installer is dependency-free).
+`);
+}
+
+function cmdVersion() {
+  process.stdout.write(readPkg().version + '\n');
+}
+
+function cmdList() {
+  let catalog;
+  try {
+    catalog = JSON.parse(fs.readFileSync(CATALOG, 'utf8'));
+  } catch (e) {
+    process.stderr.write('Could not read the skills catalog (' + CATALOG + ').\n');
+    return 1;
+  }
+  const skills = Array.isArray(catalog.skills) ? catalog.skills : [];
+  const groups = new Map();
+  for (const s of skills) {
+    const label = s.category_label || s.category || 'Other';
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label).push(s.slug);
+  }
+  process.stdout.write(`MedSci Skills — ${skills.length} skills\n`);
+  for (const [label, slugs] of groups) {
+    process.stdout.write(`\n${label}\n  ${slugs.sort().join(', ')}\n`);
+  }
+  return 0;
+}
+
+function cmdDoctor() {
+  const pkg = readPkg();
+  const py = pythonCmd();
+  const claudeDir = path.join(os.homedir(), '.claude', 'skills');
+  const codexDir = path.join(os.homedir(), '.agents', 'skills');
+  const lines = [];
+  lines.push(`medsci-skills doctor — ${pkg.name} v${pkg.version}`);
+  lines.push(`  node           : ${process.version}`);
+  lines.push(`  python3        : ${py ? py + ' (found)' : 'NOT FOUND — needed for install'}`);
+  lines.push(`  installer      : ${fs.existsSync(INSTALLER) ? 'present' : 'MISSING'}`);
+  lines.push(`  ~/.claude/skills : ${fs.existsSync(claudeDir) ? 'exists' : 'not yet created'}`);
+  lines.push(`  ~/.agents/skills : ${fs.existsSync(codexDir) ? 'exists' : 'not yet created'}`);
+  lines.push('');
+  lines.push('For a full environment check (Python, R, Git, Zotero, MCP servers),');
+  lines.push("run the in-agent 'setup-medsci' skill after installing.");
+  process.stdout.write(lines.join('\n') + '\n');
+  return py ? 0 : 1;
+}
+
+function cmdInstall(rest) {
+  const py = pythonCmd();
+  if (!py) {
+    process.stderr.write(
+      'python3 was not found on your PATH.\n' +
+      'The installer is a dependency-free Python script. Install Python 3, or use the\n' +
+      'git / classroom / plugin-marketplace install paths described in the project README.\n');
+    return 1;
+  }
+  if (!fs.existsSync(INSTALLER)) {
+    process.stderr.write('Installer not found at ' + INSTALLER + '\n');
+    return 1;
+  }
+  const r = spawnSync(py, [INSTALLER, ...rest], { stdio: 'inherit' });
+  return r.status == null ? 1 : r.status;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
+    printHelp();
+    return 0;
+  }
+  if (args[0] === '--version' || args[0] === '-v' || args[0] === 'version') {
+    cmdVersion();
+    return 0;
+  }
+  switch (args[0]) {
+    case 'list':
+      return cmdList();
+    case 'doctor':
+      return cmdDoctor();
+    case 'install':
+      return cmdInstall(args.slice(1));
+    default:
+      process.stderr.write(`Unknown command: ${args[0]}\n\n`);
+      printHelp();
+      return 2;
+  }
+}
+
+process.exit(main(process.argv));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@aperivue/medsci-skills",
+  "version": "4.1.0",
+  "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/Aperivue/medsci-skills#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Aperivue/medsci-skills.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Aperivue/medsci-skills/issues"
+  },
+  "bin": {
+    "medsci-skills": "bin/medsci-skills.js"
+  },
+  "files": [
+    "skills/",
+    "installers/install.py",
+    "installers/install-macos.command",
+    "installers/install-windows.cmd",
+    "installers/install-windows.ps1",
+    "metadata/skills_catalog.json",
+    "bin/medsci-skills.js",
+    "README.md",
+    "README_FIRST.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "medical-research",
+    "radiology",
+    "meta-analysis",
+    "systematic-review",
+    "reporting-guidelines",
+    "biostatistics",
+    "peer-review",
+    "claude-code",
+    "agent-skills",
+    "research-pipeline"
+  ],
+  "scripts": {
+    "prepack": "find skills installers -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null; true",
+    "test": "bash tests/test_npm_package.sh"
+  }
+}

--- a/scripts/check_npm_package_contents.py
+++ b/scripts/check_npm_package_contents.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""npm tarball content audit (allowlist/denylist gate).
+
+Parses the file list that `npm pack` would publish and asserts that
+(1) no private / dev / heavy / copyright-bearing path leaks into the tarball, and
+(2) the required public files are present.
+
+This is defense-in-depth on top of the `files` allowlist in package.json: if the
+allowlist is ever loosened, this gate still blocks the dangerous paths.
+
+Usage:
+    python3 scripts/check_npm_package_contents.py            # dry-run (default)
+    python3 scripts/check_npm_package_contents.py --real     # real `npm pack`, then clean up
+    python3 scripts/check_npm_package_contents.py --json-file pack.json   # parse a saved file list
+
+Exit codes: 0 = clean, 1 = violation (denied path present or required path missing),
+2 = usage/parse error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Denied path prefixes (matched after stripping a leading "package/").
+DENY_PREFIXES = (
+    "_corpus/",
+    "_improvement_plans/",
+    "dist/",
+    "demo/",
+    "evaluation/",
+    "tests/",
+    "metrics/",
+    "docs/",
+    "assets/",
+    ".git/",
+    ".github/",
+)
+# Denied path substrings (anywhere in the normalized path). Includes OS/editor junk
+# (.DS_Store) and tool caches that can hide inside the allowlisted skills/ subtree.
+DENY_SUBSTRINGS = (
+    "__pycache__",
+    "/.git/",
+    ".pyc",
+    ".DS_Store",
+    ".pytest_cache",
+    ".ipynb_checkpoints",
+)
+# Denied exact root files (private scratch / handoff / dev-only docs).
+DENY_ROOT_FILES = {
+    "paper.md",
+    "MEDSCI_AUDIT.md",
+    "IMPACT.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+}
+# Denied root-file prefixes (HANDOFF.md, HANDOFF_LESSONS_*, HANDOFF_LETTER_*, PLAN_*).
+DENY_ROOT_PREFIXES = ("HANDOFF", "PLAN_")
+
+# Required paths (normalized). Prefix entries match the start of a path.
+REQUIRED_PREFIXES = ("skills/",)
+REQUIRED_FILES = (
+    "installers/install.py",
+    "LICENSE",
+    "bin/medsci-skills.js",
+    "README.md",
+)
+
+
+def normalize(p: str) -> str:
+    p = p.replace("\\", "/")
+    if p.startswith("./"):
+        p = p[2:]
+    if p.startswith("package/"):
+        p = p[len("package/"):]
+    return p
+
+
+def get_file_list(args) -> tuple[list[str], dict[str, int]]:
+    """Return (normalized paths, {normalized path: mode}). Mode is npm's decimal mode or -1."""
+    if args.json_file:
+        with open(args.json_file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    else:
+        cmd = ["npm", "pack", "--json"]
+        if not args.real:
+            cmd.append("--dry-run")
+        # Anchor to the repo root so the audit packs the right package regardless of cwd.
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO_ROOT))
+        if proc.returncode != 0:
+            sys.stderr.write("npm pack failed:\n" + proc.stderr + "\n")
+            sys.exit(2)
+        out = proc.stdout.strip()
+        start = out.find("[")
+        if start == -1:
+            start = out.find("{")
+        if start == -1:
+            sys.stderr.write("Could not locate JSON in npm pack output.\n")
+            sys.exit(2)
+        data = json.loads(out[start:])
+        if args.real:
+            # `npm pack` (no dry-run) writes a .tgz in the repo root; remove it to avoid churn.
+            entries = data if isinstance(data, list) else [data]
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                tgz = entry.get("filename")
+                if tgz:
+                    tgz_path = REPO_ROOT / tgz
+                    if tgz_path.exists():
+                        try:
+                            tgz_path.unlink()
+                        except OSError:
+                            pass
+
+    # npm versions differ: --json may emit a single object instead of an array.
+    if isinstance(data, dict):
+        data = [data]
+
+    paths: list[str] = []
+    modes: dict[str, int] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        for f in entry.get("files", []):
+            np = normalize(f.get("path", ""))
+            if not np:
+                continue
+            paths.append(np)
+            modes[np] = f.get("mode", -1)
+    return paths, modes
+
+
+def is_denied(p: str) -> bool:
+    if any(p.startswith(pre) for pre in DENY_PREFIXES):
+        return True
+    if any(sub in p for sub in DENY_SUBSTRINGS):
+        return True
+    if "/" not in p:  # root file
+        if p in DENY_ROOT_FILES:
+            return True
+        if any(p.startswith(pre) for pre in DENY_ROOT_PREFIXES):
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="npm tarball content audit.")
+    ap.add_argument("--real", action="store_true", help="Run a real `npm pack` (then delete the tarball).")
+    ap.add_argument("--json-file", help="Parse a saved `npm pack --json` file list instead of running npm.")
+    args = ap.parse_args()
+
+    paths, modes = get_file_list(args)
+    if not paths:
+        sys.stderr.write("No files reported by npm pack — refusing to pass.\n")
+        return 2
+
+    violations = [p for p in sorted(set(paths)) if is_denied(p)]
+
+    present = set(paths)
+    missing_files = [f for f in REQUIRED_FILES if f not in present]
+    missing_prefixes = [pre for pre in REQUIRED_PREFIXES if not any(p.startswith(pre) for p in paths)]
+
+    # Executable-bit check on the CLI (warn only — npm mode reporting varies).
+    bin_mode = modes.get("bin/medsci-skills.js", -1)
+    bin_warn = bin_mode != -1 and not (bin_mode & 0o111)
+
+    print(f"npm tarball audit — {len(set(paths))} files")
+    if violations:
+        print("\nDENIED paths present in tarball:")
+        for v in violations:
+            print(f"  ! {v}")
+    if missing_files or missing_prefixes:
+        print("\nREQUIRED paths missing from tarball:")
+        for m in missing_files + [f"{pre}*" for pre in missing_prefixes]:
+            print(f"  ? {m}")
+    if bin_warn:
+        print(f"\nWARN: bin/medsci-skills.js mode {oct(bin_mode)} has no exec bit "
+              "(npm may still set it; verify with `test -x`).")
+
+    if violations or missing_files or missing_prefixes:
+        print("\nFAIL")
+        return 1
+    print("\nOK: allowlist clean, required files present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_npm_package.sh
+++ b/tests/test_npm_package.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Self-test for the npm/npx distribution baseline (PR0).
+# Verifies the CLI shim, executable bit, version sync, and the pack-content audit.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "  ok: $1"; }
+
+echo "== test_npm_package =="
+
+# 1. CLI is executable (required #2).
+[ -x bin/medsci-skills.js ] || fail "bin/medsci-skills.js is not executable (chmod +x)"
+pass "bin/medsci-skills.js is executable"
+
+# 2. Shebang present.
+head -1 bin/medsci-skills.js | grep -q '^#!/usr/bin/env node' || fail "missing '#!/usr/bin/env node' shebang"
+pass "node shebang present"
+
+# 3. --help exits 0 and mentions install.
+node bin/medsci-skills.js --help >/tmp/msk_help.txt 2>&1 || fail "--help exited non-zero"
+grep -qi 'install' /tmp/msk_help.txt || fail "--help did not mention install"
+pass "--help works"
+
+# 4. --version matches package.json.
+PKG_VER="$(node -e "process.stdout.write(require('./package.json').version)")"
+CLI_VER="$(node bin/medsci-skills.js --version | tr -d '[:space:]')"
+[ "$PKG_VER" = "$CLI_VER" ] || fail "version mismatch: package.json=$PKG_VER cli=$CLI_VER"
+pass "--version matches package.json ($PKG_VER)"
+
+# 5. list reads the catalog and prints the skill count.
+node bin/medsci-skills.js list >/tmp/msk_list.txt 2>&1 || fail "list exited non-zero"
+grep -qiE 'MedSci Skills .* [0-9]+ skills' /tmp/msk_list.txt || fail "list did not print a skill count"
+pass "list works"
+
+# 6. doctor runs (python3 present in CI -> exit 0; tolerate absence locally).
+if node bin/medsci-skills.js doctor >/tmp/msk_doctor.txt 2>&1; then
+  pass "doctor ran (exit 0)"
+else
+  echo "  note: doctor exited non-zero (python3 likely absent) — tolerated"
+fi
+grep -qi 'setup-medsci' /tmp/msk_doctor.txt || fail "doctor did not point to setup-medsci"
+pass "doctor points to setup-medsci"
+
+# 7. pack-content audit passes (no denied paths, required present).
+python3 scripts/check_npm_package_contents.py || fail "npm pack content audit failed"
+pass "npm pack content audit clean"
+
+echo "PASS: test_npm_package"


### PR DESCRIPTION
## PR0 — npm/npx distribution baseline

Adds an `npx`-installable CLI shim + a tarball-content audit so the suite gains an
npm/npx install channel. **No publish** — this is the packaging baseline only.
npm/npx becomes a terminal-friendly shortcut alongside the existing plugin-marketplace,
classroom-ZIP, and git-clone install paths (which stay primary).

### Contents
- **`package.json`** — `files` allowlist, `bin`, `engines.node>=18`, `license: "SEE LICENSE IN LICENSE"` (root LICENSE is MIT + third-party carve-out), `prepack` strips regenerable `__pycache__`, no lockfile.
- **`bin/medsci-skills.js`** — zero-dep Node CLI (`help`/`version`/`list`/`doctor`/`install`). `install`/`doctor` delegate to the dependency-free `installers/install.py` with full flag pass-through (incl. `--target cursor` / `--cursor-project`) and require a Python 3 interpreter. `doctor` defers deep environment checks to the `setup-medsci` skill.
- **`scripts/check_npm_package_contents.py`** — allowlist/denylist tarball audit, `package/` prefix normalized, repo-root anchored; blocks private/dev/junk/bytecode paths. Defense-in-depth over the `files` allowlist.
- **`tests/test_npm_package.sh`** — exec-bit + shebang + version-sync + CLI + pack-audit self-test.
- **README** — npm/npx as a new install option (terminal shortcut); hero image switched to an absolute raw URL so it renders on the npm page.
- **`validate.yml`** — `setup-node` + npm self-test + real pack audit appended after the existing gates (so packaging failures isolate cleanly).

### Verification
Full local mirror of `validate.yml` is green (skill PII/structure, routing assets, domain-probe sync, locale inventory, catalog/marketplace/detector/skill-doc generators + self-tests, A1–A6 skill tests, demo manifest). npm gates: 681-file tarball is allowlist-clean; CLI smoke (version/help/list/doctor/install --dry-run) passes. The audit caught real `__pycache__` bytecode leaking through the `skills/` allowlist during the build, now fixed via `prepack`.

### Not in scope (gated on explicit approval)
`npm publish`, GitHub release/tag, and marketplace changes are intentionally **not** performed. Package name is `@aperivue/medsci-skills` (scoped; reversible to unscoped before any publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
