### PR TITLE
release: v4.8.0 (review-harvest batch — detectors 30→32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [4.8.0] - 2026-06-24
+
+The **review-harvest batch**: deterministic detector hardening promoted from real-manuscript review
+cycles — four false-positive fixes, two new gates, nine reviewer-side domain probes, and a
+design-stage gate. **Additive and backward-compatible** — no skill, CLI, or output-path change;
+skills 45 and reporting guidelines 36 unchanged; analysis-integrity detectors **30 → 32**.
+
 ### Added
 
 - **Reader-facing supplement / multi-file hygiene gate** — new `check_supplement_hygiene.py`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "4.7.0"
+version: "4.8.0"
 date-released: "2026-06-22"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 ## What's New
 
+**v4.8** is the **review-harvest batch** — deterministic detector hardening promoted from real-manuscript review cycles. Additive and backward-compatible; still 45 skills / 36 guidelines, analysis-integrity detectors **30 → 32**:
+
+- **Two new gates** — `check_supplement_hygiene.py` lints the rendered supplement / tables / caption files (not just the manuscript) for §-labels, placeholders, build markers, response-letter framing, and unresolved body↔supplement cross-references; `check_null_calibration.py` flags a headline negative/equivalence claim made without a minimum-detectable-effect / power / equivalence statement.
+- **Four detector false-positive fixes** — gates no longer fire on a recommended colorblind-safe palette, author-footnote `§` daggers, a correctly-hedged disclaimer, or a tier-label digit; each with a regression fixture and three newly CI-wired test suites.
+- **Nine reviewer-side domain probes** (SR/MA, observational, diagnostic, AI-overclaiming, survival) plus a `/design-study` design-stage ceiling gate for perceptual/reader-AI studies and a reusable confidence-weighted-rating→AUC monotonicity template.
+
 **v4.7** is the **self-update foundation** — physician-researchers stay current without GitHub, git, or a terminal. Additive and backward-compatible; still 45 skills / 36 guidelines / 30 detectors:
 
 - **Transactional, crash-recoverable installer.** Each install runs through a durable journal state machine recovered on the next run (roll back / forward-clean / fail-closed), with per-target SHA-256 inventories — your modified or third-party skills are backed up and never clobbered or auto-deleted.

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "4.7.0",
+  "version": "4.8.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Release commit for **v4.8.0**, bundling the merged review-harvest batch (#185–#189).

- `CHANGELOG.md` — `[Unreleased]` → `## [4.8.0] - 2026-06-24` (Added / Fixed / Changed).
- `CITATION.cff` + `package.json` → 4.8.0; `metadata/distribution_manifest.json` regenerated to 4.8.0 (version-consistency 3-way OK).
- `README.md` — v4.8 "What's New" + detectors 30 → 32.

**Additive / backward-compatible** — no skill, CLI, or output-path change (45 skills / 36 guidelines unchanged) → 4.8.0, not 5.0.

After merge: tag `v4.8.0` on main → `release.yml` (version-gate → build ZIPs + provenance → attest → safe-extract round-trip → GitHub Release → Zenodo → npm publish). Then aperivue-web `skills.json` sync to 45/36/32.

Local gates green: `check_version_consistency`, `validate_catalog_consistency` (32), `gen_distribution_manifest/skill_docs/detectors_catalog --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)