### PR TITLE
self-review: composite-indicator definition drift (DERIVED_DEF_DRIFT)

### DIFF
--- a/metadata/detectors_catalog.json
+++ b/metadata/detectors_catalog.json
@@ -95,7 +95,7 @@
       "skill": "self-review",
       "family": "data_preparation",
       "family_label": "Data preparation & validation",
-      "description": "Cross-script categorical / cut-point consistency gate (self-review Phase 2.5b)."
+      "description": "Cross-script categorical / cut-point and composite-definition consistency gate (self-review Phase 2.5b)."
     },
     {
       "id": "check_checklist_dump_leak",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2868,8 +2868,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 92634,
-      "sha256": "ffc2346fbaaff613728a73676a705fe5f9e5422da6577dfee2f79d5c21564b33"
+      "size": 93517,
+      "sha256": "92b6e1c0e6cdaa27d5f033ce28e58a210208d619793d221f9ffa944aa1055bba"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",
@@ -2983,8 +2983,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_binning_consistency.py",
-      "size": 12164,
-      "sha256": "b61420592af896b2a39c373f596d2e2e0d885124d05276ca9f9f849dca21ba6b"
+      "size": 19541,
+      "sha256": "e3bf7dd2e0871ce6905abc1d33a26c7afac76a93d184bfe2d431af97d0622f74"
     },
     {
       "path": "skills/self-review/scripts/check_citation_order.py",

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -569,6 +569,17 @@ spurious "reached" stratum in the sensitivity table that vanished once the binni
 harmonized. Fix at the source by defining each cut once in a shared helper that every script
 sources.
 
+The same gate also covers the **composite-indicator** sibling failure: a derived 0/1 component
+(e.g. a metabolic-syndrome criterion built from `as.integer(a >= x | b == 1 | c == 1)`) that is
+re-built in a second script with a clause dropped or added. It splits each definition into
+comparison atoms on the top-level `|`, compares them as a SET (clause order, whitespace, outer
+parentheses, dataframe `df$` qualifiers and commutative `&`-operands are normalized away), and
+emits `DERIVED_DEF_DRIFT` (Major) when one variable carries ≥2 distinct atom sets across scripts.
+Precedent: `mets_bp <- as.integer(bl_he_sbp>=130 | bl_he_dbp>=85 | bl_tx_hypertension_med==1 |
+bl_hypertension==1)` in the benchmark script vs the same name without the final
+`| bl_hypertension==1` in a re-analysis script — the metabolic-syndrome C-index then read 0.6704
+in one table and 0.6712 in another.
+
 ### Phase 2.5c: Reference Hallucination Scan
 
 Numerical audits (2.5/2.5a/2.5b) cover in-text numbers; they do **not** cover reference-list integrity. LLM-drafted or co-author-handed-in bibliographies frequently contain fabricated DOIs, wrong author/year combinations for a real DOI, or plausible-looking references that never existed. These slip past human proofreading because the surface form looks canonical.

--- a/skills/self-review/scripts/check_binning_consistency.py
+++ b/skills/self-review/scripts/check_binning_consistency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-script categorical / cut-point consistency gate (self-review Phase 2.5b).
+"""Cross-script categorical / cut-point and composite-definition consistency gate (self-review Phase 2.5b).
 
 A derived categorical variable (age band, BMI category, eGFR/CKD stage, FIB-4
 strata, risk tier) is often re-derived in more than one analysis script — the
@@ -25,6 +25,24 @@ it can extract a complete `breaks`/`bins` operand and the signatures genuinely
 differ. The interval-closure flag is compared using each language's documented
 default (R `cut` right=TRUE, pandas `pd.cut` right=True), so an explicit
 `right=FALSE` in one file and an omitted default in another is a real difference.
+
+It ALSO extracts composite boolean-indicator definitions — the sibling failure
+mode where a derived 0/1 component (e.g. a metabolic-syndrome criterion) is built
+from a disjunction of comparison clauses and a second script omits or adds a
+clause:
+
+    R:       <var> <- as.integer(a >= x | b == 1 | c == 1)
+    R:       <var> <- as.numeric(<bool expr>)   / ifelse(<bool expr>, 1, 0)
+    Python:  <var> = np.where(<bool expr>, 1, 0)
+
+The boolean expression is split into comparison ATOMS on the top-level `|` (OR);
+clause order, whitespace, and outer parentheses do not matter (atoms are compared
+as a SET), so only a genuinely missing or added clause counts. It fires
+DERIVED_DEF_DRIFT when one variable is defined with two or more distinct atom sets.
+Motivation: `mets_bp <- as.integer(bl_he_sbp>=130 | bl_he_dbp>=85 |
+bl_tx_hypertension_med==1 | bl_hypertension==1)` in the canonical script vs the
+same name without the final `| bl_hypertension==1` in a re-analysis script — the
+metabolic-syndrome C-index then read 0.6704 in one table and 0.6712 in another.
 
 Motivation: a screening cohort binned age with
 `cut(bl_age, breaks=c(-Inf,45,50,60,Inf), right=FALSE)` in the primary script and
@@ -65,12 +83,23 @@ CATEGORICAL_HINTS = (
     "age", "bmi", "egfr", "gfr", "fib4", "fib_4", "cmb", "mets", "ckd",
 )
 
+# Name hints for composite 0/1 indicator components (the DERIVED_DEF_DRIFT path).
+INDICATOR_HINTS = (
+    "mets", "indicator", "flag", "criteria", "criterion", "_pos", "_neg",
+    "_yes", "_bin", "_ind", "comp", "positive", "present",
+)
+
 SCRIPT_SUFFIXES = (".r", ".py")
 
 
 def _is_categorical_name(name: str) -> bool:
     n = name.lower()
     return any(h in n for h in CATEGORICAL_HINTS)
+
+
+def _is_indicator_name(name: str) -> bool:
+    n = name.lower()
+    return any(h in n for h in INDICATOR_HINTS)
 
 
 def _norm_breaks(raw: str) -> str:
@@ -199,6 +228,113 @@ def extract_cut_defs(path: Path):
     return out
 
 
+# Composite boolean-indicator assignment: `lhs <- as.integer(...)`, `as.numeric`,
+# `ifelse(...)`, Python `(...).astype(int)` / `np.where(...)`.
+_ASSIGN_DERIVED_RE = re.compile(
+    r"(?P<lhs>[A-Za-z_][\w.$\[\]\"']*?)\s*(?:<<-|<-|=)\s*"
+    r"(?P<fn>as\.integer|as\.numeric|np\.where|ifelse)\s*\(",
+)
+_COMPARISON_RE = re.compile(r"==|!=|>=|<=|%in%|>|<")
+
+
+def _first_arg(call_body: str) -> str:
+    """The first top-level (depth-0) comma-delimited argument of a call body."""
+    depth = 0
+    for i, c in enumerate(call_body):
+        if c in "([":
+            depth += 1
+        elif c in ")]":
+            depth -= 1
+        elif c == "," and depth == 0:
+            return call_body[:i]
+    return call_body
+
+
+def _split_top_level(expr: str, op: str):
+    """Split on a top-level (depth-0) boolean operator char `op` ('|' or '&').
+    Parenthesized/`&`-or-`|` sub-groups stay intact; the doubled form (`||`/`&&`)
+    is treated identically as a single separator."""
+    parts, depth, cur, i = [], 0, [], 0
+    while i < len(expr):
+        c = expr[i]
+        if c in "([":
+            depth += 1
+            cur.append(c)
+        elif c in ")]":
+            depth -= 1
+            cur.append(c)
+        elif c == op and depth == 0:
+            if i + 1 < len(expr) and expr[i + 1] == op:  # collapse `||` / `&&`
+                i += 1
+            parts.append("".join(cur))
+            cur = []
+        else:
+            cur.append(c)
+        i += 1
+    if cur:
+        parts.append("".join(cur))
+    return parts
+
+
+def _strip_wrap_parens(a: str) -> str:
+    """Remove fully-wrapping outer parens, e.g. `(a | b)` -> `a | b`. A leading
+    paren that does NOT close at the end (e.g. `(a & b) | c`) is left intact."""
+    a = a.strip()
+    while len(a) >= 2 and a[0] == "(" and _find_matching_paren(a, 0) == len(a) - 1:
+        a = a[1:-1].strip()
+    return a
+
+
+def _norm_atom(a: str) -> str:
+    """Whitespace-free canonical form of one OR-clause. Dataframe qualifiers
+    (`df$col`, `sub$col`) are dropped so a bare `mutate()` reference and a base-R
+    `df$` reference to the same column compare equal, and a top-level `&`-group is
+    sorted so operand order inside an AND does not matter
+    (`x==1 & y>=2` == `y>=2 & x==1`)."""
+    a = re.sub(r"\s+", "", _strip_wrap_parens(a))
+    a = re.sub(r"[A-Za-z_]\w*\$", "", a)  # df$col / sub$col -> col
+    if "&" in a:
+        andparts = _split_top_level(a, "&")
+        if len(andparts) > 1:
+            a = "&".join(sorted(_strip_wrap_parens(p) for p in andparts))
+    return a
+
+
+def extract_derived_defs(path: Path):
+    """Yield dicts for each composite boolean-indicator assignment in a file.
+
+    Only definitions whose expression contains at least one comparison operator
+    are kept (a plain `as.integer(count)` cast is not an indicator and is skipped).
+    The atom set is order- and whitespace-insensitive."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    out = []
+    for m in _ASSIGN_DERIVED_RE.finditer(text):
+        open_idx = m.end() - 1
+        close_idx = _find_matching_paren(text, open_idx)
+        if close_idx == -1:
+            continue
+        inner = text[open_idx + 1:close_idx]
+        # np.where(expr, 1, 0) / ifelse(expr, 1, 0): the boolean test is arg 1.
+        if m.group("fn") in ("np.where", "ifelse"):
+            inner = _first_arg(inner)
+        inner = _strip_wrap_parens(inner)
+        if not _COMPARISON_RE.search(inner):
+            continue
+        atoms = sorted({_norm_atom(a) for a in _split_top_level(inner, "|") if _norm_atom(a)})
+        if not atoms:
+            continue
+        lhs = m.group("lhs").strip()
+        line_no = text[:m.start()].count("\n") + 1
+        out.append({
+            "var": lhs,
+            "kind": "derived",
+            "atoms": atoms,
+            "file": str(path),
+            "line": line_no,
+        })
+    return out
+
+
 def analyze(roots, extra_globs):
     files = []
     seen = set()
@@ -223,9 +359,15 @@ def analyze(roots, extra_globs):
             continue
 
     # Group by assigned variable name (normalized to leaf identifier).
+    # `df$col` (R) / `df['col']` (py) / `df.col` (py) / bare `col` all reduce to
+    # the COLUMN name `col` — the table handle is not the variable of interest.
     def _leaf(v):
-        v = re.sub(r"\[[^\]]*\]|\$.*$|\"|'", "", v)
-        return v.split("$")[-1].split(".")[-1].strip()
+        v = v.strip().strip("\"'")
+        m = re.search(r"\[\s*[\"']([^\"']+)[\"']\s*\]", v)   # py df['col'] / df["col"]
+        if m:
+            return m.group(1)
+        v = re.sub(r"\[[^\]]*\]", "", v)                      # drop other [..] indexers
+        return v.split("$")[-1].split(".")[-1].strip()        # R df$col / py df.col / bare
 
     groups: dict[str, list[dict]] = {}
     for d in defs:
@@ -254,14 +396,49 @@ def analyze(roots, extra_globs):
             "where": "; ".join(f"{Path(d['file']).name}:{d['line']}" for d in ds),
         })
 
