### PR TITLE
fix(gen-skill-docs): repo-relative _ignorable (RE loop iter 4)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Run gen_skill_docs.py --check (per-skill docs must match SKILL.md)
         run: python3 scripts/gen_skill_docs.py --check
 
+      - name: Run gen_skill_docs _ignorable regression test (worktree dotted-ancestor counts)
+        run: bash tests/test_gen_skill_docs_ignorable.sh
+
       - name: Run gen_skills_catalog_json.py --check (storefront catalog SSOT)
         run: python3 scripts/gen_skills_catalog_json.py --check
 

--- a/scripts/gen_skill_docs.py
+++ b/scripts/gen_skill_docs.py
@@ -121,12 +121,22 @@ def load_skill(skill_dir: Path) -> dict[str, str]:
     return fm
 
 
-def _ignorable(p: Path) -> bool:
-    """Untracked build/OS artifacts that exist locally but not in a clean checkout —
-    excluding them keeps counts identical between a working tree and CI (determinism)."""
+def _ignorable(p: Path, root: Path) -> bool:
+    """Untracked build/OS artifacts within the walked tree (`__pycache__`, `.pyc`, dotfiles).
+
+    Only the path RELATIVE to `root` is inspected. A dotted *ancestor* directory — e.g. a git
+    worktree checked out under ``~/.local/...`` — must not make every file look ignorable;
+    only dot / ``__pycache__`` components *inside* the tree being counted are excluded. This
+    keeps counts identical between a normal checkout, a worktree, and CI (determinism)."""
     if p.suffix == ".pyc":
         return True
-    return any(part == "__pycache__" or part.startswith(".") for part in p.parts)
+    try:
+        rel_parts = p.relative_to(root).parts
+    except ValueError:
+        # p is not under root (unexpected): judge by basename only — never fall back to
+        # scanning absolute ancestors, which is the very bug this function guards against.
+        rel_parts = (p.name,)
+    return any(part == "__pycache__" or part.startswith(".") for part in rel_parts)
 
 
 def list_resources(skill_dir: Path) -> dict[str, list[str]]:
@@ -140,7 +150,7 @@ def list_resources(skill_dir: Path) -> dict[str, list[str]]:
             if child.name.startswith(".") or child.name == "__pycache__":
                 continue
             if child.is_dir():
-                count = sum(1 for p in child.rglob("*") if p.is_file() and not _ignorable(p))
+                count = sum(1 for p in child.rglob("*") if p.is_file() and not _ignorable(p, child))
                 entries.append(f"`{child.name}/` ({count} file{'s' if count != 1 else ''})")
             else:
                 entries.append(f"`{child.name}`")

