### PR TITLE
feat(make-figures): Bland-Altman + confusion-matrix figure exemplars (G6)

### DIFF
--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -38,7 +38,7 @@
 - `critic_rubrics/` (2 files)
 - `design_principles.md`
 - `exemplar_diagrams/` (53 files)
-- `exemplar_plots/` (7 files)
+- `exemplar_plots/` (9 files)
 - `figure_specs.md`
 - `flow_diagram_lessons.md`
 - `jacc_central_illustration_principles.md`

--- a/reverse_engineer/gap_register.md
+++ b/reverse_engineer/gap_register.md
@@ -38,7 +38,7 @@ stop adding marginal items there).
 | G3 | make-figures | `exemplar_plots/roc_pr.md` — ROC / precision-recall anatomy (CI band, operating point, AUPRC under imbalance) | 4 | 5 | 5 | 100 | shipped (this PR) |
 | G4 | make-figures | `exemplar_plots/calibration_plot.md` — calibration anatomy (bins/loess, slope/intercept, distribution rug) | 4 | 4 | 5 | 80 | shipped (this PR) |
 | G5 | peer-review + self-review | `domain-probes/` RCT / intervention-trial probe (CONSORT: randomisation, allocation concealment, blinding, ITT, selective-outcome) — no trial probe despite trials being common | 5 | 4 | 5 | 100 | shipped (this PR) |
-| G6 | make-figures | `exemplar_plots/bland_altman.md` + `confusion_matrix.md` | 3 | 3 | 5 | 45 | open |
+| G6 | make-figures | `exemplar_plots/bland_altman.md` + `confusion_matrix.md` | 3 | 3 | 5 | 45 | in-progress (this PR) |
 | G7 | write-paper | `exemplar_introduction.md` + `exemplar_abstract.md` (the two sections without exemplars; section_guides exist) | 3 | 5 | 3 | 45 | intro shipped; abstract open |
 | G8 | check-reporting | `checklists/METRICS.md` — radiomics methodological-quality tool (named in the critical-item floor but no checklist) | 3 | 3 | 4 | 36 | open |
 | G9 | calc-sample-size | `references/justification_examples.md` — reviewer-safe sample-size justification prose per design (found via cross-skill audit; SKILL.md promised "IRB-ready justification text" but no exemplar library) | 4 | 4 | 4 | 64 | shipped (this PR) |

--- a/skills/make-figures/references/exemplar_plots/README.md
+++ b/skills/make-figures/references/exemplar_plots/README.md
@@ -30,6 +30,13 @@ against `critic_rubrics/data_plot.md`; do not copy an image.
 - `mrmc_roc.md` — multi-reader multi-case (MRMC) reader-study ROC: per-reader curves + bold
   reader-averaged curve, MRMC (reader+case) AUC CI, ΔAUC with margin, per-patient/per-lesion unit,
   fully-crossed/washout note. Pairs the analyze-stats reader-study table-type.
+- `bland_altman.md` — Bland–Altman agreement: difference vs mean-of-the-two-methods, bias line +
+  CI, ±1.96·SD limits of agreement with CIs on each limit, proportional-bias check, % within LoA,
+  pre-defined clinical-acceptability band, not a correlation plot, repeated-measures handling.
+  Pairs the analyze-stats agreement table-type.
+- `confusion_matrix.md` — confusion matrix: TP/FP/FN/TN with explicit Predicted/Actual axes, raw
+  counts AND row-normalized (recall) / column-normalized (precision) views, class-imbalance caveat,
+  stated operating threshold, per-class metrics, multi-class macro-average. Pairs roc_pr.
 
 ## Curator guidelines (for adding more)
 

