### PR TITLE
feat(self-review): exemplar Anticipated-Comment findings (RE loop iter 2)

### DIFF
--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -39,6 +39,7 @@
 **References** (`skills/self-review/references/`):
 
 - `domain-probes/` (5 files)
+- `exemplar_findings/` (5 files)
 - `panel_review_template.md`
 
 **Scripts** (`skills/self-review/scripts/`):

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -859,6 +859,13 @@ Healthy CONSENSUS is preserved — agreement on *some* themes is a strength (Ste
 
 ### Phase 3: Report
 
+Before writing the Anticipated Comments, skim `references/exemplar_findings/` for the
+finding at hand (cohort-arithmetic mismatch, unadjusted confounder, cross-sectional scope
+overreach, post-hoc primary / estimand drift). Each models the full shape — which gate
+fired, the comment in the reviewer's own words, Fatal/Fixable severity, the closest
+category letter, the concrete fix, `fixable_by_ai`, and an R0-ready line for Phase 3b.
+They are synthetic teaching models — match the structure, not the wording.
+
 Generate a concise report with this structure:
 
 ```markdown

--- a/skills/self-review/references/exemplar_findings/README.md
+++ b/skills/self-review/references/exemplar_findings/README.md
@@ -1,0 +1,43 @@
+# Exemplar Anticipated Comments — gate result → self-review finding
+
+`/self-review` runs deterministic Phase 2.5 gates (cohort arithmetic, confounding
+completeness, scope coherence, claim-vs-artifact) and a systematic A–K check, then writes
+**Anticipated Major / Minor Comments** the author can fix before a reviewer sees them. This
+directory models how a *gate hit* becomes a well-formed Anticipated Comment — the missing
+worked-example layer between "the gate fired" and "here is the comment + fix."
+
+Each file shows the same shape `/self-review` Phase 3 produces:
+
+1. **What fired** — the deterministic gate (or category) and the specific signal.
+2. **Anticipated Major/Minor Comment** — phrased the way the *reviewer* will phrase it, so
+   the author reads it as the warning it is.
+3. **Severity** — Fatal (conclusion-threatening / design-level → Anticipated **Major**) vs
+   Fixable (reporting-level → Anticipated **Minor**).
+4. **Category** — the closest letter (A–K).
+5. **Fix** — the concrete change to make now, and whether it is `fixable_by_ai`.
+6. **R0-ready** — a one-line form suitable for Phase 3b numbering into the `/revise`
+   pipeline.
+
+These differ from `/peer-review`'s `exemplar_reviews/`: those model a *reviewer's*
+partner-voice comment to authors; these model the *author's* anticipation-and-fix entry.
+
+## Contents
+
+- `cohort_arithmetic_mismatch.md` — STROBE cascade / rate back-calc fails (gate:
+  `check_cohort_arithmetic.py`) → category A.
+- `unadjusted_confounder.md` — an imbalanced measured covariate left out of the model
+  (gate: `check_confounding_completeness.py`) → category C/E.
+- `scope_overreach_cross_sectional.md` — a prognostic/surveillance claim from a
+  cross-sectional design (gate: `check_scope_coherence.py`) → category D.
+- `estimand_drift_posthoc_primary.md` — the reported "primary" differs from the registered
+  one (gate: `check_claim_artifact.py`) → category C.
+
+## Curator guidelines
+
+- **Synthetic only.** Author the example with placeholder numbers; never paste a real
+  manuscript's text or data. No PII, no real citations, English only.
+- **One gate/finding per file**, end to end (fired → comment → severity → category → fix →
+  R0 line).
+- **Tie severity to the same Fatal/Fixable rule** the skill uses, and name the gate/script
+  that surfaces it (do not re-document the gate — link by name).
+- Keep each file ~40–70 lines.

--- a/skills/self-review/references/exemplar_findings/cohort_arithmetic_mismatch.md
+++ b/skills/self-review/references/exemplar_findings/cohort_arithmetic_mismatch.md
@@ -1,0 +1,35 @@
+# Exemplar — cohort arithmetic does not reconcile
+
+**Fired:** `check_cohort_arithmetic.py` — `CASCADE_SUM` (the STROBE flow does not balance:
+start N − Σ(exclusions) ≠ final analytic N) and/or `RATE_BACKCALC` (a reported incidence
+rate does not reproduce from numerator/person-time).
+**Severity:** Fatal → Anticipated **Major**. **Category:** A. Study Design & Data Integrity.
+
+## Anticipated Major Comment (how a reviewer will put it)
+
+> The participant flow does not add up. The Methods report 1,000 screened and exclusions of
+> 120 + 60 + 40, which leaves 780, but the analytic cohort is given as 800 (Figure 1 vs
+> Results, first paragraph). Please reconcile the flow diagram, the text, and Table 1 so the
+> numbers are internally consistent, and state which figure is correct.
+>
+> Relatedly, the incidence rate of 12.0 per 1,000 person-years with 9,800 person-years
+> implies ~118 events, but 96 events are reported (Table 2). Please confirm the numerator,
+> denominator, and rate.
+
+## Severity / category rationale
+
+This is **Fatal** because the cohort size and the event/person-time are the denominators of
+every downstream estimate — if they are inconsistent, the reader cannot trust any rate or
+effect size. It is **category A** (data integrity), not a wording issue.
+
+## Fix
+
+Recompute the cascade and the rate from the source data (never hand-retype), correct the
+diagram/text/table to a single set of numbers, and add a one-line reconciliation note if a
+late exclusion was applied. `fixable_by_ai: false` — the numbers must come from the data,
+not be guessed; the author re-derives from the CSV.
+
+## R0-ready line
+
+> R0-A1 (Major, Fatal): STROBE flow and the incidence rate do not reconcile (Figure 1 /
+> Results / Table 2); re-derive from source and unify. [gate: check_cohort_arithmetic]

--- a/skills/self-review/references/exemplar_findings/estimand_drift_posthoc_primary.md
+++ b/skills/self-review/references/exemplar_findings/estimand_drift_posthoc_primary.md
@@ -1,0 +1,39 @@
+# Exemplar — the reported "primary" differs from the registered one
+
+**Fired:** `check_claim_artifact.py` — `PRIMARY_REASSIGNED` / `ESTIMAND_DRIFT` (the
+manuscript's stated primary analysis or estimand does not match the pre-registration /
+protocol), or an E-value attached to a non-primary or non-reproducing estimate.
+**Severity:** Fatal → Anticipated **Major**. **Category:** C. Validation & Statistical
+Reporting.
+
+## Anticipated Major Comment (how a reviewer will put it)
+
+> The registered protocol names the complete-case model as the primary analysis, but the
+> manuscript presents the multiple-imputation model as primary (Methods, *Primary analysis*
+> vs the registration). Selecting the primary after seeing results is outcome-dependent and
+> can bias inference. Please either (a) restore the pre-registered primary and present the
+> other model as a pre-specified sensitivity analysis, or (b) if the change was unavoidable,
+> report both models coequally, disclose the change in the Abstract and a Limitations
+> paragraph, and lodge the corresponding registration amendment.
+>
+> The reported E-value of 2.79 should also be recomputed from, and attached to, the primary
+> estimate (it currently appears to derive from a different model).
+
+## Severity / category rationale
+
+**Fatal** because *which* result is primary determines the paper's headline; choosing it
+post hoc is a credibility issue a methods reviewer catches deterministically. **Category C**
+(estimand provenance). This is the estimand-provenance-lock principle: primary contrast and
+derived statistics trace to the pre-registration, not to the data.
+
+## Fix
+
+Restore the registered primary (or present both coequally with disclosure + amendment),
+recompute the E-value from the declared primary estimate, and propagate the framing to every
+claim site (Abstract, Highlights, any plain-language summary). `fixable_by_ai: false` —
+requires the registered protocol as the source of truth and a re-run.
+
+## R0-ready line
+
+> R0-C1 (Major, Fatal): reported primary ≠ registered primary; restore or report coequally +
+> disclose + amend; recompute E-value from the primary. [gate: check_claim_artifact]

--- a/skills/self-review/references/exemplar_findings/scope_overreach_cross_sectional.md
+++ b/skills/self-review/references/exemplar_findings/scope_overreach_cross_sectional.md
@@ -1,0 +1,35 @@
+# Exemplar — a prognostic/surveillance claim from a cross-sectional design
+
+**Fired:** `check_scope_coherence.py` — `CROSS_SECTIONAL_PROGNOSTIC` (a single-timepoint /
+cross-sectional design signal co-occurs with a conclusion-region action verb such as
+"predict", "progression", "rescreen", "surveillance").
+**Severity:** Fatal → Anticipated **Major**. **Category:** D. Clinical Framing & Importance.
+
+## Anticipated Major Comment (how a reviewer will put it)
+
+> The study is cross-sectional — exposure and outcome are measured at a single visit
+> (Methods, *Study design*) — but the Conclusion recommends a "surveillance interval" and
+> describes "disease progression." A cross-sectional association cannot establish temporal
+> order or progression, so these claims outrun the design. Please reframe the conclusion to
+> the association actually estimated (e.g., "X was associated with Y at the index visit") and
+> move any prognostic or surveillance language to a clearly-labeled hypothesis for future
+> longitudinal work.
+
+## Severity / category rationale
+
+This is **Fatal** because the gap is between the *design* and the *clinical action the paper
+recommends* — a reader could adopt a surveillance schedule that the data do not support. The
+fix is reframing, not new analysis, but the claim cannot stand as written. **Category D**
+(framing / endpoint↔conclusion scope).
+
+## Fix
+
+Rewrite the Abstract Conclusion and the Discussion's closing claim to the cross-sectional
+estimand; demote prognostic/surveillance statements to "future directions." Check that the
+Title does not imply prediction. `fixable_by_ai: true` (wording), but verify the author
+agrees the longitudinal claim is genuinely unsupported before softening.
+
+## R0-ready line
+
+> R0-D1 (Major, Fatal): cross-sectional design but the Conclusion claims surveillance/
+> progression; reframe to the index-visit association. [gate: check_scope_coherence]

--- a/skills/self-review/references/exemplar_findings/unadjusted_confounder.md
+++ b/skills/self-review/references/exemplar_findings/unadjusted_confounder.md
@@ -1,0 +1,36 @@
+# Exemplar — an imbalanced measured covariate is left out of the model
+
+**Fired:** `check_confounding_completeness.py` — `UNADJUSTED_IMBALANCED` (a covariate that
+is measured and imbalanced across exposure groups in Table 1 is not in the Methods
+adjustment set).
+**Severity:** usually Fixable → Anticipated **Minor**; Fatal → Anticipated **Major** when
+the covariate plausibly explains the primary association. **Category:** C. Validation &
+Statistical Reporting (with E. Reproducibility for the model spec).
+
+## Anticipated Major/Minor Comment (how a reviewer will put it)
+
+> Baseline smoking differs between the exposed and unexposed groups (Table 1: 41% vs 23%,
+> standardized mean difference 0.39), and smoking is a plausible confounder of the
+> exposure–outcome relationship, but it does not appear in the adjustment set (Methods,
+> *Statistical analysis*). Please either add it to the multivariable model or explain why it
+> was excluded, and report whether the primary estimate changes when it is included.
+
+## Severity / category rationale
+
+It is **Minor/Fixable** when the covariate is one of several already-adjusted and the result
+is robust; it escalates to **Major/Fatal** when it is imbalanced *and* on the causal path to
+the outcome *and* the primary estimate is near the significance boundary — then an
+unadjusted confounder could flip the conclusion. Tag **category C** (the estimate's
+validity), noting the model spec under E.
+
+## Fix
+
+Add the covariate to the model (or pre-specified sensitivity model), report the adjusted
+estimate with its CI, and state the change from the unadjusted estimate. If exclusion was
+deliberate (e.g., collider/mediator), say so and cite the DAG rationale. `fixable_by_ai:
+false` — requires re-running the model on the data.
+
+## R0-ready line
+
+> R0-C2 (Major, Fatal-if-flips): smoking is imbalanced (SMD 0.39) but unadjusted; add to the
+> model and report the change in the primary estimate. [gate: check_confounding_completeness]


### PR DESCRIPTION
## Reverse-engineering loop — iteration 2 (autonomous overnight run)

Companion to iteration 1 (peer-review `exemplar_reviews/`), now in **`/self-review`'s** own
idiom. `/self-review` runs deterministic Phase 2.5 gates and a systematic A–K check but had
no worked examples of turning a *gate hit* into a well-formed **Anticipated Major/Minor
Comment**. This adds that layer.

Adds `skills/self-review/references/exemplar_findings/` — four **synthetic** models, each
tied to a real gate:

- `cohort_arithmetic_mismatch.md` — `check_cohort_arithmetic.py` → category A (Fatal)
- `unadjusted_confounder.md` — `check_confounding_completeness.py` → category C/E
- `scope_overreach_cross_sectional.md` — `check_scope_coherence.py` → category D (Fatal)
- `estimand_drift_posthoc_primary.md` — `check_claim_artifact.py` → category C (Fatal)

Each shows the full Phase 3 shape: **what fired → the comment in the reviewer's words →
Fatal/Fixable → category letter → concrete fix + `fixable_by_ai` → an R0-ready line** for the
`/revise` pipeline. Phase 3 loads the relevant model before drafting comments.

**Learn-then-synthesize:** synthetic teaching models with placeholder numbers — no copied
manuscript text, no real citations, no PII, English-only. Additive reference material; no
skill behavior changes.

**Verification:** local `validate_skills.sh`, routing-assets `--strict`, domain-probe sync
`--strict`, locale inventory, catalog + `gen_skill_docs --check` all green; `docs/skills/self-review.md` regenerated.

_Autonomous loop PR — review/merge at your convenience; not auto-merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
