### PR TITLE
Prospective DTA + MRMC: diagnostic-accuracy probe module + reader-study figure/table

### DIFF
--- a/docs/skills/analyze-stats.md
+++ b/docs/skills/analyze-stats.md
@@ -37,7 +37,7 @@
 
 - `analysis_guides/` (7 files)
 - `style/` (2 files)
-- `table-standards/` (15 files)
+- `table-standards/` (16 files)
 - `templates/` (14 files)
 
 **Scripts** (`skills/analyze-stats/scripts/`):

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -38,7 +38,7 @@
 - `critic_rubrics/` (2 files)
 - `design_principles.md`
 - `exemplar_diagrams/` (53 files)
-- `exemplar_plots/` (5 files)
+- `exemplar_plots/` (6 files)
 - `figure_specs.md`
 - `flow_diagram_lessons.md`
 - `jacc_central_illustration_principles.md`

--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -36,7 +36,7 @@
 **References** (`skills/peer-review/references/`):
 
 - `aczel_2021_reviewer2_patterns.md`
-- `domain-probes/` (7 files)
+- `domain-probes/` (8 files)
 - `exemplar_reviews/` (7 files)
 - `narrative_review_audit.md`
 - `reviewer_calibration/` (2 files)

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -38,7 +38,7 @@
 
 **References** (`skills/self-review/references/`):
 
-- `domain-probes/` (7 files)
+- `domain-probes/` (8 files)
 - `exemplar_findings/` (5 files)
 - `panel_review_template.md`
 

--- a/reverse_engineer/gap_register.md
+++ b/reverse_engineer/gap_register.md
@@ -44,6 +44,11 @@ stop adding marginal items there).
 | G9 | calc-sample-size | `references/justification_examples.md` — reviewer-safe sample-size justification prose per design (found via cross-skill audit; SKILL.md promised "IRB-ready justification text" but no exemplar library) | 4 | 4 | 4 | 64 | shipped (this PR) |
 | G10 | present-paper | `scripts/inject_speaker_notes.py` run-level markdown parser — general speaker notes rendered `**bold**` literally (the failure mode pptx-speaker-notes.md warns against); the parser existed only in inject_pronunciation_notes.py. Found while triaging the unmerged `present-paper-md-notes-glossary` branch (whose verify_refs/academic-aio parts were already superseded by main) | 3 | 4 | 4 | 48 | shipped (rescue PR) |
 | G11 | manage-refs | `scripts/render_pandoc.sh` had no pre-render reference audit — a direct render call could ship fabricated/mismatched citations (the master pre_submission_gate audits, but direct calls bypass it). Found while triaging the unmerged present-paper-md-notes-glossary branch | 4 | 3 | 4 | 48 | shipped (cleanup PR) |
+| G19 | peer-review + self-review | `domain-probes/diagnostic_accuracy.md` (NEW MODULE, D1–D6) — DTA primary studies + MRMC reader studies had no probe (sr_ma covers DTA *meta-analysis* only): verification/spectrum/blinding bias, indeterminate handling, MRMC fully-crossed/washout design, reader+case variance (Obuchowski–Rockette). Found reverse-engineering the prospective-DTA/MRMC area | 5 | 3 | 5 | 75 | in-progress (this PR) |
+| G20 | make-figures | `exemplar_plots/mrmc_roc.md` — MRMC reader-study ROC anatomy (per-reader + reader-averaged curves, MRMC reader+case CI, ΔAUC + margin, unit/design note); no reader-study figure exemplar existed | 4 | 3 | 5 | 60 | in-progress (this PR) |
+| G21 | analyze-stats | `table-types/reader_study.md` — MRMC per-reader + reader-averaged performance table (OR/DBM reader+case CI, per-patient vs per-lesion, non-inferiority margin); distinct from agreement.md (reliability) | 4 | 3 | 5 | 60 | in-progress (this PR) |
+
+> Numbering note: G12–G15 belong to the decision-curve+TRIPOD-LLM PR; G16–G18 to the AI-RCT PR; both off origin/main and still open. This branch uses G19–G21.
 
 ## Lane status
 

