### PR TITLE
fix(manage-refs): harden check_csl_render.py (5 latent bugs) + CI-wired test

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -197,6 +197,9 @@ jobs:
       - name: Run manage-refs vN-docx cross-reference test
         run: bash skills/manage-refs/tests/test_vN_docx_check.sh
 
+      - name: Run manage-refs CSL-render hardening test
+        run: bash skills/manage-refs/tests/test_csl_render.sh
+
       - name: Run polish-language consistency-linter challenge
         run: bash skills/polish-language/scripts/lint_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@
   progression no longer implies v4.8 is current. No code or count change — the SSOT was
   already correct; only the prose was stale. Verified by `validate_catalog_consistency.py`.
 
+- **`check_csl_render.py` hardening** (`/manage-refs`) — the CSL acceptance detector
+  had five latent bugs that could surface a raw traceback or a silently-wrong verdict:
+  it carried the two citekeys as module globals (`render()` was not standalone-callable),
+  did not check pandoc's return code (a failed render was analyzed as if it succeeded),
+  leaked `NamedTemporaryFile(delete=False)` temp files, imported `python-docx` deep inside
+  a function, and read the `.bib` with an unguarded `open().read()`. Now: citekeys are
+  passed as parameters, pandoc's return code (and a missing pandoc binary) raise a clear
+  error and exit 2, all temp files live in a `TemporaryDirectory`, the `python-docx` import
+  is guarded with an install hint, and a missing `.bib` reports `bib file not found`. No
+  detector-count or behavior change on the happy path. New CI-wired regression test
+  (`tests/test_csl_render.sh`, PII-free fixture) covers the error paths without requiring
+  pandoc (the no-pandoc branch runs in CI; the render branch runs wherever pandoc exists).
+
 ## [4.8.0] - 2026-06-24
 
 The **review-harvest batch**: deterministic detector hardening promoted from real-manuscript review

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2133,8 +2133,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_csl_render.py",
-      "size": 5151,
-      "sha256": "bdaf85f75a2ebfb0224d39b4862ccf31dd914453b540de8f3c1ea6e2a0dccc48"
+      "size": 7718,
+      "sha256": "a1848c33e945024719fa1b7cc996d37555801e011c6280be6644ae4f01642601"
     },
     {
       "path": "skills/manage-refs/scripts/check_reference_duplication.py",

--- a/skills/manage-refs/scripts/check_csl_render.py
+++ b/skills/manage-refs/scripts/check_csl_render.py
@@ -17,6 +17,12 @@ This script renders a 2-citation sample through pandoc + the CSL and checks:
 Compares against expected spec (from REFERENCE_STYLE_SPECS.md or CLI flags) and
 exits non-zero on mismatch — run this BEFORE submission, not after the proof PDF.
 
+Exit codes:
+  0  output matches journal spec
+  1  spec mismatch (in-text / DOI / abbreviation)
+  2  environment / input error (pandoc or python-docx missing, bib not found,
+     pandoc render failed) — reported with a clear message, never a raw traceback
+
 Usage:
   python check_csl_render.py --csl path/to.csl --bib refs.bib \\
       --expect-intext superscript --expect-doi 0 --expect-abbrev yes
@@ -24,6 +30,15 @@ Usage:
   python check_csl_render.py --csl ... --bib ... --journal jkms
 """
 import argparse, subprocess, tempfile, re, os, sys, json
+from pathlib import Path
+
+# python-docx is required for the superscript check. Import is guarded at the top
+# so a missing dependency is a clear, actionable message (exit 2) rather than an
+# ImportError traceback raised deep inside analyze().
+try:
+    from docx import Document
+except ImportError:  # pragma: no cover - environment-dependent
+    Document = None
 
 # Minimal built-in spec table (extend via REFERENCE_STYLE_SPECS.md).
 # intext: superscript|bracket|paren ; doi: 0|1 ; abbrev: yes|no
@@ -38,27 +53,71 @@ SPECS = {
 
 SAMPLE = ("Risk is elevated [@A; @B].\n\n# References\n")
 
-def render(csl, bib, fmt):
-    md = tempfile.NamedTemporaryFile("w", suffix=".md", delete=False)
-    md.write(SAMPLE.replace("@A", FIRST).replace("@B", SECOND)); md.close()
-    out = tempfile.NamedTemporaryFile(suffix=("."+fmt), delete=False).name
-    subprocess.run(["pandoc", md.name, "--citeproc", f"--bibliography={bib}",
-                    f"--csl={csl}", "-o", out], capture_output=True)
-    return out
 
-def analyze(csl, bib):
-    # need two citekeys present in bib; pick first two @article keys
-    keys = re.findall(r"@\w+\{([^,]+),", open(bib).read())
-    global FIRST, SECOND
-    FIRST, SECOND = (keys + ["A", "B"])[:2]
-    docx = render(csl, bib, "docx")
-    txt_out = render(csl, bib, "plain")
-    txt = open(txt_out).read() if os.path.exists(txt_out) else ""
-    # in-text format
-    from docx import Document
-    d = Document(docx)
-    sup = sum(1 for p in d.paragraphs for r in p.runs
-              if r.font.superscript and re.search(r"\d", r.text))
+class RenderError(RuntimeError):
+    """Environment/input failure that should exit 2 with a clear message."""
+
+
+def _read_bib(bib: str) -> str:
+    """Read the .bib file, raising a clear RenderError if it is missing/unreadable."""
+    p = Path(bib)
+    if not p.exists():
+        raise RenderError(f"bib file not found: {bib}")
+    try:
+        return p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RenderError(f"could not read bib file {bib}: {exc}") from exc
+
+
+def render(csl: str, bib: str, fmt: str, first: str, second: str, outdir: str) -> str:
+    """Render the 2-citation SAMPLE through pandoc+CSL into ``outdir``.
+
+    ``first``/``second`` are the two citekeys to substitute (passed explicitly so
+    this function is standalone-callable — no module globals). The input markdown
+    and the output file live under ``outdir`` so the caller's TemporaryDirectory
+    cleans everything up; nothing leaks. Raises RenderError if pandoc is missing
+    or returns non-zero, so a failed render can never be silently analyzed as if
+    it had succeeded.
+    """
+    md_path = os.path.join(outdir, "sample.md")
+    out_path = os.path.join(outdir, f"out.{fmt}")
+    Path(md_path).write_text(SAMPLE.replace("@A", first).replace("@B", second), encoding="utf-8")
+    try:
+        proc = subprocess.run(
+            ["pandoc", md_path, "--citeproc", f"--bibliography={bib}",
+             f"--csl={csl}", "-o", out_path],
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RenderError(
+            "pandoc not found on PATH. Install pandoc to run the CSL render check."
+        ) from exc
+    if proc.returncode != 0:
+        raise RenderError(
+            f"pandoc failed (exit {proc.returncode}) rendering {fmt}: "
+            f"{proc.stderr.strip()[:500]}"
+        )
+    return out_path
+
+
+def analyze(csl: str, bib: str) -> dict:
+    # Validate inputs first (bib path), so a missing bib is reported clearly and
+    # independently of whether the optional python-docx parser is installed.
+    keys = re.findall(r"@\w+\{([^,]+),", _read_bib(bib))
+    first, second = (keys + ["A", "B"])[:2]
+    if Document is None:
+        raise RenderError(
+            "python-docx is required for the in-text superscript check "
+            "(pip install python-docx)."
+        )
+    with tempfile.TemporaryDirectory(prefix="csl_render_") as tmp:
+        docx = render(csl, bib, "docx", first, second, tmp)
+        txt_out = render(csl, bib, "plain", first, second, tmp)
+        txt = Path(txt_out).read_text(encoding="utf-8") if os.path.exists(txt_out) else ""
+        # in-text format
+        d = Document(docx)
+        sup = sum(1 for p in d.paragraphs for r in p.runs
+                  if r.font.superscript and re.search(r"\d", r.text))
     body = txt.split("References")[0] if "References" in txt else txt
     intext = ("superscript" if sup > 0
               else "bracket" if re.search(r"\[\d", body)
@@ -83,7 +142,11 @@ def main():
     if a.expect_intext: exp["intext"] = a.expect_intext
     if a.expect_doi is not None: exp["doi"] = a.expect_doi
     if a.expect_abbrev: exp["abbrev"] = a.expect_abbrev
-    got = analyze(a.csl, a.bib)
+    try:
+        got = analyze(a.csl, a.bib)
+    except RenderError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)
     print(json.dumps({"csl": os.path.basename(a.csl), "expected": exp, "got": got}, indent=2))
     fails = []
     if exp.get("intext") and got["intext"] != exp["intext"]:

--- a/skills/manage-refs/tests/fixtures/csl_render_sample.bib
+++ b/skills/manage-refs/tests/fixtures/csl_render_sample.bib
@@ -1,0 +1,19 @@
+@article{alpha2020,
+  title   = {A synthetic study of widget reliability},
+  author  = {Alpha, Ada and Beta, Boris},
+  journal = {Journal of Synthetic Methods},
+  year    = {2020},
+  volume  = {1},
+  pages   = {10--20},
+  doi     = {10.1234/jsm.2020.001}
+}
+
+@article{gamma2021,
+  title   = {Follow-up on widget reliability},
+  author  = {Gamma, Grace and Delta, Dan},
+  journal = {Synthetic Reports},
+  year    = {2021},
+  volume  = {2},
+  pages   = {30--40},
+  doi     = {10.1234/sr.2021.002}
+}

--- a/skills/manage-refs/tests/test_csl_render.sh
+++ b/skills/manage-refs/tests/test_csl_render.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression test for the hardened CSL acceptance-check (manage-refs/check_csl_render.py).
+# Guards the robustness fixes (no module globals, checked subprocess, no temp leak,
+# guarded python-docx import, guarded bib read). Synthetic, PII-free fixtures.
+#
+# CI-safe: the deepest path (real pandoc render → docx superscript parse) needs
+# pandoc, which CI does not install. The error-handling paths this test asserts
+# do NOT need pandoc, and the no-pandoc branch is exercised exactly when pandoc is
+# absent (i.e. in CI), so fix #2 (clean "pandoc not found") is covered there while
+# fixes #1/#3/#4 (the happy path) are covered wherever pandoc is present (locally).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_csl_render.py"
+CSL="$HERE/../citation_styles/vancouver.csl"
+BIB="$HERE/fixtures/csl_render_sample.bib"
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing: $SCRIPT" >&2; exit 2; }
+[[ -f "$CSL"    ]] || { echo "ENV-ERR: csl missing: $CSL" >&2; exit 2; }
+[[ -f "$BIB"    ]] || { echo "ENV-ERR: fixture bib missing: $BIB" >&2; exit 2; }
+
+fail=0
+pass() { printf '  PASS  %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "test_csl_render:"
+
+# 1. Missing bib -> clean error (fix: guarded bib read), exit 2, no traceback.
+err="$(python3 "$SCRIPT" --csl "$CSL" --bib /nonexistent_csl_render.bib 2>&1)"; rc=$?
+if [[ $rc -eq 2 && "$err" == *"bib file not found"* && "$err" != *"Traceback"* ]]; then
+  pass "missing bib -> clean error, exit 2"
+else
+  bad "missing bib (rc=$rc): $err"
+fi
+
+# 2. Valid bib: pandoc present -> happy path renders, exit 0 + JSON.
+#    pandoc absent (e.g. CI) -> clean 'pandoc not found' error, exit 2.
+out="$(python3 "$SCRIPT" --csl "$CSL" --bib "$BIB" 2>&1)"; rc=$?
+if command -v pandoc >/dev/null 2>&1; then
+  if [[ $rc -eq 0 && "$out" == *'"got"'* && "$out" != *"Traceback"* ]]; then
+    pass "valid bib + pandoc -> renders, exit 0, JSON emitted"
+  else
+    bad "valid bib + pandoc (rc=$rc): $out"
+  fi
+else
+  if [[ $rc -eq 2 && "$out" == *"pandoc not found"* && "$out" != *"Traceback"* ]]; then
+    pass "valid bib, no pandoc -> clean 'pandoc not found', exit 2"
+  else
+    bad "valid bib, no pandoc (rc=$rc): $out"
+  fi
+fi
+
+# 3. No leftover temp dirs from this run (fix: TemporaryDirectory cleanup).
+if ls -d "${TMPDIR:-/tmp}"/csl_render_* >/dev/null 2>&1; then
+  bad "temp dir leak: csl_render_* left behind"
+else
+  pass "no temp-dir leak"
+fi
+
+if [[ $fail -eq 0 ]]; then echo "  OK"; exit 0; else echo "  $fail check(s) failed"; exit 1; fi


### PR DESCRIPTION
## What

`check_csl_render.py` is a counted MedSci-Audit detector (citation_reference family) but was not yet wired into the `/manage-refs` workflow, and a code-health audit found **five latent bugs** that could surface a raw traceback or a silently-wrong verdict. This hardens it and adds a CI-wired regression test. No detector-count change; no happy-path behavior change.

| # | Bug | Fix |
|---|-----|-----|
| 1 | `render()` used module globals `FIRST`/`SECOND` (not standalone-callable; `NameError` if called directly) | pass citekeys as parameters |
| 2 | `subprocess.run(pandoc)` return code unchecked → failed render analyzed as success | check returncode → clear error (exit 2); missing-pandoc reported cleanly |
| 3 | `NamedTemporaryFile(delete=False)` leaked temp files | all I/O in a `TemporaryDirectory` |
| 4 | `from docx import Document` inside the function → opaque `ImportError` | top-level guarded import + install hint |
| 5 | `open(bib).read()` unguarded → raw `FileNotFoundError` | `Path.read_text` guarded → `bib file not found` |

Input validation reordered so a missing `.bib` is reported independently of `python-docx` presence.

## Test

`skills/manage-refs/tests/test_csl_render.sh` (+ PII-free fixture bib) — CI-safe by construction: the **no-pandoc branch** runs in CI (CI does not install pandoc) and asserts a clean `pandoc not found` error; the **render branch** runs wherever pandoc exists (asserts exit 0 + JSON + no temp leak); the missing-bib path is environment-independent. Wired into `validate.yml`.

## Verification (local CI-mirror, all green)

- `test_csl_render.sh` — passes both locally (pandoc present) and under a simulated no-pandoc PATH
- `gen_distribution_manifest.py --check` (regenerated: only the edited detector's size/sha changed; tests excluded from payload) · `gen_detectors_catalog_json.py --check` (36 detectors unchanged) · `validate_catalog_consistency.py` · `gen_skill_docs.py --check` · `validate_skills.sh` · `check_locale_inventory.py` · `validate_routing_assets.py --strict` · `check_version_consistency.py` — all green
- `python3 -m py_compile` + `yaml.safe_load(validate.yml)` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)