### PR TITLE
feat: skill maturity taxonomy (official/experimental/community) + compliance-moat positioning (v4.6.0 PR-6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "medsci-skills",
-  "description": "Physician-built Claude Code skills for the full medical research lifecycle — literature search with anti-hallucination citation verification, study design, statistics, publication-ready figures, IMRAD manuscript drafting, reporting-compliance audits, journal selection, peer review, and revision.",
+  "description": "Physician-built Claude Code skills for clinical manuscript preparation, with deterministic integrity gates — reporting-guideline and risk-of-bias compliance, reference/citation verification, and numerical-consistency checks — plus literature search, study design, statistics, publication-ready figures, IMRAD drafting, journal selection, peer review, and revision. Submission-grade, not a generic skill catalog.",
   "owner": {
     "name": "Aperivue"
   },

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **45 skills that actually work.** Built by a physician-researcher, tested on real publications.
 
-*MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog. It competes on clinical submission reliability, not skill count.*
+*MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog. Its moat is the compliance layer — 36 reporting guidelines and risk-of-bias tools, reference/citation verification, and deterministic integrity gates, before peer review sees the manuscript. It competes on clinical submission reliability, not skill count.*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Aperivue/medsci-skills?style=flat-square&color=blue)](https://github.com/Aperivue/medsci-skills/releases/latest)

--- a/docs/skill_yml_schema_v2.md
+++ b/docs/skill_yml_schema_v2.md
@@ -33,6 +33,7 @@ Validator rule: `layer` is required and must be one of `A`, `B`, `C`, `D`.
 | `name` | yes | str | Must equal parent directory name. |
 | `layer` | yes | enum | `A` / `B` / `C` / `D`. |
 | `owner_domain` | yes | str | Key from `capabilities.yml`. |
+| `maturity` | yes | enum | `official` / `experimental` / `community` (v2.2 — see below). |
 | `when_to_use` | yes | str | One-sentence trigger description. |
 | `when_NOT_to_use` | yes | str | Anti-trigger / routing guard. |
 | `exclusive_with` | no | list[str] | Skills that MUST NOT run concurrently in same project. |
@@ -140,6 +141,24 @@ validation_commands:
 evidence_surface: demo   # exercised end-to-end by demo/02_metafor_bcg
 ```
 
+## Maturity taxonomy (v2.2, required)
+
+`maturity` is an **additive** field — `schema_version` stays `2` — but, unlike the
+optional v2.1 quality-card fields, it is **required** and validated against an enum, so a
+new skill cannot silently omit it. It separates founder-approved official skills from
+experimental or community contributions for the storefront and for contributors.
+
+| Value | Operating criteria |
+|---|---|
+| `official` | Founder-approved, documented, shipped in the catalog. Every skill currently in this repository is `official` — they are all founder-authored and maintained. |
+| `experimental` | Useful but not fully tested; may change; carries no strong reliability claim. Label a skill this way when it is shipped for feedback rather than as a stable contract. |
+| `community` | An external contribution that is not founder-validated; clearly labeled so users know to review/adapt it locally. |
+
+Classify by these criteria — do not blanket-default a new skill to `official`. The
+validator (`scripts/validate_skill_contracts.py`, `VALID_MATURITY`) requires the field and
+rejects any other value; `scripts/gen_skills_catalog_json.py` emits it into
+`metadata/skills_catalog.json` for the storefront.
+
 ## v1 → v2 migration guide
 
 1. Add `schema_version: 2`.
@@ -157,6 +176,7 @@ schema_version: 2
 name: write-paper
 layer: C
 owner_domain: manuscript_drafting
+maturity: official
 
 when_to_use: "Draft original manuscript or section from scratch."
 when_NOT_to_use: "Revising existing text; use revise. Tone cleanup; use humanize."

--- a/metadata/hero_skills.json
+++ b/metadata/hero_skills.json
@@ -11,7 +11,7 @@
       "skill": "check-reporting",
       "repo": "Aperivue/check-reporting",
       "plugin_name": "check-reporting",
-      "tagline": "Audit a medical manuscript against 32 EQUATOR reporting guidelines (STROBE, CONSORT, STARD, PRISMA, TRIPOD+AI, CLAIM, and risk-of-bias tools) — item-by-item PRESENT / PARTIAL / MISSING."
+      "tagline": "Audit a medical manuscript against 36 reporting guidelines and risk-of-bias tools (STROBE, CONSORT, STARD, PRISMA, TRIPOD+AI, CLAIM, QUADAS-2, RoB 2, ROBINS-I, PROBAST, and more) — item-by-item PRESENT / PARTIAL / MISSING."
     }
   ]
 }

--- a/metadata/skills_catalog.json
+++ b/metadata/skills_catalog.json
@@ -103,6 +103,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "manuscript_optimization",
+      "maturity": "official",
       "description": "Medical AI paper optimization for AI search engines (Perplexity, ChatGPT web, Elicit, Consensus, SciSpace) and RAG-based literature tools."
     },
     {
@@ -111,6 +112,7 @@
       "category_label": "Submission & Journals",
       "layer": "C",
       "owner_domain": "journal_profile_authoring",
+      "maturity": "official",
       "description": "Add a new journal to the MedSci Skills profile database."
     },
     {
@@ -119,6 +121,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "statistical_analysis",
+      "maturity": "official",
       "description": "Statistical analysis for medical research papers."
     },
     {
@@ -127,6 +130,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "author_profile_analysis",
+      "maturity": "official",
       "description": "PubMed author profile analysis."
     },
     {
@@ -135,6 +139,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "batch_analysis",
+      "maturity": "official",
       "description": "Generate N analysis scripts from a single methodology template × multiple exposure/outcome combinations."
     },
     {
@@ -143,6 +148,7 @@
       "category_label": "Data & Study Design",
       "layer": "A",
       "owner_domain": "study_design",
+      "maturity": "official",
       "description": "Interactive sample size calculator for medical research."
     },
     {
@@ -151,6 +157,7 @@
       "category_label": "Review & Compliance",
       "layer": "A",
       "owner_domain": "reporting_compliance",
+      "maturity": "official",
       "description": "Check manuscript compliance with medical research reporting guidelines."
     },
     {
@@ -159,6 +166,7 @@
       "category_label": "Data & Study Design",
       "layer": "B",
       "owner_domain": "data_preparation",
+      "maturity": "official",
       "description": "Interactive data profiling and cleaning assistant for medical research."
     },
     {
@@ -167,6 +175,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "cross_national_comparison",
+      "maturity": "official",
       "description": "End-to-end cross-national comparison study using KNHANES + NHANES + CHNS (or other parallel surveys)."
     },
     {
@@ -175,6 +184,7 @@
       "category_label": "Data & Study Design",
       "layer": "C",
       "owner_domain": "variable_operationalization",
+      "maturity": "official",
       "description": "Literature-grounded variable operationalization for observational research."
     },
     {
@@ -183,6 +193,7 @@
       "category_label": "Data & Study Design",
       "layer": "A",
       "owner_domain": "data_preparation",
+      "maturity": "official",
       "description": "De-identify clinical research data before LLM-assisted analysis."
     },
     {
@@ -191,6 +202,7 @@
       "category_label": "Data & Study Design",
       "layer": "D",
       "owner_domain": "study_design",
+      "maturity": "official",
       "description": "Design and validity review for studies that benchmark one or more AI systems against a human-expert panel as the reference."
     },
     {
@@ -199,6 +211,7 @@
       "category_label": "Data & Study Design",
       "layer": "D",
       "owner_domain": "study_design",
+      "maturity": "official",
       "description": "Study design and validity review for radiology and medical AI research."
     },
     {
@@ -207,6 +220,7 @@
       "category_label": "Submission & Journals",
       "layer": "A",
       "owner_domain": "form_filling",
+      "maturity": "official",
       "description": "Batch-generate per-author ICMJE Conflict of Interest Disclosure Forms (`coi_disclosure.docx`) for manuscript submission."
     },
     {
@@ -215,6 +229,7 @@
       "category_label": "Submission & Journals",
       "layer": "A",
       "owner_domain": "form_filling",
+      "maturity": "official",
       "description": "Fill institutional Word form templates (.doc/.docx) for IRB protocols, ethics applications, grant proposals, and other structured research documents while preserving the original styles, table layouts…"
     },
     {
@@ -223,6 +238,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "research_gap_analysis",
+      "maturity": "official",
       "description": "Research gap finder for longitudinal cohort databases."
     },
     {
@@ -231,6 +247,7 @@
       "category_label": "Submission & Journals",
       "layer": "D",
       "owner_domain": "journal_recommendation",
+      "maturity": "official",
       "description": "Journal recommendation engine for medical manuscripts."
     },
     {
@@ -239,6 +256,7 @@
       "category_label": "Literature & References",
       "layer": "A",
       "owner_domain": "literature_discovery",
+      "maturity": "official",
       "description": "Batch download open-access PDFs by DOI using legitimate OA APIs (Unpaywall, PMC, OpenAlex, Crossref)."
     },
     {
@@ -247,6 +265,7 @@
       "category_label": "Data & Study Design",
       "layer": "A",
       "owner_domain": "data_documentation",
+      "maturity": "official",
       "description": "Generate a citable data dictionary / codebook from a tabular dataset (CSV/TSV/Excel/Parquet/Stata/SAS)."
     },
     {
@@ -255,6 +274,7 @@
       "category_label": "Submission & Journals",
       "layer": "C",
       "owner_domain": "grant_proposal",
+      "maturity": "official",
       "description": "Grant and challenge proposal support for radiology and medical AI projects."
     },
     {
@@ -263,6 +283,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "ai_pattern_removal",
+      "maturity": "official",
       "description": "Detect and remove AI writing patterns from academic manuscripts and response-to-reviewers letters."
     },
     {
@@ -271,6 +292,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "project_intake",
+      "maturity": "official",
       "description": "Intake and normalize a new radiology research project."
     },
     {
@@ -279,6 +301,7 @@
       "category_label": "Literature & References",
       "layer": "A",
       "owner_domain": "zotero_sync",
+      "maturity": "official",
       "description": "Sync research references from .bib files to Zotero library + Obsidian literature notes."
     },
     {
@@ -287,6 +310,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "ma_topic_discovery",
+      "maturity": "official",
       "description": "Meta-analysis topic discovery and feasibility assessment."
     },
     {
@@ -295,6 +319,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "figure_generation",
+      "maturity": "official",
       "description": "Generate publication-ready figures and visual abstracts for medical research papers."
     },
     {
@@ -303,6 +328,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "project_management",
+      "maturity": "official",
       "description": "Research project management for medical manuscripts."
     },
     {
@@ -311,6 +337,7 @@
       "category_label": "Literature & References",
       "layer": "A",
       "owner_domain": "manuscript_lifecycle",
+      "maturity": "official",
       "description": "Cross-cutting reference manager for medical manuscripts."
     },
     {
@@ -319,6 +346,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "meta_analysis_integrity",
+      "maturity": "official",
       "description": "Systematic review and meta-analysis pipeline for medical research."
     },
     {
@@ -327,6 +355,7 @@
       "category_label": "Project & Workflow",
       "layer": "D",
       "owner_domain": "orchestration",
+      "maturity": "official",
       "description": "General-purpose research orchestrator."
     },
     {
@@ -335,6 +364,7 @@
       "category_label": "Review & Compliance",
       "layer": "C",
       "owner_domain": "external_peer_review",
+      "maturity": "official",
       "description": "Peer review assistant for medical journals."
     },
     {
@@ -343,6 +373,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "manuscript_optimization",
+      "maturity": "official",
       "description": "Academic English consistency linting and non-native (ESL) language polish for medical manuscripts."
     },
     {
@@ -351,6 +382,7 @@
       "category_label": "Presentation & Tooling",
       "layer": "C",
       "owner_domain": "presentation",
+      "maturity": "official",
       "description": "Academic presentation preparation — paper-driven (journal club, grand rounds, seminar) and lecture/teaching decks (course material, workshop slides, conference talks)."
     },
     {
@@ -359,6 +391,7 @@
       "category_label": "Presentation & Tooling",
       "layer": "B",
       "owner_domain": "skill_publishing",
+      "maturity": "official",
       "description": "Convert a personal agent skill into a distributable, open-source-ready skill."
     },
     {
@@ -367,6 +400,7 @@
       "category_label": "Presentation & Tooling",
       "layer": "A",
       "owner_domain": "document_layout",
+      "maturity": "official",
       "description": "Render academic Markdown documents (English or Korean) to publication-quality PDF via pandoc + xelatex."
     },
     {
@@ -375,6 +409,7 @@
       "category_label": "Analysis & Figures",
       "layer": "B",
       "owner_domain": "study_replication",
+      "maturity": "official",
       "description": "Replicate an existing cohort study's methodology on a different database."
     },
     {
@@ -383,6 +418,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "manuscript_authoring",
+      "maturity": "official",
       "description": "Scaffold and draft medical/AI literature reviews (narrative, scoping PRISMA-ScR, or systematic)."
     },
     {
@@ -391,6 +427,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "B",
       "owner_domain": "reviewer_response",
+      "maturity": "official",
       "description": "Parse peer reviewer comments and generate a structured Response to Reviewers document with tracked manuscript changes."
     },
     {
@@ -399,6 +436,7 @@
       "category_label": "Literature & References",
       "layer": "A",
       "owner_domain": "literature_discovery",
+      "maturity": "official",
       "description": "Literature search and citation management for medical research."
     },
     {
@@ -407,6 +445,7 @@
       "category_label": "Review & Compliance",
       "layer": "D",
       "owner_domain": "own_manuscript_critique",
+      "maturity": "official",
       "description": "Pre-submission self-review for the user's own manuscripts, applying a reviewer perspective."
     },
     {
@@ -415,6 +454,7 @@
       "category_label": "Presentation & Tooling",
       "layer": "A",
       "owner_domain": "environment_setup",
+      "maturity": "official",
       "description": "Diagnostic checklist for the MedSci Skills runtime."
     },
     {
@@ -423,6 +463,7 @@
       "category_label": "Submission & Journals",
       "layer": "A",
       "owner_domain": "submission_packaging",
+      "maturity": "official",
       "description": "Audit SSOT-to-submission drift and create journal submission manifests from canonical manuscript artifacts."
     },
     {
@@ -431,6 +472,7 @@
       "category_label": "Literature & References",
       "layer": "A",
       "owner_domain": "reference_integrity",
+      "maturity": "official",
       "description": "Audit-only verification of manuscript references against PubMed and CrossRef."
     },
     {
@@ -439,6 +481,7 @@
       "category_label": "Data & Study Design",
       "layer": "A",
       "owner_domain": "dataset_versioning",
+      "maturity": "official",
       "description": "Dataset version control for research reproducibility."
     },
     {
@@ -447,6 +490,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "manuscript_drafting",
+      "maturity": "official",
       "description": "Full-pipeline medical/scientific paper writing."
     },
     {
@@ -455,6 +499,7 @@
       "category_label": "Writing & Manuscript",
       "layer": "C",
       "owner_domain": "protocol_drafting",
+      "maturity": "official",
       "description": "IRB/ethics committee research protocol generator."
     }
   ]

--- a/scripts/gen_marketplace_json.py
+++ b/scripts/gen_marketplace_json.py
@@ -49,10 +49,11 @@ OUT = ROOT / ".claude-plugin" / "marketplace.json"
 SCHEMA_URL = "https://json.schemastore.org/claude-code-marketplace.json"
 MARKETPLACE_NAME = "medsci-skills"  # not a reserved name
 MARKETPLACE_DESCRIPTION = (
-    "Physician-built Claude Code skills for the full medical research lifecycle — "
-    "literature search with anti-hallucination citation verification, study design, "
-    "statistics, publication-ready figures, IMRAD manuscript drafting, "
-    "reporting-compliance audits, journal selection, peer review, and revision."
+    "Physician-built Claude Code skills for clinical manuscript preparation, with "
+    "deterministic integrity gates — reporting-guideline and risk-of-bias compliance, "
+    "reference/citation verification, and numerical-consistency checks — plus literature "
+    "search, study design, statistics, publication-ready figures, IMRAD drafting, journal "
+    "selection, peer review, and revision. Submission-grade, not a generic skill catalog."
 )
 OWNER = {"name": "Aperivue"}  # public org; no personal email (PII-safe)
 

--- a/scripts/gen_skills_catalog_json.py
+++ b/scripts/gen_skills_catalog_json.py
@@ -194,8 +194,11 @@ def build(skills_dir: Path = SKILLS_DIR) -> dict:
         yml_text = yml.read_text(encoding="utf-8")
         owner_domain = _yml_scalar(yml_text, "owner_domain")
         layer = _yml_scalar(yml_text, "layer")
+        maturity = _yml_scalar(yml_text, "maturity")
         if not owner_domain:
             raise SkillError(f"{slug}: skill.yml has no 'owner_domain'")
+        if not maturity:
+            raise SkillError(f"{slug}: skill.yml has no 'maturity' (official/experimental/community)")
         if owner_domain not in CATEGORY_BY_OWNER_DOMAIN:
             raise SkillError(
                 f"{slug}: owner_domain '{owner_domain}' is not mapped to a category in "
@@ -208,6 +211,7 @@ def build(skills_dir: Path = SKILLS_DIR) -> dict:
             "category_label": cat_label,
             "layer": layer or "",
             "owner_domain": owner_domain,
+            "maturity": maturity,
             "description": short_desc(desc),
         })
 

--- a/scripts/validate_skill_contracts.py
+++ b/scripts/validate_skill_contracts.py
@@ -46,6 +46,7 @@ REQUIRED_V2 = {
     "name",
     "layer",
     "owner_domain",
+    "maturity",
     "when_to_use",
     "when_NOT_to_use",
     "inputs",
@@ -56,6 +57,11 @@ REQUIRED_V2 = {
 }
 
 VALID_LAYERS = {"A", "B", "C", "D"}
+# Maturity taxonomy (skill.yml v2.2, additive — schema_version stays 2):
+#   official     — founder-approved, documented, shipped in the catalog (all current skills).
+#   experimental — useful but not fully tested; may change; no strong reliability claim.
+#   community    — external contribution, not founder-validated; clearly labeled.
+VALID_MATURITY = {"official", "experimental", "community"}
 
 # Schema v2.1 quality-card extension (all optional).
 VALID_EVIDENCE_SURFACE = {
@@ -151,6 +157,10 @@ def validate_v2(path: Path, skill_name: str, text: str, keys: set[str]) -> list[
     layer_val = extract_scalar(text, "layer")
     if layer_val and layer_val not in VALID_LAYERS:
         errors.append(f"layer invalid: {layer_val!r} (must be A/B/C/D)")
+
+    maturity_val = extract_scalar(text, "maturity")
+    if maturity_val and maturity_val not in VALID_MATURITY:
+        errors.append(f"maturity invalid: {maturity_val!r} (must be official/experimental/community)")
 
     for key in LIST_FIELDS & keys:
         if not list_has_item(text, key):

--- a/skills/academic-aio/skill.yml
+++ b/skills/academic-aio/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: academic-aio
 layer: C
 owner_domain: manuscript_optimization
+maturity: official
 
 when_to_use: "Optimize a medical-AI manuscript's title, abstract, and structured summary boxes for AI search engines and RAG tools, integrating TRIPOD+AI/CLAIM/STARD-AI reporting requirements."
 when_NOT_to_use: "Drafting a manuscript from scratch (use write-paper); removing AI writing tells (use humanize)."

--- a/skills/add-journal/skill.yml
+++ b/skills/add-journal/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: add-journal
 layer: C
 owner_domain: journal_profile_authoring
+maturity: official
 
 when_to_use: "Add a new journal to the profile database from its author guidelines, generating both write-paper (detailed) and find-journal (compact) profiles."
 when_NOT_to_use: "Recommending a journal for a manuscript (use find-journal)."

--- a/skills/analyze-stats/skill.yml
+++ b/skills/analyze-stats/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: analyze-stats
 layer: B
 owner_domain: statistical_analysis
+maturity: official
 
 when_to_use: "Generate reproducible Python/R analysis code with publication-ready tables and figures for a defined study design."
 when_NOT_to_use: "Sample-size planning (use calc-sample-size); figure-only generation (use make-figures)."

--- a/skills/author-strategy/skill.yml
+++ b/skills/author-strategy/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: author-strategy
 layer: D
 owner_domain: author_profile_analysis
+maturity: official
 
 when_to_use: "Analyze a PubMed author profile (study-type mix, trends) and produce a strategy report; optionally classify the trajectory into explainable career archetypes (A1-A6) after an author-disambiguation gate."
 when_NOT_to_use: "Finding meta-analysis topics (use ma-scout); literature search for a manuscript (use search-lit)."

--- a/skills/batch-cohort/skill.yml
+++ b/skills/batch-cohort/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: batch-cohort
 layer: B
 owner_domain: batch_analysis
+maturity: official
 
 when_to_use: "Generate N analysis scripts from one validated methodology template across many exposure/outcome combinations."
 when_NOT_to_use: "A single analysis (use analyze-stats); cross-country comparison (use cross-national)."

--- a/skills/calc-sample-size/skill.yml
+++ b/skills/calc-sample-size/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: calc-sample-size
 layer: A
 owner_domain: study_design
+maturity: official
 when_to_use:
   - User asks for a sample size, power calculation, or "how many patients/subjects do I need"
   - Drafting an IRB sample size justification before /write-protocol Methods

--- a/skills/check-reporting/skill.yml
+++ b/skills/check-reporting/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: check-reporting
 layer: A
 owner_domain: reporting_compliance
+maturity: official
 when_to_use:
   - Pre-submission item-level checklist run for a target reporting guideline (STROBE / CONSORT / STARD / TRIPOD / PRISMA / ARRIVE / CARE / SPIRIT / CLAIM / SQUIRE 2.0 / etc.)
   - Risk-of-bias assessment using QUADAS-2 / QUADAS-C / RoB 2 / ROBINS-I / ROBINS-E / ROBIS / PROBAST / NOS / COSMIN / RoB NMA

--- a/skills/clean-data/skill.yml
+++ b/skills/clean-data/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: clean-data
 layer: B
 owner_domain: data_preparation
+maturity: official
 
 when_to_use: "Profile and clean clinical CSV/Excel data through a three-stage workflow with user approval at each gate."
 when_NOT_to_use: "Removing PHI (use deidentify); statistical analysis (use analyze-stats)."

--- a/skills/cross-national/skill.yml
+++ b/skills/cross-national/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: cross-national
 layer: B
 owner_domain: cross_national_comparison
+maturity: official
 
 when_to_use: "Run a cross-national comparison (KNHANES + NHANES + CHNS or similar) with harmonized variables and parallel weighted analysis."
 when_NOT_to_use: "Single-cohort analysis (use analyze-stats); replicating one study on one DB (use replicate-study)."

--- a/skills/define-variables/skill.yml
+++ b/skills/define-variables/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: define-variables
 layer: C
 owner_domain: variable_operationalization
+maturity: official
 
 when_to_use: "Turn a data dictionary + research question into a citation-backed table of exposure/outcome/covariate definitions, cutoffs, and DB variable mappings."
 when_NOT_to_use: "Drafting Methods prose (use write-protocol/write-paper); finding literature (use search-lit)."

--- a/skills/deidentify/skill.yml
+++ b/skills/deidentify/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: deidentify
 layer: A
 owner_domain: data_preparation
+maturity: official
 
 when_to_use: "De-identify clinical CSV/TSV/Excel data locally before any LLM-assisted analysis."
 when_NOT_to_use: "General data cleaning or type fixing (use clean-data). Never to have the agent itself read, paste, or process raw PHI."

--- a/skills/design-ai-benchmarking/skill.yml
+++ b/skills/design-ai-benchmarking/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: design-ai-benchmarking
 layer: D
 owner_domain: study_design
+maturity: official
 
 when_to_use: "Design or review a study that benchmarks one or more AI systems against a human-expert panel: arm definition, decoupled rubric, calibration probes, reviewer panel, IRR targets, judge adjudication, and a structured export schema, before ratings are collected."
 when_NOT_to_use: "General study/validity review (use design-study); statistical execution such as ICC/DeLong (use analyze-stats); reporting-guideline item audits (use check-reporting); reviewing a finished manuscript (use peer-review or self-review)."

--- a/skills/design-study/skill.yml
+++ b/skills/design-study/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: design-study
 layer: D
 owner_domain: study_design
+maturity: official
 
 when_to_use: "Review study design and validity (analysis unit, cohort logic, leakage, comparator, validation, reporting fit) before drafting or submission."
 when_NOT_to_use: "Sample-size math (use calc-sample-size); variable definitions (use define-variables)."

--- a/skills/fill-icmje-coi/skill.yml
+++ b/skills/fill-icmje-coi/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: fill-icmje-coi
 layer: A
 owner_domain: form_filling
+maturity: official
 
 when_to_use: "Batch-generate per-author ICMJE COI disclosure forms from a synthetic seed, pre-filled as 'None' with date/name/title replaced."
 when_NOT_to_use: "Filling an IRB or institutional Word form (use fill-protocol)."

--- a/skills/fill-protocol/skill.yml
+++ b/skills/fill-protocol/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: fill-protocol
 layer: A
 owner_domain: form_filling
+maturity: official
 
 when_to_use: "Fill an institutional Word (.doc/.docx) template (IRB protocol, ethics application, grant form) while preserving styles, tables, fonts, and page geometry."
 when_NOT_to_use: "Drafting the scientific content (use write-protocol); ICMJE COI forms (use fill-icmje-coi)."

--- a/skills/find-cohort-gap/skill.yml
+++ b/skills/find-cohort-gap/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: find-cohort-gap
 layer: D
 owner_domain: research_gap_analysis
+maturity: official
 
 when_to_use: "Find research gaps in a longitudinal cohort DB by profiling its strengths, matching PI expertise, and scanning literature saturation."
 when_NOT_to_use: "Finding meta-analysis topics (use ma-scout); designing a chosen study (use design-study)."

--- a/skills/find-journal/skill.yml
+++ b/skills/find-journal/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: find-journal
 layer: D
 owner_domain: journal_recommendation
+maturity: official
 
 when_to_use: "Recommend journals for a manuscript via two-pass matching against the public profile library plus any user-local private profiles."
 when_NOT_to_use: "Adding a journal to the database (use add-journal); building the submission package (use sync-submission)."

--- a/skills/fulltext-retrieval/skill.yml
+++ b/skills/fulltext-retrieval/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: fulltext-retrieval
 layer: A
 owner_domain: literature_discovery
+maturity: official
 
 when_to_use: "Batch-download open-access full-text PDFs from a DOI list; optionally convert them to Markdown for token-efficient analysis."
 when_NOT_to_use: "Finding or verifying citations (use search-lit / verify-refs). Retrieving paywalled or non-open-access content."

--- a/skills/generate-codebook/skill.yml
+++ b/skills/generate-codebook/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: generate-codebook
 layer: A
 owner_domain: data_documentation
+maturity: official
 
 when_to_use: "Generate a data dictionary and codebook from a dataset."
 when_NOT_to_use: "Cleaning the data (use clean-data); versioning the dataset (use version-dataset)."

--- a/skills/grant-builder/skill.yml
+++ b/skills/grant-builder/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: grant-builder
 layer: C
 owner_domain: grant_proposal
+maturity: official
 
 when_to_use: "Support grant and challenge proposals (significance, innovation, approach, milestones, consortium roles) with evidence-based, executable claims."
 when_NOT_to_use: "IRB protocol content (use write-protocol); manuscript drafting (use write-paper)."

--- a/skills/humanize/skill.yml
+++ b/skills/humanize/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: humanize
 layer: C
 owner_domain: ai_pattern_removal
+maturity: official
 
 when_to_use: "Detect and remove the 18 common AI-writing patterns from an academic manuscript while preserving technical accuracy."
 when_NOT_to_use: "Drafting content (use write-paper); AI-search optimization (use academic-aio)."

--- a/skills/intake-project/skill.yml
+++ b/skills/intake-project/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: intake-project
 layer: D
 owner_domain: project_intake
+maturity: official
 
 when_to_use: "Intake and normalize a new research project: classify type, summarize state, flag missing inputs, recommend next steps, and scaffold lightweight memory files."
 when_NOT_to_use: "Ongoing project tracking (use manage-project)."

--- a/skills/lit-sync/skill.yml
+++ b/skills/lit-sync/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: lit-sync
 layer: A
 owner_domain: zotero_sync
+maturity: official
 when_to_use:
   - User wants to add PMIDs / DOIs / Zotero collection items to the project library
   - After /search-lit when verified candidates need to flow into Zotero + refs.bib

--- a/skills/ma-scout/skill.yml
+++ b/skills/ma-scout/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: ma-scout
 layer: D
 owner_domain: ma_topic_discovery
+maturity: official
 
 when_to_use: "Discover and assess meta-analysis topics, either from a professor's publication profile or from a clinical question/trend."
 when_NOT_to_use: "Running the meta-analysis (use meta-analysis); single-author profiling (use author-strategy)."

--- a/skills/make-figures/skill.yml
+++ b/skills/make-figures/skill.yml
@@ -3,6 +3,7 @@ name: make-figures
 version: 1.1.0
 layer: B
 owner_domain: figure_generation
+maturity: official
 when_to_use:
   - User requests a figure, plot, diagram, or visual abstract for a medical research manuscript
   - Triggered by /write-paper Phase 5 (figure generation step)

--- a/skills/manage-project/skill.yml
+++ b/skills/manage-project/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: manage-project
 layer: D
 owner_domain: project_management
+maturity: official
 
 when_to_use: "Manage a manuscript project: scaffold structure, track writing progress across phases, maintain memory, and generate checklists and backwards timelines."
 when_NOT_to_use: "First-time intake of a messy project (use intake-project)."

--- a/skills/manage-refs/skill.yml
+++ b/skills/manage-refs/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: manage-refs
 layer: A
 owner_domain: manuscript_lifecycle
+maturity: official
 when_to_use:
   - Render manuscript.md to journal-styled DOCX/PDF/HTML via pandoc citeproc
   - Validate citation keys (`[@bibkey]`) against refs.bib before build

--- a/skills/meta-analysis/skill.yml
+++ b/skills/meta-analysis/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: meta-analysis
 layer: B
 owner_domain: meta_analysis_integrity
+maturity: official
 when_to_use:
   - Running an end-to-end systematic review or meta-analysis (PROSPERO → search → screen → extract → synthesis → PRISMA)
   - Diagnostic test accuracy meta-analysis (bivariate / HSROC) or intervention meta-analysis (random-effects)

--- a/skills/orchestrate/skill.yml
+++ b/skills/orchestrate/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: orchestrate
 layer: D
 owner_domain: orchestration
+maturity: official
 when_to_use:
   - User describes a research goal without naming a specific skill
   - Task spans multiple skills and the right pipeline is non-obvious

--- a/skills/peer-review/skill.yml
+++ b/skills/peer-review/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: peer-review
 layer: C
 owner_domain: external_peer_review
+maturity: official
 when_to_use:
   - User received a journal review invitation and needs a structured review draft
   - Drafting reviewer comments for a specific journal's review template (RYAI / INSI / EURE / AJR / KJR)

--- a/skills/polish-language/skill.yml
+++ b/skills/polish-language/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: polish-language
 layer: C
 owner_domain: manuscript_optimization
+maturity: official
 
 when_to_use: "Lint a medical manuscript for mechanical language consistency (abbreviations, US/UK spelling, en-dash ranges, P/p case, hyphenation, units) and run a style-only ESL clarity pass."
 when_NOT_to_use: "Removing AI writing tells (use humanize); drafting content (use write-paper); reporting-guideline checks (use check-reporting); citation formatting (use manage-refs)."

--- a/skills/present-paper/skill.yml
+++ b/skills/present-paper/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: present-paper
 layer: C
 owner_domain: presentation
+maturity: official
 
 when_to_use: "Prepare academic presentations (journal club, grand rounds, seminar, lecture/teaching decks): analyze source, find references, draft audience-adapted scripts, and generate/augment PPTX with speaker notes."
 when_NOT_to_use: "Drafting a manuscript (use write-paper); building figures for a paper (use make-figures)."

--- a/skills/publish-skill/skill.yml
+++ b/skills/publish-skill/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: publish-skill
 layer: B
 owner_domain: skill_publishing
+maturity: official
 
 when_to_use: "Convert a personal agent skill into a distributable, OSS-ready skill: PII audit, generalization, license check, cross-platform review, packaging."
 when_NOT_to_use: "Authoring a brand-new skill from scratch (out of scope; this hardens an existing one)."

--- a/skills/render-pdf-doc/skill.yml
+++ b/skills/render-pdf-doc/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: render-pdf-doc
 layer: A
 owner_domain: document_layout
+maturity: official
 when_to_use:
   - Render a non-bibliography Korean/English academic markdown to publication-quality PDF
   - Research proposals, IRB cover letters, briefing handouts, anchor docs, reference tables

--- a/skills/replicate-study/skill.yml
+++ b/skills/replicate-study/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: replicate-study
 layer: B
 owner_domain: study_replication
+maturity: official
 
 when_to_use: "Replicate an existing cohort study's methodology on a different database via a variable harmonization table and a replication difference report."
 when_NOT_to_use: "Comparing countries in parallel (use cross-national); a fresh single analysis (use analyze-stats)."

--- a/skills/review-paper/skill.yml
+++ b/skills/review-paper/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: review-paper
 layer: C
 owner_domain: manuscript_authoring
+maturity: official
 
 when_to_use: "Scaffold and draft a literature review (narrative / scoping / systematic) for medical/AI research, organized around an explicit spine axis with a non-overlap boundary and reporting-guideline wiring."
 when_NOT_to_use: "Original research articles, case reports, meta-analyses with pooled synthesis (use write-paper / meta-analysis). Pre-protocol topic discovery (use ma-scout)."

--- a/skills/revise/skill.yml
+++ b/skills/revise/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: revise
 layer: B
 owner_domain: reviewer_response
+maturity: official
 when_to_use:
   - User received reviewer comments and needs a structured response-to-reviewers letter
   - Coordinating new analyses or figures triggered by reviewer requests (delegates to /analyze-stats, /make-figures)

--- a/skills/search-lit/skill.yml
+++ b/skills/search-lit/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: search-lit
 layer: A
 owner_domain: literature_discovery
+maturity: official
 when_to_use:
   - User asks to find papers, related work, citations, or background literature on a topic
   - Generating a verified candidate citation pool (PubMed / Semantic Scholar / bioRxiv / medRxiv)

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: self-review
 layer: D
 owner_domain: own_manuscript_critique
+maturity: official
 when_to_use:
   - Pre-submission self-criticism on the user's own manuscript across 10 review categories
   - Generating Anticipated Major / Minor Comments before sending to senior co-authors

--- a/skills/setup-medsci/skill.yml
+++ b/skills/setup-medsci/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: setup-medsci
 layer: A
 owner_domain: environment_setup
+maturity: official
 
 when_to_use: "Set up the local environment for MedSci Skills (dependencies, tooling checks)."
 when_NOT_to_use: "Installing the skills themselves (use installers/install.py)."

--- a/skills/sync-submission/skill.yml
+++ b/skills/sync-submission/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: sync-submission
 layer: A
 owner_domain: submission_packaging
+maturity: official
 when_to_use:
   - Auditing SSOT-to-submission drift before freezing a journal package
   - Building a journal-specific submission manifest from canonical manuscript artifacts

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: verify-refs
 layer: A
 owner_domain: reference_integrity
+maturity: official
 when_to_use:
   - Audit-only verification of manuscript references against PubMed and CrossRef
   - Pre-submission citation hallucination check (PostToolUse hook trigger on circulation/submission docx)

--- a/skills/version-dataset/skill.yml
+++ b/skills/version-dataset/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: version-dataset
 layer: A
 owner_domain: dataset_versioning
+maturity: official
 
 when_to_use: "Version-control a dataset with SHA-256 manifests for reproducibility."
 when_NOT_to_use: "Cleaning the data (use clean-data); documenting variables (use generate-codebook)."

--- a/skills/write-paper/skill.yml
+++ b/skills/write-paper/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: write-paper
 layer: C
 owner_domain: manuscript_drafting
+maturity: official
 when_to_use:
   - Drafting an original medical/scientific manuscript from outline (8-phase IMRAD workflow)
   - Original article, case report, meta-analysis report, AI validation study, animal study, or technical note

--- a/skills/write-protocol/skill.yml
+++ b/skills/write-protocol/skill.yml
@@ -2,6 +2,7 @@ schema_version: 2
 name: write-protocol
 layer: C
 owner_domain: protocol_drafting
+maturity: official
 
 when_to_use: "Generate an IRB/ethics research protocol: 4 full prose core sections (Background, Design, Sample Size, Statistical Plan) plus 6 skeleton sections with TODO markers."
 when_NOT_to_use: "Filling an institutional Word form (use fill-protocol); manuscript drafting (use write-paper)."

--- a/tests/test_skills_catalog_json.sh
+++ b/tests/test_skills_catalog_json.sh
@@ -19,7 +19,7 @@ mk_skill() {  # name owner_domain layer
   local d="$WORK/skills/$1"
   mkdir -p "$d"
   printf -- '---\nname: %s\ndescription: A synthetic %s skill for testing. Second sentence ignored.\ntriggers: a, b\ntools: Read\nmodel: sonnet\n---\nbody\n' "$1" "$1" > "$d/SKILL.md"
-  printf 'schema_version: 2\nname: %s\nlayer: %s\nowner_domain: %s\n' "$1" "$3" "$2" > "$d/skill.yml"
+  printf 'schema_version: 2\nname: %s\nlayer: %s\nowner_domain: %s\nmaturity: official\n' "$1" "$3" "$2" > "$d/skill.yml"
 }
 
 # --- 1. happy path: a mapped owner_domain generates + round-trips on --check ---


### PR DESCRIPTION
**v4.6.0 roadmap PR-6 of 7** — workstream D (D10 maturity taxonomy) + workstream C (C1/C2 positioning).

## Maturity taxonomy (D10)
A **required**, additive `maturity` field on the skill.yml v2 contract — `schema_version` stays `2`, so it is backward-compatible, but unlike the optional v2.1 quality-card fields it is enforced.

- **All 45 skills classified `official`** by the documented criteria (founder-authored, documented, shipped) — *not* a blanket default; `experimental` / `community` exist for future non-founder contributions.
- `validate_skill_contracts.py` — `maturity` added to `REQUIRED_V2` + a `VALID_MATURITY` enum; a new skill cannot omit it and an invalid value fails CI (verified: a `bogus` value is rejected, exit 1).
- `gen_skills_catalog_json.py` — emits `maturity` into `skills_catalog.json` (regenerated) for the storefront; fails loud if absent.
- `docs/skill_yml_schema_v2.md` — documents the v2.2 field, operating criteria, and example.

## Positioning (C1 / C2)
- **C1** — the README hero subline and the marketplace **source** description (`MARKETPLACE_DESCRIPTION`, regenerated into `marketplace.json` — the generated file is never hand-edited) now lead with the **compliance/integrity moat** (36 reporting guidelines + risk-of-bias tools, reference verification, deterministic integrity gates) rather than skill count. The detector total is left to the SSOT, so this PR is **base-agnostic** to the PR-3 detector bump.
- **C2** — `hero_skills.json` stale **"32 EQUATOR reporting guidelines" → "36 reporting guidelines and risk-of-bias tools"** (the 36 includes RoB/appraisal tools, so not all are EQUATOR reporting guidelines). Re-run `sync_hero_skill.py` at release to propagate to the mirror (HERO_SKILL_TOKEN unset).

## Verification
`validate_skill_contracts` (+ negative enum test), `gen_skills_catalog_json --check`, `gen_marketplace_json --check`, `gen_detectors_catalog_json --check`, `validate_catalog_consistency`, `gen_skill_docs --check`, `check_locale_inventory`, `validate_routing_assets --strict`, `validate_skills.sh` → all pass. 53 files (45 skill.yml + 8). Skills 45 / guidelines 36 unchanged.

## Merge order
Serializes after PR-3 and PR-5 (touches README + skills_catalog). Cites no hardcoded detector count, so safe on either base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)