### PR TITLE
feat(write-paper): exemplar Methods structure models (RE loop iter 6, final)

### DIFF
--- a/docs/skills/write-paper.md
+++ b/docs/skills/write-paper.md
@@ -36,6 +36,7 @@
 
 **References** (`skills/write-paper/references/`):
 
+- `exemplar_methods/` (4 files)
 - `journal_profiles/` (54 files)
 - `paper_types/` (9 files)
 - `section_guides/` (7 files)

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -192,7 +192,7 @@ Design all tables and figures BEFORE writing prose. This ensures the narrative s
 
 Write the Methods section first -- it is the most objective and anchors the rest of the paper.
 
-**Before writing:** Load `${CLAUDE_SKILL_DIR}/references/section_guides/methods.md` for PICO structure, backbone article usage, checklist cross-reference, and terminology conventions.
+**Before writing:** Load `${CLAUDE_SKILL_DIR}/references/section_guides/methods.md` for PICO structure, backbone article usage, checklist cross-reference, and terminology conventions. For the matching study type, also skim the structure model in `${CLAUDE_SKILL_DIR}/references/exemplar_methods/` (diagnostic-accuracy/STARD, AI-validation/TRIPOD+AI·CLAIM, observational-cohort/STROBE) — it lists, paragraph by paragraph, what each Methods paragraph must establish plus the element that type most often omits. Model the structure; the exemplars are synthetic, with placeholder specifics, not prose to copy.
 
 **Writing order within Methods:**
 1. Study Design and Setting

--- a/skills/write-paper/references/exemplar_methods/README.md
+++ b/skills/write-paper/references/exemplar_methods/README.md
@@ -1,0 +1,38 @@
+# Exemplar Methods sections — structure models, not prose to copy
+
+`write-paper` teaches Methods *structure* (PICO, the reporting-guideline cross-reference,
+the backbone-article strategy) but had no worked example of what a complete, well-ordered
+Methods section looks like end to end. This directory fills that gap with **structure
+exemplars**: each shows the paragraph order for a study type and, for every paragraph, *what
+it must establish* — with placeholder specifics, never copied text.
+
+These are **authored from scratch as teaching models**, not extracted from any published
+paper. Use them to check that a draft's Methods has every load-bearing paragraph in a sane
+order; do not copy wording.
+
+## How they are used
+
+In `write-paper` Phase 3 (Methods), after loading `section_guides/methods.md`: pick the
+exemplar matching the study type and confirm the draft establishes each element the
+exemplar lists (design, setting/dates, eligibility, the index test/exposure, the reference
+standard/outcome, sample-size justification, the statistical plan, and the reporting-guideline
+fit). A missing element is a gap to fill before drafting Results.
+
+## Contents
+
+- `diagnostic_accuracy_stard.md` — an index-test vs reference-standard accuracy study (STARD).
+- `ai_validation_tripod_claim.md` — an AI/ML model development + validation study (TRIPOD+AI / CLAIM).
+- `observational_cohort_strobe.md` — an exposure→outcome observational cohort (STROBE).
+
+## Curator guidelines (for adding more)
+
+- **Synthetic only.** Write the structure with placeholder specifics (`[scanner/vendor]`,
+  `[N]`, `[YYYY–YYYY]`); never paste a real paper's Methods, and use no real citations, no
+  PII, English only.
+- **One study type per file**, paragraph by paragraph, each line stating *what the paragraph
+  must establish* (not finished prose).
+- **Anchor to the reporting guideline** the study type maps to, naming the critical items
+  (see `peer-review/references/reviewer_calibration/compliance_floor.md`).
+- **Name the common omission** for each study type (the paragraph drafts most often skip).
+- Keep each file ~50–90 lines. Cross-reference `section_guides/methods.md` and the relevant
+  `paper_types/` template rather than duplicating them.

