### PR TITLE
test: CI-wire 10 skill regression tests + new deidentify PHI-scan contract

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Python deps for contract validator
-        run: pip install pyyaml
+      - name: Install Python test dependencies
+        run: pip install pyyaml pandas numpy python-pptx python-docx
 
       - name: Install exiftool + poppler (EXIF scan + check_asset_anonymization PDF text/metadata)
         run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl poppler-utils
@@ -123,8 +123,36 @@ jobs:
       - name: Run author-strategy archetype-classifier test (A14)
         run: bash skills/author-strategy/tests/test_archetype_classifier.sh
 
-      - name: Install pandas (demo manifest verification)
-        run: pip install pandas
+      # --- Tier 0/1 skill regression tests (existing + new, now CI-wired) ---
+      - name: Run make-figures legend-reconcile test
+        run: bash skills/make-figures/tests/test_legend_reconcile.sh
+
+      - name: Run clean-data structural-zero test
+        run: bash skills/clean-data/tests/test_structural_zero.sh
+
+      - name: Run lit-sync poll-logic test
+        run: bash skills/lit-sync/tests/test_poll_logic.sh
+
+      - name: Run meta-analysis pool-consistency test
+        run: bash skills/meta-analysis/tests/test_pool_consistency.sh
+
+      - name: Run generate-codebook test
+        run: bash skills/generate-codebook/tests/test_generate_codebook.sh
+
+      - name: Run present-paper speaker-notes markdown test
+        run: python3 skills/present-paper/tests/test_speaker_notes_markdown.py
+
+      - name: Run version-dataset manifest/verify test
+        run: bash skills/version-dataset/tests/test_version_dataset.sh
+
+      - name: Run manage-refs vN-docx cross-reference test
+        run: bash skills/manage-refs/tests/test_vN_docx_check.sh
+
+      - name: Run polish-language consistency-linter challenge
+        run: bash skills/polish-language/scripts/lint_challenge/verify.sh
+
+      - name: Run deidentify PHI-scan contract test
+        run: bash skills/deidentify/tests/test_deidentify_scan.sh
 
       - name: Verify demo manifest.lock files (reproducibility lock)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Test backfill — Tier 0 CI-wiring + `deidentify` PHI-scan regression test.** Ten skill regression tests that existed on disk but were never gated are now wired into `.github/workflows/validate.yml`, so a silent break fails CI: `make-figures` (legend reconcile), `clean-data` (structural-zero), `lit-sync` (poll logic), `meta-analysis` (pool consistency), `generate-codebook`, `present-paper` (speaker-notes markdown), `version-dataset` (manifest/verify), `manage-refs` (vN-docx cross-ref), and `polish-language` (consistency-linter challenge). New `skills/deidentify/tests/test_deidentify_scan.sh` asserts the exact PHI-classification contract (PHI/REVIEW_NEEDED/SAFE counts + `rrn` phi_type) on the three committed fixtures — the CSV scan path is stdlib-only and network-free, and the test file is Hangul-free (column-specific asserts read the fixture header at runtime). CI now installs pandas/numpy/python-pptx/python-docx up front (was: pandas installed after the gates, which would silently skip the dep-guarded tests); `version-dataset` gains a pandas skip-guard for local robustness. No skill/version change — test infrastructure only.
+
 ## [4.4.0] - 2026-06-20
 
 ### Added