--- a/scripts/check_domain_probe_sync.py
+++ b/scripts/check_domain_probe_sync.py
@@ -40,6 +40,7 @@ MODULES = (
     "observational_confounding.md",
     "ai_overclaiming.md",
     "rct_trial.md",
+    "diagnostic_accuracy.md",
 )
 
 CANONICAL_REL = "skills/peer-review/references/domain-probes"

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -31,7 +31,7 @@ Before reading any data file, check whether it might contain Protected Health In
 - **Table standards**: `${CLAUDE_SKILL_DIR}/references/table-standards/` -- journal-specific table formatting
   - `table-standards.md` -- universal rules, AMA rules, footnote system, mistakes checklist
   - `journal-profiles/` -- YAML profiles per journal (radiology, jama, nejm, lancet, eur_rad, ajr)
-  - `table-types/` -- templates per table type (Table 1, diagnostic accuracy, regression, survival/Cox, agreement/reliability, meta-analysis, model comparison)
+  - `table-types/` -- templates per table type (Table 1, diagnostic accuracy, regression, survival/Cox, agreement/reliability, meta-analysis, model comparison, reader study (MRMC))
   - `tool-comparison.md` -- R/Python tool comparison and recommended pipelines
 - **Figure style**: `${CLAUDE_SKILL_DIR}/references/style/figure_style.mplstyle`
 - **Project data**: See CLAUDE.md for data locations under `2_Data/`
@@ -393,6 +393,7 @@ tbl %>% as_flex_table() %>% flextable::save_as_docx(path = "table.docx")
   - IDI (Integrated Discrimination Improvement)
   - Bootstrap 95% CIs (1000+ iterations)
   - These supplement, not replace, DeLong AUC comparison
+- Reader study (MRMC): `references/table-standards/table-types/reader_study.md` (per-reader + reader-averaged AUC with an Obuchowski–Rockette/DBM reader+case CI, per-patient vs per-lesion unit, superiority vs non-inferiority margin). Use an MRMC method (not a fixed-reader DeLong CI) for a claim that generalises to readers. Pairs `make-figures` `references/exemplar_plots/mrmc_roc.md`.
 
 ### Inter-rater Agreement
 