--- a/skills/make-figures/references/exemplar_plots/bland_altman.md
+++ b/skills/make-figures/references/exemplar_plots/bland_altman.md
@@ -1,0 +1,46 @@
+# Exemplar anatomy — Bland–Altman agreement plot (two continuous methods)
+
+A worked **anatomy model** for a Bland–Altman figure — the agreement counterpart to a method-
+comparison scatter. Complements the `critic_rubrics/data_plot.md` §C *Bland–Altman* checklist
+(this composes; the rubric scores). Synthetic — describes *what each element must show* and the
+errors to avoid; not an image to copy. Pairs with `analyze-stats`
+`table-standards/table-types/agreement.md` (the LoA / ICC reliability table).
+
+## Elements
+- **Difference (y) vs mean of the two methods (x)** — y = (method A − method B), x = (A + B)/2.
+  Plotting the difference against *one* method (e.g., the reference) induces a spurious slope; the
+  mean of the two is the correct abscissa.
+- **Bias line** = the mean difference, drawn horizontally, with its value and **95% CI** printed.
+- **95% limits of agreement (LoA)** = bias ± 1.96·SD of the differences, drawn as two horizontal
+  lines, with **a confidence interval on each limit** (the LoA are themselves estimates and are
+  wide at small n) — show the CI as a footnote value or a shaded band around each LoA.
+- **The a-priori clinically acceptable difference band** overlaid, so the reader can see at a glance
+  whether the LoA fall inside the margin that was defined *before* the analysis.
+- **Proportional-bias check**: a regression of the difference on the mean; if the slope is non-zero
+  (the cloud fans out or tilts), state it and model the SD or log-transform rather than quoting a
+  single constant LoA.
+- **% of points within the LoA** annotated (≈95% expected) and **scatter points not clipped** at the
+  plot edges — outliers beyond the LoA are the most informative points and must remain visible.
+- **Units stated on both axes** (the difference is in measurement units, not %), and n pairs given.
+
+## Discipline (what the figure must not do)
+- **It is not a correlation/regression plot** — do not report Pearson r or R² as evidence of
+  agreement. High correlation is fully compatible with large systematic bias; correlation measures
+  association along a line, not closeness to identity.
+- **Do not quote a single constant LoA when bias is proportional** — if the differences widen with
+  magnitude (heteroscedasticity), constant ±1.96·SD limits are wrong across the range; log-transform
+  or model the SD as a function of the mean.
+- **Do not omit the CI on the LoA** — at small n the limits are imprecise, and an LoA that looks
+  inside the acceptability margin may not be once its upper CI is shown.
+- **Handle repeated measures correctly** — with multiple pairs per subject, the naïve SD of all
+  differences understates variability; use a repeated-measures Bland–Altman (variance-components)
+  method and report the number of replicates per subject.
+- **Clinical acceptability is a pre-specified judgement**, not read off the plot after the fact —
+  state the margin and its source, and conclude agreement only if the LoA (with CI) fall inside it.
+
+## Common omission
+- The **CI on the limits of agreement**, the **proportional-bias check**, and the **pre-defined
+  clinical-acceptability band** — the elements Bland–Altman figures most often drop, and the ones
+  that decide whether two methods are interchangeable rather than merely correlated. Cross-reference
+  `critic_rubrics/data_plot.md` §C (Bland–Altman) and `analyze-stats`
+  `table-standards/table-types/agreement.md`.