--- a/skills/deidentify/tests/test_deidentify_scan.sh
+++ b/skills/deidentify/tests/test_deidentify_scan.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression test for the PHI scanner (deidentify.py scan).
+# Asserts the exact classification contract on three committed CSV fixtures so a
+# silent break in PHI detection -- which would leak patient data -- fails CI.
+# CSV scan path is stdlib-only (openpyxl is a lazy import for .xlsx only),
+# so this test needs no third-party deps and makes no network calls.
+#
+# This shell file contains NO Hangul (keeps clear of the locale-inventory gate).
+# Column-specific assertions read the fixture header at runtime and address
+# columns positionally; the Korean data itself lives only in the fixture CSVs.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL="$HERE/.."
+SCRIPT="$SKILL/deidentify.py"
+OUTDIR="$(mktemp -d -t deid_XXXX)"
+trap 'rm -rf "$OUTDIR"' EXIT
+
+fail=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: deidentify.py missing" >&2; exit 2; }
+for fx in test_phi_korean test_clean test_edge_cases; do
+    [[ -f "$HERE/$fx.csv" ]] || { echo "ENV-ERR: fixture $fx.csv missing" >&2; exit 2; }
+done
+
+# Counts a classification class in a scan_report.json.
+# usage: count <report.json> <PHI|REVIEW_NEEDED|SAFE>
+COUNTER='
+import json,sys
+d=json.load(open(sys.argv[1]))
+from collections import Counter
+c=Counter(x["classification"] for x in d["classifications"])
+print(c.get(sys.argv[2],0))'
+count() { python3 -c "$COUNTER" "$1" "$2"; }
+
+# --- Fixture 1: Korean PHI (10 columns) -> PHI=7, REVIEW_NEEDED=0, SAFE=3 ---
+python3 "$SCRIPT" scan "$HERE/test_phi_korean.csv" --locale kr -o "$OUTDIR" >/dev/null 2>&1
+PHI_REPORT="$OUTDIR/scan_report.json"
+check "phi fixture: report written"      test -s "$PHI_REPORT"
+check "phi fixture: PHI == 7"             test "$(count "$PHI_REPORT" PHI)"           -eq 7
+check "phi fixture: REVIEW_NEEDED == 0"   test "$(count "$PHI_REPORT" REVIEW_NEEDED)" -eq 0
+check "phi fixture: SAFE == 3"            test "$(count "$PHI_REPORT" SAFE)"          -eq 3
+
+# Exactly one column has phi_type 'rrn' (resident-registration-number) -> PHI.
+check "phi fixture: rrn column is PHI/rrn" python3 -c "
+import json
+d=json.load(open('$PHI_REPORT'))
+rrn=[x for x in d['classifications'] if x.get('phi_type')=='rrn']
+assert len(rrn)==1, rrn
+assert rrn[0]['classification']=='PHI', rrn[0]"
+
+# Header positions 7 (diagnosis) and 8 (measurement) must be SAFE.
+# Read the header from the fixture so this file stays Hangul-free.
+check "phi fixture: diagnosis + measurement (cols 7,8) are SAFE" python3 -c "
+import json,csv
+d=json.load(open('$PHI_REPORT'))
+with open('$HERE/test_phi_korean.csv', encoding='utf-8') as f:
+    hdr=next(csv.reader(f))
+cl={x['column']: x['classification'] for x in d['classifications']}
+for i in (7, 8):
+    assert cl.get(hdr[i])=='SAFE', (i, hdr[i], cl.get(hdr[i]))"
+
+# --- Fixture 2: clean (no PHI) -> PHI == 0 (false-positive guard) ---
+python3 "$SCRIPT" scan "$HERE/test_clean.csv" --locale kr -o "$OUTDIR" >/dev/null 2>&1
+CLEAN_REPORT="$OUTDIR/scan_report.json"
+check "clean fixture: PHI == 0" test "$(count "$CLEAN_REPORT" PHI)" -eq 0
+
+# --- Fixture 3: edge cases -> REVIEW_NEEDED=1, SAFE=5 (no crash, fixed contract) ---
+python3 "$SCRIPT" scan "$HERE/test_edge_cases.csv" --locale kr -o "$OUTDIR" >/dev/null 2>&1
+check "edge fixture: exit 0 (no crash)" test "$?" -eq 0
+EDGE_REPORT="$OUTDIR/scan_report.json"
+check "edge fixture: REVIEW_NEEDED == 1" test "$(count "$EDGE_REPORT" REVIEW_NEEDED)" -eq 1
+check "edge fixture: SAFE == 5"          test "$(count "$EDGE_REPORT" SAFE)"          -eq 5
+
+echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"

--- a/skills/version-dataset/tests/test_version_dataset.sh
+++ b/skills/version-dataset/tests/test_version_dataset.sh
@@ -11,6 +11,10 @@ trap 'rm -rf "$TMP"' EXIT
 
 [[ -f "$VS" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
 
+# CSV manifest build goes through pandas (column-level value hashing); skip
+# cleanly when pandas is absent. CI installs it before this gate runs.
+python3 -c "import pandas" 2>/dev/null || { echo "SKIP: pandas unavailable"; exit 0; }
+
 fail=0; ran=0
 check() {
     local label="$1" expected="$2" actual="$3"


### PR DESCRIPTION
## What

Backfills test coverage along the **coverage-evenness** dimension: ten skill regression tests existed on disk but were never gated, and `deidentify` (PHI detection) had fixtures but no test.

### CI-wired (existing tests, now fail CI on breakage)
`make-figures` · `clean-data` · `lit-sync` · `meta-analysis` · `generate-codebook` · `present-paper` · `version-dataset` · `manage-refs` · `polish-language` (consistency-linter challenge)

### New
`skills/deidentify/tests/test_deidentify_scan.sh` — asserts the exact PHI-classification contract on the three committed fixtures:
- Korean PHI fixture → `PHI=7, REVIEW_NEEDED=0, SAFE=3`; resident-registration column is `PHI`/`rrn`; diagnosis + measurement columns `SAFE`
- clean fixture → `PHI=0` (false-positive guard)
- edge fixture → `REVIEW_NEEDED=1, SAFE=5` (no crash)

CSV scan path is **stdlib-only** and **network-free**; the test file is **Hangul-free** (column-specific asserts read the fixture header at runtime), so it does not add to the locale inventory.

### CI deps
`pip install` now front-loads `pandas numpy python-pptx python-docx` (previously pandas was installed *after* the gate block, which would silently skip the dep-guarded tests → nominal-only CI promotion). Removed the now-redundant late `Install pandas` step. Added a pandas skip-guard to the `version-dataset` test for local robustness.

## Verification (local CI mirror)
- All 10 wired tests pass
- `check_locale_inventory.py` OK (test file Hangul-free; inventory unchanged)
- `validate_skills.sh` ALL CHECKS PASSED
- YAML lint OK
- PII grep clean

No skill/version change — test infrastructure only (CHANGELOG `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)