### PR TITLE
chore(npm): unscoped package name medsci-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,10 +422,10 @@ dependency-free Python installer. The canonical install paths remain the plugin
 marketplace (Option 1's sibling above) and the git clone above; npm is just a shortcut.
 
 ```bash
-npx @aperivue/medsci-skills install            # all hosts (Claude, Codex, Cursor)
-npx @aperivue/medsci-skills install --target claude
-npx @aperivue/medsci-skills list               # list bundled skills
-npx @aperivue/medsci-skills doctor             # quick Node/Python/skill-folder check
+npx medsci-skills install            # all hosts (Claude, Codex, Cursor)
+npx medsci-skills install --target claude
+npx medsci-skills list               # list bundled skills
+npx medsci-skills doctor             # quick Node/Python/skill-folder check
 ```
 
 Requires Node 18+ and (for `install`/`doctor`) `python3` on your PATH.

--- a/bin/medsci-skills.js
+++ b/bin/medsci-skills.js
@@ -49,7 +49,7 @@ function printHelp() {
 MedSci Skills — medical/scientific research skill suite for AI coding agents.
 
 Usage:
-  npx @aperivue/medsci-skills <command> [options]
+  npx medsci-skills <command> [options]
   medsci-skills <command> [options]      (after a global install)
 
 Commands:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aperivue/medsci-skills",
+  "name": "medsci-skills",
   "version": "4.1.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Switch npm name `@aperivue/medsci-skills` → `medsci-skills` (unscoped): shorter `npx medsci-skills`, better npm-search discoverability, simpler publish (public by default, no org). Aperivue brand stays everywhere else. CLI help + README examples updated. Dry-run validated (`medsci-skills@4.1.0`, default access). 🤖 Generated with [Claude Code](https://claude.com/claude-code)