### PR TITLE
docs: cite the methods preprint (arXiv:2606.09500)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,3 +45,18 @@ keywords:
   - pubmed
   - irb-protocol
   - physician-researcher
+preferred-citation:
+  type: article
+  title: "Agentic Skills for Auditable and Reproducible Medical Research Writing: An Integrity-gated Architecture for LLM-Assisted Clinical Manuscripts"
+  authors:
+    - family-names: Nam
+      given-names: Yoojin
+      orcid: "https://orcid.org/0000-0001-8565-1360"
+    - family-names: Kim
+      given-names: Namkug
+  year: 2026
+  url: "https://arxiv.org/abs/2606.09500"
+  identifiers:
+    - type: other
+      value: "arXiv:2606.09500"
+      description: "arXiv preprint"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-supported-success?style=flat-square)](docs/host_compatibility.md)
 
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20155321-blue?style=flat-square)](https://doi.org/10.5281/zenodo.20155321)
+[![arXiv](https://img.shields.io/badge/arXiv-2606.09500-b31b1b?style=flat-square)](https://arxiv.org/abs/2606.09500)
 [![Citation](https://img.shields.io/badge/Cite-CITATION.cff-blue?style=flat-square)](CITATION.cff)
 ![Built by](https://img.shields.io/badge/Built_by-Physician--Researcher-blue?style=flat-square)
 
@@ -583,6 +584,18 @@ and academic use is logged in [`docs/citations.md`](docs/citations.md).
 **Used MedSci Skills in your research?** Please
 [let us know](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml).
 It helps other researchers find the toolkit — and we list it (with your permission).
+
+## Citation
+
+If you use MedSci Skills in your research, please cite the software via
+[`CITATION.cff`](CITATION.cff) (Zenodo concept DOI
+[10.5281/zenodo.20155321](https://doi.org/10.5281/zenodo.20155321)).
+
+The design and evaluation of the toolkit are described in a preprint:
+
+> Nam Y, Kim N. *Agentic Skills for Auditable and Reproducible Medical Research
+> Writing: An Integrity-gated Architecture for LLM-Assisted Clinical Manuscripts.*
+> arXiv:2606.09500 (2026). https://arxiv.org/abs/2606.09500
 
 ## Disclaimer
 


### PR DESCRIPTION
Reflect the MedSci Skills methods preprint in the repo's citation surface.

## Changes
- **README**: arXiv badge (`arXiv:2606.09500`) + a new `## Citation` section that points to the software citation (`CITATION.cff` / Zenodo concept DOI) and the design/evaluation preprint (Nam & Kim).
- **CITATION.cff**: `preferred-citation` block for the preprint (2 authors: Nam, Kim).

## Deliberately omitted
- JBI submission status — kept out until a decision lands, so the README never carries stale "under review" text. The preprint is the durable, citable artifact now.

## Rationale
- Software citation stays the default (Zenodo). The preprint is the *paper* citation, surfaced via `preferred-citation`.
- Author names appear only where the validator's author-attribution allowlist permits (`README.md`, `CITATION.cff`).

## Validation
- `validate_skills.sh` — PASS (PII/attribution clean, 6 domain-probe modules byte-identical)
- `tests/test_sync_hero_skill.sh` — 28 passed (CITATION.cff still parses for hero mirror)
- `CITATION.cff` YAML parses; `preferred-citation` resolves (title + 2 authors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)