### PR TITLE
fix(CVIR profile) + add single-arm proportion meta-analysis conventions

### DIFF
--- a/docs/skills/meta-analysis.md
+++ b/docs/skills/meta-analysis.md
@@ -48,6 +48,7 @@
 - `post_submission_release_ops.md`
 - `r_templates.md`
 - `review_orchestration.md`
+- `single_arm_proportion_ma.md`
 - `submission_package_drift.md`
 
 **Scripts** (`skills/meta-analysis/scripts/`):

--- a/skills/find-journal/references/journal_profiles/CVIR.md
+++ b/skills/find-journal/references/journal_profiles/CVIR.md
@@ -13,18 +13,25 @@ CVIR publishes original research, reviews, meta-analyses, and case reports on al
 ## Scope Keywords
 interventional radiology, embolization, ablation, vascular intervention, CBCT, cone-beam CT, drainage, stenting, angioplasty, thrombolysis, TACE, radioembolization, image-guided therapy, percutaneous biopsy, venous access, portal vein embolization, IR outcomes
 
-## Article Types Accepted
-- Original Article
-- Review Article
-- Systematic Review / Meta-Analysis
-- Technical Note
-- Case Report
-- Letter to the Editor
+## Article Types Accepted (CVIR taxonomy + limits)
+- Clinical Investigation — 2400 words, structured 250-word abstract, 6 images
+- Laboratory Investigation — 2400 words, structured 250, 6 images
+- **Scientific Paper (Other)** — 2400 words, structured 250, 6 images — **this is the type for META-ANALYSES**
+- Review Article — 3000 words, simple 125-word abstract, 10 images (includes narrative systematic reviews)
+- Case Report — 1000 words, simple 125, 3 images, refs max 10
+- Short Communication — 1200 words, structured 250, 3 images
+- Study Protocol — 2400 words, structured 250, 3 images
+- Letter to the Editor — 900 words, no abstract, 3 images, refs max 5
 
 ## Classification
 - **Tier:** Q2
-- **Open Access:** Hybrid (Springer transformative agreements)
+- **Open Access:** Hybrid (Open Choice)
 - **Field:** Radiology / Interventional radiology
+- **Peer review:** Double-blind (anonymize the main manuscript)
 
 ## Special Notes
-CVIR is the official journal of CIRSE (Cardiovascular and Interventional Radiological Society of Europe). It readily accepts systematic reviews and meta-analyses of IR procedures. Complication reporting must use SIR classification or Clavien-Dindo grading. Technical and clinical success must be explicitly defined. The journal has a European and international readership. For North American-focused IR studies, consider JVIR as an alternative.
+CVIR is the official journal of CIRSE. It readily accepts meta-analyses of IR procedures, but a **meta-analysis is the "Scientific Paper (Other)" type → 2400 words / 6 images, NOT a 3500–4000-word allowance** (a frequent miscalibration). Double-blind review: the body must be fully anonymized; all author/funding/ethics info goes on a separate Title Page with the five "Compliance with Ethical Standards" statements. Abstract: structured 250 words, **no abbreviations**, with a **Level of Evidence** line. Complication reporting must use SIR classification or Clavien-Dindo. Technical success and technique efficacy must be explicitly defined. For North American-focused IR studies, consider JVIR. Detailed profile: `write-paper/references/journal_profiles/CVIR.md`.
+
+## Verification
+- Source: CVIR Manuscript Type Manual (December 2025) + Springer Instructions for Authors.
+- Last verified: 2026-06-14.

