### PR TITLE
sync-submission + manage-refs: Springer EM packaging + BibTeX author corruption check

### DIFF
--- a/skills/manage-refs/SKILL.md
+++ b/skills/manage-refs/SKILL.md
@@ -235,6 +235,17 @@ Critical: the gate does **not** reimplement any check. It calls the existing
 scripts as subprocesses. If you find yourself wanting to add a check, add it
 to the underlying script (the gate then picks it up automatically).
 
+### F. BibTeX author-format corruption (rendered-name check)
+
+Entries written as `author = {Surname AB and Surname2 CD}` (family + initials, **no comma**) make BibTeX treat the last token as the family name, rendering "AB S, CD S2". Always store `author = {Family, Full Given}`. Concatenated initials even with a comma (`Family, AB`) still collapse to a single initial under CSL `initialize-with`, so use the full forename from PubMed `efetch`.
+
+`/verify-refs` compares bib content against PubMed but does not see the rendered output; grep the rendered docx and the bib separately:
+
+```bash
+unzip -p out.docx word/document.xml | sed 's/<[^>]*>//g' | grep -oE "[A-Z]{2} [A-Z], [A-Z]{2} [A-Z]"   # corruption signature in output
+grep -nE 'author\s*=\s*\{[A-Z][a-z]+ [A-Z]{1,3}( |\})' refs.bib                                          # no-comma source entries
+```
+
 ## Quality Gates
 
 This skill defines **three submission gates** and **one user approval gate**:

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -322,6 +322,26 @@ wording differences do not register — only a changed or absent number/heading 
 legitimately copy-specific content (a circulation cover note) shows up as `copy_only`
 and can be ignored.
 
+## Phase 9 — Springer Editorial Manager packaging (no title-page slot)
+
+Some Springer Editorial Manager journals offer only **Manuscript / Figure / Table / Supplementary / LaTeX** upload item types — no separate Title Page or Cover Letter slot, and sometimes no Graphical Abstract slot. Common for observational / cohort submissions.
+
+- **Title page → page 1 of the Manuscript file.** Build via pandoc: title-page markdown (strip internal-only blocks such as a "Manuscript Metrics" QC block, plus any Funding / Author Contributions / Keywords that also appear later) + a real docx page break (raw OpenXML `<w:br w:type="page"/>`; a bare `\newpage` is silently dropped in docx output) + the manuscript body **with its byline / affiliations / corresponding-author footnote removed** so the title page is not duplicated.
+  - Verify: at least one page break; the affiliation block appears once; the article title is followed directly by the Abstract (no repeated byline); no internal QC strings leak.
+- **Cover letter → paste into the "comments to the publication office" free-text field.**
+- **Graphical Abstract (no dedicated slot) → upload as a Figure with Description = "Graphical Abstract".**
+- **Declarations completeness (portal hard checkbox).** The manuscript "Statements and Declarations" must carry all seven Springer subheadings: Funding; Competing Interests; Ethics Approval; Consent to Participate; Consent for Publication; Author Contributions; Data Availability. For de-identified observational / registry studies, Consent to Participate = waived (existing de-identified records) and Consent for Publication = "Not applicable; only de-identified data, no individual person's identifying details, images, or videos".
+
+```bash
+for s in Funding "Competing Interests" "Ethics Approval" "Consent to Participate" "Consent for Publication" "Author Contributions" "Data Availability"; do
+  unzip -p manuscript.docx word/document.xml | sed 's/<[^>]*>//g' | grep -q "$s" && echo "OK $s" || echo "MISSING $s"; done
+```
+
+- **Ethics approval / exemption number (observational or exempt cohort).** State the IRB approval or exemption reference number in the ethics statement. Institutional exemption notices carry the reference in the document body; filename digits are usually a receipt number, not the approval number — open the notice before writing the ethics block.
+- **Word limit "including references".** When the limit counts references, the binding constraint is body+references words, not the reference-count ceiling. Measure body+refs on the rendered docx before adding references; each Vancouver reference is roughly 25–33 rendered words.
+- **Submitting via a co-author's account.** Editorial Manager auto-adds the account holder at the top of the author list, tagged first/corresponding. De-duplicate, reorder to the intended position, reassign the first-author tag to the true first author, and fill missing co-author email/ORCID.
+- **Re-read the EM-compiled submission PDF before Approve** — author order, degrees, ethics number, references, declarations, and figures.
+
 ## Verification Blind Spots
 
 Post-submission learnings (npj Digital Medicine R1, 2026-05): a clean docx-level audit still missed several stale artifacts that surfaced only at the portal review stage. Apply these whenever auditing a submission package.


### PR DESCRIPTION
## Summary
Two reusable lessons from a recent observational/cohort submission to a Springer Editorial Manager journal.

### sync-submission — Phase 9: Springer EM packaging (no title-page slot)
Some Springer EM journals expose only Manuscript/Figure/Table/Supplementary/LaTeX item types (no Title Page or Cover Letter slot). Adds guidance:
- Title page as page 1 of the Manuscript via pandoc (real OpenXML page break; bare `\newpage` is dropped in docx), with body byline/affiliations stripped to avoid duplication
- Cover letter → "comments to publication office" field; Graphical Abstract → Figure w/ Description
- 7-subheading Declarations completeness check (incl. Consent to Participate / Consent for Publication, with de-identified-cohort defaults)
- Ethics approval/exemption number in ethics statement
- Word-limit-including-references is the binding constraint (not ref count)
- Co-author-account submission auto-dup fix; re-read EM-compiled PDF before Approve

### manage-refs — F: BibTeX author-format corruption
`author = {Surname AB and ...}` (no comma) misparses last token as family → renders "AB S". Use `Family, Full Given` (full forename; concatenated initials collapse under CSL initialize-with). Rendered-docx + bib grep checks.

## Validation
`scripts/validate_skills.sh` ALL CHECKS PASSED (45 v2 contracts, 0 failures). Doc-only; no schema/code changes. PII-scrubbed (generic, no project/author/journal/manuscript identifiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)