--- a/skills/analyze-stats/references/table-standards/table-types/reader_study.md
+++ b/skills/analyze-stats/references/table-standards/table-types/reader_study.md
@@ -1,0 +1,62 @@
+# Table: Multi-Reader Multi-Case (MRMC) Reader-Study Results
+
+The table standard for a **reader study** — multiple readers interpreting the same cases under one
+or more conditions (e.g., unaided vs AI-aided, or modality A vs B). The headline is a
+**reader-averaged** performance with a confidence interval that accounts for **both reader and case
+variability**, with **per-reader** results shown so a single average cannot hide a weak reader.
+
+## Reporting Guidelines
+- **STARD / STARD-AI**: diagnostic accuracy reporting (index test, reference standard, flow)
+- **CLAIM**: AI in medical imaging (reader study is a common CLAIM design)
+- MRMC analysis convention: Obuchowski–Rockette (OR) / Dorfman–Berbaum–Metz (DBM) for reader+case variance
+
+## Standard Structure
+
+```
+Table 3. Reader Performance, Unaided vs AI-aided (MRMC, fully crossed; N readers, M cases; per-patient)
+
+Reader            Unaided AUC (95% CI)     AI-aided AUC (95% CI)     ΔAUC (95% CI)
+Reader 1          0.82 (0.76-0.88)         0.88 (0.83-0.93)          +0.06 (0.01-0.11)
+Reader 2          0.79 (0.72-0.86)         0.86 (0.80-0.92)          +0.07 (0.02-0.12)
+...               ...                      ...                       ...
+Reader N          0.85 (0.79-0.90)         0.89 (0.84-0.94)          +0.04 (-0.01-0.09)
+Reader-averaged   0.82 (0.77-0.87)*        0.88 (0.84-0.92)*         +0.06 (0.02-0.10)*
+
+* Reader-averaged AUC and ΔAUC with MRMC 95% CIs (Obuchowski-Rockette), accounting for
+  reader and case variance. N readers (random), M cases. Fully crossed. Unit: per-patient.
+  Non-inferiority margin (if applicable): ΔAUC > -0.05, pre-specified.
+```
+
+## Rules
+- **Reader-averaged headline + per-reader rows**: report the reader-averaged estimate (the inferential
+  target) *and* each reader, so reader spread is visible. A single averaged AUC alone is insufficient.
+- **MRMC CI, not fixed-reader CI**: the reader-averaged CI and any ΔAUC CI must come from an MRMC method
+  (OR/DBM) that accounts for **reader + case** variance. Do **not** report a DeLong CI (case-only) for a
+  generalising reader claim — it understates uncertainty.
+- **State the design**: fully crossed vs split-plot; number of readers (and that they are a random
+  sample of the reader population for generalisation); number of cases / prevalence.
+- **Unit of analysis**: per-patient vs per-lesion (clustered) — state it; do not analyse clustered
+  lesion data as independent.
+- **Reading order / washout**: for a within-reader condition comparison, state order randomisation and
+  the washout interval (footnote) — it is part of the design's validity.
+- **Estimand**: superiority vs non-inferiority; for non-inferiority, pre-specify and report the margin.
+  Report ΔAUC (or Δsensitivity/Δspecificity at a fixed operating point) with its MRMC CI.
+- **Operating-point metrics**: if sensitivity/specificity are reported, fix and state the operating
+  point (reader-declared threshold), and apply the same MRMC variance treatment.
+
+## Common pitfalls (flag in review)
+- Reader-averaged AUC only, no per-reader rows (hides a weak reader).
+- DeLong / fixed-reader CI used for a claim that generalises to readers (ignores reader variance).
+- Clustered per-lesion data analysed as independent.
+- Non-inferiority asserted with no pre-specified margin.
+
+## Code (illustrative)
+
+```r
+# MRMC reader-study analysis (Obuchowski-Rockette / DBM) — e.g., the RJafroc or MRMCaov package.
+# Input: long data frame (readerID, caseID, modality/condition, score, truth).
+# Output: reader-averaged AUC per condition + ΔAUC with MRMC (reader+case) CI and p; per-reader AUCs
+# from the same fit. Pair the figure with make-figures exemplar_plots/mrmc_roc.md (per-reader +
+# reader-averaged curves). Report the unit of analysis (per-patient vs per-lesion) and the design
+# (fully crossed, N readers random, M cases).
+```

--- a/skills/make-figures/references/exemplar_plots/README.md
+++ b/skills/make-figures/references/exemplar_plots/README.md
@@ -23,6 +23,9 @@ against `critic_rubrics/data_plot.md`; do not copy an image.
   point, DeLong for AUC differences, PR + AUPRC (baseline = prevalence) under imbalance.
 - `calibration_plot.md` — calibration: predicted-vs-observed with 45° line, flexible curve,
   slope/intercept, predicted-risk distribution, external set, not HL-test-alone; pairs roc_pr.
+- `mrmc_roc.md` — multi-reader multi-case (MRMC) reader-study ROC: per-reader curves + bold
+  reader-averaged curve, MRMC (reader+case) AUC CI, ΔAUC with margin, per-patient/per-lesion unit,
+  fully-crossed/washout note. Pairs the analyze-stats reader-study table-type.
 
 ## Curator guidelines (for adding more)
 