--- a/skills/write-paper/references/exemplar_methods/ai_validation_tripod_claim.md
+++ b/skills/write-paper/references/exemplar_methods/ai_validation_tripod_claim.md
@@ -1,0 +1,47 @@
+# Methods structure — AI/ML model development + validation (TRIPOD+AI / CLAIM)
+
+A structure model for a clinical AI/ML model study. Each heading is a paragraph; each bullet
+is *what it must establish*. Fill the `[brackets]`; do not copy this text.
+
+## Study design and data sources
+- Design (retrospective/prospective), the prediction task, and the intended use (where in
+  the workflow the output acts, and which decision it informs).
+- Data sources, sites, and dates for each split; how the cohort was assembled.
+
+## Participants, inputs, and outcome
+- Eligibility as a numbered list; the population the model is meant to serve.
+- Input data types and exactly which fields the model sees (flag any field that could carry
+  the label — report a no-leaky-field sensitivity analysis or mask it).
+- Outcome/label definition, who assigned it, and the reference standard for the label.
+
+## Data partition and leakage control
+- Train / validation / test split **by patient** (not by image/record), and how
+  independence was enforced; any external (geographic/temporal) test set.
+- Explicit statement that no test data informed development (preprocessing, feature/threshold
+  selection, model choice) — leakage inflates every metric and is invisible in the results.
+
+## Model development
+- Architecture, key hyperparameters, training procedure, and how the operating threshold was
+  chosen (and on which split).
+- Whether training was from scratch or fine-tuned; for an adaptation claim, a same-backbone
+  zero-shot/few-shot baseline.
+- Reproducibility: hardware/software/versions, random-seed handling, code/model availability.
+
+## Evaluation
+- Primary metric(s) with 95% CIs; **calibration** (slope/intercept or a calibration plot),
+  not discrimination alone, when probabilities drive a decision.
+- Comparator: if vs clinicians, the **same task on the same inputs under the same
+  constraints**, with a test of the difference (not two standalone AUCs); decision-curve /
+  net-benefit if a deployment/utility claim is made.
+
+## Sample size
+- Events-per-variable / minimum test-set events for the target precision, or the
+  available-sample justification.
+
+## Reporting-guideline fit
+- TRIPOD+AI (name base TRIPOD + the AI extension) and/or CLAIM 2024. Critical items: input
+  data + outcome, partition/leakage control, model + training details, calibration.
+
+## Common omission
+- **Calibration** and a **patient-level** (not image-level) split — the two most commonly
+  missing, and both can make excellent-looking metrics misleading.

--- a/skills/write-paper/references/exemplar_methods/diagnostic_accuracy_stard.md
+++ b/skills/write-paper/references/exemplar_methods/diagnostic_accuracy_stard.md
@@ -1,0 +1,50 @@
+# Methods structure — diagnostic-accuracy study (STARD)
+
+A structure model for an index-test-vs-reference-standard accuracy study. Each heading is a
+paragraph; each bullet is *what the paragraph must establish*. Placeholders in `[brackets]`
+stand for the study's real specifics — fill them; do not copy this text.
+
+## Study design and oversight
+- State the design (prospective / retrospective, consecutive / case-control sampling — and
+  why; case-control sampling inflates accuracy and must be named).
+- Setting and dates: `[single/multi-center]`, `[YYYY–YYYY]`, recruitment source.
+- Ethics approval + consent (or waiver) and registration if applicable.
+
+## Participants and eligibility
+- Eligibility as a numbered list: inclusion `(1)…(2)…`, exclusion `(1)…(2)…`.
+- The clinical question and the intended-use population the index test is meant to serve.
+- Flow that lets the reader rebuild a 2×2 (enrolled → tested → analyzed; exclusions with
+  reasons) — this is what the STARD diagram renders.
+
+## Index test
+- What it is, who performed/read it, their experience, and blinding to the reference
+  standard and to clinical data.
+- Acquisition specifics: `[scanner/vendor/field strength]`, protocol, software/version.
+- The positivity threshold/criterion and whether it was pre-specified or data-derived.
+
+## Reference standard
+- The reference standard and its rationale (the validity hierarchy: pathology > imaging
+  panel consensus > clinical follow-up at `[interval]`).
+- Who applied it, their blinding to the index test, and the index↔reference time interval
+  (verification timing).
+- How indeterminate/non-diagnostic results were handled (ITD vs per-protocol — state which).
+
+## Sample size
+- The accuracy target and precision (expected sensitivity/specificity + CI half-width) or
+  the available-sample justification; the prevalence assumed.
+
+## Statistical analysis
+- Sensitivity/specificity with 95% CIs; PPV/NPV with the prevalence they assume.
+- Comparison method if two tests (paired McNemar / difference in AUC with a test of the
+  difference — not two standalone AUCs), and any subgroup/multiplicity handling.
+- Missing/indeterminate handling and any sensitivity analysis.
+- Software + version.
+
+## Reporting-guideline fit
+- STARD 2015 (or STARD-AI for an AI index test — name BOTH base and extension). Critical
+  items: reference standard + rationale, reader blinding, participant flow, indeterminate
+  handling (see `peer-review/references/reviewer_calibration/compliance_floor.md`).
+
+## Common omission
+- Reader **blinding** to the reference standard and the **index↔reference time interval**
+  — the two details most often missing, and both bias the headline accuracy if unaddressed.

