### PR TITLE
feat(write-paper): deterministic title-page affiliation numbering (first-appearance order)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Run academic-aio summary-box detector test
         run: bash skills/academic-aio/tests/test_summary_box.sh
 
+      - name: Run write-paper title-page affiliation-order test
+        run: bash skills/write-paper/tests/test_title_page_affiliations.sh
+
       - name: Run sync-submission cross-artifact staleness gate test (A3)
         run: bash skills/sync-submission/tests/test_cross_artifact_stale.sh
 

--- a/docs/skills/write-paper.md
+++ b/docs/skills/write-paper.md
@@ -29,6 +29,8 @@
 
 - `/verify-refs --strict`
 - `/self-review`
+- `python3 scripts/build_title_page_affiliations.py --check manuscript/title_page.md --strict`
+- `bash tests/test_title_page_affiliations.sh`
 
 **Evidence** — `demo`
 
@@ -51,6 +53,7 @@
 
 **Scripts** (`skills/write-paper/scripts/`):
 
+- `build_title_page_affiliations.py`
 - `check_placeholders.py`
 
 ## Source

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -536,7 +536,7 @@ Log the self-review fix loop results to `qc/_pipeline_log.md`:
 
 Generate the following files:
 - `manuscript/manuscript.md`: Complete manuscript (with LLM disclosure in Methods and Acknowledgments if enabled)
