### PR TITLE
feat(peer-review): synthetic exemplar-reviews gallery (RE loop iter 1)

### DIFF
--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -37,6 +37,7 @@
 
 - `aczel_2021_reviewer2_patterns.md`
 - `domain-probes/` (5 files)
+- `exemplar_reviews/` (5 files)
 - `narrative_review_audit.md`
 - `reviewer_profiles/` (6 files)
 

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -161,6 +161,12 @@ Apply this 6-probe checklist (O1–O6) **only when the manuscript is an observat
 
 ### Phase 3: Draft Review
 
+Before writing comments, skim the relevant model in `references/exemplar_reviews/` for the
+finding type at hand (AI overclaiming, reference-standard validity, data leakage, missing
+calibration). Each shows the same four moves — anchor the location, state the gap, phrase
+it as a partner (Aczel-compliant), and calibrate severity (design-level → Major #1). Model
+the anchoring and phrasing; do not copy — they are synthetic teaching examples.
+
 Generate `{manuscript_id}_review_draft.md`:
 
 ```markdown

--- a/skills/peer-review/references/exemplar_reviews/README.md
+++ b/skills/peer-review/references/exemplar_reviews/README.md
@@ -1,0 +1,43 @@
+# Exemplar reviewer comments — anchoring + phrasing models
+
+The skill teaches *what* to look for (signature checks + domain probes) and *what tone*
+to use (`aczel_2021_reviewer2_patterns.md`), but until now carried no worked examples of
+how an experienced reviewer turns a finding into a comment. This directory fills that gap.
+
+Each file models one recurring finding for medical-AI / clinical papers and shows the
+same four moves a strong review makes:
+
+1. **Anchor** — name the exact location (section, figure/table, page) the concern sits in.
+2. **State the gap** — what is claimed vs what the evidence supports, concretely.
+3. **Phrase it as a partner** — hedged, first-person, critique-the-work-not-the-author
+   (Aczel-compliant: "I'd suggest…", "it would help to…", never "the authors fail to…").
+4. **Calibrate severity** — when the finding is design-level it becomes Major #1; when it
+   is fixable-as-reported it stays a Minor; the example says which and why.
+
+## How these are used
+
+The reviewer (or `/self-review`) reads the relevant exemplar before drafting Phase 3
+comments, to model the anchoring + phrasing — not to copy text. They are **teaching
+models, authored from scratch**, not extracted from any published review.
+
+## Contents
+
+- `ai_overclaiming.md` — generalizability / "outperforms" / "can replace" claims that
+  outrun single-center or single-reader evidence.
+- `reference_standard_validity.md` — an imprecise, unblinded, or mistimed reference
+  standard in a diagnostic-accuracy study.
+- `data_leakage.md` — patient-level split violations and label-bearing input features.
+- `calibration_missing.md` — discrimination (AUC) reported for a clinical prediction
+  model with no calibration assessment.
+
+## Curator guidelines (for adding more)
+
+- **Synthetic only.** Author the example; never paste a real reviewer's words or a real
+  manuscript's text. Use placeholder study details ("a single-center retrospective
+  cohort", "Figure 3").
+- **One finding per file**, showing the four moves above end to end.
+- **Show both the weak and the strong phrasing** so the contrast is teachable.
+- **Tie severity to the fatal-flaw hierarchy** the skill already uses (design-level →
+  Major #1; reporting-level → Minor).
+- Keep each file ~40–80 lines. Cross-reference the relevant domain probe or signature
+  check by name, not by copying it.

--- a/skills/peer-review/references/exemplar_reviews/ai_overclaiming.md
+++ b/skills/peer-review/references/exemplar_reviews/ai_overclaiming.md
@@ -1,0 +1,47 @@
+# Exemplar — AI overclaiming relative to the evidence
+
+**Finding class:** the conclusion's reach (generalizable / outperforms / can replace)
+exceeds what a single-center, single-reader, or internally-validated result supports.
+**Typical severity:** design-/framing-level → **Major #1** when the headline claim depends
+on it; Minor when it is only a stray adjective in the Discussion.
+
+## What the reviewer noticed
+
+The Abstract and Conclusion state the model "generalizes across institutions" and
+"outperforms radiologists," but the external test set is one site (Methods, "External
+validation"), the reader comparison used two readers on a different task tempo than the
+model (Table 3), and the confidence intervals for model vs reader AUC overlap (Figure 2).
+
+## Weak phrasing (avoid)
+
+> The authors overclaim. Saying the model generalizes and beats radiologists is not
+> justified and should be removed.
+
+(Verdict without an anchor, no path forward, gatekeeper tone.)
+
+## Strong phrasing (model this)
+
+> The Conclusion states the model "generalizes across institutions," but external
+> validation appears limited to a single site (Methods, *External validation*). I'd
+> suggest softening this to the evidence — e.g., "validated at one external site" — and
+> framing multi-institution generalizability as a stated limitation and next step.
+>
+> Relatedly, the "outperforms radiologists" claim rests on a comparison whose 95% CIs for
+> model and reader AUC overlap (Figure 2), and the reader task differs from the model's in
+> [tempo/inputs] (Table 3). It would strengthen the paper to (a) report the difference in
+> AUC with its CI and a test of that difference rather than two separate AUCs, and (b)
+> state explicitly which clinical task the comparison establishes. If the difference is
+> not statistically supported, I'd recommend reframing from "outperforms" to
+> "comparable to," which is still a meaningful and more defensible result.
+
+## Why this is Major #1 here
+
+The over-reach is in the Abstract and Conclusion and is the paper's headline, so a reader
+takes away a claim the data do not support. Anchoring it to the single-site external set
+and the overlapping CIs makes the fix concrete and keeps the contribution intact.
+
+## Related checks
+
+Signature check "Overclaiming vs evidence level"; self-review category D
+(endpoint↔conclusion scope); `check_scope_coherence.py` for surrogate→care-directive and
+cross-sectional→prognostic variants.

--- a/skills/peer-review/references/exemplar_reviews/calibration_missing.md
+++ b/skills/peer-review/references/exemplar_reviews/calibration_missing.md
@@ -1,0 +1,44 @@
+# Exemplar — calibration not reported for a clinical prediction model
+
+**Finding class:** the model is presented for clinical decision-making, but only
+discrimination (AUC/c-statistic) is reported — no calibration, and often no decision-curve
+or clinical-utility analysis.
+**Typical severity:** **Major** when the paper proposes clinical use (a probability that
+drives a decision must be calibrated); **Minor** when the model is framed as a research
+prototype only.
+
+## What the reviewer noticed
+
+Results report AUC with CIs for every model (Table 2, Figure 1), and the Discussion
+proposes using predicted probabilities to triage patients, but there is no calibration plot
+or metric (calibration slope/intercept, ECE) and no decision-curve analysis.
+
+## Weak phrasing (avoid)
+
+> AUC is not enough; the authors need calibration.
+
+(True but terse; no reason, no anchor, no path.)
+
+## Strong phrasing (model this)
+
+> The discrimination results are clearly presented (Table 2, Figure 1). Because the
+> Discussion proposes using the predicted probabilities to triage patients, it would help
+> to add an assessment of calibration — how close predicted probabilities are to observed
+> frequencies. AUC can be high while probabilities are systematically too confident, which
+> would mislead a probability-based threshold. A calibration plot with slope and intercept
+> (and ideally on the external set) would let readers judge whether the proposed thresholds
+> are safe. A decision-curve analysis would further show the net benefit across plausible
+> threshold probabilities relative to treat-all / treat-none. If recalibration was applied,
+> stating the method would also be useful.
+
+## Severity calibration
+
+If the paper's contribution is a deployable triage tool, calibration is **Major** — the
+clinical claim rests on the probabilities being trustworthy. If the model is explicitly a
+methods demonstration with no decision claim, a calibration metric is a reasonable
+**Minor** addition.
+
+## Related checks
+
+Signature check "Calibration (AUC alone insufficient)"; TRIPOD+AI / CLAIM calibration items
+via `/check-reporting`; self-review category C (calibration [CRITICAL]).

--- a/skills/peer-review/references/exemplar_reviews/data_leakage.md
+++ b/skills/peer-review/references/exemplar_reviews/data_leakage.md
@@ -1,0 +1,48 @@
+# Exemplar — data leakage (split contamination / label-bearing inputs)
+
+**Finding class:** information from the test set or the outcome reaches the model at
+training time — via a patient appearing in both train and test, or via an input feature
+that encodes the label.
+**Typical severity:** design-level → **Major #1**, because leakage inflates every reported
+metric and is often invisible in the results themselves.
+
+## What the reviewer noticed
+
+Methods report a 70/30 split "by image," but many patients contributed multiple images
+(Table 1, mean 2.4 studies/patient), so the same patient can fall on both sides of the
+split. Separately, one input feature is the radiology report impression text, while the
+outcome is the report-derived diagnosis — the input may contain the label.
+
+## Weak phrasing (avoid)
+
+> There is leakage so the model is invalid.
+
+(Asserts the conclusion; gives the authors nothing to act on.)
+
+## Strong phrasing (model this)
+
+> Two points about independence between training and evaluation that, if addressed, would
+> considerably strengthen confidence in the metrics:
+>
+> First, the 70/30 split is described as by image (Methods, *Data split*), but patients
+> contributed multiple studies (Table 1). A patient-level split prevents the model from
+> seeing the same patient in training and test; an image-level split can inflate
+> performance. I'd suggest re-splitting by patient and reporting whether the metrics change
+> — if they are stable, that is a strong robustness result to include.
+>
+> Second, one input is the report impression text while the outcome is derived from the
+> report (Methods, *Inputs* / *Outcome*). If the impression states the diagnosis, the model
+> may be reading the label rather than predicting it. Could the authors either mask the
+> diagnosis-bearing portion of the text, or report a sensitivity analysis with that feature
+> removed, to show the result does not depend on it?
+
+## Why this is Major #1
+
+Leakage does not announce itself in the results — the metrics look excellent precisely
+because of it. Anchoring to the multi-study patients (Table 1) and the report-derived
+outcome makes the concern concrete and gives two specific, runnable remedies.
+
+## Related checks
+
+Signature check "Patient-level data splitting"; self-review categories A (independence/
+leakage) and H (circularity / label-feature overlap).

--- a/skills/peer-review/references/exemplar_reviews/reference_standard_validity.md
+++ b/skills/peer-review/references/exemplar_reviews/reference_standard_validity.md
@@ -1,0 +1,45 @@
+# Exemplar — reference-standard validity in a diagnostic-accuracy study
+
+**Finding class:** the reference standard ("ground truth") is imprecisely defined, applied
+non-independently of the index test, mistimed, or read without blinding — so the reported
+sensitivity/specificity may be biased.
+**Typical severity:** design-level → **Major** (often Major #1 for a DTA paper), because it
+threatens the headline accuracy estimates.
+
+## What the reviewer noticed
+
+Methods describe the reference standard as "clinical consensus," but it is not stated who
+adjudicated, whether they were blinded to the index test, or the time interval between
+index test and reference. STARD items on the reference standard and blinding are not
+addressed.
+
+## Weak phrasing (avoid)
+
+> The ground truth is unreliable, so the results cannot be trusted.
+
+(Global dismissal, no anchor, no remedy.)
+
+## Strong phrasing (model this)
+
+> The reference standard is described as "clinical consensus" (Methods, *Reference
+> standard*), but a few details would let readers judge the accuracy estimates. Could the
+> authors specify: (1) who adjudicated and their expertise; (2) whether adjudicators were
+> blinded to the index-test result — this matters because unblinded adjudication can pull
+> the reference toward the index test and inflate agreement; (3) the interval between the
+> index test and the reference, since a long gap allows disease progression/regression
+> (verification timing); and (4) for cases where consensus was used, the inter-rater
+> agreement before consensus. If blinding was not feasible, a sentence on the expected
+> direction of bias and a sensitivity analysis on the subset with histologic confirmation
+> would reassure readers.
+
+## Severity calibration
+
+If adjudication was unblinded and the reference partly incorporates the index test, this is
+incorporation bias and belongs as **Major #1** — the sensitivity/specificity are the
+paper's product. If only the *reporting* is thin (the design is sound but undescribed),
+it is a **Minor** request for Methods detail.
+
+## Related checks
+
+Signature check "Reference standard precisely defined"; QUADAS-2 domains (reference
+standard, flow & timing) via `/check-reporting`; self-review category B.


### PR DESCRIPTION
## Reverse-engineering loop — iteration 1 (autonomous overnight run)

Fills the #1 gap the design review found in the review skills: `/peer-review` taught
*what* to look for and *what tone* to use, but carried **no worked examples** of turning a
finding into a comment.

Adds `skills/peer-review/references/exemplar_reviews/` — four **synthetic, authored-from-scratch** teaching models:

- `ai_overclaiming.md` — generalizability / "outperforms" / "can replace" beyond single-center evidence
- `reference_standard_validity.md` — imprecise / unblinded / mistimed reference standard in a DTA study
- `data_leakage.md` — patient-level split violations and label-bearing input features
- `calibration_missing.md` — AUC reported for a clinical prediction model with no calibration

Each shows the same four moves — **anchor the location → state the gap → partner-voice (Aczel) phrasing → severity calibration** (design-level → Major #1) — with both weak and strong phrasing for contrast. Phase 3 loads the relevant model before drafting comments; a README curator guide governs additions.

**Learn-then-synthesize:** these are teaching models, not extracted from any published review or manuscript (no PII, no real citations, English-only). Additive reference material; no skill behavior changes.

**Verification:** local `validate_skills.sh`, routing-assets `--strict`, locale inventory, catalog + `gen_skill_docs --check` all green; `docs/skills/peer-review.md` regenerated.

_Autonomous loop PR — review/merge at your convenience; not auto-merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
