### PR TITLE
chore(ci,skills): wire 15 dormant tests + activate PRISMA-figure detector + script taxonomy

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -230,6 +230,58 @@ jobs:
       - name: Run analyze-stats generated-code gate test
         run: bash skills/analyze-stats/tests/test_generated_code.sh
 
+      # --- previously-dormant skill regression tests, now CI-wired (v5 coverage-gap closure) ---
+      # These tests shipped with their detectors but were never added to this workflow, so CI
+      # gave false coverage. All pass on the same toolchain CI installs (stdlib + python-docx;
+      # no pandoc/R). Re-run gen_distribution_manifest.py after adding any new fixture.
+      - name: Run check-reporting checklist fail-fast test
+        run: bash skills/check-reporting/tests/test_checklist_fail_fast.sh
+
+      - name: Run check-reporting framework-naming gate test
+        run: bash skills/check-reporting/tests/test_framework_naming.sh
+
+      - name: Run check-reporting PRISMA-cascade test
+        run: bash skills/check-reporting/tests/test_prisma_cascade.sh
+
+      - name: Run check-reporting PRISMA Figure 1 audit test (Step 4d)
+        run: bash skills/check-reporting/tests/test_prisma_figure.sh
+
+      - name: Run manage-refs duplicate-bibliography gate test
+        run: bash skills/manage-refs/tests/test_reference_duplication.sh
+
+      - name: Run self-review binning-consistency gate test
+        run: bash skills/self-review/tests/test_binning_consistency.sh
+
+      - name: Run self-review float citation-order gate test
+        run: bash skills/self-review/tests/test_citation_order.sh
+
+      - name: Run self-review claim-artifact (estimand provenance) gate test
+        run: bash skills/self-review/tests/test_claim_artifact.sh
+
+      - name: Run self-review panel-diversity gate test
+        run: bash skills/self-review/tests/test_panel_diversity.sh
+
+      - name: Run self-review reviewer-team-consistency gate test
+        run: bash skills/self-review/tests/test_reviewer_team_consistency.sh
+
+      - name: Run sync-submission audit-dump leak gate test
+        run: bash skills/sync-submission/tests/test_checklist_dump_leak.sh
+
+      - name: Run sync-submission copy-divergence gate test
+        run: bash skills/sync-submission/tests/test_copy_divergence.sh
+
+      - name: Run sync-submission cross-document-N gate test
+        run: bash skills/sync-submission/tests/test_cross_document_n.sh
+
+      - name: Run sync-submission scope-drift gate test
+        run: bash skills/sync-submission/tests/test_scope_drift.sh
+
+      - name: Run sync-submission vN-docx assertion gate test
+        run: bash skills/sync-submission/tests/test_vN_docx_assertion.sh
+
+      - name: Run verify-refs pagination-placeholder gate test
+        run: bash skills/verify-refs/tests/test_pagination_placeholder.sh
+
       - name: Verify demo manifest.lock files (reproducibility lock)
         run: |
           for d in demo/01_wisconsin_bc demo/02_metafor_bcg demo/03_nhanes_obesity; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,30 @@
   (`tests/test_csl_render.sh`, PII-free fixture) covers the error paths without requiring
   pandoc (the no-pandoc branch runs in CI; the render branch runs wherever pandoc exists).
 