--- a/skills/write-paper/references/exemplar_methods/observational_cohort_strobe.md
+++ b/skills/write-paper/references/exemplar_methods/observational_cohort_strobe.md
@@ -1,0 +1,43 @@
+# Methods structure — observational cohort (STROBE)
+
+A structure model for an exposure→outcome cohort study. Each heading is a paragraph; each
+bullet is *what it must establish*. Fill the `[brackets]`; do not copy this text.
+
+## Study design and setting
+- Design (prospective / retrospective cohort) and why; data source (`[registry / EMR /
+  health-screening DB]`), sites, and the enrollment and follow-up dates (keep enrollment
+  distinct from follow-up end — do not conflate them).
+- Ethics approval / consent or waiver; registration if applicable.
+
+## Participants and eligibility
+- Eligibility as a numbered list (inclusion / exclusion).
+- The assembly cascade with counts (source → eligible → analytic), so the STROBE flow
+  reconciles (start − Σ exclusions = analytic N).
+
+## Variables — exposure, outcome, covariates
+- Exposure definition, how it was measured/classified, and the cut-points with their source
+  (cite the canonical definition; quote the data-dictionary mapping for a DB variable).
+- Outcome definition, ascertainment, and timing.
+- Covariates/confounders and how each was measured; pre-specify the adjustment set and its
+  rationale (a DAG), not a data-driven selection.
+
+## Bias, missing data, and study size
+- Sources of bias and how they were addressed (selection, measurement, confounding).
+- How missing data were handled (complete-case vs imputation — state which; complete-case
+  must reconcile: total − missing = complete).
+- Study size: the precision / event-budget justification (events per variable for the model).
+
+## Statistical analysis
+- The primary model and estimand (the contrast and effect measure), with 95% CIs; the
+  pre-registered primary if applicable (do not reassign the primary after seeing results).
+- Subgroup/interaction and sensitivity analyses, multiplicity handling, and how continuous
+  variables were modeled (linearity assumption).
+- Software + version.
+
+## Reporting-guideline fit
+- STROBE. Critical items: eligibility/selection, exposure/outcome definitions, missing-data
+  handling, participant flow (see `peer-review/references/reviewer_calibration/compliance_floor.md`).
+
+## Common omission
+- A pre-specified **adjustment set with rationale** and explicit **missing-data handling** —
+  the two paragraphs cohort drafts most often skip, and both are first-line reviewer targets.


### PR DESCRIPTION
## Reverse-engineering loop — iteration 6 / FINAL (autonomous overnight run)

`write-paper` taught Methods *structure* but had no end-to-end model of a well-ordered
Methods section. Adds `skills/write-paper/references/exemplar_methods/` — three **synthetic,
authored-from-scratch structure models**:

- `diagnostic_accuracy_stard.md` — index-test vs reference-standard accuracy (STARD)
- `ai_validation_tripod_claim.md` — AI/ML model development + validation (TRIPOD+AI / CLAIM)
- `observational_cohort_strobe.md` — exposure→outcome cohort (STROBE)

Each gives the **paragraph order** and, for every paragraph, **what it must establish**
(design, setting/dates, eligibility, index test/exposure, reference standard/outcome,
sample-size justification, statistical plan, reporting-guideline fit) plus **the element that
study type most often omits** — with placeholder specifics. Phase 3 (Methods) loads the
matching model alongside the existing section guide; a README curator guide governs additions.

**Learn-then-synthesize:** structure models with placeholder specifics — no copied paper
text, no real citations, no PII, English only. Additive reference material; no behavior change.

**Verification:** local `validate_skills.sh`, routing-assets `--strict`, domain-probe sync
`--strict`, locale, catalog + `gen_skill_docs --check` all green; `docs/skills/write-paper.md`
regenerated.

_Autonomous loop PR (final of this overnight batch) — review/merge at your convenience; not auto-merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