--- a/skills/meta-analysis/references/phase6_statistical_synthesis.md
+++ b/skills/meta-analysis/references/phase6_statistical_synthesis.md
@@ -106,8 +106,8 @@ res_prop <- metaprop(event, n, data = dat_single,
 - Use `method.tau = "DL"` (DerSimonian-Laird) — REML may not converge with sparse data.
 - Use `method.random.ci = "HK"` (Hartung-Knapp) instead of the deprecated `hakn = TRUE`.
 - Use `common = FALSE, random = TRUE` instead of deprecated `comb.fixed/comb.random`.
-- For zero cells, apply `incr = 0.5` continuity correction.
-- Egger's test is underpowered for k < 10 — note this in results.
+- For zero cells in **binary 2×2 outcomes** (OR/RR), apply `incr = 0.5` continuity correction. **Do NOT** apply a continuity correction when pooling **single-arm proportions**: use `metaprop(..., method = "GLMM", sm = "PLOGIT")`, which handles zero-event studies natively. See `single_arm_proportion_ma.md`.
+- Egger's test is underpowered for k < 10 — note this in results. **Egger/funnel tests are invalid for pooled proportions** (the SE is a deterministic function of the proportion); see `single_arm_proportion_ma.md`.
 
 ---
 

--- a/skills/meta-analysis/references/single_arm_proportion_ma.md
+++ b/skills/meta-analysis/references/single_arm_proportion_ma.md
@@ -1,0 +1,53 @@
+# Single-Arm Proportion Meta-Analysis — Conventions
+
+Pooling a single proportion (event rate) across single-arm studies — common when randomized comparators are scarce (interventional radiology, surgery, device/technique case series). These conventions prevent the failure modes a methodological reviewer reliably flags. They are distinct from DTA (sensitivity/specificity) pooling; see also `dta_meta_analysis.R`.
+
+## 1. Model: GLMM logit, not inverse-variance with continuity correction
+
+Pool with a **random-effects generalized linear mixed model (binomial-normal, logit link)** — e.g. R `meta::metaprop(..., method = "GLMM", sm = "PLOGIT")`. The GLMM uses the exact binomial likelihood and **handles zero-event studies natively — do NOT add a 0.5 continuity correction** (continuity corrections bias proportion estimates and are unnecessary under the GLMM). Inverse-variance pooling of raw or arcsine-transformed proportions with `incr = 0.5` is an older default to avoid here. Report between-study variance τ² on the **logit scale** and a **95% prediction interval** for every pool.
+
+## 2. Lead with dispersion, not a single pooled point estimate
+
+Thin, heterogeneous single-arm evidence does not yield a generalizable benchmark. Foreground:
+- the **per-study range** and the **95% prediction interval** (often very wide, e.g. a pooled 18% with a 3–59% PI), and
+- frame pooled values as **descriptive summaries of the existing evidence base**, not as effect estimates or as a guidance/technique "advantage".
+Do not let an Abstract/Key-Points headline a precise pooled percentage that the body then disclaims.
+
+## 3. Boundary-degenerate pools (near 0% or 100%)
+
+When most studies sit at the proportion boundary (e.g. 5/6 studies at 100%), the GLMM is near-degenerate: the **Q-based I² can read 0% while the logit-scale τ² and the prediction interval are large** — these are not contradictory, they reflect boundary estimation. Also, Hartung-Knapp intervals are unstable at small k and can give an uninformatively wide CI (e.g. 69–100%). Handling:
+- present such an outcome **descriptively** (e.g. "five of six studies reported 100%; one reported 97.5%"),
+- keep the pooled value only "for completeness" with an explicit footnote explaining the I²=0 vs τ²>0 artifact,
+- do not call the heterogeneity "negligible" on the strength of I²=0 alone.
+
+## 4. Report the crude rate alongside the pooled estimate
+
+With sparse events the logit-scale random-effects estimate **shrinks below the crude rate** (Σevents/Σdenominator). Report both and say so (e.g. "crude 3.3%; pooled 2.2%, the pooled value lower because of logit-scale shrinkage with sparse events"), so a reviewer does not read pooled < crude as an error.
+
+## 5. Symmetric handling of zero-event studies
+
+Decide one inclusion rule for an outcome and apply it **symmetrically**. The common defect: including narrative-zero studies (a study that says "no major complications" with a borrowed denominator) while **excluding a study that explicitly reported 0/N** — this drops zeros asymmetrically and inflates the rate. Default: **include every study that reported the outcome's status, zero or not**; exclude only studies whose arm-specific count is genuinely not separable from a comparator. State borrowed denominators explicitly.
+
+## 6. Pre-specify the event definition and verify it against each source
+
+For composite/graded outcomes (e.g. "major complication"), state an **a-priori definition** (e.g. SIR major / CTCAE Grade ≥3) in Methods, and **verify each study's count against that study's own grading table in the primary PDF** — do not trust a structured-extraction cell that disagrees with the paper's narrative. A single high-contributing study can drive the pooled estimate, so its grading must be source-confirmed. When a structured value and an extraction note conflict, the primary source decides.
+
+## 7. Publication-bias / small-study tests are invalid for proportions
+
+The standard error of a proportion is a deterministic function of the proportion, so funnel-plot asymmetry and Egger/Begg regression are **uninterpretable for pooled proportions** and must not be reported as evidence of (no) publication bias. If shown at all, a contour-enhanced funnel plot is descriptive only, with a caption stating it cannot infer small-study effects. Do not write "no publication bias was found."
+
+## 8. Unit of analysis
+
+Single-arm series mix per-patient, per-lesion, and per-session denominators. Use the most granular available unit per outcome, **disclose the mixing**, and treat the pooled CI as a descriptive-precision statement (study-level independence assumed), not an inferential interval. Where feasible, a within-study single-unit sensitivity analysis strengthens the key efficacy outcome.
+
+## 9. Certainty of evidence
+
+Formal GRADE is not standardized for single-arm proportion syntheses; use a **GRADE-informed** narrative — start at low certainty (non-comparative observational), rate down for inconsistency and imprecision (wide PIs, I²) — and **report the per-outcome rating** (commonly "very low"), not merely a statement that certainty "was not assessed".
+
+## 10. Risk of bias
+
+Use an instrument matched to the design (e.g. JBI Critical Appraisal Checklist for case series; ROBINS-I for the non-randomized comparative subset). When two instruments are used, **report agreement per instrument** (do not pool a single κ across incompatible rating scales), and get the item denominator right (Σ items per instrument).
+
+## Reviewer-facing summary
+
+A defensible single-arm proportion MA: pre-registered; GLMM logit with τ² + prediction intervals; crude reported alongside pooled; symmetric zero handling; source-verified event definitions; no Egger on proportions; descriptive (non-comparative) framing; per-outcome GRADE-informed certainty; comprehensive search with honest disclosure of database scope.

--- a/skills/write-paper/references/journal_profiles/CVIR.md
+++ b/skills/write-paper/references/journal_profiles/CVIR.md
@@ -1,157 +1,102 @@
 # Journal Profile: CardioVascular and Interventional Radiology (CVIR)
 
+> Verified against the official CVIR *Manuscript Type Manual* (last updated December 2025) and the Springer *Instructions for Authors*. Where this profile previously carried generic Springer values, they have been corrected to the journal's own stated limits.
+
 ## Journal Identity
 
 - **Full name**: CardioVascular and Interventional Radiology
 - **Abbreviation**: Cardiovasc Intervent Radiol
-- **Publisher**: Springer Nature (CIRSE — Cardiovascular and Interventional Radiological Society of Europe)
+- **Publisher**: Springer Nature (official journal of CIRSE and 20+ national/regional IR societies)
 - **ISSN**: 0174-1551 (print), 1432-086X (online)
 - **Frequency**: Monthly (12 issues/year)
 - **Impact Factor**: ~3.0 (JCR 2023)
-- **Open Access**: Hybrid (Springer transformative agreements may cover OA)
+- **Open Access**: Hybrid (Open Choice; APC applies for OA)
 - **Acceptance rate**: ~25-30%
-- **Peer review**: Single-blind; 2-3 reviewers per manuscript
+- **Peer review**: **DOUBLE-BLIND** (2-3 reviewers). The main manuscript MUST be fully anonymized — no author names, affiliations, acknowledgments, funding, grant numbers, or ethical statements in the body; all of that goes on a separate Title Page. Avoid self-citations that reveal identity.
+- **Plagiarism**: all submissions screened by iThenticate.
 
-## Manuscript Types and Word Limits
+## Manuscript Types and Limits
 
-| Type | Body Word Limit | Abstract | References | Figures/Tables |
-|------|----------------|----------|------------|----------------|
-| Original Article | 3500 words | 250 words (structured) | 30 | 6 |
-| Review Article | 5000 words | 250 words | 60 | 8 |
-| Technical Note | 2000 words | 150 words (unstructured) | 15 | 4 |
-| Case Report | 1500 words | 150 words (unstructured) | 10 | 4 |
-| Letter to the Editor | 500 words | None | 5 | 1 |
-| Systematic Review / Meta-Analysis | 4000 words | 250 words (structured) | 50 | 8 |
+These are CVIR's own per-type limits (body word count excludes references and tables). **A meta-analysis is the "Scientific Paper (Other)" type → 2400 words, structured 250-word abstract, max 6 images.** A narrative systematic review may instead be submitted as a "Review Article" (3000 words, simple 125-word abstract). Do not assume a generic 3500–5000-word allowance.
 
-Word counts exclude abstract, references, tables, and figure legends.
+| Type | Body words | Abstract | Images | Notes |
+|------|-----------|----------|--------|-------|
+| Clinical Investigation | 2400 | Structured, 250 | 6 | Human-subject studies |
+| Laboratory Investigation | 2400 | Structured, 250 | 6 | Animal/bench |
+| **Scientific Paper (Other)** | **2400** | **Structured, 250** | **6** | **Meta-analyses** and other scientific papers |
+| Review Article | 3000 | Simple, 125 | 10 | Includes narrative systematic reviews; format varies |
+| Case Report | 1000 | Simple, 125 | 3 | References max 10 |
+| Study Protocol | 2400 | Structured, 250 | 3 | Trial registration + SPIRIT |
+| Short Communication | 1200 | Structured, 250 | 3 | Concise reports / novel techniques |
+| Letter to the Editor | 900 | None | 3 | References max 5; unstructured |
+| Editorial / Commentary | 600 | None | 1 | Invited; references max 10 |
 
----
+Note on "images": CVIR states a maximum number of **images** (figures) per type; tables are listed alongside but the journal does not publish a single combined cap. Keep figures within the stated image limit and offload non-essential display items (risk-of-bias tables, sensitivity figures) to Supplementary Information.
 
 ## Abstract Requirements
 
-**Structured abstract for Original Articles and SRMAs, 250 words maximum:**
+- **Structured abstract** (Clinical/Laboratory/Scientific Paper Other, Study Protocol, Short Communication): **max 250 words**, separated into headed paragraphs — **Purpose / Materials and Methods / Results / Conclusion**.
+- **Simple abstract** (Review, Case Report): **max 125 words**, single paragraph.
+- **No abbreviations or acronyms in the abstract.** Spell everything out (e.g., "cone-beam computed tomography", "confidence interval"). Abbreviations are defined at first mention starting in the Introduction; self-created abbreviations are not accepted; do not use abbreviations in the title either.
+- **Level of Evidence** must be stated as the last line of the abstract where EBM rankings apply (scale 1–5), e.g. `Level of Evidence: Level 4, Case Series.` Indicate **"No level of evidence"** for Review Articles, Basic Science, Animal, Cadaver, and Experimental studies.
+- For clinical trials, the trial registration number + date is the last line of the abstract.
 
-```
-Purpose: [Study aim — 1-2 sentences]
-Materials and Methods: [Design, population, intervention/technique, outcomes,
-    statistical methods]
-Results: [Key results with effect sizes and CIs or p-values]
-Conclusion: [Main conclusion — 1-2 sentences]
-```
+## Compliance with Ethical Standards (Title Page)
 
-**Unstructured abstract for Technical Notes and Case Reports, 150 words maximum.**
+A separate **"Compliance with Ethical Standards"** section at the end of the Title Page must include **all five** statements, in this order and wording (even if not applicable):
 
----
+1. **Funding** — "This study was funded by X (grant number X)" or "This study was not supported by any funding."
+2. **Conflict of Interest** — disclosures, or "The authors declare that they have no conflict of interest."
+3. **Ethical approval** — for retrospective studies: "For this type of study formal consent is not required." Include IRB approval/waiver statement. For secondary analysis of published aggregate data: "This article does not contain any studies with human participants or animals performed by any of the authors."
+4. **Informed consent** — "Informed consent was obtained from all individual participants…", or "For this type of study informed consent is not required."
+5. **Consent for publication** — or "For this type of study consent for publication is not required."
 
-## Required Sections (Original Article)
+## Visual Abstract (optional)
 
-1. **Introduction** — brief (2-3 paragraphs); end with study purpose
-2. **Materials and Methods**
-   - Study Design: prospective/retrospective, IRB approval
-   - Patient Population: inclusion/exclusion criteria, recruitment period
-   - Procedure/Intervention: detailed technical description
-   - Outcome Measures: primary (technical success, clinical success) and secondary
-   - Follow-up: imaging and clinical follow-up protocol
-   - Statistical Analysis: software, tests, significance level
-3. **Results** — patient demographics, technical outcomes, clinical outcomes, complications
-4. **Discussion** — comparison with literature, limitations, clinical implications
-5. **Conclusion** — brief (1-2 sentences)
-
----
+Eligible for all types except editorials, letters, and commentaries. PowerPoint template; title capitalized (16 pt), conclusion ≤100 words (12 pt); Arial or Times New Roman; do not include authors/affiliations; 1–3 figures.
 
 ## Statistical Reporting
 
-- Report exact p-values (e.g., p = 0.032); use p < 0.001 below that threshold.
-- 95% CI for primary outcomes.
-- For diagnostic/technical studies: sensitivity, specificity, accuracy with CIs.
-- For intervention studies: technical success rate, clinical success rate with definitions.
-- Complication rates with Clavien-Dindo or SIR classification.
-- Kaplan-Meier for time-to-event outcomes; Cox regression for multivariate analysis.
-- For meta-analyses: I-squared, prediction intervals, funnel plot for publication bias.
-- Statistical software and version must be identified.
+- Exact p-values (p = 0.032; p < 0.001 below threshold); 95% CI for primary outcomes.
+- Intervention studies: technical success and clinical success with explicit operational definitions.
+- Complications: **SIR classification** (minor A,B / major C–F) and/or Clavien-Dindo; report per-patient and per-procedure separately.
+- Ablation: distinguish **technical success** (probe placement/ablation completed) from **technique efficacy** (complete ablation on first follow-up) and **local tumor progression**.
+- Meta-analyses: I², τ², **prediction intervals**, and an appropriate publication-bias approach. For **single-arm proportion** meta-analyses see the `/meta-analysis` skill reference `single_arm_proportion_ma.md` (GLMM logit, crude alongside pooled, no Egger/regression on proportions).
+- Identify statistical software and version.
 
----
+## References
 
-## IR-Specific Requirements
-
-### Complication Reporting
-
-CVIR expects standardized complication classification:
-- **SIR Classification** (Society of Interventional Radiology): Minor (A, B) and Major (C, D, E, F)
-- **Clavien-Dindo** for post-procedural complications
-- Report per-patient and per-procedure rates separately
-
-### Technical Outcome Definitions
-
-Define clearly:
-- **Technical success**: procedure completed as intended (specific criteria)
-- **Clinical success**: symptom improvement or target outcome achieved (specific criteria and timepoint)
-- **Primary patency / secondary patency** (for vascular interventions)
-- **Local tumor progression / technique efficacy** (for ablation studies)
-
-### Device and Equipment
-
-Report: device manufacturer, model, size/configuration used. CVIR readers expect this level of procedural detail.
-
----
-
-## Figures
-
-- **Maximum 6 figures/tables combined** for original articles
-- **Resolution**: 300 DPI minimum
-- **Format**: TIFF, EPS, or high-resolution JPEG
-- **Color**: Free online; grayscale for print
-- **Typical figure set for IR studies**: pre-procedure imaging, procedural images (key steps), post-procedure imaging, follow-up imaging
-
----
+- Numbered in square brackets in text, in order of appearance, e.g. [3], [1-3, 7].
+- Vancouver style; include DOIs as full links (https://doi.org/...); ISO journal abbreviations (ISSN LTWA). Generate via a reference manager / pandoc citeproc with the CVIR CSL — do not hand-type.
 
 ## Common Rejection Reasons
 
-1. **Small sample size without novelty** — single-center retrospective with N < 50 needs strong technical innovation
-2. **Inadequate complication reporting** — missing SIR classification or Clavien-Dindo grading
-3. **Vague technical success definition** — must be operationally defined before the study
-4. **Missing follow-up data** — IR studies need adequate follow-up duration with imaging
-5. **No comparison with existing techniques** — CVIR favors comparative studies
-6. **Overclaiming for observational data** — causal language in retrospective series
-
----
+1. Small single-center retrospective without technical novelty.
+2. Inadequate complication reporting (missing SIR/Clavien-Dindo).
+3. Vague, non-pre-specified technical-success definition.
+4. Inadequate follow-up.
+5. Overclaiming from observational/single-arm data (causal or comparative-advantage language).
+6. Exceeding the type's word/image limit (especially submitting a meta-analysis as if it had a 3500–4000-word allowance — it is 2400).
 
 ## Cover Letter
 
-Should emphasize:
-- Relevance to interventional radiology practice in Europe
-- Technical innovation or comparative advantage
-- Patient safety implications
-- Suggested reviewers with IR expertise
+Emphasize relevance to European IR practice, novelty/comparative value, patient-safety implications, suggested reviewers (institutional emails); confirm not under consideration elsewhere; declare AI-assistance use if any.
 
----
+## Author Guidelines
 
-## Author Guidelines URL
-
-https://www.springer.com/journal/270/submission-guidelines
-
----
+- Instructions for Authors: https://www.springer.com/journal/270/submission-guidelines
+- Manuscript Type Manual (per-type limits): downloadable from the IFA page.
+- Submission portal: https://www.editorialmanager.com/cvir/
 
 ## Positioning
 
-CVIR is appropriate when:
-- Interventional radiology procedure with clinical outcome data (embolization, ablation, drainage, vascular)
-- CBCT-guided interventions with technical or clinical outcomes
-- Comparative study of IR techniques (new vs standard)
-- Systematic review or meta-analysis of IR procedures
-- Technical innovation in IR devices or techniques
-
-Not appropriate for: diagnostic imaging studies without interventional component, pure AI methodology, non-vascular/non-interventional radiology.
-
----
+Appropriate for: IR procedures with clinical/technical outcomes (embolization, ablation, drainage, vascular), CBCT-guided interventions, comparative IR-technique studies, and **systematic reviews / meta-analyses of IR procedures**. Not for: pure diagnostic imaging without an interventional component, pure AI methodology, non-interventional radiology.
 
 ## Differentiation from JVIR
 
 | Dimension | CVIR | JVIR |
 |-----------|------|------|
 | Society | CIRSE (European) | SIR (American) |
-| Geography emphasis | European and international | North American and international |
+| Peer review | Double-blind | Single-blind |
 | Impact factor | ~3.0 | ~3.5 |
-| Scope | Cardiovascular + interventional | Interventional (broader) |
-| Meta-analyses | Accepts readily | Accepts readily |
-| Review speed | ~4-6 weeks first decision | ~4-6 weeks first decision |
+| Meta-analyses | Accepts readily (as Scientific Paper (Other), 2400 words) | Accepts readily |


### PR DESCRIPTION
## Summary
Two corrections/additions harvested from a real CVIR meta-analysis submission cycle.

### A. CVIR journal profile corrected (write-paper + find-journal)
The profile carried generic Springer values that disagreed with CVIR's own *Manuscript Type Manual* (Dec 2025) and Instructions for Authors. Fixed:
- Peer review **single-blind → double-blind** (+ main-manuscript anonymization requirement).
- **A meta-analysis is the "Scientific Paper (Other)" type → 2400 words / 6 images**, replacing an erroneous "Systematic Review / Meta-Analysis | 4000 words | 8 images" row. This miscalibration directly caused an over-length first draft in practice.
- Corrected all per-type word/image limits (Original 2400, Review 3000, Case 1000, Letter 900, Short Communication 1200, …).
- Added: no-abbreviations-in-abstract rule, Level of Evidence line, the five Compliance-with-Ethical-Standards statements, Visual Abstract, and CVIR reference style.

### B. New: `meta-analysis/references/single_arm_proportion_ma.md`
Ten reviewer-tested conventions for single-arm proportion pooling (common in IR/surgery where RCTs are scarce): GLMM logit without continuity correction, lead crude alongside pooled, boundary-degenerate handling (I²=0 vs τ²>0), symmetric zero-event inclusion, source-verified event definitions, no Egger/funnel on proportions, descriptive framing, GRADE-informed certainty, unit-of-analysis disclosure, per-instrument RoB agreement. `phase6` continuity-correction note scoped to binary 2×2 vs proportions.

## Validation
- `validate_skills.sh`: ALL CHECKS PASSED (incl. precedent/PII blocklist, personal-path, email, EXIF).
- `validate_catalog_consistency.py`: SSOT agrees with disk (no journal added; counts unchanged).
- Changes are reference-doc/profile only; no skill contract or catalog count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)