### PR TITLE
ci(release): supply-chain hardening — provenance, attestation, updater round-trip gate (PR-2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,40 @@
 name: Release
 
-# Triggered when a version tag is pushed (e.g., v3.0.0).
-# Builds the classroom installer ZIPs, creates a GitHub Release, and attaches the ZIPs.
-# Zenodo automatically archives the GitHub Release if the integration is enabled at
-# https://zenodo.org/account/settings/github/
+# Triggered when a version tag is pushed (e.g., v4.7.0).
+# Builds the classroom installer ZIPs (with an injected, verified provenance.json), attests their
+# build provenance, verifies they are consumable by the self-updater, then creates a GitHub Release
+# with the ZIPs attached. Zenodo automatically archives the GitHub Release if the integration is
+# enabled at https://zenodo.org/account/settings/github/
+#
+# Supply-chain posture (see SECURITY.md "Release integrity & revocation"): the self-updater verifies
+# each download's sha256 against the github.com API digest, which detects transport/asset tampering
+# only — it does NOT defend against a compromised publisher account. Defenses added here:
+#   * a protected `release` environment (configure a required reviewer in repo Settings → Environments
+#     so a human approves before any release is published);
+#   * least-privilege token scopes;
+#   * a version-consistency gate (CITATION == package.json == manifest == the pushed tag);
+#   * build-provenance attestation of the ZIP artifacts;
+#   * a post-build check that each ZIP round-trips through the updater's own safe-extract + provenance
+#     validation, so a release can never ship a ZIP the updater would refuse.
 
 on:
   push:
     tags:
       - "v*"
 
+# Least privilege: contents:write to publish the release; id-token + attestations for the build
+# provenance attestation. Nothing else.
 permissions:
-  contents: write  # required for gh release create
+  contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Human gate: add a required reviewer to the `release` environment (repo Settings → Environments)
+    # so publishing a release requires explicit approval. Harmless before that setting exists.
+    environment: release
 
     steps:
       - name: Checkout repository (with full history for tag annotation)
@@ -28,8 +47,39 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Build classroom release ZIPs
-        run: python scripts/build_classroom_release.py
+      - name: Version-consistency gate (CITATION == package.json == manifest == pushed tag)
+        run: |
+          set -euo pipefail
+          # CITATION == package.json == manifest (three-source version agreement)...
+          python3 scripts/check_version_consistency.py
+          # ...and the tracked distribution_files.json inventory still matches the on-disk tree, so
+          # the inventory the ZIP bundles (which the updater trusts) is anchored to the real source.
+          python3 scripts/gen_distribution_manifest.py --check
+          TAG="${GITHUB_REF_NAME}"
+          VER="${TAG#v}"
+          MAN="$(python3 -c 'import json;print(json.load(open("metadata/distribution_manifest.json"))["version"])')"
+          if [ "$VER" != "$MAN" ]; then
+            echo "::error::pushed tag ${TAG} (version ${VER}) != distribution_manifest version ${MAN}. Bump CITATION.cff/package.json/manifest before tagging." >&2
+            exit 1
+          fi
+          echo "version gate OK: ${TAG} == manifest ${MAN}"
+
+      - name: Build classroom release ZIPs (with verified provenance.json)
+        run: |
+          set -euo pipefail
+          BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python3 scripts/build_classroom_release.py \
+            --tag "${GITHUB_REF_NAME}" \
+            --git-sha "${GITHUB_SHA}" \
+            --built-at "${BUILT_AT}"
+
+      - name: Verify ZIPs are consumable by the self-updater (provenance + safe-extract round-trip)
+        run: |
+          set -euo pipefail
+          for zip in dist/medsci-skills-classroom-*.zip; do
+            python3 scripts/check_release_zip.py --zip "$zip" \
+              --expect-tag "${GITHUB_REF_NAME}" --require-provenance
+          done
 
       - name: List built artifacts
         run: |
@@ -40,6 +90,11 @@ jobs:
             echo "## ${zip}"
             unzip -l "${zip}" | head -20
           done
+
+      - name: Attest build provenance of the release ZIPs
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/medsci-skills-classroom-*.zip"
 
       - name: Extract release notes from CHANGELOG.md
         id: notes
@@ -72,9 +127,13 @@ jobs:
       - name: Create GitHub Release with classroom ZIP attached
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Publish the SAME classroom artifacts that were verified (line ~75) and attested (line ~97);
+        # the glob is identical so a release can only ship a ZIP that round-tripped + was attested.
+        # Nothing modifies dist/ between those steps and this upload, so the API sha256 the updater
+        # later checks covers exactly the verified bytes.
         run: |
           TAG="${GITHUB_REF_NAME}"
           gh release create "$TAG" \
             --title "MedSci Skills ${TAG}" \
             --notes-file /tmp/release_notes.md \
-            dist/*.zip
+            dist/medsci-skills-classroom-*.zip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,6 +49,9 @@ jobs:
       - name: install.py transactional self-test (no host/state dir touched)
         run: python3 installers/install.py --self-test
 
+      - name: Release-ZIP provenance + updater-consumability round-trip (build -> safe-extract)
+        run: bash installers/tests/test_release_zip.sh
+
       - name: Run validate_routing_assets.py (SKILL.md asset references must exist)
         run: python3 scripts/validate_routing_assets.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Release-pipeline supply-chain hardening (self-update foundation, no user-facing change).**
+  `release.yml` now: gates on a version-consistency check (the pushed tag must equal
+  `CITATION.cff` == `package.json` == `metadata/distribution_manifest.json`); injects a verified
+  `provenance.json` `{schema_version, tag, version, git_sha, built_at}` into each classroom ZIP via
+  `build_classroom_release.py --tag/--git-sha/--built-at`; attests the ZIPs' build provenance
+  (`actions/attest-build-provenance`); runs on a protected `release` environment (required-reviewer
+  approval); and — via the new `scripts/check_release_zip.py` — verifies each ZIP round-trips through
+  the **updater's own** safe-extract + provenance validation before publishing, so a release can never
+  ship a ZIP the self-updater would reject. A CI test (`installers/tests/test_release_zip.sh`) locks
+  the build → verify round-trip and the tag/version gate. `provenance.json` stays a control file
+  (excluded from the safe-extract inventory). `SECURITY.md` gains a "Release integrity & revocation"
+  section; `docs/maintainer_workflow.md` documents the protected-environment setup.
+
 ## [4.6.0] - 2026-06-21
 
 A maintainability, governance, and review-depth release. **Integrity detectors 28 → 30; domain probes 11 → 12; skills 45 and reporting guidelines 36 unchanged.** No skill rename, CLI, or output-path change — additive and backward-compatible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,46 @@ Use synthetic or public datasets in examples. The repository's validators includ
 PII/precedent scan, but the first line of defense is not pasting sensitive content
 in the first place. If you need to share a failing case that involves sensitive
 data, reduce it to a synthetic minimal reproduction.
+
+## Release integrity & revocation
+
+The classroom self-updater downloads a release ZIP and runs its bundled installer. This
+**is remote code execution within the GitHub trust boundary**. Be precise about what is and
+is not defended:
+
+- The updater verifies each download's **SHA-256 against the digest the github.com API reports
+  for that release asset**, and re-checks the asset name, the release tag, a single ZIP root,
+  and that every payload entry matches the bundled `metadata/distribution_files.json` inventory
+  (path + size + sha256). This detects a **corrupted or tampered-in-transit download**.
+- It does **not** defend against a **compromised maintainer account or a malicious official
+  release** served from the same boundary. Treat an update with the same trust you place in
+  this repository.
+
+What the release pipeline adds to make a published release trustworthy:
+
+- A **protected `release` environment** with a required reviewer (configured in repo Settings →
+  Environments) so a human approves before any release is published.
+- A **version-consistency gate**: a tag is only releasable when `CITATION.cff` ==
+  `package.json` == `metadata/distribution_manifest.json` (the version-consistency check) **and**
+  that shared version equals the pushed tag (the release-workflow tag gate).
+- **Build-provenance attestation** of the ZIP artifacts (`actions/attest-build-provenance`);
+  anyone can verify a downloaded asset with `gh attestation verify <zip> --repo Aperivue/medsci-skills`.
+- A **pre-publish round-trip check** (`scripts/check_release_zip.py`) that runs the updater's own
+  safe-extract + provenance validation, so a release cannot ship a ZIP the updater would reject.
+
+### If a release is compromised
+
+If a published release is believed to be malicious or tampered:
+
+1. **Report privately** via GitHub Security Advisories (see "Reporting a vulnerability") — do not
+   open a public issue with exploit detail first.
+2. Maintainers **delete or mark the affected release** on GitHub and **delete the tag**, then
+   publish a new patched release with a higher version. Because the updater compares **semver**,
+   users move forward to the patched version and never back to the revoked one.
+3. Maintainers **rotate any credentials** that could have been used to publish the bad release
+   and review the attestation log for the affected artifacts.
+4. The incident and the fixed version are noted in `CHANGELOG.md` and the GitHub Security Advisory.
+
+Users who are concerned can always re-install from a known-good GitHub release — download that
+release's classroom ZIP and run its bundled installer — or verify an asset's attestation with
+`gh attestation verify <zip> --repo Aperivue/medsci-skills` before installing.

--- a/docs/maintainer_workflow.md
+++ b/docs/maintainer_workflow.md
@@ -31,7 +31,14 @@ final release approval at every stage.
 ## Release checklist
 
 A release is cut from `main` by pushing a version tag; `release.yml` builds the
-ZIPs, creates the GitHub Release, and Zenodo archives it.
+ZIPs (with an injected, verified `provenance.json`), attests their build provenance,
+verifies they are consumable by the self-updater, creates the GitHub Release, and
+Zenodo archives it.
+
+**One-time setup:** in repo **Settings → Environments**, create a `release` environment
+and add yourself as a **required reviewer**. The release job then pauses for your approval
+before publishing. (The workflow names the environment unconditionally; without the setting
+it simply does not gate.)
 
 1. **Decide the version** honestly (see "Versioning" below).
 2. **Sync versions in one commit:**
@@ -39,17 +46,25 @@ ZIPs, creates the GitHub Release, and Zenodo archives it.
    - `CITATION.cff` — `version` + `date-released`.
    - `package.json` — `version` (npm).
    - `README.md` — "What's New" entry.
-3. **Regenerate catalogs** if counts changed:
-   `gen_skills_catalog_json.py`, `gen_detectors_catalog_json.py`,
-   `gen_marketplace_json.py` (then `--check` each) and
-   `validate_catalog_consistency.py`.
-4. **Tag** `vX.Y.Z` and push → `release.yml` runs. Confirm the GitHub Release and
-   Zenodo archive.
+3. **Regenerate the distribution manifest + catalogs:**
+   - `python3 scripts/gen_distribution_manifest.py` — refreshes `distribution_manifest.json`
+     (version, from `CITATION.cff`) + the `distribution_files.json` inventory. Run
+     `check_version_consistency.py` to confirm CITATION == package.json == manifest.
+   - If skill/detector counts changed: `gen_skills_catalog_json.py`,
+     `gen_detectors_catalog_json.py`, `gen_marketplace_json.py` (then `--check` each) and
+     `validate_catalog_consistency.py`.
+4. **Tag** `vX.Y.Z` and push → `release.yml` runs. It gates on the version-consistency
+   check (tag must equal the manifest version), pauses for `release`-environment approval,
+   attests the ZIPs, and verifies each is updater-consumable before publishing. **Approve**
+   the run, then confirm the GitHub Release and Zenodo archive.
 5. **Sync downstream surfaces** that live outside this repo's CI: the homepage
    `skills.json` counts and any hero-skill mirrors (`sync_hero_skill.py`).
 6. **Record evidence** — refresh [`IMPACT.md`](../IMPACT.md) (run the metrics
    snapshot *before* the release commit so the bot commit is in place) and log any
    new citations / named use.
+
+A compromised-release revocation procedure is in [`SECURITY.md`](../SECURITY.md)
+("Release integrity & revocation").
 
 ## Versioning policy
 

--- a/installers/tests/test_release_zip.sh
+++ b/installers/tests/test_release_zip.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Release-ZIP provenance + updater-consumability round-trip (PR-2, release-workflow hardening).
+#
+# Builds the real classroom ZIPs the way the release workflow does (with an injected provenance.json)
+# and verifies them with scripts/check_release_zip.py, which runs the UPDATER'S OWN safe_extract +
+# validate_provenance. This guarantees a tagged release cannot ship a ZIP the self-updater would
+# reject (inventory hash drift, missing provenance, tag mismatch). Hash-sensitive -> Ubuntu CI only
+# (the `validate` job), like gen_distribution_manifest --check.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+VER="$(python3 -c 'import json;print(json.load(open("metadata/distribution_manifest.json"))["version"])')"
+TAG="v${VER}"
+echo "release-zip test: building tag ${TAG}"
+
+cleanup() { rm -rf dist; }
+trap cleanup EXIT
+
+# 1. Build with provenance (deterministic git-sha/built-at), exactly as release.yml will.
+python3 scripts/build_classroom_release.py --tag "$TAG" --git-sha "0000000000000000000000000000000000000000" --built-at "2020-01-01T00:00:00Z" >/dev/null
+
+# 2. Both ZIPs must be updater-consumable with matching provenance tag + present provenance.
+for plat in macos windows; do
+  zip="dist/medsci-skills-classroom-${plat}.zip"
+  [ -f "$zip" ] || fail "build did not produce $zip"
+  python3 scripts/check_release_zip.py --zip "$zip" --expect-tag "$TAG" --require-provenance \
+    || fail "$zip is not updater-consumable"
+done
+echo "PASS  both ZIPs round-trip through update.safe_extract with provenance tag ${TAG}"
+
+# 3. Version gate: building with a tag that disagrees with the manifest must fail the build.
+if python3 scripts/build_classroom_release.py --tag "v0.0.0" >/dev/null 2>&1; then
+  fail "build accepted a tag that disagrees with distribution_manifest version"
+fi
+echo "PASS  build rejects a tag/version mismatch (release cannot ship a stale manifest)"
+
+# 4. Verifier rejects an expect-tag mismatch (provenance tag must equal the release tag).
+python3 scripts/build_classroom_release.py --tag "$TAG" --git-sha x --built-at 2020-01-01T00:00:00Z >/dev/null
+if python3 scripts/check_release_zip.py --zip "dist/medsci-skills-classroom-macos.zip" --expect-tag "v0.0.0" >/dev/null 2>&1; then
+  fail "verifier accepted a provenance/expect-tag mismatch"
+fi
+echo "PASS  verifier rejects a provenance/expect-tag mismatch"
+
+# 5. --expect-tag must not pass vacuously on a provenance-less (local) build.
+python3 scripts/build_classroom_release.py >/dev/null   # no --tag -> no provenance.json
+if python3 scripts/check_release_zip.py --zip "dist/medsci-skills-classroom-macos.zip" --expect-tag "$TAG" >/dev/null 2>&1; then
+  fail "verifier accepted --expect-tag on a ZIP with no provenance.json"
+fi
+echo "PASS  verifier rejects --expect-tag when provenance.json is absent"
+
+echo "test_release_zip: all checks passed"

--- a/scripts/build_classroom_release.py
+++ b/scripts/build_classroom_release.py
@@ -1,9 +1,22 @@
 #!/usr/bin/env python3
-"""Build classroom installer ZIP files for GitHub Releases."""
+"""Build classroom installer ZIP files for GitHub Releases.
+
+When invoked by the release workflow with ``--tag`` (and optionally ``--git-sha`` /
+``--built-at``), a deterministic ``provenance.json`` ``{schema_version, tag, version,
+git_sha, built_at}`` is injected at the ZIP root. The self-updater validates that the
+provenance ``tag``/``version`` match the release tag and the bundled
+``distribution_manifest.json`` before installing. ``provenance.json`` is a control file:
+it is intentionally **not** part of ``distribution_files.json`` (the safe-extract
+inventory), so injecting it never breaks the inventory's path/size/sha256 round-trip.
+
+Local builds without ``--tag`` produce provenance-free ZIPs (the updater tolerates the
+absence); only the release workflow, which knows the authoritative tag, injects it.
+"""
 
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import subprocess
 import zipfile
@@ -13,6 +26,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DIST_DIR = REPO_ROOT / "dist"
 PACKAGE_NAME = "medsci-skills-classroom"
+MANIFEST_PATH = REPO_ROOT / "metadata" / "distribution_manifest.json"
 INCLUDE_PATHS = [
     "README_FIRST.md",
     "installers",
@@ -81,7 +95,12 @@ def add_path(zipf: zipfile.ZipFile, path: Path, root_name: str) -> None:
         zipf.write(item, Path(root_name) / item.relative_to(REPO_ROOT))
 
 
-def build_zip(platform: str, version: str) -> Path:
+def manifest_version() -> str:
+    """The version recorded in the tracked distribution_manifest.json (CITATION-derived SSOT)."""
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["version"]
+
+
+def build_zip(platform: str, version: str, provenance: dict | None = None) -> Path:
     root_name = f"{PACKAGE_NAME}-{version}"
     out = DIST_DIR / f"{PACKAGE_NAME}-{platform}.zip"
     if out.exists():
@@ -91,21 +110,58 @@ def build_zip(platform: str, version: str) -> Path:
             path = REPO_ROOT / rel
             if path.exists():
                 add_path(zipf, path, root_name)
+        if provenance is not None:
+            # Deterministic bytes (sorted keys); a control file, NOT in distribution_files.json.
+            # Force a forward-slash arcname so the ZIP path is correct regardless of build OS
+            # (the updater's _zip_root / _reject_unsafe_name split on '/' and reject '\\').
+            zipf.writestr(
+                f"{root_name}/provenance.json",
+                json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+            )
     return out
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Build classroom release ZIPs.")
-    parser.add_argument("--version", default="latest", help="Version label embedded in the ZIP root folder.")
+    parser.add_argument("--version", default="latest", help="Version label for the ZIP root folder (ignored when --tag is given).")
+    parser.add_argument("--tag", default=None, help="Release tag (e.g. v4.7.0). Injects a verified provenance.json and pins the root version.")
+    parser.add_argument("--git-sha", default=None, help="Commit SHA to record in provenance.json (release workflow supplies ${{ github.sha }}).")
+    parser.add_argument("--built-at", default=None, help="Build timestamp (ISO-8601 UTC) to record in provenance.json.")
     args = parser.parse_args()
+
+    provenance: dict | None = None
+    version = args.version
+    if args.tag:
+        tag = args.tag
+        version = tag[1:] if tag.startswith("v") else tag
+        # The manifest version is the CITATION-derived SSOT (gen_distribution_manifest copies it from
+        # CITATION.cff). This gate pins the tag to that single source; the full three-way check
+        # (CITATION == package.json == manifest) runs as its own release.yml step before the build.
+        man_ver = manifest_version()
+        if version != man_ver:
+            raise SystemExit(
+                f"release tag {tag!r} (version {version!r}) != distribution_manifest version "
+                f"{man_ver!r}; bump CITATION.cff/package.json/manifest before tagging "
+                f"(scripts/check_version_consistency.py)."
+            )
+        provenance = {
+            "schema_version": 1,
+            "tag": tag,
+            "version": version,
+            "git_sha": args.git_sha or "",
+            "built_at": args.built_at or "",
+        }
 
     if DIST_DIR.exists():
         shutil.rmtree(DIST_DIR)
     DIST_DIR.mkdir(parents=True)
 
-    outputs = [build_zip("windows", args.version), build_zip("macos", args.version)]
+    outputs = [build_zip("windows", version, provenance), build_zip("macos", version, provenance)]
     for out in outputs:
         print(out)
+    if provenance is not None:
+        print(f"\nInjected provenance.json: tag={provenance['tag']} version={provenance['version']} "
+              f"git_sha={provenance['git_sha'][:12]} built_at={provenance['built_at']}")
     print("\nUpload these files as GitHub Release assets:")
     for out in outputs:
         print(f"- {out.name}")

--- a/scripts/check_release_zip.py
+++ b/scripts/check_release_zip.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Verify a built classroom release ZIP is consumable by the self-updater.
+
+This runs the SAME code the updater runs against a downloaded release — `update.safe_extract`
+(per-entry traversal/symlink/zip-bomb rejection + `distribution_files.json` allowlist & per-file
+sha256) and `update.validate_provenance` — so the release workflow cannot publish a ZIP the
+updater would later refuse to install. Offline; stdlib-only.
+
+Usage:
+    python3 scripts/check_release_zip.py --zip dist/medsci-skills-classroom-macos.zip \
+        [--expect-tag v4.7.0] [--require-provenance]
+
+Exit 0 = the ZIP is single-rooted, every inventory file is present with a matching size+hash, no
+unsafe/extra entries exist, `installers/install.py` is present, and (if provenance is injected) its
+tag/version are internally consistent and match --expect-tag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "installers"))
+import update  # noqa: E402  (reuse the updater's own verify/safe-extract path)
+
+
+def check_zip(zip_path: Path, expect_tag: str | None, require_provenance: bool) -> list[str]:
+    """Return a list of problems (empty == OK)."""
+    problems: list[str] = []
+    data = zip_path.read_bytes()
+
+    # Single root + inventory + manifest version, read exactly as the updater does. Note: the
+    # inventory is read FROM the ZIP, so this proves the ZIP is internally self-consistent (every
+    # payload file matches the bundled distribution_files.json). That the inventory itself equals the
+    # real source tree is a separate anchor — gen_distribution_manifest.py --check, run by validate.yml
+    # and re-run by release.yml before the build — not this script's job.
+    try:
+        root, inventory = update.read_inventory_from_zip(data)
+    except update.UpdateError as exc:
+        return [f"inventory: {exc}"]
+    man_version = update.read_manifest_version_from_zip(data, root)
+    if man_version == "unknown":
+        problems.append("distribution_manifest.json missing or unparseable in ZIP")
+
+    # Full safe-extract round-trip: proves every inventory entry present, hashes match, no
+    # traversal/symlink/dup/zip-bomb/extra entries (raises UpdateError otherwise).
+    with tempfile.TemporaryDirectory(prefix="relzip-") as tmp:
+        extract = Path(tmp) / "payload"
+        extract.mkdir()
+        try:
+            update.safe_extract(data, extract, inventory)
+        except update.UpdateError as exc:
+            problems.append(f"safe-extract: {exc}")
+            return problems  # nothing else is trustworthy if extraction fails
+
+        if not (extract / "installers" / "install.py").is_file():
+            problems.append("payload has no installers/install.py")
+
+        prov_path = extract / "provenance.json"
+        if not prov_path.is_file():
+            if require_provenance:
+                problems.append("provenance.json missing (release builds must inject it)")
+            elif expect_tag:
+                # --expect-tag must not pass vacuously on a provenance-less ZIP.
+                problems.append(f"--expect-tag {expect_tag} given but provenance.json is absent (cannot verify tag)")
+        else:
+            prov = json.loads(prov_path.read_text(encoding="utf-8"))
+            ptag, pver = prov.get("tag", ""), prov.get("version", "")
+            # tag/version internal consistency: vX.Y.Z <-> X.Y.Z, version == manifest version.
+            if ptag and pver and (ptag[1:] if ptag.startswith("v") else ptag) != pver:
+                problems.append(f"provenance tag {ptag!r} inconsistent with version {pver!r}")
+            if pver and man_version != "unknown" and pver != man_version:
+                problems.append(f"provenance version {pver!r} != manifest version {man_version!r}")
+            # The updater's own provenance check (tag + version) against the expected tag.
+            if expect_tag:
+                try:
+                    update.validate_provenance(extract, expect_tag, man_version)
+                except update.UpdateError as exc:
+                    problems.append(f"validate_provenance vs {expect_tag}: {exc}")
+                if ptag and ptag != expect_tag:
+                    problems.append(f"provenance tag {ptag!r} != expected {expect_tag!r}")
+
+    return problems
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Verify a built classroom release ZIP is updater-consumable.")
+    ap.add_argument("--zip", required=True, type=Path, help="path to a built classroom ZIP")
+    ap.add_argument("--expect-tag", default=None, help="assert provenance tag == this release tag")
+    ap.add_argument("--require-provenance", action="store_true", help="fail if provenance.json is absent")
+    args = ap.parse_args(argv)
+
+    if not args.zip.is_file():
+        print(f"FAIL: no such ZIP: {args.zip}", file=sys.stderr)
+        return 2
+    problems = check_zip(args.zip, args.expect_tag, args.require_provenance)
+    if problems:
+        print(f"FAIL: {args.zip.name} is not updater-consumable:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    inv_n = len(update.read_inventory_from_zip(args.zip.read_bytes())[1])
+    print(f"OK: {args.zip.name} — single root, {inv_n} inventory files match, install.py present"
+          + (f", provenance tag {args.expect_tag}" if args.expect_tag else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## PR-2 — release-pipeline supply-chain hardening (self-update foundation)

Third in the self-update series (after #177 transactional installer, #178 self-updater). Makes a
**tagged release** produce a classroom ZIP the self-updater can actually consume — and ensures a
release can never ship one the updater would reject. **No release is cut here.**

### Why
PR-1b's updater validates each download's sha256 against the github.com API digest, never
`extractall()`s, and checks `provenance.json` + the `distribution_files.json` allowlist. But the
release pipeline injected **no** `provenance.json`, had no attestation, no protected environment, and
no check that the published ZIP was even updater-consumable. This closes that gap.

### What this adds
- **`build_classroom_release.py`** — with `--tag/--git-sha/--built-at`, injects a deterministic
  `provenance.json` `{schema_version, tag, version, git_sha, built_at}` at the ZIP root and **fails the
  build** if `tag`-without-`v` ≠ the (CITATION-derived) `distribution_manifest` version. `provenance.json`
  stays a control file (excluded from the safe-extract inventory), so the round-trip stays clean.
- **`scripts/check_release_zip.py`** (new) — a release-time verifier that runs the **updater's own**
  `safe_extract` + `validate_provenance` against a built ZIP, so *publish ⊆ updater-consumable*.
- **`installers/tests/test_release_zip.sh`** (new, Ubuntu `validate` job) — locks the build→verify
  round-trip, the tag/version gate, an expect-tag mismatch, and provenance-less rejection.
- **`release.yml`** — version-consistency + tree↔inventory gate, provenance build args, post-build
  round-trip verify, `actions/attest-build-provenance@v2`, least-privilege scopes
  (`contents:write` + `id-token:write` + `attestations:write`), a protected **`release` environment**
  (required-reviewer approval, configured in repo Settings). Verify, attest, and publish all use the
  **same** classroom glob so only verified + attested ZIPs ship.
- **Docs** — `SECURITY.md` "Release integrity & revocation" (honest scope: digest/attestation =
  transport integrity, **not** publisher-compromise defense) + `docs/maintainer_workflow.md` setup.

### Trust boundary (honest scope)
The digest and the attestation detect **transport / asset tampering**. They do **not** defend against a
compromised publisher account. SECURITY.md says exactly that and documents a revocation procedure.

### Review
Folds an adversarial review (4 lenses → per-finding refutation, 17 agents): **9 confirmed
minor/nit fixes applied** (attest/publish glob coupling, forward-slash arcname, `--expect-tag`
no-op on provenance-less ZIPs, tag-time inventory re-anchor, doc accuracy + anti-overclaim), **4
refuted**. No blockers/majors.

### CI
- `validate` (Ubuntu): adds `installers/tests/test_release_zip.sh` (build the real ZIP → verify via the
  updater's safe-extract). `release.yml` itself only runs on tag push; its logic is exercised by that
  test + the version/inventory gates.
- `foundation-os` (macOS + Windows): unchanged, runs as before.

### Deferred (follow-up PR)
Increment 2 — opt-in SessionStart update-notify hook, OFF by default.

Draft until CI is green.