--- a/skills/make-figures/references/exemplar_plots/confusion_matrix.md
+++ b/skills/make-figures/references/exemplar_plots/confusion_matrix.md
@@ -1,0 +1,48 @@
+# Exemplar anatomy — confusion matrix (classifier error structure)
+
+A worked **anatomy model** for a confusion-matrix figure — the per-class error breakdown behind a
+single accuracy number. Complements the `critic_rubrics/data_plot.md` §C *confusion matrix*
+checklist (this composes; the rubric scores). Synthetic — describes *what each element must show*
+and the errors to avoid; not an image to copy. Pairs with `exemplar_plots/roc_pr.md` (the
+threshold-free discrimination side) and `analyze-stats`
+`table-standards/table-types/diagnostic_accuracy.md`.
+
+## Elements
+- **TP / FP / FN / TN laid out as a 2×2 grid** (binary case) with **explicit axis labels**: one
+  axis **Predicted (model)**, the other **Actual / Reference (truth)** — never leave the reader to
+  guess which axis is which, and state the positive class.
+- **Raw counts in every cell**, so totals and prevalence are recoverable; a percentage-only matrix
+  hides the n behind each rate.
+- **Row-normalized (recall / sensitivity) and column-normalized (precision / PPV)** views shown
+  alongside the counts — recall normalizes over true class (rows), precision over predicted class
+  (columns); the two answer different questions and must not be conflated.
+- **The operating threshold stated** — a confusion matrix is a single point on the ROC/PR curve;
+  give the probability cut-off used and how it was chosen (and on which data, not the test set).
+- **Per-class metrics derivable and reported** (sensitivity, specificity, PPV, NPV, F1) with their
+  CIs, rather than one global accuracy.
+- **Diagonal emphasized** (heavier stroke or luminosity) only as a reading aid — correct predictions
+  on the diagonal, errors off it.
+
+## Discipline (what the figure must not do)
+- **Do not let a high overall accuracy stand in for performance** — under class imbalance a
+  classifier that always predicts the majority class scores high accuracy while the minority class
+  fails completely; the off-diagonal recall for the rare class is the load-bearing number, and a
+  class-imbalance caveat belongs in the caption.
+- **Do not normalize ambiguously** — label whether percentages are over rows (recall), columns
+  (precision), or the grand total; an unlabeled "%" cell is uninterpretable.
+- **Do not present the matrix as threshold-free** — it is threshold-dependent; pair it with the
+  ROC/PR curve (`roc_pr.md`) so the reader sees the whole operating range, not one chosen point.
+- **Do not report the matrix on the data used to pick the threshold** — fix the threshold on
+  derivation data and report the matrix on the held-out/test set.
+
+## Multi-class extension
+- For K classes, show the **K×K matrix** with the same Predicted/Actual axes; report **per-class**
+  recall and precision plus a **macro-average** (unweighted over classes, so rare classes are not
+  drowned out) alongside any micro/weighted average, and name which average each headline number is.
+
+## Common omission
+- The **dual row/column normalization (recall vs precision)**, the **stated operating threshold**,
+  and the **class-imbalance caveat** — the elements confusion-matrix figures most often drop, and
+  the ones that stop a high accuracy from hiding a failing minority class. Cross-reference
+  `critic_rubrics/data_plot.md` §C (confusion matrix), `exemplar_plots/roc_pr.md`, and
+  `analyze-stats` `table-standards/table-types/diagnostic_accuracy.md`.


### PR DESCRIPTION
Closes gap **G6** (make-figures exemplar suite) by adding the two remaining non-flow figure anatomy models.

## What

Two synthetic, English-only anatomy models in `skills/make-figures/references/exemplar_plots/`, matching the existing `calibration_plot.md` / `roc_pr.md` format (Elements / Discipline / Common omission, ~40-60 lines, cross-references to `critic_rubrics/data_plot.md` §C and the paired analyze-stats table-type):

- **`bland_altman.md`** — agreement plot: difference vs mean-of-the-two-methods, bias line + CI, ±1.96·SD limits of agreement with CIs on each limit, proportional-bias regression check, % within LoA, pre-defined clinical-acceptability band; discipline = not a correlation/regression plot (no r/R² as agreement), state units, repeated-measures handling. Pairs the analyze-stats `agreement` table-type.
- **`confusion_matrix.md`** — error structure: TP/FP/FN/TN with explicit Predicted vs Actual axes, raw counts AND row-normalized (recall) / column-normalized (precision) views, class-imbalance caveat (high accuracy can hide a failing minority class), stated operating threshold, per-class metrics, multi-class macro-average. Pairs `roc_pr.md`.

## Also

- `exemplar_plots/README.md` — Contents bullet added for each new file.
- generated `docs/skills/make-figures.md` — exemplar_plots count 7 → 9 (via `gen_skill_docs.py`).
- `reverse_engineer/gap_register.md` — G6 status set to `in-progress (this PR)` (not shipped).

## Verify

Full `.github/workflows/validate.yml` mirror run locally — all green. Synthetic anatomy models only: no real citations, no real data, no PII, English only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)