### PR TITLE
chore(metrics): capture top referrers + paths weekly (durable attribution)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,14 +1,20 @@
 name: metrics
 
-# Weekly adoption snapshot. GitHub only retains traffic (views/clones) for 14
-# days and exposes it to repo admins only — without this job that data is lost
-# every day. Appends one row per run to metrics/traffic_log.csv so the growth
-# curve survives as a durable, auditable record.
+# Weekly adoption snapshot. GitHub only retains traffic for 14 days and exposes
+# it to repo admins only — without this job that data is lost every day. Appends:
+#   * metrics/traffic_log.csv   — one row/run: stars, forks, downloads, 14d views/clones, Zenodo
+#   * metrics/referrers_log.csv — top referrers/run (date, referrer, count, uniques)
+#   * metrics/paths_log.csv     — top viewed paths/run (date, path, title, count, uniques)
+# The referrer/path snapshots are the most strategically useful AND the most
+# ephemeral data GitHub exposes: they reveal which channel (Google / Reddit /
+# chatgpt.com / a directory) drove a wave, but are a top-10 point-in-time view
+# that vanishes after 14 days. Long-format rows let you pivot a channel's trend
+# over weeks (e.g. is AEO traffic from chatgpt.com / perplexity.ai compounding?).
 #
-# Traffic endpoints (/traffic/views, /traffic/clones) require push access. The
-# default GITHUB_TOKEN may return 403; set a repo secret METRICS_PAT (a fine-
-# grained PAT with "Administration: read" on this repo) to capture them. Public
-# metrics (stars/forks/release downloads/Zenodo) work without any PAT.
+# Traffic endpoints (/traffic/*) require push access. The default GITHUB_TOKEN may
+# return 403; set a repo secret METRICS_PAT (a fine-grained PAT with
+# "Administration: read" on this repo) to capture them. Public metrics
+# (stars/forks/release downloads/Zenodo) work without any PAT.
 
 on:
   schedule:
@@ -54,6 +60,11 @@ jobs:
           CLONES=$(echo "$CJSON" | jq -r '.count // ""')
           UCLONES=$(echo "$CJSON"| jq -r '.uniques // ""')
 
+          # --- Top referrers + paths (top-10 point-in-time; default [] so a 403/error
+          #     yields zero rows rather than a malformed append) ---
+          RJSON=$(gh api "repos/$REPO/traffic/popular/referrers" 2>/dev/null || echo '[]')
+          PJSON=$(gh api "repos/$REPO/traffic/popular/paths"     2>/dev/null || echo '[]')
+
           # --- Zenodo (public API, blank-tolerant) ---
           ZJSON=$(curl -fsSL "https://zenodo.org/api/records/$ZENODO_RECORD" 2>/dev/null || echo '{}')
           ZVIEWS=$(echo "$ZJSON" | jq -r '(.stats.version_views // .stats.views) // ""' 2>/dev/null || echo "")
@@ -66,10 +77,30 @@ jobs:
           echo "$DATE,$STARS,$FORKS,$WATCH,$DL,$VIEWS,$UVIEWS,$CLONES,$UCLONES,$ZVIEWS,$ZDL" >> metrics/traffic_log.csv
           echo "Appended: $DATE stars=$STARS forks=$FORKS downloads=$DL views=$VIEWS clones=$CLONES"
 
+          # Referrers (date,referrer,count,uniques). @csv quotes fields safely; `if type==array`
+          # tolerates a 403/{} fallback by emitting nothing. Header written once.
+          if [ ! -f metrics/referrers_log.csv ]; then
+            echo "date,referrer,count,uniques" > metrics/referrers_log.csv
+          fi
+          echo "$RJSON" | jq -r --arg d "$DATE" \
+            'if type=="array" then .[] else empty end | [$d, .referrer, .count, .uniques] | @csv' \
+            >> metrics/referrers_log.csv
+          NREF=$(echo "$RJSON" | jq -r 'if type=="array" then length else 0 end')
+
+          # Popular paths (date,path,title,count,uniques).
+          if [ ! -f metrics/paths_log.csv ]; then
+            echo "date,path,title,count,uniques" > metrics/paths_log.csv
+          fi
+          echo "$PJSON" | jq -r --arg d "$DATE" \
+            'if type=="array" then .[] else empty end | [$d, .path, .title, .count, .uniques] | @csv' \
+            >> metrics/paths_log.csv
+          NPATH=$(echo "$PJSON" | jq -r 'if type=="array" then length else 0 end')
+          echo "Referrers captured: $NREF; paths captured: $NPATH (0 = no PAT / no traffic data)"
+
       - name: Commit snapshot
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add metrics/traffic_log.csv
+          git add metrics/traffic_log.csv metrics/referrers_log.csv metrics/paths_log.csv
           git diff --staged --quiet || git commit -m "chore(metrics): weekly adoption snapshot [skip ci]"
           git push

