### PR TITLE
feat(meta-analysis): AI-assisted extraction suggestions (Phase 4.0.1) + challenge card

### DIFF
--- a/docs/skills/meta-analysis.md
+++ b/docs/skills/meta-analysis.md
@@ -28,6 +28,7 @@
 
 - `python3 scripts/screening_reconcile.py`
 - `python3 scripts/check_pool_consistency.py`
+- `bash scripts/extract_assist_challenge/verify.sh  # deterministic, network-free`
 
 **Evidence** — `demo`
 
@@ -56,6 +57,8 @@
 - `check_pool_consistency.py`
 - `cohort_overlap_check.py`
 - `dta_extraction_qc.py`
+- `extract_assist.py`
+- `extract_assist_challenge/` (6 files)
 - `screening_reconcile.py`
 
 **Templates** (`skills/meta-analysis/templates/`):

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -45,6 +45,14 @@ with specialized support for diagnostic test accuracy (DTA) meta-analyses.
 - **Extraction Form v2** (`templates/extraction_form_v2.md`) -- dual-extractor schema with `source_page_ref`, `source_verbatim_quote`, `cohort_source`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool` columns. Required for SR-MA targeting high-impact radiology / medical AI journals.
 - **Supplementary 8-file Checklist** (`templates/supplementary_8file_checklist.md`) -- S1-S8 mandatory package (PRISMA, PROSPERO, search strategy, exclusion list, extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication bias) with a submission-gate bash check.
 
+### Built-in Scripts (`${CLAUDE_SKILL_DIR}/scripts/`)
+
+- **`screening_reconcile.py`** -- Phase 3f ID-set screening reconciliation.
+- **`check_pool_consistency.py`** -- pool-composition / PRISMA count consistency.
+- **`cohort_overlap_check.py`** -- shared-database cohort-overlap detection.
+- **`extract_assist.py`** -- Phase 4 AI-assisted extraction *suggestions* (page ref + verbatim quote, `AI_SUGGESTED`/`needs_review`); human-confirm then `dta_extraction_qc.py`. Challenge card: `scripts/extract_assist_challenge/`.
+- **`dta_extraction_qc.py`** -- 2x2 cell ↔ source sens/spec QC on the **confirmed** extraction CSV.
+
 ---
 
 ## Meta-Analysis Types
@@ -327,6 +335,39 @@ Before opening the extraction form: if a senior mentor or collaborator has share
 - Trust hierarchy for this phase: **SSOT (source PDF + own analysis stdout) > mentor's direct text (email / track-changes) > attached AI-draft**. Do not promote an AI-draft from tier 3 to tier 2.
 
 Precedent (an active meta-analysis project): Ishikawa 2017 "treatment support 5/70 vs no support 12/33" in Claude-drafted directive → source PDF was 35/68 (single arm). Verbatim absorption would have produced a denominator-hallucinated meta-analysis.
+
+#### 4.0.1 AI-assisted extraction suggestions (optional, suggestions not decisions)
+
+To scaffold (not replace) manual extraction from a full-text paper, use the
+deterministic helper `scripts/extract_assist.py`. It scans a Markdown full text
+(e.g. `/fulltext-retrieval`'s PDF→MD output) for schema-defined fields and emits
+**candidate values, each with a `source_page_ref` and a verbatim source quote** —
+the extraction-stage analog of the screening-stage `ai_pre_screening_template.py`.
+
+```bash
+python3 scripts/extract_assist.py \
+  --md paper.md --schema schema.yaml --study-id StudyA_2021 --out suggestions.tsv
+```
+
+- **Suggestions, never decisions.** Every row is `extraction_consensus_status =
+  AI_SUGGESTED` and `needs_review = true`. The tool invents nothing — values and
+  quotes are copied literally from the text; absent fields become explicit
+  `not_found` rows; unit-ambiguous values (e.g. `92%` vs `0.92`) are emitted as
+  multiple candidates side by side so the reviewer reconciles them.
+- **Human confirmation is mandatory.** Apply the 4.0 gate: treat every candidate
+  N / denominator / 2x2 cell / effect estimate as hallucination-suspect until
+  confirmed against the source PDF, recording reconciliations in
+  `extraction_consensus_log.md`. Confirm or overturn each suggestion into the
+  `extraction_form_v2.md` columns.
+- **Then, and only then, QC.** Build the confirmed DTA CSV and run
+  `dta_extraction_qc.py` on **that** table — never on the suggestion TSV.
+  Passing QC is not extract-assist's acceptance criterion; per-cell human
+  confirmation is.
+
+A deterministic, network-free challenge card demonstrating the full
+suggestions → confirm → QC pipeline lives in
+`scripts/extract_assist_challenge/` (synthetic paper + schema + expected output
++ `verify.sh`).
 
 #### DTA Meta-Analysis:
 Generate a data extraction form with:

--- a/skills/meta-analysis/scripts/extract_assist.py
+++ b/skills/meta-analysis/scripts/extract_assist.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+AI-assisted extraction *suggestions* for SR/MA data extraction (Phase 4).
+
+Scans a full-text paper (Markdown, e.g. produced by /fulltext-retrieval's
+PDF->MD step) for schema-defined fields and emits SUGGESTED candidate values,
+each carrying a page reference and a verbatim source quote. This is the
+extraction-stage analog of the screening-stage `ai_pre_screening_template.py`:
+it produces *suggestions, never decisions*.
+
+CRITICAL — suggestions, not decisions
+-------------------------------------
+Every emitted row is labeled `extraction_consensus_status = AI_SUGGESTED` and
+`needs_review = true`. A human extractor MUST confirm or overturn each value
+against the source PDF before it enters the confirmed extraction table. Only
+the human-confirmed DTA CSV is fed to `dta_extraction_qc.py` — this tool's
+output is NOT a QC-acceptable table. Per the Phase 4.0 gate, treat every
+candidate N / denominator / 2x2 cell / effect estimate as hallucination-suspect
+until reconciled against the source.
+
+The script never invents values: every `value` and `verbatim_quote` is copied
+literally from the Markdown, and `source_page_ref` comes from a literal page
+marker in the text. If a field is not found, it emits a `not_found` row so the
+gap is explicit rather than silently dropped.
+
+Usage
+-----
+    python3 extract_assist.py --md paper.md --schema schema.yaml --out suggestions.tsv
+    python3 extract_assist.py --md paper.md --schema schema.json --study-id StudyA_2021
+
+Schema (YAML or JSON)
+---------------------
+    study_id: StudyA_2021          # optional; --study-id overrides
+    fields:
+      - {name: study_design, type: study_design}
+      - {name: sample_n,     type: sample_n}
+      - {name: source_sens,  type: sensitivity}
+      - {name: source_spec,  type: specificity}
+      - {name: extracted_tp, type: tp}
+      - {name: country, type: regex, pattern: "conducted in ([A-Z][A-Za-z]+)"}
+
+Built-in field types: sensitivity, specificity, sample_n, study_design, year,
+tp, fp, fn, tn, regex (requires `pattern` with one capture group).
+
+Page markers recognized: `<!-- page: N -->`, `<!-- page N -->`, `[page N]`,
+`## Page N`, `===PAGE N===` (case-insensitive).
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+OUT_COLUMNS = [
+    "study_id", "field", "value", "source_page_ref",
+    "verbatim_quote", "confidence", "needs_review", "extraction_consensus_status",
+]
+
+PAGE_RE = re.compile(
+    r"(?:<!--\s*page:?\s*(\d+)\s*-->|\[page\s+(\d+)\]|^#{1,3}\s*page\s+(\d+)\b|===\s*page\s+(\d+)\s*===)",
+    re.I,
+)
+
+# Built-in extractors: type -> compiled regex with one numeric/text capture group.
+BUILTIN = {
+    "sensitivity": re.compile(r"sensitivit(?:y|ies)\s*(?:was|were|of|=|:|,)?\s*(\d{1,3}(?:\.\d+)?\s*%|0?\.\d+|\d{1,3}(?:\.\d+)?)", re.I),
+    "specificity": re.compile(r"specificit(?:y|ies)\s*(?:was|were|of|=|:|,)?\s*(\d{1,3}(?:\.\d+)?\s*%|0?\.\d+|\d{1,3}(?:\.\d+)?)", re.I),
+    "sample_n": re.compile(r"(?:\bn\s*=\s*(\d+)|\b(\d+)\s+(?:patients|participants|subjects|cases|nodules|lesions|images|scans|examinations))", re.I),
+    "study_design": re.compile(r"\b(retrospective|prospective|cross-sectional|case-control|cohort)\b", re.I),
+    "year": re.compile(r"\b(19\d{2}|20\d{2})\b"),
+    "tp": re.compile(r"(?:true[\s-]?positives?|TP)\s*(?:=|:|of|was|were)?\s*(\d+)", re.I),
+    "fp": re.compile(r"(?:false[\s-]?positives?|FP)\s*(?:=|:|of|was|were)?\s*(\d+)", re.I),
+    "fn": re.compile(r"(?:false[\s-]?negatives?|FN)\s*(?:=|:|of|was|were)?\s*(\d+)", re.I),
+    "tn": re.compile(r"(?:true[\s-]?negatives?|TN)\s*(?:=|:|of|was|were)?\s*(\d+)", re.I),
+}
+
+
+def load_schema(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    try:
+        import yaml  # PyYAML; used across medsci-skills scripts
+    except ImportError:  # pragma: no cover
+        sys.exit("ERROR: PyYAML required for .yaml schemas (or use a .json schema).")
+    return yaml.safe_load(text)
+
+
+def page_for_line(line_pages: list[int], idx: int) -> str:
+    """Page number in effect at 0-based line index idx ('?' before first marker)."""
+    return str(line_pages[idx]) if line_pages[idx] is not None else "?"
+
+
+def first_group(m: re.Match) -> str:
+    for g in m.groups():
+        if g is not None:
+            return g.strip()
+    return m.group(0).strip()
+
+
+def find_field(field: dict, lines: list[str], line_pages: list[int]) -> list[dict]:
+    """Return candidate rows (dicts) for one schema field, in document order."""
+    name = field["name"]
+    ftype = field.get("type", "regex")
+    if ftype == "regex":
+        pat = field.get("pattern")
+        if not pat:
+            sys.exit(f"ERROR: field '{name}' type=regex requires a 'pattern'.")
+        rx = re.compile(pat)
+    else:
+        rx = BUILTIN.get(ftype)
+        if rx is None:
+            sys.exit(f"ERROR: unknown field type '{ftype}' for '{name}'.")
+
+    hits = []
+    for i, line in enumerate(lines):
+        for m in rx.finditer(line):
+            val = first_group(m) if m.groups() else m.group(0).strip()
+            hits.append({
+                "field": name,
+                "value": re.sub(r"\s+", "", val) if ftype in {"sensitivity", "specificity"} else val,
+                "source_page_ref": page_for_line(line_pages, i),
+                "verbatim_quote": line.strip(),
+            })
+    n = len(hits)
+    if n == 0:
+        return [{
+            "field": name, "value": "", "source_page_ref": "?",
+            "verbatim_quote": "", "confidence": "not_found",
+        }]
+    for k, h in enumerate(hits, 1):
+        h["confidence"] = "single" if n == 1 else f"candidate_{k}_of_{n}"
+    return hits
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="AI-assisted extraction suggestions (Phase 4).")
+    ap.add_argument("--md", required=True, help="full-text paper in Markdown")
+    ap.add_argument("--schema", required=True, help="extraction schema (.yaml or .json)")
+    ap.add_argument("--study-id", default=None, help="overrides schema study_id")
+    ap.add_argument("--out", default=None, help="output TSV (default: stdout)")
+    args = ap.parse_args(argv)
+
+    schema = load_schema(Path(args.schema))
+    study_id = args.study_id or schema.get("study_id", "UNKNOWN")
+    fields = schema.get("fields", [])
+    if not fields:
+        sys.exit("ERROR: schema has no 'fields'.")
+
+    raw = Path(args.md).read_text(encoding="utf-8")
+    lines = raw.splitlines()
+
+    # Build per-line current-page map from literal page markers.
+    line_pages: list[int] = []
+    current = None
+    for line in lines:
+        m = PAGE_RE.search(line)
+        if m:
+            current = int(next(g for g in m.groups() if g is not None))
+        line_pages.append(current)
+
+    rows = []
+    for field in fields:
+        for cand in find_field(field, lines, line_pages):
+            cand["study_id"] = study_id
+            cand["needs_review"] = "true"
+            cand["extraction_consensus_status"] = "AI_SUGGESTED"
+            rows.append(cand)
+
+    out_lines = ["\t".join(OUT_COLUMNS)]
+    for r in rows:
+        out_lines.append("\t".join(str(r.get(c, "")) for c in OUT_COLUMNS))
+    blob = "\n".join(out_lines) + "\n"
+
+    if args.out:
+        Path(args.out).write_text(blob, encoding="utf-8")
+    else:
+        sys.stdout.write(blob)
+
+    n_found = sum(1 for r in rows if r.get("confidence") != "not_found")
+    n_missing = sum(1 for r in rows if r.get("confidence") == "not_found")
+    sys.stderr.write(
+        f"[extract_assist] study={study_id}: {n_found} suggestion(s), "
+        f"{n_missing} field(s) not found. ALL rows are AI_SUGGESTED / needs_review=true — "
+        f"a human must confirm against the source PDF before building the DTA CSV for "
+        f"dta_extraction_qc.py.\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/meta-analysis/scripts/extract_assist_challenge/expected/suggestions.tsv
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/expected/suggestions.tsv
@@ -1,0 +1,13 @@
+study_id	field	value	source_page_ref	verbatim_quote	confidence	needs_review	extraction_consensus_status
+StudyA_2021	study_design	retrospective	1	This was a retrospective single-center study conducted in Synthetica.	single	true	AI_SUGGESTED
+StudyA_2021	country	Synthetica	1	This was a retrospective single-center study conducted in Synthetica.	single	true	AI_SUGGESTED
+StudyA_2021	sample_n	120	1	A total of 120 patients were enrolled between 2018 and 2021.	candidate_1_of_2	true	AI_SUGGESTED
+StudyA_2021	sample_n	120	2	The index test was evaluated against the reference standard in all 120 patients.	candidate_2_of_2	true	AI_SUGGESTED
+StudyA_2021	source_sens	92%	3	The sensitivity was 92% and the specificity was 85% in the primary analysis.	candidate_1_of_2	true	AI_SUGGESTED
+StudyA_2021	source_sens	0.92	3	A sensitivity of 0.92 was also reported in the sensitivity analysis.	candidate_2_of_2	true	AI_SUGGESTED
+StudyA_2021	source_spec	85%	3	The sensitivity was 92% and the specificity was 85% in the primary analysis.	single	true	AI_SUGGESTED
+StudyA_2021	extracted_tp	55	3	The 2x2 table yielded TP = 55, FP = 9, FN = 5, and TN = 51.	single	true	AI_SUGGESTED
+StudyA_2021	extracted_fp	9	3	The 2x2 table yielded TP = 55, FP = 9, FN = 5, and TN = 51.	single	true	AI_SUGGESTED
+StudyA_2021	extracted_fn	5	3	The 2x2 table yielded TP = 55, FP = 9, FN = 5, and TN = 51.	single	true	AI_SUGGESTED
+StudyA_2021	extracted_tn	51	3	The 2x2 table yielded TP = 55, FP = 9, FN = 5, and TN = 51.	single	true	AI_SUGGESTED
+StudyA_2021	comparator_design		?		not_found	true	AI_SUGGESTED

--- a/skills/meta-analysis/scripts/extract_assist_challenge/fixture/confirmed_example.csv
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/fixture/confirmed_example.csv
@@ -1,0 +1,2 @@
+study_id,source_pmid,source_sens,source_spec,extracted_tp,extracted_fn,extracted_tn,extracted_fp,source_cohort,source_page_ref
+StudyA_2021,00000000,0.92,0.85,55,5,51,9,primary_analysis,Results page 3

--- a/skills/meta-analysis/scripts/extract_assist_challenge/fixture/paper.md
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/fixture/paper.md
@@ -1,0 +1,17 @@
+<!-- page: 1 -->
+# Synthetic Diagnostic Accuracy Study
+
+This was a retrospective single-center study conducted in Synthetica.
+A total of 120 patients were enrolled between 2018 and 2021.
+
+<!-- page: 2 -->
+## Methods
+
+The index test was evaluated against the reference standard in all 120 patients.
+
+<!-- page: 3 -->
+## Results
+
+The sensitivity was 92% and the specificity was 85% in the primary analysis.
+The 2x2 table yielded TP = 55, FP = 9, FN = 5, and TN = 51.
+A sensitivity of 0.92 was also reported in the sensitivity analysis.

--- a/skills/meta-analysis/scripts/extract_assist_challenge/fixture/schema.yaml
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/fixture/schema.yaml
@@ -1,0 +1,12 @@
+study_id: StudyA_2021
+fields:
+  - {name: study_design, type: study_design}
+  - {name: country, type: regex, pattern: "conducted in ([A-Z][A-Za-z]+)"}
+  - {name: sample_n, type: sample_n}
+  - {name: source_sens, type: sensitivity}
+  - {name: source_spec, type: specificity}
+  - {name: extracted_tp, type: tp}
+  - {name: extracted_fp, type: fp}
+  - {name: extracted_fn, type: fn}
+  - {name: extracted_tn, type: tn}
+  - {name: comparator_design, type: regex, pattern: "double-blinded RCT of ([A-Za-z]+)"}

--- a/skills/meta-analysis/scripts/extract_assist_challenge/problem.md
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/problem.md
@@ -1,0 +1,71 @@
+# Challenge card — AI-assisted extraction suggestions (meta-analysis Phase 4)
+
+## Problem
+
+Data extraction is the bottleneck and a top source of SR/MA errors (2x2
+cell-swaps, denominator confusion, % vs decimal mix-ups). Tools like Elicit and
+SciSpace auto-fill extraction columns from full text — but a raw auto-fill is
+hallucination-prone and unauditable. Before this gate, `meta-analysis` shipped a
+manual extraction form (`extraction_form_v2.md`) and a confirmed-table QC
+(`dta_extraction_qc.py`), but **nothing to scaffold candidate values from the
+full text with provenance** for a human to confirm.
+
+## What the new gate does
+
+`scripts/extract_assist.py` scans a full-text Markdown paper for schema-defined
+fields and emits **AI_SUGGESTED** candidates — each with a `source_page_ref` and
+a **verbatim_quote** copied literally from the text. It invents nothing: values
+and quotes are pulled from the document; missing fields become explicit
+`not_found` rows. Every row is `needs_review = true`.
+
+It is the extraction-stage analog of `ai_pre_screening_template.py`:
+**suggestions, never decisions.**
+
+## Pipeline (suggestions → human confirm → QC)
+
+```
+extract_assist.py  ──►  AI_SUGGESTED candidates (+page +quote)
+                         │   human reconciles vs source PDF
+                         ▼   (e.g., picks 0.92 over the "92%" duplicate)
+                   confirmed DTA CSV  ──►  dta_extraction_qc.py  ──►  OK
+```
+
+`dta_extraction_qc.py` is **only** run on the human-confirmed CSV — never on the
+suggestion TSV. Passing QC is not extract-assist's acceptance criterion.
+
+## Fixture (synthetic only — no real paper/PII)
+
+- `fixture/paper.md` — synthetic DTA paper with `<!-- page: N -->` markers.
+- `fixture/schema.yaml` — fields incl. 2x2 cells, a custom-regex country, and a
+  deliberately-absent `comparator_design` (→ `not_found`).
+- `fixture/confirmed_example.csv` — the human-confirmed table after reconciling
+  the unit-ambiguous sensitivity (`92%` vs `0.92`).
+
+## Expected
+
+- `expected/suggestions.tsv` — 11 candidates + 1 `not_found`; `source_sens`
+  surfaces **two** candidates (`92%`, `0.92`) so the reviewer must reconcile the
+  unit; all rows `AI_SUGGESTED` / `needs_review=true`.
+- Confirmed CSV then yields `DTA QC: OK=1 | SWAP=0 | MISMATCH=0`.
+
+## Baseline vs new gate
+
+| | Baseline | New extract-assist gate |
+|---|---|---|
+| Candidate values from full text | manual typing | scaffolded suggestions |
+| Per-cell provenance | author discipline | page_ref + verbatim_quote on every row |
+| Hallucination posture | — | literal-only; `AI_SUGGESTED`/`needs_review`; not_found explicit |
+| Unit-ambiguity surfacing | — | multiple candidates emitted side by side |
+
+## Verifier (deterministic, no network)
+
+```bash
+bash verify.sh
+```
+
+## Acknowledgement
+
+The "fixture + expected + deterministic verifier" packaging is inspired by
+public reproducible-audit layouts such as
+[EinsteinArena](https://einsteinarena.com/) (design inspiration only; no code,
+solutions, or data were copied).

--- a/skills/meta-analysis/scripts/extract_assist_challenge/verify.sh
+++ b/skills/meta-analysis/scripts/extract_assist_challenge/verify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the extract-assist challenge card.
+# Demonstrates the full Phase-4 pipeline:
+#   (1) extract_assist.py emits AI_SUGGESTED candidates with page + verbatim quote
+#       (including a unit-ambiguous source_sens: "92%" vs "0.92", and a not_found
+#       field) — diffed against expected/suggestions.tsv.
+#   (2) AFTER a human reconciles the candidates into a confirmed DTA CSV, that CSV
+#       (NOT the suggestion TSV) passes dta_extraction_qc.py.
+# No network. Exit 0 = both stages match expectations.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$HERE/.."
+
+# --- Stage 1: suggestions are AI_SUGGESTED, with provenance, never decisions ---
+actual="$(python3 "$SCRIPTS/extract_assist.py" \
+  --md "$HERE/fixture/paper.md" \
+  --schema "$HERE/fixture/schema.yaml" 2>/dev/null)"
+
+if ! diff -u "$HERE/expected/suggestions.tsv" <(printf '%s\n' "$actual"); then
+  echo "FAIL: extract_assist suggestions drifted from expected/suggestions.tsv" >&2
+  exit 1
+fi
+
+# Every non-header row must be AI_SUGGESTED + needs_review=true (suggestions, not decisions).
+bad=$(printf '%s\n' "$actual" | tail -n +2 | grep -cv $'\tAI_SUGGESTED$' || true)
+if [ "$bad" -ne 0 ]; then
+  echo "FAIL: $bad suggestion row(s) not labeled AI_SUGGESTED" >&2
+  exit 1
+fi
+
+# --- Stage 2: human-confirmed CSV then passes the downstream QC gate ---
+qc_out="$(mktemp)"
+summary="$(python3 "$SCRIPTS/dta_extraction_qc.py" \
+  --input "$HERE/fixture/confirmed_example.csv" \
+  --out "$qc_out" 2>/dev/null | grep '^DTA QC:')"
+rm -f "$qc_out"
+
+if printf '%s' "$summary" | grep -q "OK=1 | SWAP=0 | MISMATCH=0"; then
+  echo "PASS: 11 AI_SUGGESTED candidates with page+quote (1 not_found); human-confirmed CSV clears dta_extraction_qc ($summary)."
+else
+  echo "FAIL: confirmed CSV did not pass dta_extraction_qc cleanly: $summary" >&2
+  exit 1
+fi

--- a/skills/meta-analysis/skill.yml
+++ b/skills/meta-analysis/skill.yml
@@ -23,6 +23,7 @@ outputs:
   - manuscript/manuscript.md
 deterministic_scripts:
   - scripts/screening_reconcile.py
+  - scripts/extract_assist.py  # Phase 4 AI-assisted extraction suggestions (provenance + human gate); challenge card in scripts/extract_assist_challenge/
 side_effects:
   - writes_project_artifacts
 downstream_consumers:
@@ -44,4 +45,5 @@ known_limitations:
 validation_commands:
   - "python3 scripts/screening_reconcile.py"
   - "python3 scripts/check_pool_consistency.py"
+  - "bash scripts/extract_assist_challenge/verify.sh  # deterministic, network-free"
 evidence_surface: demo


### PR DESCRIPTION
## Summary
Adds **B** from the research-tool feature scan: the medsci-native analog of Elicit/SciSpace *extract-into-columns*, as a meta-analysis Phase 4 enhancement (no new skill).

`scripts/extract_assist.py` scans a full-text Markdown paper (e.g. `/fulltext-retrieval`'s PDF→MD output) for schema-defined fields and emits **AI_SUGGESTED** candidates, each with a `source_page_ref` and a **verbatim source quote**. It is the extraction-stage analog of the screening-stage `ai_pre_screening_template.py`: **suggestions, never decisions**.

- Invents nothing — values and quotes are copied literally from the text.
- Absent fields → explicit `not_found` rows (no silent drops).
- Unit-ambiguous values (`92%` vs `0.92`) emitted as side-by-side candidates for human reconciliation.
- Every row `extraction_consensus_status = AI_SUGGESTED`, `needs_review = true`.

## Pipeline (suggestions → confirm → QC)
```
extract_assist.py  →  AI_SUGGESTED (+page +quote)
   → human confirms vs source PDF (Phase 4.0 hallucination-suspect gate)
   → confirmed DTA CSV  →  dta_extraction_qc.py  →  OK
```
`dta_extraction_qc.py` runs **only** on the human-confirmed CSV — passing QC is *not* extract-assist's acceptance criterion (per-cell human confirmation is).

## Reproducible challenge card
`scripts/extract_assist_challenge/` — synthetic paper + schema + `expected/suggestions.tsv` + `verify.sh`, demonstrating the **full** suggestions→confirm→QC pipeline (the confirmed CSV clears `dta_extraction_qc`). No network. Packaging inspired by public reproducible-audit layouts (EinsteinArena); **no code/data copied**.

```
bash skills/meta-analysis/scripts/extract_assist_challenge/verify.sh
# PASS: 11 AI_SUGGESTED candidates (+page+quote, 1 not_found); confirmed CSV → DTA QC OK=1
```

## Validation (all green)
`validate_skills.sh` (+domain-probe sync), catalog consistency, locale inventory, all 4 `gen_*.py --check`, detectors self-test, npm pack audit, challenge `verify.sh`. SKILL.md Phase 4.0.1 + Built-in Scripts index; `skill.yml` updated; `docs/skills/meta-analysis.md` regenerated.

## Notes
- No skill count change (enhancement to existing `meta-analysis`).
- Built on latest main (after #123 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)