### PR TITLE
fix(detectors): clear four self-review/analyze-stats false positives

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -209,6 +209,15 @@ jobs:
       - name: Run fulltext-retrieval pdf_to_md helper test
         run: python3 skills/fulltext-retrieval/tests/test_pdf_to_md.py
 
+      - name: Run self-review scope-coherence gate test
+        run: bash skills/self-review/tests/test_scope_coherence.sh
+
+      - name: Run self-review cohort-arithmetic gate test
+        run: bash skills/self-review/tests/test_cohort_arithmetic.sh
+
+      - name: Run analyze-stats generated-code gate test
+        run: bash skills/analyze-stats/tests/test_generated_code.sh
+
       - name: Verify demo manifest.lock files (reproducibility lock)
         run: |
           for d in demo/01_wisconsin_bc demo/02_metafor_bcg demo/03_nhanes_obesity; do

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -358,8 +358,8 @@
     },
     {
       "path": "skills/analyze-stats/scripts/check_generated_code.py",
-      "size": 14525,
-      "sha256": "b9918728e4eac298fdb6adffa2a79faf835b395b65bace69409c190e88c13619"
+      "size": 15024,
+      "sha256": "b8643d9d9a4b600af428604811135fc27cee6eb2140bdae5e393ed9b3be37fae"
     },
     {
       "path": "skills/analyze-stats/skill.yml",
@@ -2963,13 +2963,13 @@
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",
-      "size": 10067,
-      "sha256": "5cf7f9a331a4ebcb6f8523fcb5fd1b872079e3bb6e00bf9821a03d504174fdaa"
+      "size": 10953,
+      "sha256": "3b5c85edc57ee607a2b0a10898d68ac163ce3be6fe50b82c8c11490d7bc2705a"
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 23363,
-      "sha256": "4ef7bded82091bc6cac8bf35cfa19bc1651acb7e0df2aa8b742bd7a04c8b3991"
+      "size": 23868,
+      "sha256": "55933d25d824bf073c0a8b7abc42d2f160c459a288ab932c50d63cf8c03afd37"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",
@@ -2998,8 +2998,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_scope_coherence.py",
-      "size": 9538,
-      "sha256": "45915b2736f0356e1b2e827939090e5034a01ba5c310b952dd13ad6f2df45a61"
+      "size": 10818,
+      "sha256": "820dfc264c2a4f62c79c0c7123a3e1a8b59a100b89654617a08ff55deeb25a75"
     },
     {
       "path": "skills/self-review/skill.yml",

--- a/skills/analyze-stats/scripts/check_generated_code.py
+++ b/skills/analyze-stats/scripts/check_generated_code.py
@@ -145,9 +145,15 @@ def check_text_common(src: str, lang: str) -> list[dict]:
     for m in NUM_LITERAL_BODY.finditer(src):
         body = m.group(1)
         # ignore obvious non-data: ranges, single repeated, function-call args with kwargs
-        nums = NUM_TOKEN.findall(body)
         if "=" in body:  # kwargs like figsize=(8,6) or linspace(0,1,...) — not table data
             continue
+        # A list/tuple of string literals (e.g. a hex-color palette
+        # ['#000000','#E69F00',...] — exactly the colorblind-safe WONG palette that
+        # make-figures recommends) is NOT hand-typed tabular data. Strip quoted
+        # substrings before counting numeric tokens, so digits living inside string
+        # literals (the "00" in '#E69F00', RGBA codes, category labels) don't make a
+        # string list look table-shaped. Genuine numeric data is unquoted.
+        nums = NUM_TOKEN.findall(STR_LITERAL.sub("", body))
         if len(nums) >= DATA_LITERAL_STANDALONE or (len(nums) >= DATA_LITERAL_MIN and has_read):
             ln = src[:m.start()].count("\n") + 1
             claims.append({

--- a/skills/analyze-stats/tests/fixtures/gen_palette.py
+++ b/skills/analyze-stats/tests/fixtures/gen_palette.py
@@ -1,0 +1,22 @@
+"""
+Analysis: synthetic CLEAN fixture exercising the colorblind-safe palette.
+A hex-color list must NOT be flagged HARDCODED_DATA_LITERAL even alongside a
+data-file read (regression for the WONG-palette false positive).
+Date: 2026-01-01
+Random seed: 42
+"""
+import numpy as np
+import pandas as pd
+
+np.random.seed(42)
+
+# The Wong (2011) colorblind-safe palette that make-figures recommends. Eight
+# string literals; the digits live inside the hex codes, not in tabular data.
+WONG = ["#000000", "#E69F00", "#56B4E9", "#009E73",
+        "#F0E442", "#0072B2", "#D55E00", "#CC79A7"]
+
+# portable relative path; no hand-typed numeric data
+df = pd.read_csv("cohort.csv")
+
+means = df.groupby("group")["auc"].mean()
+print(WONG[0], float(means.iloc[0]))

--- a/skills/analyze-stats/tests/test_generated_code.sh
+++ b/skills/analyze-stats/tests/test_generated_code.sh
@@ -55,5 +55,17 @@ check "exit 0 (clean .py)" test "$?" -eq 0
 python3 "$SCRIPT" --code-dir "$HERE/fixtures" --strict --quiet >/dev/null 2>&1
 check "exit 1 (--code-dir scan)" test "$?" -eq 1
 
+# (5) hex-color palette + data read -> NOT HARDCODED_DATA_LITERAL (WONG-palette
+#     false-positive regression); the script is otherwise clean -> exit 0
+PALETTE="$HERE/fixtures/gen_palette.py"
+python3 "$SCRIPT" "$PALETTE" --out "$OUT" --quiet >/dev/null 2>&1
+check "no HARDCODED_DATA_LITERAL on hex-color palette" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='HARDCODED_DATA_LITERAL' for c in d['claims']), 'palette flagged as data literal'
+"
+python3 "$SCRIPT" "$PALETTE" --strict --quiet >/dev/null 2>&1
+check "exit 0 on clean palette script" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/scripts/check_classical_style.py
+++ b/skills/self-review/scripts/check_classical_style.py
@@ -45,6 +45,18 @@ import re
 import sys
 from pathlib import Path
 
+# The § AI-tell is a SECTION CROSS-REFERENCE ("Methods §2", "(see §3.1)", "§L4"),
+# not the dagger-family footnote markers (†, ‡, §, ¶) that legitimately mark
+# author/affiliation footnotes and co-senior-author lines (e.g. "§ Dr. Hong and
+# Dr. Kim are co-senior authors", a superscript "^§"). Count only § that is part
+# of a section reference: § followed by a section id (digit, or up to 3 letters
+# then a digit — §3, §L4, §S1, §2.1), or a section noun immediately before §.
+SECTION_XREF = re.compile(
+    r"§\s*[A-Za-z]{0,3}\d"
+    r"|(?:see|in|per|section|sections|methods?|results?|discussion|introduction|"
+    r"appendix|appendices|supplement(?:ary|al)?|table|figure)\s+§",
+    re.IGNORECASE)
+
 INBODY_AI_DISCLOSURE = re.compile(
     r"generative ai was not used|artificial intelligence disclosure|"
     r"during the preparation of (?:this|the) (?:manuscript|work|study)[^.]{0,120}?"
@@ -66,15 +78,17 @@ EFFECT_DECIMAL = re.compile(
 def check(text: str, em_dash_max: int) -> list[dict]:
     claims = []
 
-    # SECTION_SYMBOL (Major)
-    if "§" in text:
-        n = text.count("§")
-        first = text.find("§")
+    # SECTION_SYMBOL (Major) — only § used as a section cross-reference, not the
+    # dagger-family author/affiliation footnote markers.
+    xrefs = list(SECTION_XREF.finditer(text))
+    if xrefs:
+        n = len(xrefs)
+        first = xrefs[0].start()
         claims.append({
             "verdict": "SECTION_SYMBOL",
             "severity": "Major",
-            "detail": f"the § symbol appears {n} time(s) — a senior-reviewer AI tell; "
-                      f"replace with the section name (manuscript-style-classical §6)",
+            "detail": f"a § section cross-reference appears {n} time(s) — a senior-reviewer "
+                      f"AI tell; replace with the section name (manuscript-style-classical §6)",
             "where": text[max(0, first - 30):first + 20].replace("\n", " ").strip()[:120],
         })
 

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -132,7 +132,14 @@ def _pick(header: list[str], hints: tuple[str, ...]):
 
 RATE_LINE_RE = re.compile(
     r"([0-9][0-9,]*\.?[0-9]*)\s*(?:per|/)\s*([0-9][0-9,]*)\s*person[-\s]?years?", re.I)
-EVENTS_NEAR_RE = re.compile(r"([0-9][0-9,]*)\s*(?:events?|cases?|incident\b)", re.I)
+# The numerator must be a count glued to a count noun (events/cases), optionally
+# "N incident cases/events". Two guards against grabbing the wrong integer:
+#   (a) lookbehind (?<![A-Za-z0-9.]) so a tier label's digit ("T1") or a decimal's
+#       fractional part ("0.97") is never captured as the numerator;
+#   (b) drop the bare "incident" alternative, which matched the word in "incident
+#       rate" and bound the nearest stray small integer (the false-positive source).
+EVENTS_NEAR_RE = re.compile(
+    r"(?<![A-Za-z0-9.])([0-9][0-9,]*)\s*(?:incident\s+)?(?:events?|cases?)\b", re.I)
 PY_NEAR_RE = re.compile(r"([0-9][0-9,]*)\s*(?:person[-\s]?years?|py\b)", re.I)
 
 

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -57,6 +57,20 @@ PROGNOSTIC_VERB = re.compile(
     r"prognost|predict(?:s|ing|ed)?\s+(?:incident|future|long[-\s]?term|the risk of developing)|"
     r"longitudinal (?:follow|risk|trajector)", re.IGNORECASE)
 
+# A prognostic/surveillance token sitting inside a negation/deferral frame is a
+# correct hedge, not an overclaim ("describes concurrent burden RATHER THAN
+# surveillance intervals, which WOULD REQUIRE PROSPECTIVE data"). You cannot
+# disavow surveillance without naming it; do not fire CROSS_SECTIONAL_PROGNOSTIC
+# when the match is disclaimed in its immediate vicinity.
+PROGNOSTIC_DISCLAIMER = re.compile(
+    r"rather than|instead of|not\s+(?:a\s+|the\s+)?(?:surveillance|prognostic|longitudinal)|"
+    r"does not (?:establish|imply|support|provide|address|determine|permit)|"
+    r"cannot (?:establish|determine|inform|assess|address)|"
+    r"would require|requires?\s+prospective|warrants?\s+prospective|"
+    r"defer(?:s|red|ring)?\b[^.]{0,40}\bprospective|"
+    r"beyond the scope|no (?:prognostic|surveillance|longitudinal) (?:claim|inference|conclusion)",
+    re.IGNORECASE)
+
 DIRECTIVE_VERB = re.compile(
     r"\bdefer(?:ral|red|ring)?\b|\bwithhold\b|\bforgo\b|\binitiat(?:e|ed|ion)\b|"
     r"\bdiscontinu(?:e|ed|ation)\b|start(?:ing)?\s+(?:statin|therapy|treatment|pharmacotherapy)|"
@@ -107,8 +121,13 @@ def check(text: str) -> list[dict]:
     concl = conclusion_region(text)
 
     if DESIGN_CROSS_SECTIONAL.search(text):
-        pm = PROGNOSTIC_VERB.search(concl)
-        if pm:
+        # Fire only on a prognostic/surveillance token that is NOT inside a
+        # negation/deferral frame; iterate all matches so a real claim later in the
+        # conclusion still fires even if an earlier mention was a disclaimer.
+        for pm in PROGNOSTIC_VERB.finditer(concl):
+            window = concl[max(0, pm.start() - 120):pm.end() + 120]
+            if PROGNOSTIC_DISCLAIMER.search(window):
+                continue
             claims.append({
                 "verdict": "CROSS_SECTIONAL_PROGNOSTIC",
                 "severity": "Major",
@@ -116,6 +135,7 @@ def check(text: str) -> list[dict]:
                            f"prognostic/surveillance claim ('{pm.group(0).strip()}')"),
                 "where": concl[max(0, pm.start() - 40):pm.end() + 40].strip()[:160],
             })
+            break
 
     dm = DIRECTIVE_VERB.search(concl)
     sm = SURROGATE_SIGNAL.search(concl)

--- a/skills/self-review/tests/fixtures/cohort_rate_tier_fp.md
+++ b/skills/self-review/tests/fixtures/cohort_rate_tier_fp.md
@@ -1,0 +1,4 @@
+# Results
+
+Among the prespecified strata, stratum 1 incident rates reached 2.48 per 100
+person-years (882 events over 35,581 person-years of follow-up).

--- a/skills/self-review/tests/fixtures/scope_disclaimer.md
+++ b/skills/self-review/tests/fixtures/scope_disclaimer.md
@@ -1,0 +1,9 @@
+# Methods
+
+This was a cross-sectional analysis of a single-visit health-screening cohort.
+
+# Conclusion
+
+Our findings describe the concurrent burden of fibrosis at the time of imaging
+rather than surveillance intervals or disease progression, which would require
+prospective longitudinal data to establish.

--- a/skills/self-review/tests/fixtures/style_dagger_footnote.md
+++ b/skills/self-review/tests/fixtures/style_dagger_footnote.md
@@ -1,0 +1,11 @@
+# **METHODS**
+
+We extracted study-level data in duplicate and resolved disagreements by consensus.
+
+# Title Page
+
+Author One^{1,§}, Author Two^{2,§}, Author Three^{3,†}
+
+§ Dr. Alpha and Dr. Beta are co-senior authors.
+
+† These authors contributed equally to this work.

--- a/skills/self-review/tests/test_classical_style.sh
+++ b/skills/self-review/tests/test_classical_style.sh
@@ -51,5 +51,17 @@ d=json.load(open('$OUT'))
 assert not any(c['verdict']=='EM_DASH_OVERUSE' for c in d['claims']), 'structural dashes were counted as prose'
 "
 
+# (4) § used as author/affiliation footnote dagger (co-senior-author line, super-
+#     script markers) must NOT fire SECTION_SYMBOL — only a § section cross-ref does.
+DAGGER="$HERE/fixtures/style_dagger_footnote.md"
+python3 "$SCRIPT" --manuscript "$DAGGER" --out "$OUT" --quiet >/dev/null 2>&1
+check "no SECTION_SYMBOL on footnote daggers" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='SECTION_SYMBOL' for c in d['claims']), 'dagger § flagged as section symbol'
+"
+python3 "$SCRIPT" --manuscript "$DAGGER" --strict --quiet >/dev/null 2>&1
+check "exit 0 on dagger-footnote manuscript" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_cohort_arithmetic.sh
+++ b/skills/self-review/tests/test_cohort_arithmetic.sh
@@ -69,5 +69,18 @@ check "exit 1 (analysis unit, explicit --id-col)" test "$?" -eq 1
 python3 "$SCRIPT" --manuscript "$DISC" --data "$REPEAT" --strict --quiet >/dev/null 2>&1
 check "exit 0 when analysis unit disclosed" test "$?" -eq 0
 
+# (7) a tier label ("stratum 1") and "incident rate" sitting near a small integer
+#     must NOT mis-bind the numerator: the rate recomputes from 882 events /
+#     35,581 PY -> NO RATE_BACKCALC false positive, exit 0 (regression).
+RFP="$HERE/fixtures/cohort_rate_tier_fp.md"
+python3 "$SCRIPT" --manuscript "$RFP" --out "$OUT" --quiet >/dev/null 2>&1
+check "no RATE_BACKCALC false positive (tier + incident-rate)" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='RATE_BACKCALC' for c in d['claims']), 'numerator mis-bound -> false RATE_BACKCALC'
+"
+python3 "$SCRIPT" --manuscript "$RFP" --strict --quiet >/dev/null 2>&1
+check "exit 0 on correct-rate manuscript" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -58,5 +58,18 @@ d=json.load(open('$OUT'))
 assert not any(c['verdict']=='CROSS_SECTIONAL_YIELD_LANGUAGE' for c in d['claims'])
 "
 
+# (6) cross-sectional design + a DISCLAIMED surveillance/prognostic token
+#     ("... rather than surveillance intervals ... which would require prospective
+#     data ...") -> NO CROSS_SECTIONAL_PROGNOSTIC, exit 0 (regression).
+DISC="$HERE/fixtures/scope_disclaimer.md"
+python3 "$SCRIPT" --manuscript "$DISC" --out "$OUT" --quiet >/dev/null 2>&1
+check "no CROSS_SECTIONAL_PROGNOSTIC when disclaimed" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']), 'disclaimer flagged as prognostic claim'
+"
+python3 "$SCRIPT" --manuscript "$DISC" --strict --quiet >/dev/null 2>&1
+check "exit 0 on disclaimer manuscript" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## What

Four deterministic gates were firing **Major** on legitimate (often *recommended*) patterns, degrading the tools. Each fix is narrowly scoped and ships a synthetic, PII-free regression fixture. The three previously **unwired** test suites are now wired into CI.

| Detector | False positive | Fix |
|---|---|---|
| `analyze-stats/check_generated_code.py` | `HARDCODED_DATA_LITERAL` on a hex-color list — the colorblind-safe **WONG palette** that `make-figures` itself recommends | strip quoted substrings before counting numeric tokens; digits inside string literals (`#E69F00`) no longer make a string list look table-shaped |
| `self-review/check_classical_style.py` | `SECTION_SYMBOL` on a `§` used as an **author-footnote dagger** (co-senior-author / equal-contribution line) | fire only on a `§` section cross-reference (`§3`, `§L4`, `Methods §X`) |
| `self-review/check_scope_coherence.py` | `CROSS_SECTIONAL_PROGNOSTIC` on a **disclaimer** ("describes concurrent burden *rather than* surveillance intervals … *which would require prospective* data") | clear when the prognostic/surveillance token sits inside a negation/deferral frame |
| `self-review/check_cohort_arithmetic.py` | `RATE_BACKCALC` mis-bound the numerator (`1` from a tier label `T1` / the word "incident" in "incident rate") | lookbehind rejects a digit glued to a letter/decimal; drop the bare `incident` alternative; require a count noun (events/cases) |

## Tests / CI

- Added a regression case + fixture to each of the four suites (assert the verdict is now absent; existing assertions unchanged).
- Wired `test_scope_coherence.sh`, `test_cohort_arithmetic.sh`, `test_generated_code.sh` into `validate.yml` (`test_classical_style.sh` was already wired).
- Local: all four suites green; `validate_skills.sh` (PII + structure + domain-probe vendoring), `check_locale_inventory.py`, `check_version_consistency.py`, YAML lint all pass. No skill/detector count change → catalogs untouched, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)