### PR TITLE
feat(peer-review): reviewer_calibration compliance-floor (RE loop iter 3)

### DIFF
--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -38,6 +38,7 @@
 - `aczel_2021_reviewer2_patterns.md`
 - `domain-probes/` (5 files)
 - `narrative_review_audit.md`
+- `reviewer_calibration/` (2 files)
 - `reviewer_profiles/` (6 files)
 
 ## Source

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -79,7 +79,7 @@ methodology and study design.
      redundant". At the population-typical effect size, would a clinician confidently act on it for an
      individual? The point is to let these axes diverge from validity (e.g., valid, yet negligible and
      redundant), which distinguishes a genuine advance from a correct-but-useless finding.
-5. **Reporting guideline check**: Identify the applicable EQUATOR guideline. Flag MISSING items as candidate comments. If `/check-reporting` is available, delegate.
+5. **Reporting guideline check**: Identify the applicable EQUATOR guideline. Flag MISSING items as candidate comments. If `/check-reporting` is available, delegate. Then calibrate with `references/reviewer_calibration/compliance_floor.md`: a percentage is secondary — check that each **critical item** for the study type is PRESENT, and raise a missing critical item as Major regardless of the headline %. Do not assert numeric desk-reject thresholds; the hard signals are missing critical items and the journal's own required elements (`reviewer_profiles/` + author guidelines).
 6. **Prioritize**: Rank issues by impact on validity. Select top 3-5 for Major, 3-4 for Minor. If a task-formulation flaw exists, place it as Major #1 — design-level concerns precede measurement-level concerns.
 7. **Gate**: Present findings to user — "Here are the key issues I found — do you agree with this prioritization?"
 

--- a/skills/peer-review/references/reviewer_calibration/README.md
+++ b/skills/peer-review/references/reviewer_calibration/README.md
@@ -1,0 +1,34 @@
+# Reviewer calibration — turning a compliance % into a judgment
+
+`/check-reporting` reports how many guideline items are PRESENT / PARTIAL / MISSING and a
+compliance percentage. A percentage alone does not answer the reviewer's actual question:
+**is this manuscript reporting-complete enough, and which gaps are serious?** This directory
+holds that judgment layer.
+
+It is deliberately **not** in `reviewer_profiles/` — that directory is "form fields, not
+opinions" (the scorecard a journal's editorial system shows). Calibration is opinion, so it
+lives here, as the reviewer's own guideline.
+
+## What it provides
+
+- `compliance_floor.md` — the principle that **critical-item presence outranks the overall
+  percentage**, a per-guideline list of items that are reject-risk when MISSING regardless
+  of the headline %, and the desk-rejection-risk signals to weigh.
+
+## How it is used
+
+In `/peer-review` Phase 2 (reporting-guideline check) and `/self-review` (category G), after
+`/check-reporting` produces its table: don't stop at the percentage. Check that each
+**critical item** for the study type is PRESENT; a 90%-compliant manuscript that is missing
+a critical item is weaker than an 80%-compliant one that has them all.
+
+## Boundaries (read before adding)
+
+- **No fabricated thresholds.** This file does not assert "journal X desk-rejects below
+  Y%." Journals rarely publish a numeric floor. The *only* hard signals are (a) a missing
+  critical item and (b) the journal's own stated required elements (which live in
+  `reviewer_profiles/` and the author guidelines — verify there, do not invent).
+- **Critical-item lists are methodological judgment**, grounded in the guideline's own item
+  set (public), not in any single manuscript or review.
+- Keep it general and study-type-keyed; per-journal specifics belong in `reviewer_profiles/`
+  and are cited, not duplicated here.

