### PR TITLE
docs(governance): ROADMAP/MAINTAINERS/SECURITY + AEO FAQ + README answer-block/workflows/validation-status (v4.6.0 PR-5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/detector_request.yml
+++ b/.github/ISSUE_TEMPLATE/detector_request.yml
@@ -1,0 +1,55 @@
+name: Detector request
+description: Propose a new deterministic integrity detector (a check that should not rely on model judgment)
+title: "[detector] <short name>"
+labels: ["enhancement", "detector"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a detector. A detector is a **deterministic, stdlib-only
+        check** (same input, same verdict, no model in the decision path) that catches
+        a fabricated, drifted, or non-compliant pattern before review — see
+        [`MEDSCI_AUDIT.md`](../../MEDSCI_AUDIT.md). The strongest proposals come from a
+        real failure that a deterministic rule would have caught. Keep examples
+        public/synthetic.
+  - type: textarea
+    id: failure
+    attributes:
+      label: What failure should it catch?
+      description: The concrete defect (e.g. "a reported incidence rate that exceeds its person-time") and, ideally, a real cycle where it bit.
+      placeholder: "Symptom: ... | Why no existing check catches it: ..."
+    validations:
+      required: true
+  - type: textarea
+    id: rule
+    attributes:
+      label: Proposed deterministic rule
+      description: How would a script decide pass/fail from the inputs, with no model judgment?
+      placeholder: "Inputs: ... | Verdict logic: ... | What is a hard blocker vs an advisory warning?"
+    validations:
+      required: true
+  - type: input
+    id: owner-skill
+    attributes:
+      label: Which skill should own it?
+      description: The detector lives under that skill's scripts/ (e.g. sync-submission, self-review, check-reporting).
+      placeholder: "e.g. sync-submission"
+    validations:
+      required: true
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Are you willing to open a pull request?
+      options:
+        - "Yes, I can draft the detector + challenge test"
+        - "Maybe, with guidance"
+        - "No, requesting only"
+    validations:
+      required: true
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Public-repo hygiene
+      options:
+        - label: This request contains no PHI, real names, manuscript IDs, project codes, or institution-specific details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/installation_problem.yml
+++ b/.github/ISSUE_TEMPLATE/installation_problem.yml
@@ -1,0 +1,61 @@
+name: Installation problem
+description: Report a problem installing or running MedSci Skills
+title: "[install] <short summary>"
+labels: ["installation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please include enough detail to reproduce. Keep
+        everything public/synthetic — no real names, manuscript IDs, institution
+        context, or private absolute paths (redact home directories).
+  - type: dropdown
+    id: method
+    attributes:
+      label: Install method
+      options:
+        - Claude Code plugin (marketplace)
+        - install.py (manual, all skills)
+        - npm / npx
+        - Individual skill copy
+        - Other (explain below)
+    validations:
+      required: true
+  - type: input
+    id: host
+    attributes:
+      label: Host / environment
+      description: Host app (Claude Code / Codex / Cursor / Copilot) + OS.
+      placeholder: "e.g. Claude Code on macOS 15"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: MedSci Skills version
+      description: Release tag or commit (see the README badge / CITATION.cff).
+      placeholder: "e.g. v4.6.0"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: What you did and what happened
+      description: Exact command(s), expected result, and the actual error output (redact private paths).
+      placeholder: "Command: ... | Expected: ... | Got: ..."
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: Output of `/setup-medsci` or `python3 --version` / `node --version` if relevant.
+    validations:
+      required: false
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Public-repo hygiene
+      options:
+        - label: This report contains no PHI, real names, manuscript IDs, project codes, or unredacted private paths.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,3 +38,8 @@ See CONTRIBUTING.md for the full workflow and PII/publication hygiene rules.
 - [ ] New scripts include a short usage example and deterministic expected behavior.
 - [ ] The skill documentation states when the skill should **not** be used.
 - [ ] Public-facing copy is suitable for an open-source repository.
+
+## Medical claims & classification
+
+- [ ] No unsupported medical claims. If this PR changes a medical/research claim, it needs founder / Clinical-Lead review (see `MAINTAINERS.md`), and the change only makes the claim **more** cautious/accurate/scoped.
+- [ ] Classification: this is an **official** / **experimental** / **community** change (delete as appropriate).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Per-skill documentation under `docs/skills/` is **generated** from each `skills/
 - [ ] New scripts have a short usage example and deterministic expected behavior.
 - [ ] Documentation states when the skill should not be used.
 - [ ] Public-facing copy is suitable for an open-source repository.
+- [ ] **Does this PR change a medical/research claim?** If yes, it needs founder / Clinical-Lead review (see [`MAINTAINERS.md`](MAINTAINERS.md)). Only make such claims **more** cautious, accurate, or clearly scoped — never broader.
+- [ ] **Status declared** — is this an *official* (founder-approved, documented, tested), *experimental* (useful but not fully tested), or *community* (external, not founder-validated) contribution?
 
 ## PII and Publication Hygiene
 

--- a/IMPACT.md
+++ b/IMPACT.md
@@ -31,7 +31,19 @@ How the numbers are captured:
 
 Trend over time lives in [`metrics/traffic_log.csv`](metrics/traffic_log.csv); a
 star-history chart is available at
-[star-history.com](https://star-history.com/#Aperivue/medsci-skills&Date).
+[star-history.com](https://star-history.com/#Aperivue/medsci-skills&Date). The
+Snapshot block is a point-in-time capture; the live figures are in the traffic log.
+
+## Interpretation of metrics
+
+These numbers are read conservatively, because most of them measure *interest*, not
+confirmed use:
+
+- **Stars** indicate interest, not confirmed use.
+- **Forks** may indicate experimentation or reuse — a somewhat stronger signal than a star.
+- **Clones / downloads** are inflated by CI and mirroring traffic; the *unique* columns are more meaningful.
+- **Confirmed use cases and academic citations** are the strongest evidence, and are scarcer than raw stars.
+- **Current status: early community interest for a niche biomedical-workflow repository — not widespread adoption.** This page never claims adoption that has not been observed; a thin section is a truthful section.
 
 ---
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,63 @@
+# Maintainers
+
+MedSci Skills is a physician-built toolkit. Its value comes from real
+manuscript-writing, submission, reviewer-feedback, and revision experience, so the
+roles below deliberately separate **clinical/research authority** (which stays with
+the founder) from **technical maintenance** (which can be shared).
+
+## Roles
+
+### Founder / Clinical Lead
+
+Final authority on everything that touches clinical or research validity:
+
+- the project's clinical/research **scope** (what the toolkit does and does not do);
+- inclusion of an **official** skill, detector, probe, or reporting checklist;
+- any **medical / research claim** in the docs or skill content;
+- interpretation of **benchmark / evaluation** results;
+- the final **release** approval.
+
+External contributors do **not** add unsupported medical claims independently;
+those changes require Clinical Lead review.
+
+### Technical Maintainer (role, may be shared in future)
+
+Maintains the engineering surface, but not the clinical validity of content:
+
+- PR hygiene and review structure; CI; issue triage;
+- documentation consistency, changelog, release-note drafting;
+- version synchronization (`package.json` / `CITATION.cff` / release tag / catalog
+  counts) and packaging/release automation;
+- non-medical documentation cleanup.
+
+### Clinical Reviewers (optional, future)
+
+Domain experts who review specific skills, detectors, or reporting content. An
+optional role to grow review capacity without expanding merge rights.
+
+### Community Contributors
+
+Anyone opening issues, examples, or pull requests. Contributions follow
+[`CONTRIBUTING.md`](CONTRIBUTING.md); they must not introduce unsupported medical
+claims, PHI, or private manuscript content.
+
+## Decision rule
+
+If a change affects **clinical/research scope, an official-skill decision, a
+medical/research claim, or a benchmark interpretation**, it needs Clinical Lead
+sign-off. Everything else (CI, docs, packaging, refactors, test coverage) is
+ordinary technical maintenance.
+
+## Permission ramp for a future part-time technical maintainer
+
+To onboard help safely, merge rights expand with demonstrated trust — not all at
+once. The detailed ramp lives in
+[`docs/maintainer_workflow.md`](docs/maintainer_workflow.md); in brief: triage →
+docs-only merges → non-medical merges, with the founder retaining final release
+approval throughout.
+
+## Current
+
+- **Founder / Clinical Lead:** Yoojin Nam, MD ([ORCID 0000-0001-8565-1360](https://orcid.org/0000-0001-8565-1360)).
+- **Technical Maintainer:** the founder, currently; the role is documented so it
+  can be shared.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@
 
 ---
 
+## What is MedSci Skills?
+
+MedSci Skills is an open-source Claude Code skill collection for **clinical
+manuscript preparation**. It helps physician-researchers and biomedical
+investigators move from literature search, study design, statistics, and figures to
+reporting-guideline compliance, citation/reference auditing, numerical-consistency
+checks, and response-to-reviewer workflows — combining agentic writing with
+**deterministic integrity gates** for submission-grade biomedical research. It is
+**not** a diagnostic tool, an autonomous author, or a general AI-scientist platform;
+every output requires human-expert verification. New here? See the
+[3 workflows below](#start-here-3-workflows), the [FAQ](docs/faq.md), and the
+[scope boundary](ROADMAP.md#not-planned--explicitly-out-of-scope).
+
+---
+
 ## Quick Start
 
 **No terminal?** Use the classroom installer ZIP — download, unzip, double-click the installer, then restart your agent app (see [Installation](#installation)).
@@ -90,9 +105,37 @@ All eight plugins share the same repository source, so this groups and enables s
 **Want just one capability?** Two skills are also published as focused standalone repos (generated mirrors; this repo stays the source of truth), each installable on its own with `/plugin marketplace add Aperivue/<repo>`:
 
 - [`Aperivue/verify-refs`](https://github.com/Aperivue/verify-refs) — catch fabricated/mismatched citations (PubMed + CrossRef).
-- [`Aperivue/check-reporting`](https://github.com/Aperivue/check-reporting) — audit a manuscript against 32 EQUATOR reporting guidelines.
+- [`Aperivue/check-reporting`](https://github.com/Aperivue/check-reporting) — audit a manuscript against the bundled EQUATOR reporting guidelines and risk-of-bias tools.
 
 ---
+
+## Start here: 3 workflows
+
+New users don't need all the skills at once. Most work starts as one of three
+workflows. Each runs through `/orchestrate` or by invoking the named skills in
+order; all outputs require human-expert review.
+
+**Workflow A — Manuscript pre-submission audit.** *Use when* a manuscript is nearly
+ready and you want it checked before a reviewer sees it. *Skills:* `/self-review` →
+`/check-reporting` → `/verify-refs` → `/sync-submission`. *In:* your manuscript
+(+ `refs.bib`, tables/figures). *Out:* anticipated reviewer comments, an item-by-item
+reporting-guideline audit, a citation-integrity report, and a submission-package
+drift check. *Safety:* it flags issues; you fix and verify them.
+
+**Workflow B — Data to manuscript package.** *Use when* you have a cleaned dataset
+and need a full draft. *Skills:* `/clean-data` → `/analyze-stats` → `/make-figures` →
+`/write-paper` → `/check-reporting` → `/find-journal`. *In:* a cleaned CSV/parquet
++ a research question. *Out:* reproducible analysis code, publication-ready figures,
+an IMRaD draft, a reporting checklist, and a journal shortlist. *Safety:* statistics
+and claims must be verified against your data; the toolkit never fabricates numbers
+or references.
+
+**Workflow C — Systematic review / meta-analysis.** *Use when* you are running an
+SR/MA. *Skills:* `/meta-analysis` (with `/search-lit`, `/make-figures`,
+`/check-reporting`). *In:* a research question + search strategy. *Out:* PROSPERO-style
+protocol scaffolding, screening/extraction structure, PRISMA-consistent counts and
+diagram, pooled-estimate figures, and a manuscript draft. *Safety:* screening and
+extraction decisions stay with the human review team.
 
 ## Live Demos: Three Study Types, Three Full Pipelines
 
@@ -515,6 +558,14 @@ Projects declare their source-of-truth layout in `SSOT.yaml`, and a `qc/migratio
 ### Skills Work Together
 Skills call each other. `check-reporting` invokes `make-figures` for PRISMA diagrams. `write-paper` calls `search-lit` for citation verification. `self-review` delegates reporting compliance to `check-reporting`. `calc-sample-size` output feeds directly into `write-protocol`'s IRB justification section.
 
+### Validation status — available vs CI-gated vs evaluated
+Be precise about what "validated" means here — the three tiers are different facts:
+- **Available** — every bundled skill and deterministic detector. The current totals are the single source of truth in [`metadata/catalog_counts.json`](metadata/catalog_counts.json) and [`MEDSCI_AUDIT.md`](MEDSCI_AUDIT.md).
+- **CI-gated** — detectors with a committed challenge/regression test that runs on every push via [`validate.yml`](.github/workflows/validate.yml).
+- **Formally evaluated** — the subset measured by the canonical evaluation harness **E1** in [`evaluation/`](evaluation/), which is v3.8-era and validates the then-current detector subset; detectors added since are **CI-tested, not yet E1-evaluated** (the size of the catalog and the size of the evaluated subset are deliberately reported as separate facts — see `MEDSCI_AUDIT.md`).
+
+The toolkit is *designed to reduce common manuscript-preparation errors*; it does **not** guarantee correctness and is **not** clinically validated.
+
 ## Setup
 
 **New to Python, R, or the command line?** The full step-by-step guide for clinicians is in [`docs/setup/`](docs/setup/README.md):
@@ -622,7 +673,14 @@ Every contribution is gated the same way the maintainers are: it must be a self-
 file, pass the CI (`validate.yml` — PII scan, structure, catalog consistency), and carry no
 patient or author identifiers. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the PR checklist
 and the PII/publication hygiene rules. New ideas that don't fit a template? Open a
-[skill request](https://github.com/Aperivue/medsci-skills/issues/new?template=skill_request.yml).
+[skill request](https://github.com/Aperivue/medsci-skills/issues/new?template=skill_request.yml)
+or a [detector request](https://github.com/Aperivue/medsci-skills/issues/new?template=detector_request.yml).
+
+**Governance:** [`ROADMAP.md`](ROADMAP.md) (priorities + scope boundary),
+[`MAINTAINERS.md`](MAINTAINERS.md) (roles — clinical authority stays with the founder),
+[`docs/maintainer_workflow.md`](docs/maintainer_workflow.md) (review + release process),
+and [`SECURITY.md`](SECURITY.md) (vulnerability reporting + the medical-scope boundary).
+A change that touches a medical/research claim needs Clinical-Lead review.
 
 ## In the Wild
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,64 @@
+# Roadmap
+
+MedSci Skills is a physician-built, submission-grade clinical-manuscript workflow
+toolkit with deterministic integrity gates. This roadmap states what the project
+prioritizes and — just as important — what it deliberately will **not** become. It
+is a direction document, not a delivery commitment; priorities shift with real
+manuscript, review, and submission experience.
+
+See also [`docs/competitive_positioning.md`](docs/competitive_positioning.md) for
+where the toolkit sits relative to broad agent-skill catalogs, and
+[`README.md` § What This Is NOT](README.md) for the scope boundary.
+
+## Near-term priorities
+
+The work that keeps the toolkit trustworthy for real submissions:
+
+- **Manuscript-audit reliability** — keep the deterministic detectors precise
+  (few false positives) and reproducible; expand challenge-card coverage.
+- **Reporting-guideline compliance** — keep the bundled EQUATOR / risk-of-bias
+  checklists current and correctly versioned (base + extension naming).
+- **Reference and citation integrity** — verification against PubMed / CrossRef /
+  OpenAlex before a reference is trusted; no references written from model memory.
+- **Numerical, cohort, and cross-artifact consistency** — counts, denominators,
+  and submission-package artifacts that agree across the manuscript lifecycle.
+- **Release stability and documentation clarity** — honest versioning, a clear
+  "start here", and reproducible public demos.
+- **Maintainability and governance** — lightweight contributor and maintainer
+  process so the project can accept help without diluting clinical scope
+  (see [`MAINTAINERS.md`](MAINTAINERS.md)).
+- **Citation / adoption evidence** — a durable, cautious record of real use
+  (see [`IMPACT.md`](IMPACT.md)); JOSS / software-paper readiness.
+
+## Under consideration (not committed)
+
+Candidate directions that depend on demand and on staying within scope:
+
+- Deeper structured-summary-box and disclosure/availability checks as journals
+  formalize their requirements.
+- Fairness / equity / subgroup-performance review depth as standards stabilize.
+- Broader journal-profile coverage for medical-AI venues.
+
+## Not planned / explicitly out of scope
+
+MedSci Skills is **narrow on purpose**. It will not become:
+
+- a clinical **diagnosis** or decision-support tool, or anything that gives
+  patient-specific medical advice;
+- an **autonomous manuscript generator** that replaces human authors,
+  statisticians, reviewers, IRBs, or journal requirements;
+- a broad **general AI-scientist** platform spanning chemistry / drug discovery /
+  bench biology;
+- a source of **unsupported guideline interpretation** or **clinical-validation**
+  claims about the toolkit itself.
+
+These boundaries are a feature: the value comes from doing clinical-manuscript
+workflow well, with human experts in the loop, not from breadth.
+
+## How priorities are set
+
+Priorities come from real manuscript cycles — what actually caused a revision
+round, a desk reject, or a reviewer concern — promoted into a reusable detector,
+probe, checklist, or doc. Proposals are welcome via the issue templates; the
+founder approves anything touching clinical/research scope or medical claims
+(see [`MAINTAINERS.md`](MAINTAINERS.md)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security & Scope Boundary
+
+MedSci Skills is open-source tooling for clinical-manuscript preparation. This page
+covers how to report a vulnerability and — because this is medical-domain software —
+the safety boundary and the data-hygiene rules for public issues.
+
+## Reporting a vulnerability
+
+If you find a security issue (for example, a script that could execute untrusted
+input, a dependency vulnerability, or a path that could exfiltrate local data),
+please report it privately rather than opening a public issue:
+
+- Use GitHub's **"Report a vulnerability"** (Security → Advisories) on the
+  repository, or
+- contact the maintainer listed in [`CITATION.cff`](CITATION.cff).
+
+Please include reproduction steps and the affected version. We will acknowledge the
+report and work on a fix; please allow reasonable time before public disclosure.
+
+## Medical scope boundary
+
+MedSci Skills supports **manuscript preparation and research workflow**. It is
+**not** a clinical tool. Specifically, it:
+
+- does **not** provide patient-specific medical advice;
+- does **not** make diagnoses or recommend treatment;
+- does **not** replace authors, statisticians, reviewers, IRBs, or journal
+  requirements;
+- **requires human-expert verification** of every output — it can produce
+  incomplete or incorrect results if used without review.
+
+The deterministic detectors are designed to **reduce common manuscript-preparation
+errors** before review; they do not guarantee correctness and are not a substitute
+for expert judgment.
+
+## Data hygiene — keep PHI and private content out of public issues
+
+This is a public repository. When filing issues, PRs, or examples, do **not**
+include:
+
+- protected health information (PHI) or any patient-level data;
+- unredacted local file paths, private emails, or institution-only context;
+- unpublished manuscript content, private manuscript IDs, or project codes;
+- confidential reviewer comments (unless fully anonymized and you have the right to
+  share them).
+
+Use synthetic or public datasets in examples. The repository's validators include a
+PII/precedent scan, but the first line of defense is not pasting sensitive content
+in the first place. If you need to share a failing case that involves sensitive
+data, reduce it to a synthetic minimal reproduction.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,86 @@
+# Frequently asked questions
+
+A plain-language reference for researchers evaluating MedSci Skills, and a
+search/answer-engine-friendly summary of what it is and is not.
+
+## What is MedSci Skills?
+
+MedSci Skills is an open-source Claude Code skill collection for **clinical
+manuscript preparation**. It helps physician-researchers and biomedical
+investigators move from literature search, study design, statistics, and figures to
+reporting-guideline compliance, citation/reference auditing, numerical-consistency
+checks, and response-to-reviewer workflows. It combines agentic writing workflows
+with **deterministic integrity gates** for submission-grade biomedical research.
+
+## Who should use it?
+
+Physician-researchers, biomedical investigators, and research teams writing
+clinical, diagnostic-accuracy, observational, or systematic-review/meta-analysis
+manuscripts — especially in radiology and medical AI, where the bundled reporting
+guidelines and journal profiles are deepest.
+
+## Is MedSci Skills a "medical writing AI"? Does it replace human authors?
+
+No. It is workflow tooling with deterministic checks, not an autonomous author. It
+**does not replace** authors, statisticians, reviewers, IRBs, or journal
+requirements, and every output **requires human-expert verification**. Its goal is
+to make manuscripts more auditable and reproducible and to reduce common
+preparation errors — not to write the paper for you.
+
+## Is it clinically validated? Is it a clinical/diagnostic tool?
+
+No. MedSci Skills is **not** a clinical-decision-support or diagnostic tool and
+makes no clinical-validation claim about itself. It supports manuscript and research
+**workflow** only (see [`SECURITY.md`](../SECURITY.md) for the scope boundary).
+
+## Does it check STROBE, PRISMA, STARD (and other guidelines)?
+
+Yes. It bundles a set of EQUATOR-network reporting checklists and risk-of-bias /
+appraisal tools (STROBE, CONSORT and CONSORT-AI, STARD and STARD-AI, PRISMA and
+PRISMA-DTA, TRIPOD and TRIPOD+AI, QUADAS-2, RoB 2, ROBINS-I, AMSTAR 2, and more) and
+audits a manuscript item by item. The authoritative current list and count are in
+[`metadata/catalog_counts.json`](../metadata/catalog_counts.json) and the
+[README](../README.md).
+
+## Can it verify references and citations?
+
+Yes. References are checked against PubMed / CrossRef / OpenAlex (including
+first-author and full-author cross-checks) before they are trusted; the toolkit
+never writes references from model memory. See `/verify-refs`.
+
+## Can it detect numerical inconsistencies?
+
+Yes. Deterministic detectors check numerical and cohort arithmetic, pooled-estimate
+consistency, and cross-artifact drift across the manuscript, tables, figures, and
+submission package. These are part of the **MedSci-Audit** detector layer
+(see [`MEDSCI_AUDIT.md`](../MEDSCI_AUDIT.md)).
+
+## How is it different from a general AI writing assistant?
+
+A general assistant drafts prose. MedSci Skills adds the clinical-submission layer a
+generic tool lacks: reporting-guideline audits, reference verification, numerical /
+cross-artifact consistency gates, journal-specific profiles, and ICMJE/IRB form
+support — deterministic checks that run before a reviewer sees the manuscript.
+
+## How is it different from a general "AI scientist" agent?
+
+It is intentionally narrow. It does not span chemistry, drug discovery, or bench
+biology, and it is not an autonomous research agent. It is one physician-researcher's
+clinical-manuscript pipeline with integrity gates (see
+[`ROADMAP.md`](../ROADMAP.md) for the scope boundary).
+
+## Is it free and open-source?
+
+Yes — MIT licensed (see [`LICENSE`](../LICENSE); note any per-file carve-outs noted
+in the file headers).
+
+## How widely adopted is it?
+
+It has **early community adoption signals** (stars, forks, and a few named uses) for
+a niche biomedical-workflow repository — not widespread adoption. The honest,
+continuously updated record is in [`IMPACT.md`](../IMPACT.md).
+
+## How do I cite MedSci Skills?
+
+Use [`CITATION.cff`](../CITATION.cff) or the archived Zenodo DOI listed in the
+[README](../README.md).

--- a/docs/maintainer_workflow.md
+++ b/docs/maintainer_workflow.md
@@ -1,0 +1,67 @@
+# Maintainer workflow & release checklist
+
+How a maintainer reviews PRs and prepares a release, and how a future part-time
+technical maintainer can be onboarded safely. Roles are defined in
+[`MAINTAINERS.md`](../MAINTAINERS.md).
+
+## Permission ramp (onboarding a part-time technical maintainer)
+
+Merge rights expand with demonstrated trust, never all at once. The founder retains
+final release approval at every stage.
+
+| Stage | What they can do |
+|-------|------------------|
+| **Month 1** | Triage and comment only — label issues, request changes, review PRs. No merge. |
+| **Months 2–3** | Merge **docs-only** PRs and simple CI/docs fixes. |
+| **After trust is established** | Merge **non-medical** PRs (refactors, tests, packaging, CI). Prepare release drafts. |
+| **Always** | **Final release approval stays with the founder.** Anything touching clinical/research scope or a medical claim needs Clinical-Lead sign-off. |
+
+## Reviewing a PR
+
+1. CI is green (`.github/workflows/validate.yml`).
+2. The PR states its **type** (skill / detector / docs / CI / release) and whether
+   it changes a **medical/research claim** (if yes → founder review).
+3. Catalog consistency: if a skill / checklist / journal profile / detector was
+   added or removed, `metadata/catalog_counts.json` and the generated catalogs were
+   updated and `python3 scripts/validate_catalog_consistency.py` passes.
+4. No PHI, private paths, manuscript IDs, or unsupported medical claims
+   (see [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`SECURITY.md`](../SECURITY.md)).
+5. New deterministic scripts ship a challenge/regression test wired into CI.
+
+## Release checklist
+
+A release is cut from `main` by pushing a version tag; `release.yml` builds the
+ZIPs, creates the GitHub Release, and Zenodo archives it.
+
+1. **Decide the version** honestly (see "Versioning" below).
+2. **Sync versions in one commit:**
+   - `CHANGELOG.md` — move `[Unreleased]` to `[x.y.z]` with today's date.
+   - `CITATION.cff` — `version` + `date-released`.
+   - `package.json` — `version` (npm).
+   - `README.md` — "What's New" entry.
+3. **Regenerate catalogs** if counts changed:
+   `gen_skills_catalog_json.py`, `gen_detectors_catalog_json.py`,
+   `gen_marketplace_json.py` (then `--check` each) and
+   `validate_catalog_consistency.py`.
+4. **Tag** `vX.Y.Z` and push → `release.yml` runs. Confirm the GitHub Release and
+   Zenodo archive.
+5. **Sync downstream surfaces** that live outside this repo's CI: the homepage
+   `skills.json` counts and any hero-skill mirrors (`sync_hero_skill.py`).
+6. **Record evidence** — refresh [`IMPACT.md`](../IMPACT.md) (run the metrics
+   snapshot *before* the release commit so the bot commit is in place) and log any
+   new citations / named use.
+
+## Versioning policy
+
+Semantic versioning, read honestly:
+
+- **Patch (x.y.Z)** — critical install / CI / broken-workflow fixes.
+- **Minor (x.Y.z)** — new skills, detectors, checklists, or docs; additive,
+  backward-compatible changes (the common case here).
+- **Major (X.y.z)** — a **structural or breaking** change: an install-layout
+  change, a skill removal/merge/rename, or an output-path change. A major bump is
+  reserved for a real break, not for a large additive release — version inflation
+  reads as a credibility tell to an academic audience.
+
+Release notes distinguish: **Added / Changed / Fixed / Deprecated /
+Validation-Evidence / Breaking changes / Documentation.**

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -420,7 +420,7 @@ echo "========================================="
 # the same line is still caught. The author name is no longer spelled out here.
 META_FAIL=0
 META_SCANNED=0
-AUTHOR_ATTRIB_RE='^(README\.md|CITATION\.cff|paper\.md|\.zenodo\.json)$'
+AUTHOR_ATTRIB_RE='^(README\.md|CITATION\.cff|paper\.md|\.zenodo\.json|MAINTAINERS\.md)$'
 while IFS= read -r rel; do
   case "$rel" in
     scripts/validate_skills.sh|scripts/check_precedent.py|scripts/precedent_hashes.txt|scripts/precedent_author_hashes.txt) continue ;;  # self-exempt: blocklist machinery


### PR DESCRIPTION
**v4.6.0 roadmap PR-5 of 7** — workstream D (governance, docs, AEO), the primary thrust. Pure prose; no catalog-SSOT or behavior change. Cautious, anti-overclaiming language throughout.

## New files
- **`ROADMAP.md`** — near-term priorities + an explicit **Not planned / out of scope** (no diagnosis/decision-support, no autonomous authorship, no general AI-scientist, no clinical-validation claims).
- **`MAINTAINERS.md`** — founder/Clinical-Lead (clinical scope + official-skill inclusion + medical claims + release approval) vs Technical Maintainer; a part-time-maintainer permission ramp.
- **`SECURITY.md`** — vulnerability reporting + the medical-scope boundary + "keep PHI out of public issues".
- **`docs/maintainer_workflow.md`** — PR-review + release checklist + honest versioning policy (major = a real break, not version inflation).
- **`docs/faq.md`** — AEO/GEO Q&A (what is it / does it replace authors [no] / clinically validated [no] / STROBE-PRISMA-STARD / reference + numerical checks / how to cite).
- `.github/ISSUE_TEMPLATE/installation_problem.yml` + `detector_request.yml`.

## Enhanced
- **README** — a "What is MedSci Skills?" answer block, **"Start here: 3 workflows"** (pre-submission audit / data-to-package / SR-MA), a **"Validation status"** section (available vs CI-gated vs **E1-evaluated**, counts pointed at the SSOT, not hardcoded — so this PR is base-agnostic to the PR-3 detector bump), governance links, and a stale "32 EQUATOR" hero line de-numbered.
- **CONTRIBUTING + PR template** — a medical-claim → founder-review gate and an official/experimental/community classification line.
- **IMPACT.md** — an "Interpretation of metrics" caveat block (stars = interest not use; clones inflated by CI; "early community interest, not widespread adoption").

Much of the ChatGPT governance brief was already implemented (CONTRIBUTING/PR-template/issue-templates/CoC/IMPACT existed); this PR fills the genuine gaps and enhances the rest — it does not duplicate.

## Verification
`validate_catalog_consistency`, `check_locale_inventory`, `gen_skill_docs --check`, `gen_skills_catalog_json --check`, `validate_skills.sh`, YAML lint (both new templates) → all pass. No skill / guideline / detector count change.

## Merge order
Per the roadmap: **PR-3 → PR-5 → PR-6 → PR-7** serialize (PR-3/PR-5/PR-6 all touch README; PR-5/PR-7 touch IMPACT/CHANGELOG). PR-5 cites no hardcoded detector count, so it is safe on either base, but should merge after PR-3 and before PR-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)