### PR TITLE
feat(panel): poolability probe (P11) + editor per-reviewer signal + prior-art check

### DIFF
--- a/skills/peer-review/references/domain-probes/sr_ma.md
+++ b/skills/peer-review/references/domain-probes/sr_ma.md
@@ -6,9 +6,9 @@
        - self-review: Anticipated Major / Minor Comments (Fatal / Fixable) mapped to category letters.
      Do NOT edit one copy only — run `python3 scripts/check_domain_probe_sync.py --sync`. -->
 
-# Systematic Review / Meta-Analysis probes (P0–P10)
+# Systematic Review / Meta-Analysis probes (P0–P11)
 
-Internal-consistency-first gate (P0) plus a 10-probe checklist (P1–P10). These probes complement (do not replace) the generic Phase 2 issue checklist.
+Internal-consistency-first gate (P0) plus an 11-probe checklist (P1–P11). These probes complement (do not replace) the generic Phase 2 issue checklist.
 
 **P0 — Internal-consistency-first gate (run before P1; gates any fabrication claim)**:
 - Before alleging fabrication on a manuscript that "feels AI-generated", reproduce the headline pooled statistics, paired study counts (k), and subgroup counts directly from the extracted data table (or supplement included-studies table).
@@ -71,6 +71,12 @@ Internal-consistency-first gate (P0) plus a 10-probe checklist (P1–P10). These
 **P10 — Citation-metadata confusion class (over-escalation guard)**:
 - DOI-suffix digits that surface as an apparent article number (e.g., a DOI tail "77196" against article number 26068, or "60466-1" against 6274) are cosmetic metadata confusion, **not** fabrication — do not escalate them as fabricated references.
 - Reference-list duplicates are handled by `/verify-refs` (`duplicate_findings[]`); AI-disclosure presence is the cross-cutting P8 check. Neither is unique to SR/MA.
+
+**P11 — Poolability / construct-validity gate (does this synthesis hold at all?)**:
+- Before refining cell-level extraction (P0/P1), ask the higher-altitude question the forensic layer skips: are the pooled studies answering the *same clinical question* on *comparable populations / index tests / reference standards*, such that combining them into one estimate is meaningful?
+- Check that the quality / risk-of-bias instrument is valid for the included *study/model class* (e.g., a radiomics-specific QA tool applied to deep-learning studies; METRICS vs CLAIM / PROBAST mismatch). An instrument applied outside its intended class invalidates the RoB synthesis.
+- When k is small and P2 non-independence reduces the independent-cohort count further (e.g., k=6 → k≈4 after overlap), quantitative pooling itself may be inappropriate → a systematic review with **descriptive synthesis** is the correct form, not a forced meta-analytic pool (and not merely a sensitivity analysis layered on top).
+- This is an **unfixable-in-current-form** defect when present: cell-level re-extraction cannot rescue a synthesis that should not have been pooled. Let it dominate the severity tier over fixable extraction/reporting defects — strong cell-level forensics must not set a lenient tier when the synthesis itself is invalid.
 
 **Output template (P1 cell-swap example)**:
 > "I spot-checked [Author Year] (PMID [...]) against the source paper and found that the values in Figure X are swapped. The source paper reports external-test sensitivity A% / specificity B% (n=N); the manuscript forest entries place [num1/denom1] in the sensitivity slot (which is the source's specificity numerator/denominator) and [num2/denom2] in the specificity slot (which is the source's sensitivity)."

--- a/skills/self-review/references/domain-probes/sr_ma.md
+++ b/skills/self-review/references/domain-probes/sr_ma.md
@@ -6,9 +6,9 @@
        - self-review: Anticipated Major / Minor Comments (Fatal / Fixable) mapped to category letters.
      Do NOT edit one copy only — run `python3 scripts/check_domain_probe_sync.py --sync`. -->
 
-# Systematic Review / Meta-Analysis probes (P0–P10)
+# Systematic Review / Meta-Analysis probes (P0–P11)
 
-Internal-consistency-first gate (P0) plus a 10-probe checklist (P1–P10). These probes complement (do not replace) the generic Phase 2 issue checklist.
+Internal-consistency-first gate (P0) plus an 11-probe checklist (P1–P11). These probes complement (do not replace) the generic Phase 2 issue checklist.
 
 **P0 — Internal-consistency-first gate (run before P1; gates any fabrication claim)**:
 - Before alleging fabrication on a manuscript that "feels AI-generated", reproduce the headline pooled statistics, paired study counts (k), and subgroup counts directly from the extracted data table (or supplement included-studies table).
@@ -71,6 +71,12 @@ Internal-consistency-first gate (P0) plus a 10-probe checklist (P1–P10). These
 **P10 — Citation-metadata confusion class (over-escalation guard)**:
 - DOI-suffix digits that surface as an apparent article number (e.g., a DOI tail "77196" against article number 26068, or "60466-1" against 6274) are cosmetic metadata confusion, **not** fabrication — do not escalate them as fabricated references.
 - Reference-list duplicates are handled by `/verify-refs` (`duplicate_findings[]`); AI-disclosure presence is the cross-cutting P8 check. Neither is unique to SR/MA.
