### PR TITLE
feat(reverse-engineer): corpus pipeline infrastructure (PR1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,9 @@ skills/**/TODO_*.md
 # Gemini/Antigravity AI assistant scratchpad (per-session, not for repo)
 .gemini/
 _pr_drafts/
+
+# Reverse-engineering corpus — raw OA PDFs, open-review full text, and per-paper
+# analysis JSON are LEARN-ONLY: never committed (copyright + size). Only distilled
+# patterns and freshly-authored synthetic exemplars reach the public repo.
+# See reverse_engineer/LICENSING.md for the learn-then-synthesize policy.
+_corpus/

--- a/reverse_engineer/LICENSING.md
+++ b/reverse_engineer/LICENSING.md
@@ -1,0 +1,63 @@
+# Reverse-engineering: learn-then-synthesize licensing policy
+
+This directory holds the tooling for a long-running program that studies open-access
+(OA) papers and published peer reviews to improve the MedSci Skills suite (better
+review probes, exemplars, rubrics, and detectors). This document is the **copyright
+firewall** for that program. It is binding on every commit produced by the program.
+
+## The one rule
+
+**Learn from sources privately; publish only synthesis.**
+
+- **Private (never committed):** raw OA PDFs, full-text article prose, full peer-review
+  reports, figures/tables copied from papers, and any per-paper analysis that quotes
+  source text. These live only under `_corpus/`, which is gitignored.
+- **Public (committed to this repo):** distilled *ideas, structure, and facts* (which
+  are not copyrightable expression) and *freshly authored synthetic prose/exemplars*
+  written in the style of — never copied from — the originals.
+
+If a candidate public artifact cannot be produced without copying source expression,
+it does not get committed. Capture the *pattern*, author a *new* example.
+
+## What "synthesis" may contain
+
+| Allowed in public commits | Not allowed in public commits |
+|---|---|
+| Abstracted descriptions ("excellent Methods sections state the reference standard, its timing, and reader blinding in the first paragraph") | Verbatim or lightly-paraphrased sentences from a paper |
+| Reviewer-concern *patterns* ("reviewers flag single-center external validation when authors claim generalizability") | A copied peer-review report, even excerpted |
+| New synthetic exemplars authored from scratch | Cropped figures/tables from non-CC sources |
+| Facts and numbers that are not creative expression (e.g., a guideline item exists) | A figure anchor from any source not verified CC-BY / CC0 |
+| Figure anchors **only** from CC-BY / CC0 sources, with attribution | |
+
+## The manifest gate
+
+Every source that informs a public artifact must have a record in the corpus manifest
+(`_corpus/manifest.json`, schema: `source_manifest.schema.json`). Each record carries:
+
+- `license` / `license_url` — the source's actual license (verified per record).
+- `verbatim_allowed` — default **false**.
+- `public_reuse_policy` — default **`synthetic_only`**. `paraphrase_ok` and
+  `cc_by_attribution` require a verified permissive license on that record.
+
+`scripts/distill.py` refuses to emit a public artifact for a source whose manifest
+record is missing or whose policy does not permit the intended reuse. A source with an
+unverified or unknown license is **learn-only**: it may inform the maintainers' reading
+but must not appear in any committed artifact.
+
+## Source license notes (verify per record — do not assume)
+
+- **F1000Research** peer-review reports are published CC-BY — `paraphrase_ok` /
+  `cc_by_attribution` is defensible *after* confirming the specific report.
+- **eLife / PeerJ / BMJ Open** publish reviews, but the licence varies by record and
+  venue — confirm each before raising the policy above `synthetic_only`.
+- **OA articles** range from CC-BY to CC-BY-NC-ND — the licence governs figure anchors
+  and any quotation; the *ideas* are free to learn from regardless.
+
+When in doubt, keep the record at the default (`verbatim_allowed: false`,
+`public_reuse_policy: synthetic_only`) and publish synthesis only.
+
+## Distribution note
+
+`reverse_engineer/` is maintainer tooling. It is excluded from the npm tarball
+(not in the `package.json` `files` allowlist) and `_corpus/` is gitignored, so neither
+raw sources nor this tooling ship to end users.

--- a/reverse_engineer/PLAYBOOK.md
+++ b/reverse_engineer/PLAYBOOK.md
@@ -1,0 +1,106 @@
+# Reverse-engineering PLAYBOOK — one loop iteration
+
+This is the single source of truth the self-improvement loop follows. Each iteration
+turns a small batch of open-access papers / published reviews into **one** concrete,
+committed improvement to a skill, with a Codex review checkpoint and hard outward gates.
+
+Read `LICENSING.md` first — it is binding on every artifact this loop commits.
+
+## Invariants (every iteration)
+
+- **One improvement per iteration.** A single new probe section, one rubric extension,
+  one exemplar set, one calibration table, or one detector — never a grab-bag.
+- **Learn-then-synthesize.** Sources stay in `_corpus/` (gitignored). Commits carry only
+  distilled patterns + freshly authored synthetic content (+ CC-BY/CC0 anchors). The
+  `distill.py` manifest gate enforces this.
+- **Feature branch only.** Commit and push to a `feat/*` branch. **Never** merge to main,
+  publish, tag, release, or change the marketplace without explicit human approval.
+- **Green before commit.** The full local mirror of `.github/workflows/validate.yml`
+  must pass (see Step E).
+- **Codex is a lead, not a verdict.** Fold in only the feedback you can verify; record
+  rejections with a one-line reason.
+
+## Step A — Acquire
+
+1. Pull the next batch (N ≈ 5) of `record_id`s / DOIs from `doi_lists/queue.txt`.
+2. Fetch full text into `_corpus/papers/<record_id>.md` (use the `fulltext-retrieval`
+   skill for OA articles; open-review APIs for review reports). `scripts/acquire.py`
+   prepares the batch directory and a manifest stub per record.
+3. Fill each manifest record in `_corpus/manifest.json` (schema:
+   `source_manifest.schema.json`): real `license` / `license_url`, `retrieved_at`,
+   and keep the defaults (`verbatim_allowed: false`, `public_reuse_policy: synthetic_only`)
+   unless a permissive license is **verified** for that record.
+4. Unknown/unverifiable license → leave it learn-only (defaults). It can inform reading
+   but cannot appear in a committed artifact.
+
+## Step B — Analyze
+
+For each paper, write a structured analysis to `_corpus/analysis/<record_id>.json`
+(`scripts/analyze_paper.py` scaffolds and validates the shape). Capture *patterns*, not
+copied prose: study type, applicable reporting guideline, what makes the
+Methods/Results/Discussion strong, figure/table strengths, and the concerns a sharp
+reviewer would raise (in your own words).
+
+## Step C — Distill
+
+Aggregate the batch into **one** candidate improvement. Pick the highest-priority open
+item from the priority order below. Author it as synthesis:
+
+- a new domain-probe **section** (extend an existing module — see the probe note below),
+- a `critic_rubrics/` or `reviewer_calibration/` extension,
+- a synthetic `exemplar_*` set (with a `_why.md` curator note),
+- a journal compliance-floor table, or
+- a deterministic detector candidate.
+
+Run `scripts/distill.py --check` so the manifest gate confirms every source feeding the
+artifact permits the reuse you applied.
+
+## Step D — Integrate
+
+Wire the artifact into the target skill the lean way: keep `SKILL.md` short, put the
+knowledge in `references/` loaded on demand.
+
+- **Domain probes are vendored byte-identical** across `peer-review` and `self-review`.
+  Prefer adding a **section to an existing module**, then run
+  `python3 scripts/check_domain_probe_sync.py --sync`. A genuinely new probe **file**
+  requires updating `check_domain_probe_sync.py` `MODULES`, both skills' copies, and any
+  generated docs in the **same** commit, or CI fails.
+- **A new detector** follows the 8-step contract (FAMILY_BY_ID in
+  `gen_detectors_catalog_json.py`, regenerate + `--check`, PII-free fixture, test,
+  `validate.yml` wiring, `catalog_counts.json` bump). A detector ships as P0 only after
+  measuring precision on the corpus; otherwise it lands as a P1 warning.
+
+## Step E — Verify, review, commit
+
+1. **Codex checkpoint.** Manuscript/design artifacts → `/codex:adversarial-review
+   --background`; detector/CLI code (< 3 files) → `/codex:review --wait`. Read the
+   output critically; apply only verified findings; record rejections with a reason.
+2. **Local CI mirror.** Run every step in `.github/workflows/validate.yml`
+   (validate_skills, routing assets, domain-probe sync, locale inventory, the catalog/
+   marketplace/detector/skill-doc generators + self-tests, A1–A6, demo manifest). All
+   green.
+3. **Anti-leak grep.** Confirm the diff carries no verbatim source prose, no figure from
+   a non-CC source, and nothing under `_corpus/`.
+4. **Commit + push** to the feature branch. Append a row to `PROGRESS.md`.
+5. **ScheduleWakeup** (1200–1800s) for the next iteration, or stop at a merge/release
+   gate for human approval.
+
+## Priority order (work top-down)
+
+1. Review skills: `peer-review` / `self-review` probes + `exemplar_reviews/` (from
+   published open reviews).
+2. `reviewer_calibration/` — journal compliance floors + critical items (a new
+   reference dir, **not** `reviewer_profiles/`, which is form-fields-only).
+3. `write-paper` `exemplar_methods` / `exemplar_results` / `exemplar_discussion`
+   (synthetic).
+4. `analyze-stats` `exemplar_tables/`.
+5. `make-figures` non-flow exemplars (roc / forest / km / calibration / visual_abstract).
+6. `check-reporting` compliance-floor integration.
+7. New deterministic detectors (corpus-precision-validated).
+8. Token-efficiency pass (probe-sync CI, SKILL.md duplication → references, catalog SSOT).
+
+## Outward-action gates (require explicit human approval)
+
+Merge to main · `npm publish` · GitHub release · tag · marketplace change · opening a PR
+for merge. Feature-branch commit and push are the only outward actions the loop performs
+on its own (reversible).

--- a/reverse_engineer/PROGRESS.md
+++ b/reverse_engineer/PROGRESS.md
@@ -1,0 +1,13 @@
+# Reverse-engineering progress ledger
+
+One row per completed loop iteration. The loop appends here in Step E.
+`Sources` lists `record_id`s (defined in `_corpus/manifest.json`, gitignored).
+
+| # | Date | Batch (record_ids) | Improvement | Target skill | Codex (kept/total) | Branch | Status |
+|---|------|--------------------|-------------|--------------|--------------------|--------|--------|
+| 0 | 2026-06-11 | — | Infrastructure: PLAYBOOK, licensing firewall, manifest schema, helpers | reverse_engineer/ | — | feat/reverse-engineer-infra | infra only |
+
+## Queue health
+
+- Pending records in `doi_lists/queue.txt`: see that file (seeded by domain, license-checked at acquire time).
+- Next priority item (per PLAYBOOK priority order): **#1 — peer-review / self-review probe + exemplar_reviews from published open reviews.**

--- a/reverse_engineer/doi_lists/README.md
+++ b/reverse_engineer/doi_lists/README.md
@@ -1,0 +1,30 @@
+# DOI / source lists
+
+The loop pulls work from `queue.txt`. This directory defines **where** to source from
+(by domain) and the rules for adding a record. Specific DOIs/URLs are added to
+`queue.txt` only when verified at acquire time — never fabricated here.
+
+## Curation rules
+
+- **Open access or open review only.** Verify the license per record at acquire time and
+  record it in `_corpus/manifest.json`. Unknown license → learn-only (never committed).
+- **Spread across domains.** Don't over-fit to one field; rotate through the domains in
+  `sources_by_domain.md` so the distilled probes/exemplars generalize.
+- **Prefer published open reviews for review-skill work** — they are real reviewer
+  language, and venues like F1000Research publish them under CC-BY.
+- **No fabricated identifiers.** A DOI/PMID enters `queue.txt` only after it resolves.
+  Use the `verify-refs` / `search-lit` skills to confirm before queueing.
+
+## queue.txt format
+
+One record per line: `record_id<TAB>doi_or_url<TAB>domain`. Lines starting with `#`
+are comments. `record_id` must match the manifest schema pattern
+(`^[a-z0-9][a-z0-9_]{2,79}$`). Example (illustrative — replace with verified entries):
+
+```
+# record_id                         doi_or_url                              domain
+f1000_review_dta_calibration_2024   https://doi.org/10.12688/...            radiology_ai
+```
+
+`acquire.py` reads the next N uncommented lines, scaffolds `_corpus/` directories, and
+creates a manifest stub per record for you to complete.

--- a/reverse_engineer/doi_lists/queue.txt
+++ b/reverse_engineer/doi_lists/queue.txt
@@ -1,0 +1,10 @@
+# Reverse-engineering work queue.
+# Format (tab-separated): record_id<TAB>doi_or_url<TAB>domain
+# Lines beginning with '#' are comments. Add entries only after the DOI/URL resolves
+# (use verify-refs / search-lit). See README.md and ../LICENSING.md.
+#
+# record_id must match: ^[a-z0-9][a-z0-9_]{2,79}$
+# domain is one of: radiology_ai, medical_ai, medical_education, clinical, biostatistics, ml_medicine
+#
+# (empty — the first batch is seeded in PR2, when peer-review open-review records are
+#  acquired and license-verified per record.)

--- a/reverse_engineer/doi_lists/sources_by_domain.md
+++ b/reverse_engineer/doi_lists/sources_by_domain.md
@@ -1,0 +1,31 @@
+# OA + open-review sources by domain
+
+Venues that reliably offer open-access full text or published peer reviews, grouped by
+the medical domains the suite must serve. These are sourcing *starting points* — confirm
+the license of each specific record at acquire time. No specific DOIs are listed here on
+purpose (they are added to `queue.txt` only after verification).
+
+## Published peer reviews (best for review-skill work)
+
+- **F1000Research** — peer-review reports published CC-BY (strongest license footing).
+- **eLife** — public reviews / assessments alongside Reviewed Preprints (confirm per record).
+- **PeerJ** — optional open review histories (confirm per record).
+- **BMJ Open** — pre-publication histories on many articles (license varies per record).
+
+## OA articles by domain
+
+- **Radiology / imaging** — Radiology and European Radiology OA articles; RSNA OA.
+- **Medical AI / informatics** — Lancet Digital Health (OA), npj Digital Medicine (OA),
+  Radiology: Artificial Intelligence OA articles.
+- **Medical education** — BMC Medical Education (OA).
+- **Clinical specialties / general medicine** — PLOS Medicine (OA), BMJ Open (OA).
+- **Medical statistics / methods** — OA articles in BMC Medical Research Methodology;
+  selected OA statistics-in-medicine methods papers.
+- **ML/DL for medicine (CS venues)** — open proceedings (e.g., MICCAI/MELBA open content)
+  and arXiv/medRxiv preprints (preprint license varies — confirm).
+
+## Reviewer guidance / reporting standards (background, not corpus records)
+
+EQUATOR Network reporting guidelines and their explanation-and-elaboration documents,
+and publishers' public reviewer guides, inform the probes/rubrics directly. They are
+reference material, not `_corpus/` records, and are cited where used.

--- a/reverse_engineer/scripts/acquire.py
+++ b/reverse_engineer/scripts/acquire.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Step A helper — prepare the next batch from the queue.
+
+Reads the next N uncommented lines of doi_lists/queue.txt, scaffolds the gitignored
+_corpus/ directories, and appends a manifest stub per record (with safe defaults:
+verbatim_allowed=false, public_reuse_policy=synthetic_only) for the agent to complete.
+
+This does NOT download anything — fetching full text is done per PLAYBOOK Step A using
+the fulltext-retrieval skill (OA articles) or open-review APIs. This only stages the
+batch and the provenance ledger.
+
+Usage:
+    python3 reverse_engineer/scripts/acquire.py --batch 5
+    python3 reverse_engineer/scripts/acquire.py --batch 5 --date 2026-06-12
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+RE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = RE_DIR.parent
+QUEUE = RE_DIR / "doi_lists" / "queue.txt"
+CORPUS = REPO_ROOT / "_corpus"
+MANIFEST = CORPUS / "manifest.json"
+RECORD_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_]{2,79}$")
+DOMAINS = {"radiology_ai", "medical_ai", "medical_education", "clinical", "biostatistics", "ml_medicine"}
+
+
+def read_queue(n: int) -> list[dict]:
+    if not QUEUE.exists():
+        sys.exit(f"queue not found: {QUEUE}")
+    out = []
+    for ln, raw in enumerate(QUEUE.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = [p.strip() for p in re.split(r"\t+", line)]
+        if len(parts) < 3:
+            sys.exit(f"queue.txt line {ln}: expected 'record_id<TAB>doi_or_url<TAB>domain'")
+        rid, src, domain = parts[0], parts[1], parts[2]
+        if not RECORD_ID_RE.match(rid):
+            sys.exit(f"queue.txt line {ln}: bad record_id '{rid}'")
+        if domain not in DOMAINS:
+            sys.exit(f"queue.txt line {ln}: unknown domain '{domain}' (one of {sorted(DOMAINS)})")
+        out.append({"record_id": rid, "source": src, "domain": domain})
+        if len(out) >= n:
+            break
+    return out
+
+
+def load_manifest() -> dict:
+    if MANIFEST.exists():
+        return json.loads(MANIFEST.read_text(encoding="utf-8"))
+    return {"schema_version": 1, "records": []}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Stage the next corpus batch + manifest stubs.")
+    ap.add_argument("--batch", type=int, default=5, help="How many queue records to stage.")
+    ap.add_argument("--date", default="", help="retrieved_at date (YYYY-MM-DD). Pass explicitly; not auto-stamped.")
+    args = ap.parse_args()
+
+    batch = read_queue(args.batch)
+    if not batch:
+        print("Queue is empty — nothing to stage.")
+        return 0
+
+    (CORPUS / "papers").mkdir(parents=True, exist_ok=True)
+    (CORPUS / "analysis").mkdir(parents=True, exist_ok=True)
+
+    manifest = load_manifest()
+    existing = {r.get("record_id") for r in manifest.get("records", [])}
+    added = 0
+    for item in batch:
+        rid = item["record_id"]
+        if rid in existing:
+            continue
+        manifest["records"].append({
+            "record_id": rid,
+            "source_url": item["source"],
+            "doi": item["source"] if item["source"].startswith("http") and "doi.org" in item["source"] else None,
+            "source_type": "open_review" if "review" in rid else "oa_article",
+            "license": "unknown",
+            "license_url": "",
+            "retrieved_at": args.date or "TODO-YYYY-MM-DD",
+            "verbatim_allowed": False,
+            "public_reuse_policy": "synthetic_only",
+            "notes": "STUB — set real license/license_url and retrieved_at before distilling."
+        })
+        added += 1
+
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Staged {len(batch)} record(s); {added} new manifest stub(s) in {MANIFEST}.")
+    print("Next: fetch full text into _corpus/papers/<record_id>.md, then complete each")
+    print("manifest record's license/license_url/retrieved_at (defaults stay until verified).")
+    for item in batch:
+        print(f"  - {item['record_id']}  [{item['domain']}]  {item['source']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/analyze_paper.py
+++ b/reverse_engineer/scripts/analyze_paper.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Step B helper — scaffold / validate a per-paper analysis.
+
+The analysis captures *patterns* (study type, applicable reporting guideline, what makes
+the sections strong, the concerns a sharp reviewer would raise) — in the agent's own
+words, never copied source prose. This helper only scaffolds the JSON shape and validates
+it; the content is written by the agent per PLAYBOOK Step B.
+
+Usage:
+    python3 reverse_engineer/scripts/analyze_paper.py --scaffold <record_id>
+    python3 reverse_engineer/scripts/analyze_paper.py --validate <record_id>
+    python3 reverse_engineer/scripts/analyze_paper.py --validate-all
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+RE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = RE_DIR.parent
+ANALYSIS_DIR = REPO_ROOT / "_corpus" / "analysis"
+
+REQUIRED_KEYS = [
+    "record_id",
+    "study_type",
+    "reporting_guideline",
+    "methods_strengths",
+    "results_strengths",
+    "discussion_strengths",
+    "figure_table_notes",
+    "reviewer_concerns",
+]
+LIST_KEYS = [
+    "methods_strengths",
+    "results_strengths",
+    "discussion_strengths",
+    "figure_table_notes",
+    "reviewer_concerns",
+]
+
+
+def scaffold(rid: str) -> int:
+    ANALYSIS_DIR.mkdir(parents=True, exist_ok=True)
+    path = ANALYSIS_DIR / f"{rid}.json"
+    if path.exists():
+        print(f"exists: {path} (not overwriting)")
+        return 0
+    template = {
+        "record_id": rid,
+        "study_type": "",
+        "reporting_guideline": "",
+        "methods_strengths": [],
+        "results_strengths": [],
+        "discussion_strengths": [],
+        "figure_table_notes": [],
+        "reviewer_concerns": [],
+        "_instructions": "Fill in your own words. Patterns only — no copied source prose. Remove this key when done.",
+    }
+    path.write_text(json.dumps(template, indent=2) + "\n", encoding="utf-8")
+    print(f"scaffolded: {path}")
+    return 0
+
+
+def validate_one(path: Path) -> list[str]:
+    errs: list[str] = []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        return [f"{path.name}: invalid JSON ({e})"]
+    if "_instructions" in data:
+        errs.append(f"{path.name}: remove the '_instructions' key when analysis is complete")
+    for k in REQUIRED_KEYS:
+        if k not in data:
+            errs.append(f"{path.name}: missing key '{k}'")
+    for k in LIST_KEYS:
+        if k in data:
+            if not isinstance(data[k], list):
+                errs.append(f"{path.name}: '{k}' must be a list")
+            elif not data[k]:
+                errs.append(f"{path.name}: '{k}' is empty")
+    if data.get("reviewer_concerns") == []:
+        pass  # already flagged above
+    return errs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Scaffold/validate a per-paper analysis JSON.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--scaffold", metavar="RECORD_ID")
+    g.add_argument("--validate", metavar="RECORD_ID")
+    g.add_argument("--validate-all", action="store_true")
+    args = ap.parse_args()
+
+    if args.scaffold:
+        return scaffold(args.scaffold)
+
+    if args.validate:
+        path = ANALYSIS_DIR / f"{args.validate}.json"
+        if not path.exists():
+            sys.exit(f"not found: {path}")
+        errs = validate_one(path)
+    else:
+        if not ANALYSIS_DIR.exists():
+            print("no analysis directory yet — nothing to validate")
+            return 0
+        errs = []
+        for path in sorted(ANALYSIS_DIR.glob("*.json")):
+            errs.extend(validate_one(path))
+
+    if errs:
+        print("INVALID:")
+        for e in errs:
+            print(f"  - {e}")
+        return 1
+    print("OK: analysis shape valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/distill.py
+++ b/reverse_engineer/scripts/distill.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Step C gate — the license firewall in code.
+
+Before any public artifact is emitted from a corpus source, the source must have a
+complete, valid manifest record whose policy permits the intended reuse. This script:
+
+  --check                 validate _corpus/manifest.json against the schema (stdlib only,
+                          no jsonschema dependency) and reject leftover stubs.
+  --authorize ID MODE     exit 0 iff record ID is valid AND permits MODE; MODE in
+                          {synthetic, paraphrase, verbatim}. The record is re-validated
+                          here too, so an invalid record can never authorize reuse.
+
+Reuse rules (fail-closed):
+  synthetic   — non-derivative output. Allowed only if the license is known (honest
+                provenance); permitted for any known license.
+  paraphrase  — allowed only if public_reuse_policy in {paraphrase_ok, cc_by_attribution}
+                AND the license is permissive (CC-BY / CC0 family). NC/ND are blocked.
+  verbatim    — allowed only if verbatim_allowed is strictly True AND public_reuse_policy
+                == cc_by_attribution AND the license is permissive AND attribution is set.
+
+A record with an unknown/empty license is learn-only: it authorizes nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+RE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = RE_DIR.parent
+SCHEMA = RE_DIR / "source_manifest.schema.json"
+MANIFEST = REPO_ROOT / "_corpus" / "manifest.json"
+RECORD_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_]{2,79}$")
+MODES = ("synthetic", "paraphrase", "verbatim")
+
+# Licenses that permit derivative reuse (paraphrase / verbatim). Compared lower-cased.
+# NonCommercial (NC) and NoDerivatives (ND) variants are intentionally excluded.
+PERMISSIVE_LICENSES = {
+    "cc-by-4.0", "cc-by-3.0", "cc-by-2.0", "cc-by", "cc-by-sa-4.0",
+    "cc0-1.0", "cc0", "publicdomain", "public-domain",
+}
+UNKNOWN_LICENSE = {"", "unknown", "none", "n/a", "na"}
+
+
+def norm_license(lic) -> str:
+    return str(lic or "").strip().lower()
+
+
+def license_known(lic) -> bool:
+    return norm_license(lic) not in UNKNOWN_LICENSE
+
+
+def is_permissive(lic) -> bool:
+    return norm_license(lic) in PERMISSIVE_LICENSES
+
+
+def load_schema_enums() -> dict:
+    """Read enum lists + required fields from the schema so it stays the SSOT."""
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    rec = schema["$defs"]["record"]
+    return {
+        "required": rec["required"],
+        "source_type": rec["properties"]["source_type"]["enum"],
+        "public_reuse_policy": rec["properties"]["public_reuse_policy"]["enum"],
+    }
+
+
+def load_manifest() -> dict:
+    if not MANIFEST.exists():
+        sys.exit(f"manifest not found: {MANIFEST} (run acquire.py first)")
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def validate_record(r: dict, enums: dict) -> list[str]:
+    """Per-record validation. Used by both --check and the --authorize gate."""
+    errs: list[str] = []
+    tag = r.get("record_id", "<no record_id>")
+    for k in enums["required"]:
+        if k not in r:
+            errs.append(f"{tag}: missing required field '{k}'")
+    rid = r.get("record_id", "")
+    if rid and not RECORD_ID_RE.match(rid):
+        errs.append(f"{tag}: bad record_id pattern")
+    if r.get("source_type") not in enums["source_type"]:
+        errs.append(f"{tag}: source_type must be one of {enums['source_type']}")
+    policy = r.get("public_reuse_policy")
+    if policy not in enums["public_reuse_policy"]:
+        errs.append(f"{tag}: public_reuse_policy must be one of {enums['public_reuse_policy']}")
+    # Strict types on the leakage-relevant fields.
+    if not isinstance(r.get("verbatim_allowed"), bool):
+        errs.append(f"{tag}: verbatim_allowed must be a JSON boolean (true/false)")
+    if not isinstance(r.get("license", ""), str):
+        errs.append(f"{tag}: license must be a string")
+    # Stub / consistency checks.
+    if str(r.get("retrieved_at", "")).startswith("TODO"):
+        errs.append(f"{tag}: retrieved_at is still a stub")
+    if "STUB" in str(r.get("notes", "")):
+        errs.append(f"{tag}: notes still marked STUB — complete the record")
+    # Policy ⇄ license/attribution coherence.
+    if policy and policy != "synthetic_only" and not license_known(r.get("license")):
+        errs.append(f"{tag}: unknown license cannot carry policy '{policy}'")
+    if policy in ("paraphrase_ok", "cc_by_attribution"):
+        if not r.get("license_url"):
+            errs.append(f"{tag}: policy '{policy}' requires a license_url")
+        if not is_permissive(r.get("license")):
+            errs.append(f"{tag}: policy '{policy}' requires a permissive license (CC-BY/CC0); got '{r.get('license')}'")
+    if policy == "cc_by_attribution" and not str(r.get("attribution", "")).strip():
+        errs.append(f"{tag}: policy 'cc_by_attribution' requires a non-empty attribution")
+    if r.get("verbatim_allowed") is True and policy != "cc_by_attribution":
+        errs.append(f"{tag}: verbatim_allowed requires public_reuse_policy 'cc_by_attribution'")
+    return errs
+
+
+def validate(manifest: dict, enums: dict) -> list[str]:
+    errs: list[str] = []
+    if manifest.get("schema_version") != 1:
+        errs.append("schema_version must be 1")
+    records = manifest.get("records")
+    if not isinstance(records, list):
+        return ["'records' must be a list"]
+    seen = set()
+    for r in records:
+        rid = r.get("record_id", "")
+        if rid in seen:
+            errs.append(f"{rid}: duplicate record_id")
+        seen.add(rid)
+        errs.extend(validate_record(r, enums))
+    return errs
+
+
+def find_record(manifest: dict, rid: str) -> dict | None:
+    for r in manifest.get("records", []):
+        if r.get("record_id") == rid:
+            return r
+    return None
+
+
+def authorize(rec: dict, mode: str) -> tuple[bool, str]:
+    lic = rec.get("license")
+    if not license_known(lic):
+        return False, "license is unknown/empty — acquire a real license before any reuse"
+    policy = rec.get("public_reuse_policy", "synthetic_only")
+    if mode == "synthetic":
+        return True, "synthetic (non-derivative) output is permitted"
+    if mode == "paraphrase":
+        if policy in ("paraphrase_ok", "cc_by_attribution") and is_permissive(lic):
+            return True, f"paraphrase permitted under '{policy}' ({lic})"
+        return False, f"paraphrase needs policy paraphrase_ok/cc_by_attribution + a permissive license (got '{policy}', '{lic}')"
+    if mode == "verbatim":
+        if (rec.get("verbatim_allowed") is True
+                and policy == "cc_by_attribution"
+                and is_permissive(lic)
+                and str(rec.get("attribution", "")).strip()):
+            return True, "verbatim permitted (verbatim_allowed + cc_by_attribution + permissive + attribution)"
+        return False, "verbatim needs verbatim_allowed=true + cc_by_attribution + permissive license + attribution"
+    return False, f"unknown mode '{mode}'"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Manifest reuse gate (license firewall).")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--check", action="store_true", help="Validate the whole manifest.")
+    g.add_argument("--authorize", nargs=2, metavar=("RECORD_ID", "MODE"),
+                   help="Exit 0 iff RECORD_ID is valid and permits MODE (synthetic|paraphrase|verbatim).")
+    args = ap.parse_args()
+
+    enums = load_schema_enums()
+    manifest = load_manifest()
+
+    if args.check:
+        errs = validate(manifest, enums)
+        if errs:
+            print("MANIFEST INVALID:")
+            for e in errs:
+                print(f"  - {e}")
+            return 1
+        print(f"OK: manifest valid ({len(manifest.get('records', []))} record(s))")
+        return 0
+
+    rid, mode = args.authorize
+    if mode not in MODES:
+        sys.exit(f"MODE must be one of {MODES}")
+    rec = find_record(manifest, rid)
+    if rec is None:
+        print(f"DENY: no manifest record for '{rid}'")
+        return 1
+    # An invalid record can never authorize reuse (fail-closed).
+    rec_errs = validate_record(rec, enums)
+    if rec_errs:
+        print(f"DENY: record '{rid}' fails validation:")
+        for e in rec_errs:
+            print(f"  - {e}")
+        return 1
+    ok, reason = authorize(rec, mode)
+    print(f"{'ALLOW' if ok else 'DENY'}: {rid} / {mode} — {reason}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/source_manifest.schema.json
+++ b/reverse_engineer/source_manifest.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Aperivue/medsci-skills/reverse_engineer/source_manifest.schema.json",
+  "title": "Reverse-engineering corpus manifest",
+  "description": "Provenance + license ledger for every source the reverse-engineering program studies. Lives at _corpus/manifest.json (gitignored). distill.py enforces the per-record public_reuse_policy before emitting any public artifact.",
+  "type": "object",
+  "required": ["schema_version", "records"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "records": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/record" }
+    }
+  },
+  "$defs": {
+    "record": {
+      "type": "object",
+      "required": [
+        "record_id",
+        "source_url",
+        "source_type",
+        "license",
+        "license_url",
+        "retrieved_at",
+        "verbatim_allowed",
+        "public_reuse_policy"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "record_id": {
+          "type": "string",
+          "description": "Stable slug, e.g. 'f1000_review_2024_dta_calibration'. Used by distill.py to authorize reuse.",
+          "pattern": "^[a-z0-9][a-z0-9_]{2,79}$"
+        },
+        "source_url": { "type": "string", "format": "uri" },
+        "doi": {
+          "type": ["string", "null"],
+          "description": "DOI if the source has one; null for DOI-less reports.",
+          "default": null
+        },
+        "source_type": {
+          "type": "string",
+          "enum": ["oa_article", "open_review"],
+          "description": "oa_article = open-access paper; open_review = published peer-review report."
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX-style id or short name, e.g. 'CC-BY-4.0', 'CC-BY-NC-ND-4.0', 'CC0-1.0', or 'unknown'."
+        },
+        "license_url": {
+          "type": "string",
+          "description": "Link to the license text or the page asserting the license. Use '' only when license is 'unknown'."
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date",
+          "description": "YYYY-MM-DD the source was fetched into _corpus/."
+        },
+        "verbatim_allowed": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether any verbatim quotation may appear in a committed artifact. Default false. Set true only for confirmed CC-BY / CC0 sources, and even then prefer synthesis."
+        },
+        "public_reuse_policy": {
+          "type": "string",
+          "enum": ["synthetic_only", "paraphrase_ok", "cc_by_attribution"],
+          "default": "synthetic_only",
+          "description": "synthetic_only = only freshly-authored, non-derivative output may be committed; paraphrase_ok = close paraphrase permitted (requires a permissive license); cc_by_attribution = CC-BY/CC0 content may be reused with attribution."
+        },
+        "attribution": {
+          "type": "string",
+          "description": "Required citation line when public_reuse_policy is cc_by_attribution. Optional otherwise."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-text: why this license was assigned, what was learned, caveats."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR1 — reverse-engineering corpus pipeline (infrastructure only)

Maintainer tooling for the long-running program that studies open-access papers and
published peer reviews to improve the suite. **No skills, catalogs, or detectors change**
in this PR, and **no sources are acquired yet** — this lays the copyright firewall and the
loop procedure before any paper is touched (that begins in PR2).

### Contents
- **`LICENSING.md`** — the *learn-then-synthesize* policy. Raw OA PDFs, open-review full
  text, and per-paper analysis stay in the gitignored `_corpus/`; public commits carry
  only distilled patterns + freshly authored synthetic exemplars (+ CC-BY/CC0 anchors
  with attribution).
- **`source_manifest.schema.json`** — per-record provenance/license ledger schema.
- **`scripts/distill.py`** — the license firewall in code. Validates the manifest and
  gates reuse (`synthetic` / `paraphrase` / `verbatim`), fail-closed: unknown and NC/ND
  licenses authorize nothing; paraphrase/verbatim require a permissive (CC-BY/CC0)
  license; verbatim also needs `verbatim_allowed` (strict boolean) + a non-empty
  attribution; `--authorize` re-validates the record before allowing.
- **`scripts/acquire.py`**, **`analyze_paper.py`** — thin batch-staging + analysis-shape
  scaffolds (no downloads; fetching uses the `fulltext-retrieval` skill per the playbook).
- **`PLAYBOOK.md`** — the one-iteration loop SSOT (Acquire → Analyze → Distill → Integrate
  → Verify), with the Codex review checkpoint and the outward-action gates.
- **`PROGRESS.md`**, **`doi_lists/`** — the iteration ledger and per-domain OA/open-review
  sourcing rules (no fabricated DOIs; entries are added only after they resolve).
- **`.gitignore`** — `_corpus/` (raw sources are never committed).

### Safety
`reverse_engineer/` is excluded from the npm tarball (not in the `files` allowlist), and
`_corpus/` is gitignored, so neither raw sources nor this tooling ship to end users. The
license firewall was hardened after an adversarial review (strict boolean checks,
permissive-license allowlist that blocks NC/ND, attribution enforcement, and record
re-validation inside `--authorize`).

### Verification
Local `validate_skills.sh`, locale inventory, and catalog/generator `--check` gates pass.
The acquire → manifest → distill gate was exercised end-to-end against attack cases
(string booleans, NC/ND licenses, missing attribution, unknown-license variants — all
correctly denied). Outward actions (merge / publish / release) remain gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