--- a/IMPACT.md
+++ b/IMPACT.md
@@ -9,8 +9,10 @@ are expected to fill over time.
 How the numbers are captured:
 
 - **Automated**: a weekly workflow ([`.github/workflows/metrics.yml`](.github/workflows/metrics.yml))
-  appends a row to [`metrics/traffic_log.csv`](metrics/traffic_log.csv) — stars,
-  forks, release downloads, 14-day traffic, and Zenodo views/downloads.
+  appends to [`metrics/traffic_log.csv`](metrics/traffic_log.csv) (stars, forks, release
+  downloads, 14-day traffic, Zenodo views/downloads) and — so the *source* of each wave is not
+  lost after GitHub's 14-day window — to [`metrics/referrers_log.csv`](metrics/referrers_log.csv)
+  (top referring sites) and [`metrics/paths_log.csv`](metrics/paths_log.csv) (top viewed paths).
 - **Manual**: academic citations and named downstream use are logged in
   [`docs/citations.md`](docs/citations.md) as they are discovered.
 

--- a/metrics/paths_log.csv
+++ b/metrics/paths_log.csv
@@ -1,0 +1,11 @@
+date,path,title,count,uniques
+"2026-06-22","/Aperivue/medsci-skills","Overview",904,604
+"2026-06-22","/Aperivue/medsci-skills/tree/main/skills","/tree/main/skills",98,56
+"2026-06-22","/Aperivue/medsci-skills/tree/main","/tree/main",51,26
+"2026-06-22","/Aperivue/medsci-skills/issues","/issues",29,21
+"2026-06-22","/Aperivue/medsci-skills/releases","/releases",22,5
+"2026-06-22","/Aperivue/medsci-skills/tree/main/demo/02_metafor_bcg","/tree/main/demo/02_metafor_bcg",19,6
+"2026-06-22","/Aperivue/medsci-skills/tree/main/.claude-plugin","/tree/main/.claude-plugin",14,10
+"2026-06-22","/Aperivue/medsci-skills/blob/main/docs/setup/mcp-setup.md","/blob/main/docs/setup/mcp-setup.md",14,9
+"2026-06-22","/Aperivue/medsci-skills/releases/tag/v4.3.0","/releases/tag/v4.3.0",13,9
+"2026-06-22","/Aperivue/medsci-skills/blob/main/README.md","/blob/main/README.md",12,8

--- a/metrics/referrers_log.csv
+++ b/metrics/referrers_log.csv
@@ -1,0 +1,11 @@
+date,referrer,count,uniques
+"2026-06-22","Google",337,172
+"2026-06-22","github.com",254,124
+"2026-06-22","reddit.com",77,34
+"2026-06-22","chatgpt.com",45,27
+"2026-06-22","l.threads.com",36,28
+"2026-06-22","linkedin.com",22,8
+"2026-06-22","Bing",18,11
+"2026-06-22","perplexity.ai",9,3
+"2026-06-22","claude.ai",9,2
+"2026-06-22","l.facebook.com",5,1


### PR DESCRIPTION
## Capture top referrers + paths weekly (durable attribution)

Adds the one piece of adoption telemetry that was being lost: **where each traffic wave comes from.**

### Why
GitHub's Traffic API exposes **top referrers** and **top viewed paths** only as a **14-day, admin-only,
top-10 point-in-time** view. That's the single most useful signal for *"which channel drove this"*
(Google / Reddit / chatgpt.com / a directory / arXiv) — and the first to vanish. `metrics.yml` already
logged view/clone **counts** but not the **source**, so referrer attribution evaporated every 14 days.

### What this adds
- `metrics/referrers_log.csv` — `date, referrer, count, uniques`
- `metrics/paths_log.csv` — `date, path, title, count, uniques`

Both are **long format**, so a channel's trend pivots cleanly over weeks (e.g. is AEO traffic from
`chatgpt.com` / `perplexity.ai` compounding?). The weekly `metrics.yml` run now also appends to them.

- **Blank-tolerant:** a 403 / no-PAT run resolves to `[]` → zero rows, header still written; the existing
  header is never duplicated. `@csv` quotes every field (comma-safe). No commit-loop (the workflow runs
  on schedule/dispatch only, with `[skip ci]`).
- **Seeded** with the **2026-06-22** snapshot so the current wave is preserved immediately rather than
  waiting on the next cron — e.g. referrers Google 337/172, github.com 254/124, reddit.com 77/34,
  chatgpt.com 45/27, threads/linkedin/bing/perplexity/claude/facebook.
- `IMPACT.md` updated to document the two new logs.

### Verification
Capture logic tested against the live Traffic API (exact `jq | @csv` output); CSVs parse cleanly
(uniform columns). Adversarially reviewed: header guards always create both files before the commit
step (incl. the no-PAT path), `jq` emits zero rows on `[]`/`{}`, no commit-loop, no PII (domains + repo
paths only). `gen_distribution_manifest --check` unaffected (`metrics/` is not part of the install payload).

No skill / detector / version change.