+
+**P11 — Poolability / construct-validity gate (does this synthesis hold at all?)**:
+- Before refining cell-level extraction (P0/P1), ask the higher-altitude question the forensic layer skips: are the pooled studies answering the *same clinical question* on *comparable populations / index tests / reference standards*, such that combining them into one estimate is meaningful?
+- Check that the quality / risk-of-bias instrument is valid for the included *study/model class* (e.g., a radiomics-specific QA tool applied to deep-learning studies; METRICS vs CLAIM / PROBAST mismatch). An instrument applied outside its intended class invalidates the RoB synthesis.
+- When k is small and P2 non-independence reduces the independent-cohort count further (e.g., k=6 → k≈4 after overlap), quantitative pooling itself may be inappropriate → a systematic review with **descriptive synthesis** is the correct form, not a forced meta-analytic pool (and not merely a sensitivity analysis layered on top).
+- This is an **unfixable-in-current-form** defect when present: cell-level re-extraction cannot rescue a synthesis that should not have been pooled. Let it dominate the severity tier over fixable extraction/reporting defects — strong cell-level forensics must not set a lenient tier when the synthesis itself is invalid.
 
 **Output template (P1 cell-swap example)**:
 > "I spot-checked [Author Year] (PMID [...]) against the source paper and found that the values in Figure X are swapped. The source paper reports external-test sensitivity A% / specificity B% (n=N); the manuscript forest entries place [num1/denom1] in the sensitivity slot (which is the source's specificity numerator/denominator) and [num2/denom2] in the specificity slot (which is the source's sensitivity)."

--- a/skills/self-review/references/panel_review_template.md
+++ b/skills/self-review/references/panel_review_template.md
@@ -104,6 +104,7 @@ design-level finding, **Fixable** for a reporting-level finding.
 - Transportability: cross-domain failure framed as success; negative R² read as a weak metric.
 - Multiplicity across model × threshold / cohort grids; small-cohort bootstrap intervals.
 - Leakage (patient-level vs image-level splits); calibration beyond discrimination.
+- Prior-art / dual-publication (salami): does the contribution duplicate a findable prior paper (same dataset size / architecture / metric values, delta-only)? An undisclosed near-duplicate is a contribution killer — check prior art, do not assume novelty.
 
 **Clinical translation / reference standard**
 - Reference-standard validity and verification bias.
@@ -138,13 +139,24 @@ design-level finding, **Fixable** for a reporting-level finding.
 > Read enough of the manuscript to adjudicate conflicts and weigh severity yourself.
 > Then:
 > 1. Reach an internal readiness decision and state the rationale honestly. (This sets
->    the Phase 3c verdict / score; it is not a journal recommendation to print.)
+>    the Phase 3c verdict / score; it is not a journal recommendation to print.) Run BOTH
+>    lenses before settling the tier: the measurement/design lens AND a contribution/priority
+>    lens (is the value and the novelty actually there?). A measurement-only read is the
+>    classic cause of a too-lenient verdict. When an **unfixable-in-current-form** defect is
+>    present — invalid poolability/construct validity, irrecoverable leakage/circularity, an
+>    undisclosed near-identical prior publication, or (for a review/primer) weak novelty /
+>    no distinct contribution since the contribution IS the product — let it dominate the
+>    tier over fixable reporting defects rather than letting the fixable framing soften it.
 > 2. De-duplicate and consolidate the major comments by theme. For each consolidated
 >    point, flag CONSENSUS (raised by ≥2 reviewers) or single-reviewer, and attribute
 >    (R1/R2/R3).
 > 3. List the top priority pre-submission actions, ranked and concrete.
 > 4. Give an honest readiness verdict: ready for the target tier now, fix specific
 >    items first, or consider a different tier.
+> 5. Rate each reviewer's contribution as high-signal / mixed / low-signal with one
+>    reason (which of their findings survived consolidation; their signal-to-noise; any
+>    whole-axis they uniquely covered). This makes the per-lens contribution explicit
+>    rather than implicit in the attribution.
 >
 > Map every finding onto the self-review framing (Fatal / Fixable, category letters
 > A–K) and emit it through the Phase 3 report, Phase 3b R0 numbering, and Phase 3c


### PR DESCRIPTION
## Summary
Three panel-mode review enhancements distilled from a retrospective calibration pass over past reviewer-side decision audits (all generalized, no manuscript identifiers).

- **sr_ma.md — new P11 poolability / construct-validity gate.** Forces the higher-altitude "does this synthesis hold at all?" question (same clinical question? QA/RoB instrument valid for the study/model class? small-k + cohort overlap → descriptive synthesis, not a forced pool). Marked unfixable-in-current-form so it dominates the severity tier over fixable extraction defects. Vendored byte-identical across `/peer-review` (canonical) and `/self-review`.
- **panel_review_template.md — editor synthesis.** Editor now runs BOTH the measurement/design lens AND a contribution/priority lens before settling the tier, and lets unfixable defects (poolability, leakage, undisclosed near-identical prior publication, weak-novelty-for-reviews) dominate. New step 5: rate each reviewer high/mixed/low-signal with one reason (makes per-lens contribution explicit).
- **panel_review_template.md — ML/Statistics focus checklist.** Add prior-art / dual-publication (salami) check: does the contribution duplicate a findable prior paper (same dataset/architecture/metrics, delta-only)?

## Motivation
Recurring patterns across past review calibration audits: (1) strong cell-level forensics but under-weighted poolability/construct validity; (2) measurement-only editor reads producing too-lenient verdicts when an unfixable defect was present; (3) a missed undisclosed near-duplicate prior publication.

## Validation
- `validate_skills.sh` — ALL CHECKS PASSED (incl. PII scan)
- `check_domain_probe_sync.py` — 11 modules byte-identical across both skills
- `check_locale_inventory.py` — OK
- `validate_catalog_consistency.py` — OK (no skill/detector count change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)