### PR TITLE
test(routing-assets): references/ pointer-gate regression test + load-model memo (v4.6.0 PR-1)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run validate_routing_assets.py (SKILL.md asset references must exist)
         run: python3 scripts/validate_routing_assets.py --strict
 
+      - name: Run validate_routing_assets.py self-test (dangling references/ pointer fails)
+        run: bash tests/test_routing_assets.sh
+
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 

--- a/docs/skill_references_load_model.md
+++ b/docs/skill_references_load_model.md
@@ -1,0 +1,69 @@
+# Skill `references/` load model + routing-asset gate
+
+A maintainer note that records two decisions for the v4.6.0 cleanup: (1) the
+`references/` load model that gates the `write-paper` Phase-7 extraction pilot,
+and (2) why the routing-asset gate scans the `${CLAUDE_SKILL_DIR}/`-prefixed form
+and **not** bare `references/...` paths.
+
+## 1. Load model — extraction reduces per-invocation context
+
+In the Agent Skills model, a skill's `SKILL.md` **body** is loaded into context
+when the skill is invoked, while files under `references/` are read **on demand**
+— only when the `SKILL.md` instructs the agent to read them. The repo's own
+convention confirms this: reference files are introduced as
+`${CLAUDE_SKILL_DIR}/references/<file>` with "read it before X" phrasing
+(e.g. `skills/revise/SKILL.md`, `skills/humanize/SKILL.md`), i.e. they are not
+assumed already-present, they are fetched when needed.
+
+Consequence for the token diet:
+
+- The always-on routing cost (a skill's frontmatter `description`) is **unchanged**
+  by extraction.
+- The per-invocation cost (the loaded `SKILL.md` body) **shrinks** when large,
+  conditionally-needed prose moves into `references/` that is read only when that
+  phase actually runs.
+
+So moving `write-paper` Phase 7 (~460 lines, only relevant during the final
+polish pass) into `references/` reduces what a `write-paper` invocation must carry
+up front. **Conclusion: the extraction pilot (A1) is worth doing.** The pilot
+should still measure the realized delta on `write-paper` before extending the
+pattern to other skills (A2/A3, deferred to v5.1).
+
+## 2. Routing-asset gate scans `${CLAUDE_SKILL_DIR}/...`, not bare `references/...`
+
+The extraction creates a new pointer from `SKILL.md` to an extracted
+`references/...` file. To catch a mistyped/dangling pointer,
+`scripts/validate_routing_assets.py` already validates every
+`${CLAUDE_SKILL_DIR}/<path>` asset reference (scan A) plus the `check-reporting`
+checklist bullets (scan B).
+
+A bare `references/<path>` existence scan was considered and **rejected** — an
+empirical scan of the live repo found 13 bare `references/...` mentions, **none of
+which are bundled-asset bugs**, in two categories a path-existence check cannot
+distinguish:
+
+- **Cross-skill references** — the path names *another* skill's `references/` dir,
+  not the current skill's: `humanize` → `revise`'s `r2r_voice.md`; `revise` →
+  `humanize`'s `ai_patterns.md`; `analyze-stats` → `make-figures`'
+  `exemplar_plots/*.md`; `calc-sample-size` → `analyze-stats`' `templates/`;
+  `write-paper` → `manage-refs`' `check_xref_symptoms.md`.
+- **Runtime project artifacts** — files the skill writes/reads in the *user's*
+  project workspace, not bundled in the repo: `references/library.bib`
+  (`search-lit` output), `references/zotero_collection.json` (`lit-sync` writes it
+  "in the project workspace"), `references/verified_references.tsv` (`verify-refs`
+  output).
+
+A bare-path existence gate would red CI on all 13 — exactly the false-positive
+risk the plan flagged. **Decision:** rely on the unambiguous
+`${CLAUDE_SKILL_DIR}/references/<file>` form (scan A) and require extraction
+pointers to use that prefix — which is already the repo convention. The only gap
+was that this gate had **no regression test**; PR-1 adds one
+(`tests/test_routing_assets.sh`).
+
+### Implication for the A1 extraction
+
+Write the Phase-7 pointers as
+`${CLAUDE_SKILL_DIR}/references/phase7_integrity_audits.md` and
+`${CLAUDE_SKILL_DIR}/references/phase7_docx_build.md` so scan A validates them. A
+dangling pointer then fails `validate_routing_assets.py --strict` (covered by the
+new test).

--- a/tests/test_routing_assets.sh
+++ b/tests/test_routing_assets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression test for scripts/validate_routing_assets.py — the gate that guards
+# extracted references/ pointers (see docs/skill_references_load_model.md).
+# Confirms a valid ${CLAUDE_SKILL_DIR}/references/... pointer passes and a
+# dangling one fails under --strict. This is the coverage the validator lacked.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+V="$REPO_ROOT/scripts/validate_routing_assets.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-46s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-46s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# 1) a valid ${CLAUDE_SKILL_DIR}/references/... pointer -> exit 0
+mkdir -p "$TMP/good/references"
+printf 'Body. See ${CLAUDE_SKILL_DIR}/references/exists.md before drafting.\n' > "$TMP/good/SKILL.md"
+echo "ok" > "$TMP/good/references/exists.md"
+python3 "$V" --strict --scan "$TMP/good/SKILL.md" > /dev/null 2>&1
+ck "valid references/ pointer passes" 0 "$?"
+
+# 2) a dangling pointer -> exit 1 under --strict
+mkdir -p "$TMP/bad"
+printf 'Body. See ${CLAUDE_SKILL_DIR}/references/missing.md before drafting.\n' > "$TMP/bad/SKILL.md"
+python3 "$V" --strict --scan "$TMP/bad/SKILL.md" > /dev/null 2>&1
+ck "dangling references/ pointer fails (--strict)" 1 "$?"
+
+# 3) the same dangling pointer is reported but tolerated without --strict
+python3 "$V" --scan "$TMP/bad/SKILL.md" > /dev/null 2>&1
+ck "dangling pointer tolerated without --strict" 0 "$?"
+
+# 4) the live repo's routing assets must be clean (the CI invariant)
+python3 "$V" --strict > /dev/null 2>&1
+ck "live repo routing assets clean" 0 "$?"
+
+echo "----"
+echo "test_routing_assets: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
**v4.6.0 roadmap PR-1 of 7** — workstream A (cleanup), items A0 + A8. Foundational safety gate; lands before the Phase-7 extraction pilot (PR-4).

## What

- **A0 — `docs/skill_references_load_model.md`**: records that Agent Skills load the `SKILL.md` body on invocation and read `references/` on demand, so extracting conditionally-needed prose (e.g. `write-paper` Phase 7) into `references/` reduces per-invocation context. Conclusion: the extraction pilot is worth doing (still measure the realized delta before extending the pattern).
- **A8 — `tests/test_routing_assets.sh`**: the regression test `validate_routing_assets.py` lacked. A valid `${CLAUDE_SKILL_DIR}/references/...` pointer passes; a dangling one fails under `--strict`; a dangling one is tolerated without `--strict`; the live repo is clean. Wired into `validate.yml`.

## Why not a bare `references/...` scan

The plan originally proposed scanning bare `references/...` links. An empirical scan of the live repo found **13** bare `references/...` mentions, **none of which are bundled-asset bugs**:
- **cross-skill refs** (`humanize`→`revise`'s `r2r_voice.md`; `analyze-stats`→`make-figures`' `exemplar_plots/*`; `revise`→`humanize`'s `ai_patterns.md`; `write-paper`→`manage-refs`' `check_xref_symptoms.md`; `calc-sample-size`→`analyze-stats`' `templates/`), and
- **runtime project artifacts** (`library.bib`, `zotero_collection.json`, `verified_references.tsv`) the skill writes/reads in the *user's* workspace.

A path-existence check can't distinguish these and would red CI — the exact false-positive risk the plan flagged. So PR-1 relies on the unambiguous `${CLAUDE_SKILL_DIR}/references/...` form (already the repo convention) and adds the missing test instead.

## Verification
- `bash tests/test_routing_assets.sh` → 4/4 pass
- `python3 scripts/validate_routing_assets.py --strict` → clean
- `validate_skills.sh`, `check_locale_inventory.py`, `validate_catalog_consistency.py`, YAML lint → pass

No skill / reporting-guideline / detector count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)