--- a/skills/make-figures/references/exemplar_plots/mrmc_roc.md
+++ b/skills/make-figures/references/exemplar_plots/mrmc_roc.md
@@ -1,0 +1,41 @@
+# Exemplar anatomy — MRMC reader-study ROC (multi-reader multi-case)
+
+A worked **anatomy model** for the ROC figure of a **multi-reader multi-case (MRMC)** study — the
+reader-study counterpart to the single-model `roc_pr.md`. The point of an MRMC figure is to show
+that readers are a *sample*: the curve must communicate both the reader-averaged performance and
+the spread across readers, so a comparison (e.g., AI-aided vs unaided, or modality A vs B) is read
+as generalising to the reader population, not to two specific experts. Complements
+`critic_rubrics/data_plot.md` §C and pairs `analyze-stats`
+`table-standards/table-types/reader_study.md`. Synthetic — describes *what each element must show*
+and the errors to avoid; not an image to copy, no real citations.
+
+## Elements
+- **Fixed 0–1 axes**, sensitivity (y) vs 1 − specificity (x), with the chance diagonal.
+- **Per-reader curves** (thin, one per reader) **and** the **reader-averaged curve** (bold) for each
+  condition being compared — so the reader spread is visible, not hidden inside one mean line.
+- The **reader-averaged AUC with an MRMC 95% CI** (accounting for **both reader and case** variance —
+  Obuchowski–Rockette / DBM), per condition, in the legend or panel.
+- For a comparison, **both conditions on the same axes** (e.g., unaided vs AI-aided) and the
+  **ΔAUC with its MRMC CI / p**; if the design is non-inferiority, mark the **pre-specified margin**.
+- The **operating point(s)** actually used by readers (e.g., recommend-biopsy threshold), and a note
+  of the **unit of analysis** (per-patient vs per-lesion) and the **fully-crossed** design.
+
+## Discipline (what the figure must not do)
+- **Do not show only the reader-averaged curve** — without per-reader curves (or a reader-spread band)
+  the figure hides whether the gain is uniform or driven by one weak reader.
+- **Do not quote a naïve (fixed-reader) AUC CI** for a generalising claim — the CI must reflect reader
+  sampling (MRMC variance); a DeLong CI that ignores reader variance understates uncertainty.
+- **Do not pool all readers' reads as if independent**, and do not mix per-patient and per-lesion units
+  on one curve without saying so.
+- **Do not imply a population-level "AI matches radiologists" claim from 2–3 expert readers** — the
+  figure (and caption) should make the reader sample and its generalisation limit explicit.
+- If readers were aided by AI, **state the reading order/washout** so the comparison is not confounded
+  by case recognition.
+
+## Common omission
+- The **per-reader curves**, the **MRMC (reader+case) CI** on the averaged AUC, and the **unit of
+  analysis / fully-crossed design** note — the elements MRMC figures most often drop, and the ones
+  that decide whether the comparison generalises to readers rather than to the specific panel.
+  Cross-reference `critic_rubrics/data_plot.md` §C, the diagnostic-accuracy probes
+  `peer-review/references/domain-probes/diagnostic_accuracy.md` (D5/D6), and
+  `analyze-stats` `table-standards/table-types/reader_study.md`.

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -193,6 +193,12 @@ Apply this 8-probe checklist (RC0–RC7) **only when the manuscript is a randomi
 
 **Probe detail (RC0–RC7), with output templates and the leads-vs-findings discipline:** `${CLAUDE_SKILL_DIR}/references/domain-probes/rct_trial.md`. Load it and apply each probe when the trigger fires. Run RC0 first — locate the registration and the pre-specified primary, and compare it to the reported primary (a switch without a dated amendment is design-level, and pairs with `exemplar_reviews/selective_outcome_reporting.md`). In this skill, map each probe finding to the review draft as a Major / Minor comment; a broken-randomisation primary (RC3, per-protocol/completers), unconcealed allocation (RC1), or an open-label trial with a subjective outcome (RC2, functional unblinding) is design-level — surface it in the Confidential Comments to the Editor and place it as the Major #1 candidate. A reported baseline significance test (RC5) is MINOR.
 
+### Phase 2I: Diagnostic-Accuracy / Reader-Study Extension
+
+Apply this 6-probe checklist (D1–D6) **only when the manuscript is a diagnostic test accuracy (DTA) primary study** — an index test against a reference standard — including **multi-reader multi-case (MRMC)** reader studies (AI-vs-reader or modality comparison). These probes complement (do not replace) the generic Phase 2 issue checklist and the STARD / QUADAS-2 items; they target verification/spectrum/blinding bias and the MRMC design/variance issues a reader study adds. (For a DTA **meta-analysis**, use Phase 2A / `sr_ma.md`.)
+
+**Probe detail (D1–D6), with output templates and the leads-vs-findings discipline:** `${CLAUDE_SKILL_DIR}/references/domain-probes/diagnostic_accuracy.md`. Load it and apply each probe when the trigger fires. In this skill, map each probe finding to the review draft as a Major / Minor comment; two-gate (case-control) sampling (D2), verification/incorporation bias (D1), or an MRMC analysis that ignores reader variance (D6) is design/analysis-level — surface it in the Confidential Comments to the Editor and place it as the Major #1 candidate. Pairs the `analyze-stats` `table-types/reader_study.md` table and the `make-figures` `exemplar_plots/mrmc_roc.md` figure; a test-set-tuned operating threshold pairs with `exemplar_reviews/optimistic_validation_reporting.md`.
+
 ### Phase 3: Draft Review
 
 Before writing comments, skim the relevant model in `references/exemplar_reviews/` for the