+    # --- Composite boolean-indicator definition drift (DERIVED_DEF_DRIFT) -----
+    derived_defs = []
+    for p in sorted(files):
+        try:
+            derived_defs.extend(extract_derived_defs(p))
+        except OSError:
+            continue
+
+    dgroups: dict[str, list[dict]] = {}
+    for d in derived_defs:
+        dgroups.setdefault(_leaf(d["var"]), []).append(d)
+
+    for var, ds in sorted(dgroups.items()):
+        sigs = {tuple(d["atoms"]) for d in ds}
+        if len(ds) < 2 or len(sigs) < 2:
+            continue
+        n_files = len({d["file"] for d in ds})
+        # Conservative focus: indicator/categorical-looking name OR re-derived in >=2 files.
+        if not (_is_indicator_name(var) or _is_categorical_name(var) or n_files >= 2):
+            continue
+        siglist = [set(s) for s in sigs]
+        diff = sorted(set().union(*siglist) - set.intersection(*siglist))
+        detail_parts = [f"{Path(d['file']).name}:{d['line']} {{{', '.join(d['atoms'])}}}" for d in ds]
+        claims.append({
+            "verdict": "DERIVED_DEF_DRIFT",
+            "severity": "Major",
+            "var": var,
+            "detail": f"`{var}` defined with {len(sigs)} different clause sets across "
+                      f"{n_files} file(s); differing clause(s): {{{', '.join(diff)}}}. "
+                      + " | ".join(detail_parts),
+            "where": "; ".join(f"{Path(d['file']).name}:{d['line']}" for d in ds),
+        })
+
     n_major = sum(1 for c in claims if c["severity"] == "Major")
     return {
         "scanned": [str(p) for p in sorted(files)],
-        "definitions": defs,
+        "definitions": defs + derived_defs,
         "claims": claims,
         "summary": {
             "n_files": len(files),
-            "n_definitions": len(defs),
+            "n_definitions": len(defs) + len(derived_defs),
+            "n_cut_definitions": len(defs),
+            "n_derived_definitions": len(derived_defs),
             "n_claims": len(claims),
             "n_major": n_major,
             "verdict": "MAJOR_CANDIDATE" if n_major else "OK",
@@ -274,7 +451,7 @@ def render(result: dict) -> str:
     for c in result["claims"]:
         lines.append(f"| {c['verdict']} | {c['severity']} | {c['detail']} |")
     if len(lines) == 2:
-        lines.append("| (none) | — | no cross-script binning drift detected |")
+        lines.append("| (none) | — | no cross-script binning or definition drift detected |")
     return "\n".join(lines)
 
 
@@ -299,17 +476,18 @@ def main() -> int:
 
     if not args.quiet:
         print("=" * 46)
-        print(" Cross-script Binning Consistency (Phase 2.5c)")
+        print(" Cross-script Categorical / Definition Consistency (Phase 2.5c)")
         print("=" * 46)
         print(render(result))
         print()
         s = result["summary"]
+        defs_desc = (f"{s['n_cut_definitions']} cut + {s['n_derived_definitions']} "
+                     f"composite definitions in {s['n_files']} files")
         if s["n_major"]:
-            print(f"MAJOR candidate: {s['n_major']} variable(s) binned inconsistently "
-                  f"across scripts ({s['n_definitions']} cut definitions in {s['n_files']} files).")
+            print(f"MAJOR candidate: {s['n_major']} variable(s) derived inconsistently "
+                  f"across scripts ({defs_desc}).")
         else:
-            print(f"OK: no cross-script binning drift "
-                  f"({s['n_definitions']} cut definitions in {s['n_files']} files).")
+            print(f"OK: no cross-script binning or definition drift ({defs_desc}).")
 
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)

--- a/skills/self-review/tests/fixtures/derived_clean/canonical.R
+++ b/skills/self-review/tests/fixtures/derived_clean/canonical.R
@@ -1,0 +1,6 @@
+df <- df %>% mutate(
+  mets_bp = as.integer(bl_he_sbp >= 130 | bl_he_dbp >= 85 |
+                       bl_tx_hypertension_med == 1 | bl_hypertension == 1),
+  mets_wc = as.integer((bl_sex == 1 & bl_he_wc >= 90) |
+                       (bl_sex == 0 & bl_he_wc >= 80))
+)

--- a/skills/self-review/tests/fixtures/derived_clean/shared.R
+++ b/skills/self-review/tests/fixtures/derived_clean/shared.R
@@ -1,0 +1,6 @@
+# same definitions: clauses reordered, tighter whitespace, extra outer parens,
+# and the &-group operands swapped — all semantically identical.
+df2 <- df2 %>% mutate(
+  mets_bp = as.integer((bl_hypertension==1 | bl_tx_hypertension_med==1 | bl_he_dbp>=85 | bl_he_sbp>=130)),
+  mets_wc = as.integer((bl_he_wc >= 80 & bl_sex == 0) | (bl_he_wc >= 90 & bl_sex == 1))
+)

--- a/skills/self-review/tests/fixtures/derived_drift/canonical.R
+++ b/skills/self-review/tests/fixtures/derived_drift/canonical.R
@@ -1,0 +1,7 @@
+# canonical MetS component definitions (benchmark script)
+df <- df %>% mutate(
+  mets_bp = as.integer(bl_he_sbp >= 130 | bl_he_dbp >= 85 |
+                       bl_tx_hypertension_med == 1 | bl_hypertension == 1),
+  mets_fg = as.integer(bl_b_glu >= 100 | bl_tx_diabetes_med == 1 |
+                       bl_diabetes == 1)
+)

--- a/skills/self-review/tests/fixtures/derived_drift/reanalysis.R
+++ b/skills/self-review/tests/fixtures/derived_drift/reanalysis.R
@@ -1,0 +1,6 @@
+# re-analysis script DROPS the prevalent-disease clause (the bug)
+df <- df %>% mutate(
+  mets_bp = as.integer(bl_he_sbp >= 130 | bl_he_dbp >= 85 |
+                       bl_tx_hypertension_med == 1),
+  mets_fg = as.integer(bl_b_glu >= 100 | bl_tx_diabetes_med == 1)
+)

--- a/skills/self-review/tests/test_binning_consistency.sh
+++ b/skills/self-review/tests/test_binning_consistency.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Regression test for the cross-script binning-consistency gate (Phase 2.5b).
-# Synthetic, PII-free fixtures reproduce a derived `age_band` binned with two
-# different cut signatures (breaks 45/50/60 right=FALSE vs 44/49/59 right=TRUE)
-# across two analysis scripts — a real-world binning bug — and a clean pair that
-# shares one identical cut signature.
+# Regression test for the cross-script categorical / definition-consistency gate
+# (Phase 2.5b/c). Synthetic, PII-free fixtures cover two failure modes:
+#   BINNING_DRIFT     — a derived `age_band` binned with two different cut
+#                       signatures (45/50/60 right=FALSE vs 44/49/59 right=TRUE)
+#                       across two scripts, plus a clean pair sharing one signature.
+#   DERIVED_DEF_DRIFT — a composite indicator (`mets_bp`/`mets_fg`) defined with a
+#                       dropped OR-clause across two scripts, plus a clean pair that
+#                       is identical up to clause order / whitespace / outer parens /
+#                       commutative `&`-operand order.
 # Stdlib-only (python3).
 set -u
 
@@ -11,6 +15,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$HERE/../scripts/check_binning_consistency.py"
 DRIFT="$HERE/fixtures/binning_drift"
 CLEAN="$HERE/fixtures/binning_clean"
+DDRIFT="$HERE/fixtures/derived_drift"
+DCLEAN="$HERE/fixtures/derived_clean"
 OUT="$(mktemp -t bin_XXXX).json"
 trap 'rm -f "$OUT"' EXIT
 
@@ -40,6 +46,20 @@ python3 "$SCRIPT" --root "$CLEAN" --strict --quiet >/dev/null 2>&1
 check "exit 0 on consistent binning" test "$?" -eq 0
 python3 "$SCRIPT" --root "$CLEAN" --out "$OUT" --quiet >/dev/null 2>&1
 check "no BINNING_DRIFT on clean fixtures" bash -c "
+python3 -c \"import json; d=json.load(open('$OUT')); assert not d['claims']\"
+"
+
+# (3) composite-definition drift: DERIVED_DEF_DRIFT (Major) -> exit 1 under --strict
+python3 "$SCRIPT" --root "$DDRIFT" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 under --strict (composite clause dropped)" test "$?" -eq 1
+check "DERIVED_DEF_DRIFT detected (mets_bp/mets_fg clause omission)" has_verdict DERIVED_DEF_DRIFT
+
+# (4) clean composite fixtures: same atom SET (reordered / whitespace / parens /
+#     commutative &) -> exit 0, no claim
+python3 "$SCRIPT" --root "$DCLEAN" --strict --quiet >/dev/null 2>&1
+check "exit 0 on order-/whitespace-/paren-equivalent composite defs" test "$?" -eq 0
+python3 "$SCRIPT" --root "$DCLEAN" --out "$OUT" --quiet >/dev/null 2>&1
+check "no DERIVED_DEF_DRIFT on clean composite fixtures" bash -c "
 python3 -c \"import json; d=json.load(open('$OUT')); assert not d['claims']\"
 "
 


### PR DESCRIPTION
## What

Extends `check_binning_consistency.py` (self-review Phase 2.5b) to a second
cross-script failure mode: **composite-indicator definition drift**.

The gate already catches cut-point divergence (`BINNING_DRIFT`) — the same derived
*categorical* binned with different `(breaks, right)` across analysis scripts. This
adds the sibling for derived *0/1 indicators* (e.g. a metabolic-syndrome criterion
built from `as.integer(a >= x | b == 1 | c == 1)`): when one script re-derives the
variable with an OR-clause dropped or added, the same cohort yields different
values and the statistic it feeds (a C-index) silently disagrees between two tables
of one manuscript — a reviewer/co-author catches it on sight.

## How

- `extract_derived_defs` parses `as.integer(...)` / `as.numeric(...)` / `ifelse(...)`
  (R) and `np.where(...)` (Python) indicator assignments, splits the boolean
  expression into comparison **atoms** on the top-level `|`, and compares them as a
  **set**.
- Normalized away so they never false-positive: clause order, whitespace,
  fully-wrapping parentheses, dataframe `df$`/`sub$` qualifiers, and commutative
  `&`-operand order.
- Emits `DERIVED_DEF_DRIFT` (Major), surfacing the exact differing clause.
- Bonus: fixes a latent `_leaf` bug where base-R `df$col <-` column assignments all
  collapsed to the variable name `df`.

## Tests

`tests/test_binning_consistency.sh` gains 4 cases:
- `derived_drift/` (positive): a `mets_bp`/`mets_fg` indicator with a dropped OR-clause → fires.
- `derived_clean/` (negative): the same atom set written with reordered clauses,
  tighter whitespace, extra outer parens, and swapped `&`-operands → stays clean.

All 9 cases pass. CI mirrors (detectors catalog / distribution manifest / skill
docs `--check`), `validate_catalog_consistency.py`, and `validate_skills.sh` all
pass. Detector count unchanged at 36 (this extends an existing detector; no new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)