### PR TITLE
feat(verify-refs): OpenAlex tertiary index for conference-proceedings / non-DOI recovery

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Run verify-refs corporate-author gate test (A8)
         run: bash skills/verify-refs/tests/test_corporate_author.sh
 
+      - name: Run verify-refs OpenAlex tertiary-index test (A8b)
+        run: bash skills/verify-refs/tests/test_openalex_tier.sh
+
       - name: Run self-review parenthesis-span corruption gate test (A9)
         run: bash skills/self-review/tests/test_paren_spans.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`/verify-refs` — OpenAlex tertiary index (conference-proceedings / non-DOI recovery).** PubMed covers only biomedical literature and CrossRef's proceedings coverage is uneven, so NeurIPS / ICLR / ACL-style citations — common in medical-AI manuscripts — fall through both and were marked `UNVERIFIED`. After the PubMed and CrossRef tiers, `verify_refs.py` now consults OpenAlex (`https://api.openalex.org`, free, no API key) **only when no authoritative author list was obtained yet** (a reference already resolved by PubMed/CrossRef incurs no extra call). It resolves by DOI when present, otherwise by a token-similarity-guarded title search so a fabricated title cannot earn a spurious `OK`. This is the free analogue of the second index (e.g. Scopus) that journal portals run alongside CrossRef. Because OpenAlex display names carry no structured family/given field and mix `First Last` with `Last, First` forms, OpenAlex-sourced authors support an existence check plus a tolerant first-author *membership* check but **never** drive the strict positional or author-count MISMATCH (reserved for PubMed efetch / CrossRef); an OpenAlex miss is `UNVERIFIED`, never `FABRICATED`. New `--no-openalex` flag restricts verification to PubMed + CrossRef. Ships a network-free regression test (`tests/test_openalex_tier.sh`, monkeypatched `http_json`, CI gate A8b). Motivation: a medical-AI reference list where two NeurIPS citations validated on Scopus but not CrossRef in a journal portal's reference check.
+
 ## [4.3.0] - 2026-06-16
 
 ### Added

--- a/docs/skills/verify-refs.md
+++ b/docs/skills/verify-refs.md
@@ -23,11 +23,13 @@
 
 - Confirms DOI/PMID and author identity, not topical appropriateness of the citation.
 - CrossRef given-name errors are possible; PubMed efetch is treated as authoritative.
+- OpenAlex (tertiary index for conference proceedings / non-DOI works) gives an existence check plus a tolerant first-author membership check only; its display names carry no structured family field, so it never drives the strict positional or author-count cross-check. Use --no-openalex to restrict to PubMed + CrossRef.
 
 **Validation**
 
 - `bash scripts/verify_cli.sh <refs.bib>`
 - `confirm qc/reference_audit.json submission_safe: true`
+- `bash tests/test_openalex_tier.sh`
 
 **Evidence** — `bundled_script`
 

--- a/skills/verify-refs/SKILL.md
+++ b/skills/verify-refs/SKILL.md
@@ -63,8 +63,26 @@ For hooks or quick manual runs, use the wrapper:
 `--strict` forbids `--offline` and exits non-zero on any UNVERIFIED row.
 Full checkpoint protocol: `references/manual_checkpoint_guide.md`.
 