--- a/tests/test_gen_skill_docs_ignorable.sh
+++ b/tests/test_gen_skill_docs_ignorable.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression test for gen_skill_docs.py _ignorable(): a dotted ANCESTOR directory
+# (e.g. a git worktree checked out under ~/.local/...) must not make every reference
+# file count as 0. Only dot/__pycache__/.pyc components INSIDE the walked tree are excluded.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+echo "== test_gen_skill_docs_ignorable =="
+
+python3 - "$REPO_ROOT" <<'PY'
+import sys, tempfile, shutil, importlib.util
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("gsd_under_test", repo / "scripts" / "gen_skill_docs.py")
+gsd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gsd)
+
+fails = []
+tmp = Path(tempfile.mkdtemp())
+try:
+    # Skill tree under a DOTTED ancestor dir (mimics a worktree under ~/.local/...).
+    base = tmp / ".dotted_ancestor" / "skillX"
+    sub = base / "references" / "examples"
+    sub.mkdir(parents=True)
+    (sub / "real_one.md").write_text("x", encoding="utf-8")
+    (sub / "real_two.md").write_text("y", encoding="utf-8")
+    (sub / "__pycache__").mkdir()
+    (sub / "__pycache__" / "c.pyc").write_text("z", encoding="utf-8")
+    (sub / ".hidden.md").write_text("h", encoding="utf-8")
+
+    # _ignorable: a real file must NOT be flagged despite the dotted ancestor; in-tree
+    # pycache/.pyc/dotfiles MUST still be flagged.
+    if gsd._ignorable(sub / "real_one.md", sub):
+        fails.append("real file flagged ignorable despite dotted ancestor (the bug)")
+    if not gsd._ignorable(sub / "__pycache__" / "c.pyc", sub):
+        fails.append(".pyc inside the tree not flagged")
+    if not gsd._ignorable(sub / ".hidden.md", sub):
+        fails.append("dotfile inside the tree not flagged")
+
+    # Fallback branch (p NOT under root): judged by basename only, never by absolute
+    # ancestors — a dotted ancestor must still not flag a real file.
+    outside = Path("/no/such/root")
+    if gsd._ignorable(sub / "real_one.md", outside):
+        fails.append("out-of-root real file flagged via dotted ancestor (fallback bug)")
+    if not gsd._ignorable(sub / ".hidden.md", outside):
+        fails.append("out-of-root dotfile not flagged by basename fallback")
+    if not gsd._ignorable(sub / "__pycache__" / "c.pyc", outside):
+        fails.append("out-of-root .pyc not flagged")
+
+    # list_resources: count must be 2 (the two real .md), not 0.
+    res = gsd.list_resources(base)
+    entry = next((e for e in res.get("references", []) if e.startswith("`examples/`")), None)
+    if entry is None:
+        fails.append("examples/ subdir not listed by list_resources")
+    elif "(2 files)" not in entry:
+        fails.append(f"wrong count under dotted ancestor: {entry!r} (expected '2 files')")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+if fails:
+    print("FAIL:")
+    for f in fails:
+        print("  -", f)
+    sys.exit(1)
+print("  ok: dotted-ancestor counts correct; in-tree pycache/.pyc/dotfiles excluded")
+PY
+
+# Real-repo behavior must be unchanged.
+python3 scripts/gen_skill_docs.py --check >/dev/null 2>&1 \
+  && echo "  ok: gen_skill_docs.py --check still passes (counts unchanged on a normal checkout)" \
+  || { echo "FAIL: gen_skill_docs.py --check regressed"; exit 1; }
+
+echo "PASS: test_gen_skill_docs_ignorable"


### PR DESCRIPTION
## Reverse-engineering loop — iteration 4 (autonomous overnight run, Codex-reviewed)

A small but real tooling fix found while running the loop itself in git worktrees.

**Bug:** `scripts/gen_skill_docs.py` `_ignorable()` walked the **absolute** path parts and
treated any `.`-prefixed component as ignorable. So when the repo is checked out under a
dotted ancestor directory — e.g. a worktree under `~/.local/...` — **every reference file
counted as 0**, corrupting the per-skill "Bundled resources" file counts (only in
worktrees; normal checkouts were fine).

**Fix:** `_ignorable(p, root)` now inspects only `p.relative_to(root).parts`, and the single
call site passes the walked subdir as `root`. A dotted **ancestor** no longer flags files,
while real `__pycache__` / `.pyc` / dotfiles **inside** the tree are still excluded. Counts
are identical on a normal checkout (`gen_skill_docs.py --check` unchanged), in a worktree,
and in CI.

**Codex guarded review folded in:** the `ValueError` fallback now judges by **basename only**
(`(p.name,)`) instead of `p.parts`, so an out-of-root caller can never reintroduce
absolute-ancestor scanning. Codex made no edits (verified: `git status` = exactly the 3
intended files).

**Test:** new `tests/test_gen_skill_docs_ignorable.sh` builds a skill tree under a dotted
ancestor and asserts the count is correct (2, not 0), exercises the basename fallback, and
confirms `--check` still passes; wired into `validate.yml`.

**Verification:** full local mirror green (validate_skills, routing-assets `--strict`,
domain-probe-sync `--strict`, locale, all catalog `--check`, `gen_skill_docs --check`, the
new test, `py_compile`).

_Autonomous loop PR — review/merge at your convenience; not auto-merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
