### PR TITLE
ci(release): auto-publish to npm on tag (idempotent, npm provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,15 @@ name: Release
 
 # Triggered when a version tag is pushed (e.g., v4.7.0).
 # Builds the classroom installer ZIPs (with an injected, verified provenance.json), attests their
-# build provenance, verifies they are consumable by the self-updater, then creates a GitHub Release
-# with the ZIPs attached. Zenodo automatically archives the GitHub Release if the integration is
-# enabled at https://zenodo.org/account/settings/github/
+# build provenance, verifies they are consumable by the self-updater, creates a GitHub Release with
+# the ZIPs attached, and publishes the npm package (idempotently, with npm provenance) so the
+# `npx medsci-skills@latest install` channel never drifts behind the GitHub release. Zenodo
+# automatically archives the GitHub Release if the integration is enabled at
+# https://zenodo.org/account/settings/github/
+#
+# The npm publish step runs only when the `NPM_TOKEN` repo secret is set (a granular/automation token
+# scoped to medsci-skills with publish rights + 2FA bypass), and skips if that version is already on
+# npm, so re-running a tag is safe. It runs AFTER the GitHub Release so an npm hiccup never blocks it.
 #
 # Supply-chain posture (see SECURITY.md "Release integrity & revocation"): the self-updater verifies
 # each download's sha256 against the github.com API digest, which detects transport/asset tampering
@@ -35,6 +41,9 @@ jobs:
     # Human gate: add a required reviewer to the `release` environment (repo Settings → Environments)
     # so publishing a release requires explicit approval. Harmless before that setting exists.
     environment: release
+    env:
+      # 'true' only when the secret exists, so the npm steps are skipped on forks / before setup.
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
 
     steps:
       - name: Checkout repository (with full history for tag annotation)
@@ -137,3 +146,28 @@ jobs:
             --title "MedSci Skills ${TAG}" \
             --notes-file /tmp/release_notes.md \
             dist/medsci-skills-classroom-*.zip
+
+      # --- npm publish (last, gated on NPM_TOKEN, idempotent) so a npm issue never blocks the release ---
+      - name: Set up Node for npm publish
+        if: env.HAS_NPM_TOKEN == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm (idempotent; npm provenance via OIDC)
+        if: env.HAS_NPM_TOKEN == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          VER="${GITHUB_REF_NAME#v}"
+          # Idempotent: re-running a tag must not fail on "version already published".
+          if npm view "medsci-skills@${VER}" version >/dev/null 2>&1; then
+            echo "medsci-skills@${VER} is already on npm — skipping publish."
+            exit 0
+          fi
+          # --provenance links the published package to this GitHub Actions build via OIDC
+          # (uses the id-token permission already granted above).
+          npm publish --provenance --access public
+          echo "Published medsci-skills@${VER} to npm."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Release pipeline now also publishes to npm** (idempotent, with npm provenance via OIDC), so the
+  `npx medsci-skills@latest install` channel no longer drifts behind the GitHub release. The step runs
+  only when the `NPM_TOKEN` repo secret is set, skips if that version is already on npm (re-running a
+  tag is safe), and runs after the GitHub Release so an npm hiccup never blocks it. No product change.
+
 ## [4.7.0] - 2026-06-22
 
 The **self-update foundation**: physician-researchers stay current without GitHub, git, or a

--- a/docs/maintainer_workflow.md
+++ b/docs/maintainer_workflow.md
@@ -55,8 +55,14 @@ it simply does not gate.)
      `validate_catalog_consistency.py`.
 4. **Tag** `vX.Y.Z` and push → `release.yml` runs. It gates on the version-consistency
    check (tag must equal the manifest version), pauses for `release`-environment approval,
-   attests the ZIPs, and verifies each is updater-consumable before publishing. **Approve**
-   the run, then confirm the GitHub Release and Zenodo archive.
+   attests the ZIPs, verifies each is updater-consumable, publishes the GitHub Release, and
+   then **publishes to npm** (idempotent, with npm provenance — needs the `NPM_TOKEN` repo
+   secret; skips if that version is already on npm). **Approve** the run, then confirm the
+   GitHub Release, npm (`npm view medsci-skills version`), and the Zenodo archive.
+   - **One-time:** add an `NPM_TOKEN` repo secret — a granular/automation npm token scoped to
+     `medsci-skills` with publish rights and **2FA bypass enabled** (a 2FA `auth-and-writes`
+     account otherwise demands an OTP the CI cannot provide). Without the secret the npm step
+     is skipped and you publish manually (`npm publish --otp=<code>`).
 5. **Sync downstream surfaces** that live outside this repo's CI: the homepage
    `skills.json` counts and any hero-skill mirrors (`sync_hero_skill.py`).
 6. **Record evidence** — refresh [`IMPACT.md`](../IMPACT.md) (run the metrics


### PR DESCRIPTION
## Auto-publish to npm on release (idempotent, npm provenance)

Closes the gap that left `npx medsci-skills@latest install` **stale at 4.1.0** while the repo was at
4.7.0. From now on a tag push publishes the npm package alongside the GitHub Release.

### What it adds to `release.yml`
- **Gated** on the `NPM_TOKEN` repo secret (a granular/automation token scoped to `medsci-skills`,
  publish rights + **2FA bypass** — a `auth-and-writes` account otherwise demands an OTP CI can't give).
  Skipped on forks / before the secret exists, so it never breaks other runs.
- **Idempotent:** skips if that version is already on npm → re-running a tag is safe (no
  `EPUBLISHCONFLICT`).
- **Runs last** (after the GitHub Release) so an npm issue never blocks the release.
- **`npm publish --provenance --access public`** links the published package to this Actions build via
  OIDC, reusing the `id-token: write` permission already granted for ZIP attestation — the npm-native
  analogue of the build-provenance attestation on the classroom ZIPs.

`docs/maintainer_workflow.md` documents the one-time `NPM_TOKEN` setup; CHANGELOG noted. **No product /
skill / version change.**

### Note on testing
`release.yml` runs only on a tag push, so this PR's CI doesn't exercise it. Validated by YAML parse +
step-structure assertion; the step is gated, idempotent, and last (graceful degradation). It first runs
on the **next** tag (v4.7.0 is already published to npm, so even an immediate re-run would no-op).