-The script uses DOI, PMID, CrossRef, and PubMed E-utilities where available. If
-network verification fails, it records `UNVERIFIED` rather than silently passing.
+The script uses DOI, PMID, CrossRef, PubMed E-utilities, and OpenAlex where
+available. If network verification fails, it records `UNVERIFIED` rather than
+silently passing.
+
+**OpenAlex tertiary index (existence recovery).** PubMed covers only biomedical
+literature and CrossRef's conference-proceedings coverage is uneven, so
+NeurIPS / ICLR / ACL-style citations — common in medical-AI manuscripts — fall
+through both and would be marked `UNVERIFIED`. After the PubMed and CrossRef tiers,
+the script consults OpenAlex (`https://api.openalex.org`, free, no API key) **only
+when no authoritative author list was obtained yet** (so a reference already
+resolved by PubMed/CrossRef incurs no extra call). It resolves by DOI when present,
+otherwise by a title search guarded by a token-similarity threshold so a fabricated
+title cannot earn a spurious `OK`. This is the free analogue of the second index
+(e.g. Scopus) that journal submission portals run alongside CrossRef. OpenAlex
+display names carry no structured family/given split and mix `First Last` with
+`Last, First` forms, so OpenAlex-sourced authors support an existence check plus a
+tolerant first-author *membership* check, but never drive the strict positional or
+author-count MISMATCH (those stay reserved for PubMed efetch / CrossRef). An
+OpenAlex miss is recorded as `UNVERIFIED`, never `FABRICATED`. Pass `--no-openalex`
+to restrict verification to PubMed + CrossRef.
 
 ## Output Contract (v1.3.0)
 

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -507,7 +507,104 @@ def verify_pubmed_title(title: str, timeout: int) -> tuple[str, str, list]:
     return "OK", f"PubMed title match; PMID candidates={','.join(ids)}", []
 
 