--- a/skills/peer-review/references/domain-probes/diagnostic_accuracy.md
+++ b/skills/peer-review/references/domain-probes/diagnostic_accuracy.md
@@ -1,0 +1,41 @@
+<!-- Domain probe module — shared, vendored BYTE-IDENTICAL by /peer-review and /self-review.
+     Severity words below (MAJOR / MINOR / major / minor) denote finding severity, NOT a journal
+     recommendation. Each consuming skill maps findings to its own output:
+       - peer-review: Major / Minor comments + Confidential Comments to the Editor; a design-level
+         flaw (verification bias, two-gate sampling, unblinded reference) is placed as Major #1.
+       - self-review: Anticipated Major / Minor Comments (Fatal / Fixable) mapped to category letters.
+     Do NOT edit one copy only — run `python3 scripts/check_domain_probe_sync.py --sync`. -->
+
+# Diagnostic-accuracy / reader-study probes (D1–D6)
+
+A checklist for **diagnostic test accuracy (DTA) primary studies** — an index test against a reference standard, including **multi-reader multi-case (MRMC)** reader studies (e.g., AI-vs-reader or modality-comparison). These probes complement (do not replace) the generic Phase 2 issue checklist and the STARD / QUADAS-2 items; they target the biases QUADAS-2 names and the MRMC design/variance issues a reader study adds. Pairs the `analyze-stats` `table-standards/table-types/reader_study.md` table and the `make-figures` `exemplar_plots/mrmc_roc.md` figure. (For a DTA **meta-analysis**, use `sr_ma.md`.)
+
+**D1 — Reference standard validity + verification bias**:
+- Is the **reference standard** appropriate and applied to (essentially) all participants? Partial verification (only test-positives get the gold standard), differential verification (different reference standards by index result), and **incorporation bias** (the index test is part of the reference) each inflate accuracy. QUADAS-2 Domain 3/4.
+- Was the reference standard interpreted **without** knowledge of the index result, and was the **time interval** between index and reference short enough that the target condition did not change? A long or undefined interval, or a reference that incorporates the index, → MAJOR.
+
+**D2 — Spectrum + sampling design**:
+- How were participants sampled — a **single-gate** consecutive/random series of those with the target condition suspected (preserves spectrum and prevalence), or a **two-gate** case-control design (known cases vs healthy controls)? Two-gate sampling **overestimates** accuracy and distorts spectrum; it is a MAJOR interpretive limit when the headline is clinical accuracy, not just proof-of-concept.
+- Is the study **prospective** with a pre-specified index threshold, or retrospective with a threshold chosen on the same data (D-linked to optimism)? Spectrum (disease severity, comorbid mimics) should match the intended-use population.
+
+**D3 — Blinding of index and reference interpretation**:
+- Was the **index test** interpreted blind to the reference standard and to clinical information that would not be available at the point of use, and vice versa? Unblinded interpretation (review bias) inflates agreement.
+- For an AI index test, was the **operating threshold pre-specified** (not tuned on the test set)? A test-set-tuned threshold reported as the result is an optimistic-validation finding (pair with `exemplar_reviews/optimistic_validation_reporting.md`).
+
+**D4 — Indeterminate / uninterpretable results**:
+- How were **indeterminate, uninterpretable, or intermediate** index results handled — excluded, or counted (intention-to-diagnose)? Silently dropping them inflates accuracy. State the rule and report an **intention-to-diagnose** sensitivity analysis (non-diagnostic counted as wrong). Undisclosed exclusion of indeterminates → MAJOR.
+
+**D5 — MRMC reader-study design**:
+- Is the design **fully crossed** (every reader reads every case in every modality) or a nested/split-plot variant — and is that stated? Was **reading order randomized** and a **washout** interval used between modalities so a case is not recognised from a prior read? Absent washout/order control in a within-reader modality comparison → MAJOR (memory/recognition bias).
+- Are the **readers sampled to generalise** to the intended reader population (number, expertise mix), and were **training/instructions and the information available** (priors, clinical data) standardised? A 2–3 expert-reader convenience panel cannot support a population-level "AI matches radiologists" claim — flag the generalisation gap.
+
+**D6 — MRMC analysis + estimand**:
+- Does the analysis account for **both reader and case variability** (Obuchowski–Rockette / Dorfman–Berbaum–Metz or an equivalent multi-reader model), or does it treat readers as fixed / pool reads as if independent? Ignoring reader variance understates uncertainty and is a MAJOR statistical flaw for a generalising claim.
+- Is the **estimand** clear: reader-averaged vs a fixed specific reader; per-**patient** vs per-**lesion** (clustered) unit; superiority vs **non-inferiority** with a pre-specified margin? Are **per-reader** results shown alongside the reader-averaged estimate (a single averaged AUC can hide one weak reader)? A non-inferiority claim with no pre-specified margin, or a clustered design analysed as independent, → MAJOR.
+
+**Output template (D2 / D6 example)**:
+> "The study uses a case-control (two-gate) design — confirmed cases versus healthy controls — rather than a consecutive series of patients in whom the diagnosis was suspected. This typically overestimates accuracy and does not reflect the intended-use spectrum, so I'd read the reported sensitivity/specificity as proof-of-concept rather than clinical accuracy, and suggest tempering the Abstract accordingly. Separately, the reader study reports a single reader-averaged AUC; because readers are a sample, I'd suggest an MRMC analysis (e.g., Obuchowski–Rockette) that accounts for both reader and case variance, with per-reader estimates shown and the unit of analysis (per-patient vs per-lesion) stated."
+
+**Discipline — leads vs findings (applies to D1–D6)**:
+- A verification/blinding/spectrum concern from a quick scan is a **lead until Methods and the participant flow are read together** — distinguish under-reporting (ask to clarify) from a true design bias (MAJOR).
+- Anchor each comment to the exact bias (partial vs differential verification; single- vs two-gate; reader-averaged vs fixed-reader; per-patient vs per-lesion) and the location. Keep severity tied to what the flaw does: two-gate sampling, incorporation bias, or ignoring reader variance is design/analysis-level (MAJOR, often Major #1); an unreported reading-order detail is a clarify-request.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -281,6 +281,7 @@ These modules carry the same domain-specific critique probes used by `/peer-revi
 | Narrative / review article / primer / state-of-the-art | `references/domain-probes/narrative_review.md` (RV1–RV9) |
 | AI/ML primary study with a clinical claim (generalizable / outperforms clinicians / deployment-ready / can replace a reader) | `references/domain-probes/ai_overclaiming.md` (AO0–AO5) |
 | Randomised controlled trial (parallel / crossover / cluster / stepped-wedge) | `references/domain-probes/rct_trial.md` (RC0–RC7) |
+| Diagnostic test accuracy (DTA) primary study / multi-reader multi-case (MRMC) reader study (index test vs reference standard, AI-vs-reader, modality comparison) | `references/domain-probes/diagnostic_accuracy.md` (D1–D6) |
 
 When the manuscript matches a row, read `${CLAUDE_SKILL_DIR}/references/domain-probes/<module>.md` and apply each probe as an additional source of Anticipated Major / Minor Comments. The module severity words (MAJOR / MINOR) map to this skill's framing as follows: a conclusion-threatening or design-level finding becomes a **Fatal** Anticipated Major Comment, a reporting-level finding becomes a **Fixable** Anticipated Minor Comment, and each is tagged with the closest category letter (A–K). These probes **complement** categories A–K above; they do not replace them. (The modules are vendored byte-identical from `/peer-review`; do not edit one copy only — run `python3 scripts/check_domain_probe_sync.py --sync`.)
 

--- a/skills/self-review/references/domain-probes/diagnostic_accuracy.md
+++ b/skills/self-review/references/domain-probes/diagnostic_accuracy.md
@@ -1,0 +1,41 @@
+<!-- Domain probe module — shared, vendored BYTE-IDENTICAL by /peer-review and /self-review.
+     Severity words below (MAJOR / MINOR / major / minor) denote finding severity, NOT a journal
+     recommendation. Each consuming skill maps findings to its own output:
+       - peer-review: Major / Minor comments + Confidential Comments to the Editor; a design-level
+         flaw (verification bias, two-gate sampling, unblinded reference) is placed as Major #1.
+       - self-review: Anticipated Major / Minor Comments (Fatal / Fixable) mapped to category letters.
+     Do NOT edit one copy only — run `python3 scripts/check_domain_probe_sync.py --sync`. -->
+
+# Diagnostic-accuracy / reader-study probes (D1–D6)
+
+A checklist for **diagnostic test accuracy (DTA) primary studies** — an index test against a reference standard, including **multi-reader multi-case (MRMC)** reader studies (e.g., AI-vs-reader or modality-comparison). These probes complement (do not replace) the generic Phase 2 issue checklist and the STARD / QUADAS-2 items; they target the biases QUADAS-2 names and the MRMC design/variance issues a reader study adds. Pairs the `analyze-stats` `table-standards/table-types/reader_study.md` table and the `make-figures` `exemplar_plots/mrmc_roc.md` figure. (For a DTA **meta-analysis**, use `sr_ma.md`.)
+
+**D1 — Reference standard validity + verification bias**:
+- Is the **reference standard** appropriate and applied to (essentially) all participants? Partial verification (only test-positives get the gold standard), differential verification (different reference standards by index result), and **incorporation bias** (the index test is part of the reference) each inflate accuracy. QUADAS-2 Domain 3/4.
+- Was the reference standard interpreted **without** knowledge of the index result, and was the **time interval** between index and reference short enough that the target condition did not change? A long or undefined interval, or a reference that incorporates the index, → MAJOR.
+
+**D2 — Spectrum + sampling design**:
+- How were participants sampled — a **single-gate** consecutive/random series of those with the target condition suspected (preserves spectrum and prevalence), or a **two-gate** case-control design (known cases vs healthy controls)? Two-gate sampling **overestimates** accuracy and distorts spectrum; it is a MAJOR interpretive limit when the headline is clinical accuracy, not just proof-of-concept.
+- Is the study **prospective** with a pre-specified index threshold, or retrospective with a threshold chosen on the same data (D-linked to optimism)? Spectrum (disease severity, comorbid mimics) should match the intended-use population.
+
+**D3 — Blinding of index and reference interpretation**:
+- Was the **index test** interpreted blind to the reference standard and to clinical information that would not be available at the point of use, and vice versa? Unblinded interpretation (review bias) inflates agreement.
+- For an AI index test, was the **operating threshold pre-specified** (not tuned on the test set)? A test-set-tuned threshold reported as the result is an optimistic-validation finding (pair with `exemplar_reviews/optimistic_validation_reporting.md`).
+
+**D4 — Indeterminate / uninterpretable results**:
+- How were **indeterminate, uninterpretable, or intermediate** index results handled — excluded, or counted (intention-to-diagnose)? Silently dropping them inflates accuracy. State the rule and report an **intention-to-diagnose** sensitivity analysis (non-diagnostic counted as wrong). Undisclosed exclusion of indeterminates → MAJOR.
+
+**D5 — MRMC reader-study design**:
+- Is the design **fully crossed** (every reader reads every case in every modality) or a nested/split-plot variant — and is that stated? Was **reading order randomized** and a **washout** interval used between modalities so a case is not recognised from a prior read? Absent washout/order control in a within-reader modality comparison → MAJOR (memory/recognition bias).
+- Are the **readers sampled to generalise** to the intended reader population (number, expertise mix), and were **training/instructions and the information available** (priors, clinical data) standardised? A 2–3 expert-reader convenience panel cannot support a population-level "AI matches radiologists" claim — flag the generalisation gap.
+
+**D6 — MRMC analysis + estimand**:
+- Does the analysis account for **both reader and case variability** (Obuchowski–Rockette / Dorfman–Berbaum–Metz or an equivalent multi-reader model), or does it treat readers as fixed / pool reads as if independent? Ignoring reader variance understates uncertainty and is a MAJOR statistical flaw for a generalising claim.
+- Is the **estimand** clear: reader-averaged vs a fixed specific reader; per-**patient** vs per-**lesion** (clustered) unit; superiority vs **non-inferiority** with a pre-specified margin? Are **per-reader** results shown alongside the reader-averaged estimate (a single averaged AUC can hide one weak reader)? A non-inferiority claim with no pre-specified margin, or a clustered design analysed as independent, → MAJOR.
+
+**Output template (D2 / D6 example)**:
+> "The study uses a case-control (two-gate) design — confirmed cases versus healthy controls — rather than a consecutive series of patients in whom the diagnosis was suspected. This typically overestimates accuracy and does not reflect the intended-use spectrum, so I'd read the reported sensitivity/specificity as proof-of-concept rather than clinical accuracy, and suggest tempering the Abstract accordingly. Separately, the reader study reports a single reader-averaged AUC; because readers are a sample, I'd suggest an MRMC analysis (e.g., Obuchowski–Rockette) that accounts for both reader and case variance, with per-reader estimates shown and the unit of analysis (per-patient vs per-lesion) stated."
+
+**Discipline — leads vs findings (applies to D1–D6)**:
+- A verification/blinding/spectrum concern from a quick scan is a **lead until Methods and the participant flow are read together** — distinguish under-reporting (ask to clarify) from a true design bias (MAJOR).
+- Anchor each comment to the exact bias (partial vs differential verification; single- vs two-gate; reader-averaged vs fixed-reader; per-patient vs per-lesion) and the location. Keep severity tied to what the flaw does: two-gate sampling, incorporation bias, or ignoring reader variance is design/analysis-level (MAJOR, often Major #1); an unreported reading-order detail is a clarify-request.


### PR DESCRIPTION
Third batch of the **scaffold-now, tacit-later** reverse-engineering loop (overnight run). Extends existing skills only — **no new skills, no detector-count change, no guideline-count change**. All three artifacts are methodology-general synthetic (DTA/QUADAS/STARD + MRMC/Obuchowski–Rockette conventions), so no source was distilled and `_corpus` is unused this PR.

### Artifacts (gaps G19–G21)
- **peer-review / self-review** `domain-probes/diagnostic_accuracy.md` (NEW MODULE, D1–D6) — DTA primary studies + MRMC reader studies, a gap the suite did not cover (`sr_ma` handles DTA *meta-analysis* only). D1 reference-standard validity + verification bias, D2 spectrum + single- vs two-gate sampling, D3 blinding + pre-specified threshold, D4 indeterminate handling (intention-to-diagnose), D5 MRMC fully-crossed/washout design + reader generalisation, D6 reader+case variance (Obuchowski–Rockette/DBM) + estimand. Registered in the MODULES tuple, vendored byte-identical, routed from both skills (peer-review **Phase 2I**; self-review routing table). **G19**
- **make-figures** `exemplar_plots/mrmc_roc.md` (NEW) — MRMC reader-study ROC anatomy (per-reader + reader-averaged curves, MRMC reader+case CI, ΔAUC + margin, unit/design note). Synthetic, no real citations. **G20**
- **analyze-stats** `table-types/reader_study.md` (NEW) — MRMC per-reader + reader-averaged performance table (OR/DBM reader+case CI, per-patient vs per-lesion, non-inferiority margin); distinct from `agreement.md`. **G21**

The three pair each other: the probe checks the design/analysis, the figure shows per-reader + reader-averaged ROC, the table standardises the numbers.

### Note
No catalog count changes (no new checklist/detector/skill), so **no sibling count-conflict** with #141/#142 — this PR is independent and can merge in any order.

### Verification
Full `.github/workflows/validate.yml` mirror locally: **27/27 green** (incl. domain-probe sync with the new 8th module, routing-asset integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)