-- `manuscript/title_page.md`: Title page with author info, word count, key points if required
+- `manuscript/title_page.md`: Title page with author info, word count, key points if required. **Number the author affiliations by first appearance** (affiliation 1 = the first author's first affiliation; each new affiliation gets the next integer as the author list is read left to right; each ends with city + country) — required by Nature Portfolio / npj technical checks. Do not hand-number; generate and verify with `scripts/build_title_page_affiliations.py` (`--authors authors.yaml` to build, `--check title_page.md --strict` to verify). See `references/section_guides/title_abstract.md` § "Title Page — Author & Affiliation Order".
 - `qc/reporting_checklist.md`: Filled reporting guideline checklist from Step 7.2
 - `qc/self_review.md`: Final self-review report from Step 7.4
 - `qc/_pipeline_log.md`: Pipeline execution log

--- a/skills/write-paper/references/section_guides/title_abstract.md
+++ b/skills/write-paper/references/section_guides/title_abstract.md
@@ -43,6 +43,44 @@ Before finalizing, verify:
 
 ---
 
+## Title Page — Author & Affiliation Order
+
+Journals — and **every Nature Portfolio / npj technical check** — require the
+title-page affiliations to be **numbered in the order the authors first introduce
+them**, not grouped by institution. Do **not** hand-number them (an LLM groups by
+institution or lets a late author keep a low number, which the technical check
+bounces). The rule, stated once:
+
+- **Affiliation 1 belongs to the first author's first affiliation.** Walk the author
+  list left to right; each new affiliation gets the next integer the **first** time
+  it appears; a repeat of an earlier affiliation reuses its number.
+- The affiliation block is then listed in **ascending numeric order** (= first
+  appearance), contiguous (1..N, no gaps), every number cited by ≥1 author.
+- **Each affiliation ends with its city and country** (e.g. "…, Seoul, Republic of
+  Korea").
+- Corresponding authors get a `*` (and equal-contribution a `†`) appended to their
+  superscript; the footnotes follow the block.
+
+**Generate and verify this deterministically** rather than by hand:
+
+```bash
+# build the byline + affiliation block from an ordered authors file
+python3 "${CLAUDE_SKILL_DIR}/scripts/build_title_page_affiliations.py" \
+  --authors authors.yaml --out manuscript/title_page_affiliations.md
+
+# verify an existing title page before submission (catches out-of-order numbering,
+# gaps, undefined/orphan affiliations, and a missing city/country)
+python3 "${CLAUDE_SKILL_DIR}/scripts/build_title_page_affiliations.py" \
+  --check manuscript/title_page.md --strict
+```
+
+`authors.yaml` is an ordered `authors:` list (each with `name`, an ordered
+`affiliations:` list of keys, optional `corresponding`/`equal_contribution`) plus an
+`affiliations:` dict mapping each key to its full "Department, Institution, City,
+Country" text. The script assigns the numbers; you never type a superscript.
+
+---
+
 ## Abstract
 
 ### Structure

--- a/skills/write-paper/scripts/build_title_page_affiliations.py
+++ b/skills/write-paper/scripts/build_title_page_affiliations.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Title-page author/affiliation builder + checker (write-paper).
+
+Most journals — and every Nature Portfolio / npj technical check — require the
+title-page affiliations to be **numbered in the order the authors first introduce
+them**: affiliation 1 belongs to the first author, and each new affiliation gets
+the next number the first time it appears as you read the author list left to
+right. Each affiliation must also carry its city and country. An LLM hand-numbering
+this gets the order wrong (it groups by institution, or lets a late author's
+affiliation keep a low number), which the technical check bounces.
+
+This script makes that numbering deterministic.
+
+BUILD (default): read an authors YAML and emit the correctly-numbered author line
++ affiliation block + corresponding-author footnotes.
+
+  python3 build_title_page_affiliations.py --authors authors.yaml [--out title_page_affiliations.md]
+
+CHECK: parse an existing title page and verify the numbering is by first
+appearance (affiliation 1 == first author's first affiliation), with no gaps,
+orphans, or out-of-order definitions, and a city+country on every affiliation.
+
+  python3 build_title_page_affiliations.py --check title_page.md [--strict]
+
+authors.yaml
+------------
+    authors:
+      - name: "Yoojin Nam"
+        affiliations: [scch_rad, amc_convergence]   # ordered; keys into `affiliations`
+        corresponding: false                         # optional -> appends "*"
+        equal_contribution: false                    # optional -> appends "†"
+      - name: "Pa Hong"
+        affiliations: [scch_rad]
+        corresponding: true
+    affiliations:
+      scch_rad: "Department of Radiology, Samsung Changwon Hospital, ..., Changwon, Republic of Korea"
+      amc_convergence: "Department of Convergence Medicine, ..., Seoul, Republic of Korea"
+
+Exit codes: 0 clean (build, or check with no violations / report-only); 1 a check
+violation under --strict; 2 input/usage error. Stdlib-only except PyYAML (already a
+repo dependency); a JSON authors file also works.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# A country token a city+country affiliation tail is expected to end with. Not
+# exhaustive — used as a soft "looks like it has a country" heuristic.
+COUNTRY_RE = re.compile(
+    r"(Republic of Korea|South Korea|\bKorea\b|United States|\bUSA\b|\bU\.?S\.?A?\.?\b|"
+    r"United Kingdom|\bUK\b|\bChina\b|\bJapan\b|\bGermany\b|\bFrance\b|\bItaly\b|\bSpain\b|"
+    r"\bCanada\b|\bAustralia\b|\bIndia\b|\bSingapore\b|\bTaiwan\b|\bNetherlands\b|"
+    r"\bSwitzerland\b|\bSweden\b|\bBelgium\b|\bBrazil\b|\bIsrael\b|\bAustria\b|\bDenmark\b|"
+    r"\bNorway\b|\bFinland\b|\bPoland\b|\bTurkey\b|\bIreland\b|\bPortugal\b|\bGreece\b)\.?\s*$"
+)
+
+
+def _err(msg: str) -> int:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    return 2
+
+
+def load_authors(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in (".json",):
+        return json.loads(text)
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        raise SystemExit("PyYAML required for YAML input (or pass a .json file).")
+    return yaml.safe_load(text)
+
+
+# ---------------------------------------------------------------- build --------
+
+def assign_numbers(authors: list[dict]) -> dict[str, int]:
+    """First-appearance numbering across the ordered author list."""
+    order: dict[str, int] = {}
+    nxt = 1
+    for a in authors:
+        for key in a.get("affiliations", []):
+            if key not in order:
+                order[key] = nxt
+                nxt += 1
+    return order
+
+
+def build(data: dict) -> tuple[str, list[str]]:
+    authors = data.get("authors") or []
+    affil = data.get("affiliations") or {}
+    problems: list[str] = []
+    if not authors:
+        problems.append("no authors")
+    order = assign_numbers(authors)
+
+    # validate keys + city/country
+    for key in order:
+        if key not in affil:
+            problems.append(f"affiliation key '{key}' used by an author but not defined")
+    for key in affil:
+        if key not in order:
+            problems.append(f"affiliation '{key}' is defined but no author uses it")
+    for key, num in sorted(order.items(), key=lambda kv: kv[1]):
+        text = affil.get(key, "")
+        if text and not COUNTRY_RE.search(text):
+            problems.append(f"affiliation {num} ('{key}') has no recognizable city+country tail")
+
+    # author line
+    names: list[str] = []
+    for a in authors:
+        nums = [str(order[k]) for k in a.get("affiliations", []) if k in order]
+        marks = "".join(nums and [",".join(nums)] or [])
+        suffix = ""
+        if a.get("equal_contribution"):
+            suffix += ",†" if marks else "†"
+        if a.get("corresponding"):
+            suffix += ",\\*" if (marks or suffix) else "\\*"
+        sup = (marks + suffix).lstrip(",")
+        names.append(f"{a['name']}^{sup}^" if sup else a["name"])
+    author_line = "; ".join(names)
+
+    # affiliation block (numeric = first-appearance order)
+    block = [
+        f"^{num}^ {affil.get(key, '[MISSING AFFILIATION TEXT]')}"
+        for key, num in sorted(order.items(), key=lambda kv: kv[1])
+    ]
+
+    out = [author_line, ""]
+    out += block
+    footnotes = []
+    if any(a.get("equal_contribution") for a in authors):
+        footnotes.append("† These authors contributed equally to this work.")
+    corr = [a for a in authors if a.get("corresponding")]
+    if corr:
+        footnotes.append("\\* Corresponding author" + ("s" if len(corr) > 1 else "") + ".")
+    if footnotes:
+        out += [""] + footnotes
+    return "\n".join(out) + "\n", problems
+
+
+# ---------------------------------------------------------------- check --------
+
+SUP_RE = re.compile(r"\^([0-9,\\\*†‡§ ]+)\^")
+AFFIL_LINE_RE = re.compile(r"^\s*\^(\d+)\^\s+(.*\S)\s*$")
+# An author token: a name followed by a ^...^ superscript, separated by ; or ,
+AUTHOR_TOKEN_RE = re.compile(r"([^;]+?)\^([0-9,\\\*†‡§ ]+)\^")
+
+
+def parse_author_line(text: str) -> list[list[int]]:
+    """Return, per author (in order), the list of affiliation numbers they cite.
+    Looks at the densest superscript-bearing line (the author byline)."""
+    best_line, best_count = "", 0
+    for ln in text.splitlines():
+        c = len(SUP_RE.findall(ln))
+        if c > best_count:
+            best_line, best_count = ln, c
+    per_author: list[list[int]] = []
+    for _name, sup in AUTHOR_TOKEN_RE.findall(best_line):
+        nums = [int(n) for n in re.findall(r"\d+", sup)]
+        per_author.append(nums)
+    return per_author
+
+
+def parse_affil_block(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for ln in text.splitlines():
+        m = AFFIL_LINE_RE.match(ln.replace("\\", ""))
+        if m:
+            out.append((int(m.group(1)), m.group(2).rstrip(" \\")))
+    return out
+
+
+def check_title_page(text: str) -> list[dict]:
+    findings: list[dict] = []
+    per_author = parse_author_line(text)
+    block = parse_affil_block(text)
+    if not per_author:
+        return [{"severity": "hard", "rule": "author_line", "detail": "no author byline with ^superscripts^ found"}]
+    if not block:
+        return [{"severity": "hard", "rule": "affil_block", "detail": "no '^N^ affiliation' block found"}]
+
+    defined = [n for n, _ in block]
+    defined_set = set(defined)
+
+    # 1. affiliation 1 == first author's first affiliation
+    first_nums = per_author[0]
+    if not first_nums or first_nums[0] != 1:
+        findings.append({"severity": "hard", "rule": "first_author_is_1",
+                         "detail": f"affiliation 1 must be the first author's first affiliation; first author cites {first_nums or '∅'}"})
+
+    # 2. first-appearance order == 1,2,3,... (a new number may only be the next integer)
+    seen: list[int] = []
+    expected_next = 1
+    for ai, nums in enumerate(per_author, 1):
+        for n in nums:
+            if n not in seen:
+                if n != expected_next:
+                    findings.append({"severity": "hard", "rule": "first_appearance_order",
+                                     "detail": f"affiliation {n} first appears at author #{ai} but {expected_next} has not appeared yet — numbering is not in author order"})
+                seen.append(n)
+                expected_next = max(expected_next, n) + 1 if n == expected_next else expected_next
+
+    # 3. block defined in ascending order, contiguous, no dup
+    if defined != sorted(defined):
+        findings.append({"severity": "hard", "rule": "block_ascending", "detail": f"affiliation block is not in ascending numeric order: {defined}"})
+    if len(defined) != len(defined_set):
+        findings.append({"severity": "hard", "rule": "block_duplicate", "detail": f"duplicate affiliation number(s) in the block: {defined}"})
+    if defined_set and sorted(defined_set) != list(range(1, max(defined_set) + 1)):
+        findings.append({"severity": "hard", "rule": "block_gaps", "detail": f"affiliation numbers are not contiguous 1..N: {sorted(defined_set)}"})
+
+    # 4. cross-reference: every cited number defined, every defined number cited
+    cited = {n for nums in per_author for n in nums}
+    for n in sorted(cited - defined_set):
+        findings.append({"severity": "hard", "rule": "undefined_affiliation", "detail": f"author cites affiliation {n} but the block does not define it"})
+    for n in sorted(defined_set - cited):
+        findings.append({"severity": "soft", "rule": "orphan_affiliation", "detail": f"affiliation {n} is defined but no author cites it"})
+
+    # 5. city + country on each affiliation
+    for n, t in block:
+        if not COUNTRY_RE.search(t):
+            findings.append({"severity": "soft", "rule": "city_country", "detail": f"affiliation {n} has no recognizable city+country tail: '{t[:60]}...'"})
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build or check title-page author/affiliation numbering (first-appearance order).")
+    ap.add_argument("--authors", help="authors YAML/JSON (build mode)")
+    ap.add_argument("--check", help="existing title page (.md/.qmd) to verify")
+    ap.add_argument("--out", help="write the built block here (build mode)")
+    ap.add_argument("--strict", action="store_true", help="exit 1 on a hard check violation")
+    args = ap.parse_args()
+
+    if not args.authors and not args.check:
+        return _err("pass --authors (build) or --check <title_page> (verify)")
+
+    rc = 0
+    if args.authors:
+        p = Path(args.authors)
+        if not p.is_file():
+            return _err(f"authors file not found: {p}")
+        rendered, problems = build(load_authors(p))
+        if args.out:
+            Path(args.out).write_text(rendered, encoding="utf-8")
+            print(f"wrote {args.out}")
+        else:
+            print(rendered)
+        for pr in problems:
+            print(f"  [warn] {pr}", file=sys.stderr)
+
+    if args.check:
+        p = Path(args.check)
+        if not p.is_file():
+            return _err(f"title page not found: {p}")
+        findings = check_title_page(p.read_text(encoding="utf-8"))
+        print("=" * 41)
+        print(" Title-Page Affiliation Order")
+        print("=" * 41)
+        hard = [f for f in findings if f["severity"] == "hard"]
+        if not findings:
+            print("OK: affiliations are numbered by author first-appearance, contiguous, with city+country.")
+        for f in findings:
+            print(f"  [{f['severity']}] {f['rule']}: {f['detail']}")
+        if hard and args.strict:
+            print("\nTITLE_PAGE_AFFILIATION_ORDER_VIOLATION", file=sys.stderr)
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/write-paper/skill.yml
+++ b/skills/write-paper/skill.yml
@@ -46,4 +46,6 @@ known_limitations:
 validation_commands:
   - "/verify-refs --strict"
   - "/self-review"
+  - "python3 scripts/build_title_page_affiliations.py --check manuscript/title_page.md --strict"
+  - "bash tests/test_title_page_affiliations.sh"
 evidence_surface: demo

--- a/skills/write-paper/tests/test_title_page_affiliations.sh
+++ b/skills/write-paper/tests/test_title_page_affiliations.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Challenge/regression test for build_title_page_affiliations.py — deterministic,
+# network-free, runtime fixtures. Build uses a .json authors file (no PyYAML dep);
+# check is stdlib-only.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+S="$HERE/../scripts/build_title_page_affiliations.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" cond="$2"
+  if [ "$cond" = "1" ]; then printf '  PASS  %s\n' "$label"; pass=$((pass + 1))
+  else printf '  FAIL  %s\n' "$label"; fail=$((fail + 1)); fi
+}
+ rc() { "$@" > /dev/null 2>&1; echo $?; }
+
+# --- BUILD: first-appearance numbering, affiliation reuse, ascending block ---
+cat > "$TMP/authors.json" <<'JSON'
+{"authors":[
+  {"name":"Yoojin Nam","affiliations":["scch","amc"]},
+  {"name":"Taein An","affiliations":["hallym"]},
+  {"name":"Pa Hong","affiliations":["scch"],"corresponding":true},
+  {"name":"Namkug Kim","affiliations":["amc","amcrad"],"corresponding":true}],
+ "affiliations":{
+  "scch":"Department of Radiology, Samsung Changwon Hospital, Changwon, Republic of Korea",
+  "amc":"Department of Convergence Medicine, Asan Medical Center, Seoul, Republic of Korea",
+  "hallym":"Department of Radiology, Dongtan Sacred Heart Hospital, Hwaseong, Republic of Korea",
+  "amcrad":"Department of Radiology, Asan Medical Center, Seoul, Republic of Korea"}}
+JSON
+python3 "$S" --authors "$TMP/authors.json" --out "$TMP/built.md" > /dev/null 2>&1
+ck "build emits first-appearance numbering (Nam^1,2^)" "$(grep -cF 'Yoojin Nam^1,2^' "$TMP/built.md")"
+ck "build reuses affiliation 1 for a later author (Pa Hong^1)" "$(grep -cF 'Pa Hong^1,\*^' "$TMP/built.md")"
+ck "build reuses 2 + adds 4 (Namkug Kim^2,4)" "$(grep -cF 'Namkug Kim^2,4,\*^' "$TMP/built.md")"
+ck "block lists ^4^ last" "$(grep -cE '^\^4\^ ' "$TMP/built.md")"
+
+# --- CHECK: the built title page round-trips clean ---
+ck "built title page passes --check --strict" "$([ "$(rc python3 "$S" --check "$TMP/built.md" --strict)" = "0" ] && echo 1 || echo 0)"
+
+# --- CHECK: out-of-order (affiliation 1 is not the first author's) -> exit 1 ---
+cat > "$TMP/bad_order.md" <<'MD'
+Alice Lee^3^; Bob Park^1^; Carol Kim^2,1^
+
+^1^ Department of X, Hospital A, Seoul, Republic of Korea
+^2^ Department of Y, Hospital B, Busan, Republic of Korea
+^3^ Department of Z, Hospital C, Daegu, Republic of Korea
+MD
+ck "out-of-order numbering fails (--strict)" "$([ "$(rc python3 "$S" --check "$TMP/bad_order.md" --strict)" = "1" ] && echo 1 || echo 0)"
+ck "out-of-order tolerated without --strict" "$([ "$(rc python3 "$S" --check "$TMP/bad_order.md")" = "0" ] && echo 1 || echo 0)"
+
+# --- CHECK: author cites an undefined affiliation -> exit 1 ---
+cat > "$TMP/undef.md" <<'MD'
+Alice Lee^1^; Bob Park^2^
+
+^1^ Department of X, Hospital A, Seoul, Republic of Korea
+MD
+ck "undefined affiliation reference fails (--strict)" "$([ "$(rc python3 "$S" --check "$TMP/undef.md" --strict)" = "1" ] && echo 1 || echo 0)"
+
+# --- CHECK: missing city/country is a SOFT finding (exit 0 without --strict) ---
+cat > "$TMP/nocity.md" <<'MD'
+Alice Lee^1^; Bob Park^2^
+
+^1^ Department of X, Hospital A
+^2^ Department of Y, Hospital B, Seoul, Republic of Korea
+MD
+ck "missing city/country is soft (exit 0)" "$([ "$(rc python3 "$S" --check "$TMP/nocity.md")" = "0" ] && echo 1 || echo 0)"
+
+echo "----"
+echo "test_title_page_affiliations: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem
On a real npj Digital Medicine submission, the title-page **affiliations were not numbered in author order**, and the technical check required: *"affiliations in sequential order corresponding to the author list, affiliation 1 associated with the first author, each affiliation includes its city and country."* `write-paper` had **no deterministic rule** for this — the byline superscripts were hand-numbered, so an LLM groups by institution or lets a late author keep a low number, and the check bounces it (fixed manually at v7).

## Fix
New `skills/write-paper/scripts/build_title_page_affiliations.py` — **build + check**:

- **BUILD** (`--authors authors.yaml`): from an ordered authors file (each `name` + ordered `affiliations:` keys + optional `corresponding`/`equal_contribution`, plus an `affiliations:` dict of full "Department, Institution, City, Country" text) it emits the byline with correct superscripts and the affiliation block in **ascending first-appearance order** + corresponding/equal footnotes. The author never types a number.
- **CHECK** (`--check title_page.md --strict`): parses an existing title page and flags **out-of-order numbering** (affiliation 1 not the first author's), gaps, duplicates, undefined/orphan affiliations, and a **missing city/country**; exit 1 under `--strict`.

The numbering algorithm: walk authors left-to-right; each affiliation key gets the next integer the first time it appears; repeats reuse the number; block listed in numeric (= first-appearance) order.

## Verification
- `--check` on the **real (fixed) npj DM title page** → clean.
- `--check --strict` on a deliberately out-of-order fixture → exit 1 with the precise violation.
- 9-case network-free **challenge test** (`tests/test_title_page_affiliations.sh`) wired into CI.
- Guidance added to `title_abstract.md` § "Title Page — Author & Affiliation Order" + the title-page deliverable; `skill.yml` validation_commands updated.

Named `build_*` so it stays off the detector glob — **no catalog count change** (skills 45 / guidelines 36 / detectors 30 unchanged). Cross-references the `npj-nature-technical-check` §7 affiliation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)