-def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
+def _title_similarity(a: str, b: str) -> float:
+    """Token Jaccard on normalized titles (stdlib-only).
+
+    Guards OpenAlex title matches: a fabricated title must not earn a spurious OK
+    just because a full-text search returned some unrelated work. Stop-short tokens
+    (<=2 chars) are dropped so connective words do not inflate similarity.
+    """
+    def toks(s: str) -> set:
+        s = re.sub(r"[^a-z0-9 ]", " ", s.lower())
+        return {w for w in s.split() if len(w) > 2}
+    ta, tb = toks(a), toks(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def _openalex_families(work: dict) -> list:
+    """Best-effort family-name list from an OpenAlex work's authorships.
+
+    OpenAlex exposes only `author.display_name` with NO structured family/given
+    split, and the live data mixes "First Last" and "Last, First" forms within a
+    single record (observed: 'Noah Shinn' alongside 'Cassano, Federico'). This list
+    is therefore informational only — it is NOT used to drive the authoritative
+    family-by-family MISMATCH cross-check (that stays reserved for PubMed efetch /
+    CrossRef, which carry a structured family field). See verify_record.
+    """
+    families: list[str] = []
+    for au in work.get("authorships") or []:
+        name = ((au.get("author") or {}).get("display_name") or "").strip()
+        if not name:
+            continue
+        if "," in name:
+            # "Last, First" → family is the part before the comma.
+            fam = name.split(",", 1)[0].strip()
+        else:
+            toks = name.split()
+            fam = toks[-1] if toks else ""
+            # Strip a trailing initials block ("Madaan A").
+            if fam and re.match(r"^[A-Z]{1,4}$", fam) and len(toks) >= 2:
+                fam = toks[-2]
+        if fam:
+            families.append(fam)
+    return families
+
+
+def verify_openalex(doi: str, title: str, timeout: int) -> tuple[str, str, list]:
+    """Tertiary index for conference proceedings / non-DOI / non-biomedical works.
+
+    PubMed covers only biomedical literature and CrossRef's proceedings coverage is
+    spotty, so NeurIPS / ICLR / ACL-style citations (common in medical-AI papers)
+    fall through both. OpenAlex (https://api.openalex.org) is free and key-less and
+    ingests those venues, so it recovers them — the free analogue of the second
+    index (e.g. Scopus) that journal portals use alongside CrossRef.
+
+    Resolves by DOI when available (exact); otherwise by title.search with a
+    similarity guard so a fabricated title cannot earn a spurious OK. Returns
+    (status, evidence, family_names). Never returns FABRICATED: an OpenAlex miss is
+    a coverage gap, not proof of fabrication.
+    """
+    work = None
+    via = ""
+    if doi:
+        data = http_json(
+            "https://api.openalex.org/works/https://doi.org/" + urllib.parse.quote(doi),
+            timeout,
+        )
+        if data and data.get("id"):
+            work = data
+            via = "doi"
+    if work is None and title:
+        url = "https://api.openalex.org/works?" + urllib.parse.urlencode(
+            {"filter": "title.search:" + title, "per-page": "5"}
+        )
+        data = http_json(url, timeout)
+        results = (data or {}).get("results") or []
+        best, best_sim = None, 0.0
+        for w in results:
+            sim = _title_similarity(title, w.get("title") or w.get("display_name") or "")
+            if sim > best_sim:
+                best, best_sim = w, sim
+        if best is not None and best_sim >= 0.8:
+            work = best
+            via = f"title(sim={best_sim:.2f})"
+    if work is None:
+        return "UNVERIFIED", "OpenAlex: no confident match", []
+    families = _openalex_families(work)
+    wtitle = (work.get("title") or work.get("display_name") or "")[:120]
+    year = work.get("publication_year")
+    ev = f"OpenAlex OK via {via}; title={wtitle}"
+    if year:
+        ev += f"; year={year}"
+    if families:
+        ev += f"; authors={len(families)} (first={families[0]})"
+    return "OK", ev, families
+
+
+def verify_record(record: RefRecord, offline: bool, timeout: int,
+                  use_openalex: bool = True) -> RefRecord:
     """v1.3.0: full-author cross-check.
 
     Authoritative source priority for the actual author list:
@@ -516,7 +613,9 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
          also catches AI-generated bib entries with hallucinated #2..#N family
          names — a real AI-assembled bib registered 7 of 10 fabricated co-author names).
       2. CrossRef DOI (fallback when no PMID).
-      3. PubMed esummary (fast count check; family-name approximation only).
+      3. OpenAlex (tertiary; conference proceedings / non-DOI / non-biomedical works
+         that PubMed and CrossRef miss — the free analogue of a portal's Scopus pass).
+      4. PubMed esummary (fast count check; family-name approximation only).
     All cited authors (BibTeX) are compared family-by-family against the
     authoritative list AND total counts are compared. Any cited author beyond
     the actual list, any per-index family mismatch, and any count mismatch are
@@ -540,6 +639,11 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
     actual_authors: list[str] = []
     actual_givens: list[str] = []
     sources_consulted: list[str] = []
+    # True when the actual_authors list came from OpenAlex, whose display names carry
+    # no structured family field and mix "First Last" / "Last, First" forms. Such a
+    # list can support a tolerant first-author membership check but NOT the strict
+    # positional + author-count cross-check (which would mis-fire on the format noise).
+    actual_authors_soft = False
 
     # Step 1 — PubMed efetch (authoritative) when PMID present.
     if record.pmid:
@@ -571,8 +675,24 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
             actual_authors = fams_cr
             sources_consulted.append("crossref")
 
-    # Step 3 — title-only fallback (no confident author list).
-    if not statuses:
+    # Step 3 — OpenAlex tertiary index. Fires only when no authoritative author list
+    # was obtained yet (no PMID/DOI, or those lookups returned no authors), so a
+    # biomedical reference already resolved by PubMed/CrossRef incurs no extra call.
+    # Recovers conference proceedings and non-biomedical works (NeurIPS/ICLR/ACL) and
+    # retries DOIs that CrossRef missed.
+    if use_openalex and not actual_authors:
+        st_oa, ev_oa, fams_oa = verify_openalex(record.doi, record.title_guess, timeout)
+        time.sleep(0.2)
+        statuses.append(st_oa)
+        evidence_parts.append(ev_oa)
+        if st_oa == "OK":
+            sources_consulted.append("openalex")
+            if fams_oa:
+                actual_authors = fams_oa
+                actual_authors_soft = True
+
+    # Step 4 — PubMed title-only final fallback when nothing confident resolved.
+    if "OK" not in statuses and not actual_authors:
         st_t, ev_t, _ = verify_pubmed_title(record.title_guess, timeout)
         time.sleep(0.2)
         statuses.append(st_t)
@@ -596,7 +716,8 @@ def verify_record(record: RefRecord, offline: bool, timeout: int) -> RefRecord:
         evidence_parts.append("CORPORATE AUTHOR (collective/organization; family cross-check skipped)")
 
     mismatches: list[str] = []
-    if not (record.corporate_author or source_corporate) and record.cited_authors and actual_authors:
+    if (not (record.corporate_author or source_corporate)
+            and record.cited_authors and actual_authors and not actual_authors_soft):
         compare_n = min(len(record.cited_authors), len(actual_authors))
         for i in range(compare_n):
             cited = record.cited_authors[i]
@@ -776,7 +897,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Verify manuscript references.")
     parser.add_argument("input", help="Input .md, .docx, .bib, .txt, or .tsv file")
     parser.add_argument("--project-root", default=".", help="Project root for output artifacts")
-    parser.add_argument("--offline", action="store_true", help="Do not call PubMed/CrossRef APIs")
+    parser.add_argument("--offline", action="store_true", help="Do not call PubMed/CrossRef/OpenAlex APIs")
+    parser.add_argument("--no-openalex", action="store_true",
+                        help="Disable the OpenAlex tertiary index (restrict to PubMed + CrossRef)")
     parser.add_argument("--timeout", type=int, default=10, help="HTTP timeout seconds")
     parser.add_argument("--strict", action="store_true", help="Exit non-zero on any UNVERIFIED row, and forbid --offline")
     args = parser.parse_args()
@@ -804,7 +927,10 @@ def main() -> int:
         print("No references detected.", file=sys.stderr)
         return 3
 
-    verified = [verify_record(rec, args.offline, args.timeout) for rec in records]
+    verified = [
+        verify_record(rec, args.offline, args.timeout, use_openalex=not args.no_openalex)
+        for rec in records
+    ]
     for rec in verified:
         flag_pagination_placeholder(rec)
     duplicate_findings = detect_duplicates(verified)

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -38,7 +38,9 @@ safety_boundaries:
 known_limitations:
   - "Confirms DOI/PMID and author identity, not topical appropriateness of the citation."
   - "CrossRef given-name errors are possible; PubMed efetch is treated as authoritative."
+  - "OpenAlex (tertiary index for conference proceedings / non-DOI works) gives an existence check plus a tolerant first-author membership check only; its display names carry no structured family field, so it never drives the strict positional or author-count cross-check. Use --no-openalex to restrict to PubMed + CrossRef."
 validation_commands:
   - "bash scripts/verify_cli.sh <refs.bib>"
   - "confirm qc/reference_audit.json submission_safe: true"
+  - "bash tests/test_openalex_tier.sh"
 evidence_surface: bundled_script

--- a/skills/verify-refs/tests/test_openalex_tier.sh
+++ b/skills/verify-refs/tests/test_openalex_tier.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Regression test for the OpenAlex tertiary index (conference proceedings / non-DOI
+# / non-biomedical recovery). Network-free: monkeypatches http_json so no live API
+# is called. Motivation: NeurIPS/ICLR/ACL citations common in medical-AI papers fall
+# through PubMed (not biomedical) and CrossRef (spotty proceedings) — OpenAlex is the
+# free analogue of a journal portal's second index (e.g. Scopus). Stdlib-only.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/verify_refs.py"
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+python3 - "$SCRIPT" <<'PY'
+import importlib.util, sys
+
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+vr = importlib.util.module_from_spec(spec)
+sys.modules["vr"] = vr  # dataclass resolution needs the module registered (py3.14)
+spec.loader.exec_module(vr)
+
+fail = 0
+def check(label, cond):
+    global fail
+    if cond:
+        print(f"  PASS  {label}")
+    else:
+        print(f"  FAIL  {label}")
+        fail += 1
+
+# --- _title_similarity ----------------------------------------------------------
+t = "Reflexion: Language agents with verbal reinforcement learning"
+check("title sim exact == 1.0", abs(vr._title_similarity(t, t) - 1.0) < 1e-9)
+check("title sim unrelated < 0.3",
+      vr._title_similarity(t, "A meta-analysis of CT screening for lung cancer") < 0.3)
+check("title sim empty == 0.0", vr._title_similarity("", t) == 0.0)
+
+# --- _openalex_families ---------------------------------------------------------
+work = {"authorships": [
+    {"author": {"display_name": "Aman Madaan"}},
+    {"author": {"display_name": "Niket Tandon"}},
+    {"author": {"display_name": "Madaan A"}},   # trailing-initials form
+]}
+fams = vr._openalex_families(work)
+check("families last-token parse", fams[:2] == ["Madaan", "Tandon"])
+check("families strip trailing initials", fams[2] == "Madaan")
+
+# --- verify_openalex via monkeypatched http_json --------------------------------
+DOI_WORK = {"id": "https://openalex.org/W1",
+            "title": "Self-Refine: Iterative refinement with self-feedback",
+            "publication_year": 2023,
+            "authorships": [{"author": {"display_name": "Aman Madaan"}}]}
+TITLE_HIT = {"results": [
+    {"title": "Reflexion: Language agents with verbal reinforcement learning",
+     "publication_year": 2023,
+     "authorships": [{"author": {"display_name": "Noah Shinn"}},
+                     {"author": {"display_name": "Federico Cassano"}}]},
+    {"title": "Some unrelated paper about kidneys", "authorships": []},
+]}
+TITLE_MISS = {"results": [
+    {"title": "Completely different work on radiology", "authorships": []}]}
+
+def make_http(mapping):
+    def _http(url, timeout):
+        for needle, payload in mapping.items():
+            if needle in url:
+                return payload
+        return None
+    return _http
+
+# (a) DOI resolve
+vr.http_json = make_http({"api.openalex.org/works/https://doi.org/": DOI_WORK})
+st, ev, fams = vr.verify_openalex("10.5555/self-refine", "", 5)
+check("openalex DOI resolve OK", st == "OK" and fams == ["Madaan"] and "via doi" in ev)
+
+# (b) title.search with strong similarity → OK
+vr.http_json = make_http({"api.openalex.org/works?": TITLE_HIT})
+st, ev, fams = vr.verify_openalex(
+    "", "Reflexion: Language agents with verbal reinforcement learning", 5)
+check("openalex title hit OK", st == "OK" and fams[0] == "Shinn" and "via title" in ev)
+
+# (c) title with no close match → UNVERIFIED (fabrication guard)
+vr.http_json = make_http({"api.openalex.org/works?": TITLE_MISS})
+st, ev, fams = vr.verify_openalex(
+    "", "Reflexion: Language agents with verbal reinforcement learning", 5)
+check("openalex weak-title rejected (UNVERIFIED)", st == "UNVERIFIED" and fams == [])
+
+# (d) no DOI, no title, no match → UNVERIFIED, never FABRICATED
+vr.http_json = make_http({})
+st, ev, fams = vr.verify_openalex("", "", 5)
+check("openalex empty never FABRICATED", st == "UNVERIFIED")
+
+# --- integration through verify_record ------------------------------------------
+# A conference paper: no PMID, no DOI, title only. OpenAlex resolves it and the
+# cited first author matches → status OK, source includes openalex.
+vr.http_json = make_http({"api.openalex.org/works?": TITLE_HIT})
+rec = vr.RefRecord(
+    ref_id="reflexion2023",
+    raw="Shinn N, Cassano F, et al. Reflexion: Language agents with verbal reinforcement learning. NeurIPS 2023.",
+    title_guess="Reflexion: Language agents with verbal reinforcement learning",
+    cited_authors=["Shinn", "Cassano"],
+    first_author_guess="Shinn",
+)
+out = vr.verify_record(rec, offline=False, timeout=5, use_openalex=True)
+check("verify_record conference OK via openalex",
+      out.status == "OK" and "openalex" in out.evidence)
+
+# Same record with a fabricated first author → MISMATCH from OpenAlex authors.
+vr.http_json = make_http({"api.openalex.org/works?": TITLE_HIT})
+rec_bad = vr.RefRecord(
+    ref_id="reflexion_bad",
+    raw="Ebrahimi A, et al. Reflexion: Language agents with verbal reinforcement learning. NeurIPS 2023.",
+    title_guess="Reflexion: Language agents with verbal reinforcement learning",
+    cited_authors=["Ebrahimi", "Cassano"],
+    first_author_guess="Ebrahimi",
+)
+out_bad = vr.verify_record(rec_bad, offline=False, timeout=5, use_openalex=True)
+check("verify_record catches first-author hallucination via openalex",
+      out_bad.status == "MISMATCH" and "AUTHOR MISMATCH" in out_bad.evidence)
+
+# --no-openalex equivalent: use_openalex=False leaves a no-identifier record UNVERIFIED.
+vr.http_json = make_http({"api.openalex.org/works?": TITLE_HIT})
+rec_off = vr.RefRecord(
+    ref_id="reflexion_off",
+    raw="Reflexion NeurIPS 2023.",
+    title_guess="Reflexion: Language agents with verbal reinforcement learning",
+    cited_authors=["Shinn"],
+    first_author_guess="Shinn",
+)
+out_off = vr.verify_record(rec_off, offline=False, timeout=5, use_openalex=False)
+check("use_openalex=False skips OpenAlex (no openalex source)",
+      "openalex" not in out_off.evidence)
+
+print(f"fail={fail}")
+print("ALL PASS" if fail == 0 else f"FAILURES: {fail}")
+sys.exit(fail)
+PY


### PR DESCRIPTION
## Motivation

A journal portal's reference-validation pass checks **Scopus + CrossRef**. On a medical-AI reference list, two NeurIPS citations validated on **Scopus but not CrossRef** — the classic blind spot: conference proceedings (NeurIPS / ICLR / ACL) are not in PubMed (biomedical only) and are spottily covered by CrossRef, so `/verify-refs` marked them `UNVERIFIED`.

Scopus itself is paywalled + API-key-gated, which breaks the skill's free-public-API anti-hallucination design. The free analogue that covers the same gap is **OpenAlex** (no key) — already used by `/search-lit`, but `/verify-refs` lagged behind on indexes.

## Change

Adds OpenAlex as a **tertiary tier** in `verify_refs.py`, after PubMed (efetch/esummary) and CrossRef:

- Fires **only when no authoritative author list was obtained yet** → a reference already resolved by PubMed/CrossRef incurs **no extra call**.
- Resolves by **DOI** when present; otherwise a **title search guarded by a token-similarity threshold** so a fabricated title cannot earn a spurious `OK`.
- An OpenAlex miss is `UNVERIFIED`, **never `FABRICATED`** (absence ≠ fabrication).
- New `--no-openalex` flag restricts to PubMed + CrossRef.

### Why OpenAlex is existence-only, not a strict author authority

Live data shows OpenAlex `display_name` carries **no structured family/given split** and mixes forms within one record (`'Noah Shinn'` next to `'Cassano, Federico'`). So OpenAlex-sourced authors drive an **existence check + tolerant first-author *membership* check** only — never the strict positional / author-count MISMATCH, which stays reserved for PubMed efetch / CrossRef (structured family fields). This mirrors what a portal's second index actually does: confirm the work exists, not adjudicate every co-author surname.

## Verification

- Live smoke: the two NeurIPS refs that CrossRef missed → now `OK` via OpenAlex; a fabricated first author on the same title → still `MISMATCH`.
- Regression: a DOI-resolved biomedical ref → resolved via CrossRef, OpenAlex **not** consulted (no extra call).
- Network-free regression test `tests/test_openalex_tier.sh` (monkeypatched `http_json`, 12 assertions) wired into CI as gate **A8b**.
- Existing `test_corporate_author.sh`, locale-inventory, catalog-consistency, and `validate_skills.sh` (PII) all pass. Integrity-detector count unchanged (27); storefront catalog untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)