### PR TITLE
CMH profile: APC $2,000 + blinded-submission file handling

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1103,8 +1103,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Clinical_and_Molecular_Hepatology.md",
-      "size": 2151,
-      "sha256": "7b343dd7628ec9c6efcd4c9afcb66ca35846d48af20c62e58038c437f0405a0a"
+      "size": 2391,
+      "sha256": "7d923a09bc543fe49db28b9b79714958522e2fe1781d60c6f22dc1efcd3ba650"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Cureus.md",
@@ -3518,8 +3518,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Clinical_and_Molecular_Hepatology.md",
-      "size": 7981,
-      "sha256": "666c53f8c68b3a3436beafdb76a3671825802c5d6fe0a92c052db9075848c7da"
+      "size": 8585,
+      "sha256": "b268d9cf8caa255e72ab4cbc7960473de7666e8c65e86cb3d2e41ea6791a0642"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md",

--- a/skills/find-journal/references/journal_profiles/Clinical_and_Molecular_Hepatology.md
+++ b/skills/find-journal/references/journal_profiles/Clinical_and_Molecular_Hepatology.md
@@ -25,8 +25,8 @@ hepatology, liver disease, MASLD, NAFLD, MetALD, ALD, chronic hepatitis B, chron
 
 ## Classification
 - **Tier:** Q1 hepatology
-- **Open Access:** Full OA (APC US$1,500 since 2024-02-05)
+- **Open Access:** Full OA (APC US$2,000 for original/review articles submitted on/after 2026-02-01; was US$1,500 from 2024-02)
 - **Field:** hepatology, observational cohort epidemiology, Korean/Asian clinical research
 
 ## Special Notes
-KASL flagship journal with strong preference for Korean screening-cohort epidemiology and 2023 SLD nomenclature applications. Original articles require a mandatory graphical abstract (531×531 px, 600 dpi) and structured abstract (Background/Aims, Methods, Results, Conclusions). Fast-track review available for US$1,000 with 7-day first decision. AI policy: follows ICMJE — disclose AI use in Acknowledgements with software name, version, manufacturer, dates, and description of use; AI cannot be author; citation of AI-generated material as primary source is prohibited.
+KASL flagship journal with strong preference for Korean screening-cohort epidemiology and 2023 SLD nomenclature applications. Original articles require a mandatory graphical abstract (531×531 px, 600 dpi) and structured abstract (Background/Aims, Methods, Results, Conclusions). Fast-track review available for US$1,000 with 7-day first decision. **Blinded review**: Main Document = no author info; portal has no "Title Page" file designation, so upload title page + ICMJE forms as "Supplemental File NOT for Review". AI policy: follows ICMJE — disclose AI use in Acknowledgements with software name, version, manufacturer, dates, and description of use; AI cannot be author; citation of AI-generated material as primary source is prohibited.

--- a/skills/write-paper/references/journal_profiles/Clinical_and_Molecular_Hepatology.md
+++ b/skills/write-paper/references/journal_profiles/Clinical_and_Molecular_Hepatology.md
@@ -8,9 +8,10 @@
 - **ISSN**: 2287-2728 (print), 2287-285X (online)
 - **Frequency**: Quarterly (January, April, July, October)
 - **Impact Factor**: [TODO: verify at JCR]
-- **Open Access**: Full OA (APC US$1,500 since February 2024; previously US$1,000)
+- **Open Access**: Full OA. APC **US$2,000** for original and unsolicited review articles submitted on/after 1 February 2026 (previously US$1,500 from February 2024, US$1,000 before)
 - **Acceptance rate**: [TODO: verify at journal site]
 - **Peer review**: Blind peer review; ≥2 referees; first decision in approximately 1 month; fast-track option (7-day first decision) available for additional US$1,000
+- **Blinded-submission file handling**: Main Document must carry no author-identifying information; the title page is a separate file. The portal file-designation dropdown has **no "Title Page" option** — upload the title page (and the ICMJE COI forms, which name authors) as **"Supplemental File NOT for Review"** so they are excluded from the blinded reviewer packet. Blinded supplementary and reporting checklists may be "Supplemental File for Review"; the graphical abstract is "Graphic Abstract".
 
 ## Manuscript Types and Word Limits
 


### PR DESCRIPTION
Updates the Clinical and Molecular Hepatology profile (find-journal compact + write-paper detail) from a live submission.

## Changes
- **APC**: US$1,500 → **US$2,000** for original and unsolicited review articles submitted on/after 2026-02-01 (per current Instructions for Authors).
- **Blinded-submission file handling**: the submission portal's file-designation dropdown has no "Title Page" option; the title page and ICMJE COI forms (which name authors) must be uploaded as **Supplemental File NOT for Review** to keep them out of the blinded reviewer packet.

Profile already covered: blind peer review, mandatory graphical abstract (531×531 px / 600 dpi), structured abstract, Highlights, 6,000-word limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)