+- **CI test-coverage gap closure (15 dormant tests wired)** — fifteen skill regression
+  tests shipped with their detectors but were never added to `.github/workflows/validate.yml`,
+  so CI gave false coverage (`check-reporting` fail-fast / framework-naming / PRISMA-cascade,
+  `manage-refs` duplicate-bibliography, `self-review` binning-consistency / citation-order /
+  claim-artifact / panel-diversity / reviewer-team-consistency, `sync-submission` audit-dump-leak
+  / copy-divergence / cross-document-N / scope-drift / vN-docx-assertion, `verify-refs`
+  pagination-placeholder). All pass on the toolchain CI installs (stdlib + python-docx; no
+  pandoc/R) and are now `run:` steps in `validate.yml`.
+
+- **Dormant PRISMA Figure 1 detector activated** — `check_prisma_figure.py` (a counted
+  MedSci-Audit detector implementing `/check-reporting` Step 4d's arithmetic + body↔figure
+  cross-reference audit) existed and worked but was never invoked: Step 4d described the
+  algorithm in prose and asked the model to extract numbers by hand. Step 4d now runs the
+  deterministic script first (manual algorithm kept as the PNG/SVG-transcription fallback),
+  with a new CI-wired test (`tests/test_prisma_figure.sh`, PII-free fixtures). The two
+  `manage-refs` CSL tools surfaced by the same audit (`check_csl_render.py`,
+  `fill_journal_abbrev.py`) are now documented in that skill's tool table.
+
+- **`skills/MAINTENANCE.md`** — documents the four skill-script categories (counted detector /
+  helper / run-once authoring tool / test fixture) and the wiring rules that prevent a detector
+  or test from going dormant again (a detector must be invoked from SKILL.md and CI-tested; a
+  test only counts as coverage if it is a `run:` step in `validate.yml`). No skill or detector
+  count change.
+
 ## [4.8.0] - 2026-06-24
 
 The **review-harvest batch**: deterministic detector hardening promoted from real-manuscript review

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -52,6 +52,11 @@
       "sha256": "6a632a88617889a1ac36418822b8af3f2bcab75bfa28169e99ae4fdf0b810365"
     },
     {
+      "path": "skills/MAINTENANCE.md",
+      "size": 4061,
+      "sha256": "a4eaa6062e7d5879afcdac3bd954fcb783282707eea22b815d5a6f794d5a5217"
+    },
+    {
       "path": "skills/academic-aio/SKILL.md",
       "size": 31396,
       "sha256": "339f937d2218e11c8f6576df9bb6d5b2b827634092d8f4e6c1b6110e092076b5"
@@ -468,8 +473,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 35025,
-      "sha256": "b2808d9de4873aebe2006ceb00d0a4577cdb02d9709cb9777bdf4b8513f79710"
+      "size": 35835,
+      "sha256": "a11617fb2bcf03b63a788638ad68ab9dac8623281e8b58428706b7c43a02e8c3"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -2028,8 +2033,8 @@
     },
     {
       "path": "skills/manage-refs/SKILL.md",
-      "size": 17482,
-      "sha256": "74309d07f0145b2805b53050eb37e72471067da4bed7b6ed569d3945dff06e14"
+      "size": 18165,
+      "sha256": "49adc82dea2b5d7eb93946b2cd8143d66d50b53169d3ed18f4bd738bfe3af39f"
     },
     {
       "path": "skills/manage-refs/citation_styles/README.md",

--- a/skills/MAINTENANCE.md
+++ b/skills/MAINTENANCE.md
@@ -1,0 +1,68 @@
+# Skill Script Maintenance — taxonomy & wiring rules
+
+Every `.py`/`.sh` under `skills/*/scripts/` and `skills/*/tests/` falls into one of
+four categories. Misclassifying one is how a detector goes "dormant" (counted in the
+catalog but never invoked) or how a regression test gives false coverage (exists but
+never runs in CI). This file is the source of truth for which is which and what each
+category must satisfy.
+
+## 1. Counted analysis-integrity detector
+
+A script whose **filename** matches the catalog glob — `check_*.py`, `detect_*.py`,
+`derive_*.py`, or `verify_refs.py` — under `skills/*/scripts/`. The glob is the SSOT:
+`scripts/gen_detectors_catalog_json.py` and `scripts/validate_catalog_consistency.py`
+both count these and they must agree with `metadata/catalog_counts.json`
+(`integrity_detectors`).
+
+A counted detector MUST:
+- be registered in `scripts/gen_detectors_catalog_json.py` `FAMILY_BY_ID` (an unmapped id
+  fails generation), and bump `metadata/catalog_counts.json` + `MEDSCI_AUDIT.md` when added;
+- be **invoked** from its skill's `SKILL.md` (a named workflow step) — otherwise it is
+  dormant (counted but never run on a real manuscript);
+- have a **CI-wired** regression test (a `tests/test_*.sh` step in
+  `.github/workflows/validate.yml`) with PII-free synthetic fixtures.
+
+> Naming trap: a reusable helper must NOT be named `check_*`/`detect_*` or it inflates the
+> detector count. Prefix helpers with `_` (see category 2).
+
+## 2. Helper / library module
+
+Shared logic imported by other scripts in the **same** skill (skills are self-contained —
+no cross-skill imports). Name it with a leading underscore (`_yaml_frontmatter.py`) or a
+plain verb (`fill_journal_abbrev.py`) so the detector glob never counts it. Helpers do not
+need their own SKILL.md step, but if a user runs them directly they should be listed in the
+skill's tool table (e.g. `manage-refs` documents `fill_journal_abbrev.py`).
+
+## 3. Run-once authoring tool
+
+A generator a maintainer runs by hand to (re)build a committed asset — NOT invoked at skill
+invocation. These are intentionally not wired into any SKILL.md step. Keep them; document
+their purpose in their own docstring. Current run-once tools:
+
+- `skills/make-figures/scripts/build_jacc_template.py` — rebuilds the committed JACC Central
+  Illustration PPTX template (`references/visual_abstract_templates/jacc_central_illustration.pptx`).
+- `skills/make-figures/scripts/extract_exemplar_from_pdf.py` — extracts a figure region from a
+  PDF page to grow the make-figures Critic-Loop exemplar reference set.
+
+## 4. Test fixture / regression test
+
+Lives under `skills/<skill>/tests/`. A `test_*.sh`/`test_*.py` is only real coverage if it
+is wired into `.github/workflows/validate.yml` as a `run:` step. **Adding a test file is not
+enough** — if it is not listed in `validate.yml` it never runs and gives false confidence.
+When you add a detector and its test in the same PR, add the `validate.yml` step in that PR.
+
+## When you touch a skill script — checklist
+
+1. New `check_*`/`detect_*` detector → register in `gen_detectors_catalog_json.py`
+   (`FAMILY_BY_ID`) + bump `catalog_counts.json` + `MEDSCI_AUDIT.md` + wire into the skill's
+   `SKILL.md` + add a CI-wired test. Then run all three generators in `--check` mode.
+2. New helper → underscore/plain name (never `check_*`), import only within the same skill.
+3. New asset/fixture file → re-run `python3 scripts/gen_distribution_manifest.py` (it tracks
+   payload files and hashes; tests are excluded from the distributed payload but the manifest
+   `--check` still gates on edited payload scripts).
+4. New/edited test → add its `run:` step to `.github/workflows/validate.yml`.
+
+Run the full local CI-mirror before pushing (see the repo `CONTRIBUTING.md` / `validate.yml`
+gates): `validate_skills.sh`, the three `gen_*.py --check`, `validate_catalog_consistency.py`,
+`check_version_consistency.py`, `gen_skill_docs.py --check`, `check_locale_inventory.py`,
+`validate_routing_assets.py --strict`, and the installer tests.

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -248,6 +248,23 @@ study's data integrity immediately.
 - Reasons for exclusion (Methods + Figure legend) agree on counts and category names.
 
 **Procedure:**
+
+Run the deterministic implementation first — it performs steps 1, 4, 5, and 6 below
+automatically (same keyword regex, the four arithmetic equations, the body↔figure
+cross-reference) and writes `qc/prisma_figure_audit.json`:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/check_prisma_figure.py \
+  --md <manuscript.md> --figure <Figure 1 source: .md manifest / caption / text export> \
+  --out qc/prisma_figure_audit.json
+```
+
+Exit `1` = an arithmetic or cross-reference MISMATCH (log a Part C Action Item labelled
+`[PRISMA-FIGURE]`, `fixable_by_ai: false` — the author must reconcile the numbers); exit
+`2` = missing/unparsable input. The manual algorithm below documents exactly what the
+script checks and is the fallback when Figure 1 numbers live only in a PNG/SVG that must
+be transcribed by hand:
+
 1. Extract numbers from manuscript Results / PRISMA flow paragraph (regex: integers near
    keywords `identified`, `duplicates`, `screened`, `excluded`, `sought`, `retrieved`,
    `assessed`, `included`).

--- a/skills/check-reporting/tests/fixtures/prisma_body.md
+++ b/skills/check-reporting/tests/fixtures/prisma_body.md
@@ -1,0 +1,7 @@
+## PRISMA flow
+
+A total of 1000 records identified through database searching. After 200 duplicates
+removed, 800 records screened. Of these, 600 records excluded at screening, leaving
+200 reports sought for retrieval. 10 reports not retrieved. 190 reports retrieved and
+190 reports assessed for eligibility. 40 records excluded with reasons. 150 studies
+included in the synthesis.

--- a/skills/check-reporting/tests/fixtures/prisma_fig_clean.md
+++ b/skills/check-reporting/tests/fixtures/prisma_fig_clean.md
@@ -1,0 +1,10 @@
+1000 records identified
+200 duplicates removed
+800 records screened
+600 records excluded at screening
+200 reports sought for retrieval
+10 reports not retrieved
+190 reports retrieved
+190 reports assessed for eligibility
+40 records excluded with reasons
+150 studies included

--- a/skills/check-reporting/tests/fixtures/prisma_fig_mismatch.md
+++ b/skills/check-reporting/tests/fixtures/prisma_fig_mismatch.md
@@ -1,0 +1,10 @@
+1000 records identified
+200 duplicates removed
+800 records screened
+600 records excluded at screening
+200 reports sought for retrieval
+10 reports not retrieved
+190 reports retrieved
+190 reports assessed for eligibility
+40 records excluded with reasons
+149 studies included

--- a/skills/check-reporting/tests/test_prisma_figure.sh
+++ b/skills/check-reporting/tests/test_prisma_figure.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Regression test for the PRISMA Figure 1 arithmetic + cross-reference audit
+# (check-reporting Step 4d / check_prisma_figure.py). Synthetic, PII-free fixtures.
+# Stdlib-only (python3); no network, no pandoc.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_prisma_figure.py"
+BODY="$HERE/fixtures/prisma_body.md"
+CLEAN="$HERE/fixtures/prisma_fig_clean.md"
+MM="$HERE/fixtures/prisma_fig_mismatch.md"
+OUT="$(mktemp -t prisma_fig_XXXX).json"
+trap 'rm -f "$OUT"' EXIT
+
+for f in "$SCRIPT" "$BODY" "$CLEAN" "$MM"; do
+  [[ -f "$f" ]] || { echo "ENV-ERR: missing $f" >&2; exit 2; }
+done
+
+fail=0
+pass() { printf '  PASS  %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "test_prisma_figure:"
+
+# 1. Clean figure (numbers match body, arithmetic consistent) -> audit_safe, exit 0.
+python3 "$SCRIPT" --md "$BODY" --figure "$CLEAN" --out "$OUT" >/dev/null 2>&1; rc=$?
+if [[ $rc -eq 0 ]] && python3 -c "import json,sys; sys.exit(0 if json.load(open('$OUT'))['audit_safe'] else 1)"; then
+  pass "clean body/figure -> audit_safe, exit 0"
+else
+  bad "clean case rc=$rc (expected 0 + audit_safe)"
+fi
+
+# 2. Mismatched figure (included 149 vs body 150) -> MISMATCH, exit 1, PRISMA-FIGURE flag.
+out="$(python3 "$SCRIPT" --md "$BODY" --figure "$MM" --out "$OUT" 2>&1)"; rc=$?
+if [[ $rc -eq 1 && "$out" == *"[PRISMA-FIGURE]"* ]] \
+   && python3 -c "import json,sys; d=json.load(open('$OUT')); sys.exit(0 if (not d['audit_safe'] and d['action_items']) else 1)"; then
+  pass "mismatched figure -> MISMATCH flagged, exit 1"
+else
+  bad "mismatch case rc=$rc (expected 1 + [PRISMA-FIGURE] + action_items)"
+fi
+
+# 3. Missing input -> clean error, exit 2 (no traceback).
+err="$(python3 "$SCRIPT" --md /nonexistent_prisma.md --figure "$CLEAN" --out "$OUT" 2>&1)"; rc=$?
+if [[ $rc -eq 2 && "$err" == *"not found"* && "$err" != *"Traceback"* ]]; then
+  pass "missing manuscript -> clean error, exit 2"
+else
+  bad "missing-input case rc=$rc: $err"
+fi
+
+if [[ $fail -eq 0 ]]; then echo "  OK"; exit 0; else echo "  $fail check(s) failed"; exit 1; fi

--- a/skills/manage-refs/SKILL.md
+++ b/skills/manage-refs/SKILL.md
@@ -78,6 +78,8 @@ Validated 2026-05-01 against a 21-reference meta-analysis manuscript
 | Validate `[@bibkey]` ↔ `refs.bib` (UNDEFINED / UNUSED keys) | `scripts/check_citation_keys.py` | Hard build gate, runs in seconds |
 | Single-author submission lockdown, frozen output | `scripts/render_pandoc.sh -j <journal>` | Reproducible, CI-friendly |
 | Cascade rejection (e.g., ER → JVIR → CVIR) | `render_pandoc.sh` with new `-j` | CSL swap reformats references in seconds |
+| Verify a journal CSL renders the in-text format / DOI / journal-name style the author guide actually requires | `scripts/check_csl_render.py --csl <x>.csl --bib refs.bib --journal <key>` | A stub/"dependent" CSL inherits its parent's format, which may differ from the guide (parenthetical vs superscript, DOI kept, full journal names). Run BEFORE submission, not after the proof PDF |
+| Reference list prints FULL journal names but the journal wants NLM abbreviations | `scripts/fill_journal_abbrev.py` | Resolves each entry DOI → PMID → PubMed NLM `shortjournal` into the `.bib` so CSL `form="short"` renders abbreviations; authoritative source, never invents abbreviations |
 | Reviewer revision: add 1–2 refs to a Word doc with co-authors live | Zotero Word plugin (user GUI) | Minimal disruption to track-changes flow |
 | Reviewer revision: bulk reference change | Edit markdown SSOT, re-run `render_pandoc.sh` | Consistency, no cherry-pick risk |
 | Migrate `[N]` numeric markers → `[@key]` for pandoc | `scripts/md_marker_convert.py --to-keys` | Mapping-driven, partial conversion safe |


### PR DESCRIPTION
## What

A script audit found latent gaps where shipped code never actually ran. All changes are **additive** (no removals, no skill/detector count change — 45 skills / 36 detectors unchanged).

### 1. CI test-coverage gap — 15 dormant tests wired
Fifteen skill regression tests shipped alongside their detectors but were never added to `validate.yml`, so CI gave **false coverage**. All pass on the toolchain CI installs (stdlib + `python-docx`; no pandoc/R) and are now `run:` steps:

`check-reporting` fail-fast / framework-naming / PRISMA-cascade · `manage-refs` duplicate-bibliography · `self-review` binning-consistency / citation-order / claim-artifact / panel-diversity / reviewer-team-consistency · `sync-submission` audit-dump-leak / copy-divergence / cross-document-N / scope-drift / vN-docx-assertion · `verify-refs` pagination-placeholder.

### 2. Dormant PRISMA Figure 1 detector activated
`check_prisma_figure.py` (a counted MedSci-Audit detector implementing `/check-reporting` Step 4d's arithmetic + body↔figure cross-reference audit) existed and worked but was **never invoked** — Step 4d described the algorithm in prose and asked the model to extract numbers by hand. Step 4d now runs the deterministic script first (manual algorithm kept as the PNG/SVG-transcription fallback) + a new CI-wired test (`test_prisma_figure.sh` + PII-free fixtures, covering clean / mismatch / missing-input).

### 3. `manage-refs` CSL tools documented
`check_csl_render.py` + `fill_journal_abbrev.py` (surfaced by the same audit) added to the skill's tool table.

### 4. `skills/MAINTENANCE.md` — script taxonomy
Documents the four script categories (counted detector / helper / run-once authoring tool / test fixture) and the wiring rules that prevent recurrence: a detector must be invoked from SKILL.md **and** CI-tested; a test only counts as coverage if it is a `run:` step in `validate.yml`.

## Verification (local CI-mirror, all green)

- All 15 dormant tests + the new `test_prisma_figure.sh` pass locally
- `gen_distribution_manifest.py --check` (regenerated: only `skills/MAINTENANCE.md` added to payload; tests/fixtures excluded) · `gen_detectors_catalog_json.py --check` (36 unchanged) · `validate_catalog_consistency.py` · `gen_skill_docs.py --check` · `validate_skills.sh` · `validate_routing_assets.py --strict` (224 refs, all exist) · `check_locale_inventory.py` · `check_version_consistency.py`
- `yaml.safe_load(validate.yml)` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)