--- a/skills/peer-review/references/reviewer_calibration/compliance_floor.md
+++ b/skills/peer-review/references/reviewer_calibration/compliance_floor.md
@@ -1,0 +1,52 @@
+# Compliance floor — critical-item presence over headline percentage
+
+A reporting-compliance percentage is a coarse summary. Two manuscripts at the same
+percentage can differ enormously in reviewability, because **not all items carry equal
+weight**. Calibrate the reviewer comment to *which* items are missing, not just how many.
+
+## The principle
+
+1. **Critical items are pass/fail.** For each study type there is a small set of items that
+   a methods reviewer or editor treats as non-waivable. If one is MISSING, raise it as a
+   Major comment **regardless of the overall percentage** — an otherwise 90%-compliant paper
+   that cannot be reproduced or whose ground truth is undefined is not "90% acceptable."
+2. **The overall percentage is a secondary signal**, useful for "is the reporting broadly
+   thorough or broadly thin," not for a desk-reject line. Do not assert a numeric floor a
+   journal has not published.
+3. **The journal's own required elements are hard.** A missing structured-abstract heading,
+   a missing required panel (e.g., Key Points / Summary Statement), or the wrong reporting
+   checklist for the study type is a concrete, citable gap — but those facts live in
+   `reviewer_profiles/` and the author guidelines; verify there, never invent them.
+
+## Critical items by guideline (MISSING → Major / reject-risk)
+
+These are the items most consistently treated as non-waivable. Phrase the comment as the
+specific missing item, anchored to where it should appear.
+
+| Guideline (study type) | Critical items (raise as Major if MISSING) |
+|---|---|
+| **CLAIM** (AI in medical imaging) | Model architecture + training procedure; ground-truth/reference-standard definition; data-partition method (train/val/test, leakage control); evaluation metrics with uncertainty |
+| **TRIPOD+AI** (prediction model) | Source and types of input data; outcome definition and timing; how the model was developed and validated; performance with **calibration**, not discrimination only |
+| **STARD-AI / STARD** (diagnostic accuracy) | Reference standard and its rationale; blinding of index-test vs reference readers; participant flow (2×2 recoverable); handling of indeterminate results |
+| **STROBE** (observational) | Eligibility criteria and selection; outcome/exposure definitions; **how missing data were handled**; participant flow (cascade reconciles) |
+| **PRISMA / PRISMA-DTA** (systematic review) | Full search strategy (≥1 database verbatim); flow diagram that reconciles; per-study risk-of-bias; pre-registration/protocol reference |
+
+Extensions name the base instrument too (e.g., STARD **and** STARD-AI) — a manuscript that
+cites only the extension and skips the base items is itself an item to flag.
+
+## Desk-rejection-risk signals (weigh, don't over-assert)
+
+- A **critical item is MISSING** (above) — the strongest single signal.
+- The manuscript uses the **wrong reporting guideline** for its design (e.g., a prediction
+  model reported only against STROBE).
+- A journal **required element is absent** (per `reviewer_profiles/` + author guidelines).
+- The **reporting checklist is not uploaded** or references a stale manuscript version.
+
+When several co-occur, say so in the Confidential Comments to the Editor as a coherent
+"reporting readiness" concern, not as a list of nitpicks.
+
+## Integration
+
+Run `/check-reporting` first for the item-by-item table, then apply this file:
+- `/peer-review` Phase 2 (reporting-guideline check) and Phase 4 self-QC.
+- `/self-review` category G — flag MISSING critical items as Anticipated Major Comments.


### PR DESCRIPTION
## Reverse-engineering loop — iteration 3 (autonomous overnight run)

Fills the gap between `/check-reporting`'s compliance **percentage** and a reviewer
**judgment**: a percentage alone doesn't say whether a manuscript is reporting-complete
enough, or which gaps are serious.

Adds `skills/peer-review/references/reviewer_calibration/` — deliberately **not**
`reviewer_profiles/` (which is "form fields, not opinions"). `compliance_floor.md`:

- **Critical-item presence outranks the headline %** — a 90%-compliant paper missing a
  critical item (undefined ground truth, no calibration, unhandled missing data) is weaker
  than an 80%-compliant one that has them all.
- A per-guideline table of **non-waivable items** (CLAIM, TRIPOD+AI, STARD-AI, STROBE,
  PRISMA) whose absence is reject-risk regardless of the percentage.
- **Desk-rejection-risk signals** to weigh (missing critical item, wrong guideline for the
  design, missing required element, checklist not uploaded).

Phase 2's reporting-guideline check now calibrates with it.

**No fabricated thresholds:** the file asserts no numeric desk-reject line; the only hard
signals are missing critical items + the journal's own required elements (verified in
`reviewer_profiles/` + author guidelines). Critical-item lists are methodological judgment
grounded in each guideline's **public** item set — no copied text, no real citations, no PII.

**Verification:** local `validate_skills.sh`, routing-assets `--strict`, domain-probe sync
`--strict`, locale inventory, catalog + `gen_skill_docs --check` all green; `docs/skills/peer-review.md` regenerated.

_Autonomous loop PR — review/merge at your convenience; not auto-merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
