### PR TITLE
feat(ci): frontmatter schema gate (Agent Skills portability) + fix manage-project invalid YAML

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Run validate_catalog_consistency.py (doc counts must match disk SSOT)
         run: python3 scripts/validate_catalog_consistency.py
 
+      - name: Run check_frontmatter_schema.py (Agent Skills frontmatter spec — valid YAML, name, description)
+        run: python3 scripts/check_frontmatter_schema.py
+
+      - name: Run frontmatter-schema gate self-test
+        run: bash tests/test_frontmatter_schema.sh
+
       - name: Run gen_skill_docs.py --check (per-skill docs must match SKILL.md)
         run: python3 scripts/gen_skill_docs.py --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@
   Analysis-integrity detectors **32 → 33**; skills 45 and reporting guidelines 36
   unchanged. Additive and backward-compatible.
 
+- **Frontmatter schema gate (Agent Skills cross-platform portability)** — new
+  `scripts/check_frontmatter_schema.py` + CI step strictly `yaml.safe_load`s every
+  `skills/*/SKILL.md` frontmatter and enforces the published Agent Skills spec: valid
+  YAML, `name` ≤64 chars / lowercase-hyphen / no reserved `claude`/`anthropic` token,
+  `description` present / ≤1024 chars / no XML angle brackets. The repo's own generators
+  use a tolerant line-based reader, so a frontmatter block that is not valid YAML could
+  pass every prior gate yet be rejected by a strict-YAML consumer (the agentskills.io
+  directory validator or another agent platform). Self-test (`tests/test_frontmatter_schema.sh`)
+  covers each violation class. This is a repo-CI validator, not a counted detector.
+
 ### Fixed
 
 - **Public-doc count reconciliation** — `README.md` (MedSci-Audit suite line) and
@@ -122,6 +132,13 @@
   or test from going dormant again (a detector must be invoked from SKILL.md and CI-tested; a
   test only counts as coverage if it is a `run:` step in `validate.yml`). No skill or detector
   count change.
+
+- **`manage-project` frontmatter was not valid YAML** — its inline `description` ended with
+  `Commands: init, status, …`, and the `: ` makes a plain inline scalar invalid YAML (a strict
+  parser raises "mapping values are not allowed here"). The repo's tolerant reader accepted it,
+  so it passed every prior gate, but a strict-YAML consumer would reject the skill. Quoted the
+  description value (text unchanged; the storefront catalog first-sentence and per-skill docs are
+  byte-identical). Found by the new frontmatter schema gate above.
 
 ## [4.8.0] - 2026-06-24
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1983,8 +1983,8 @@
     },
     {
       "path": "skills/manage-project/SKILL.md",
-      "size": 12313,
-      "sha256": "ea1925634e5da4eff202fd34ae874f64b7b76d577ffa0bd49c406a5d84bd4441"
+      "size": 12315,
+      "sha256": "40c3a0098a3729b839e132db3987ad0f3fc5f3eeaf1c5a56dd77673cffdb5dbd"
     },
     {
       "path": "skills/manage-project/references/pre_submission_checklist.md",

--- a/scripts/check_frontmatter_schema.py
+++ b/scripts/check_frontmatter_schema.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Frontmatter schema gate for Agent Skills cross-platform portability.
+
+The repo's own generators parse SKILL.md frontmatter with a tolerant line-based
+reader (`gen_skills_catalog_json._frontmatter_field`), so a frontmatter block that
+is NOT valid YAML can still pass every existing gate — but a strict-YAML consumer
+(the agentskills.io directory validator, or another agent platform that loads the
+skill) would reject it. This check enforces the published Agent Skills spec
+(https://agentskills.io/specification) so skills stay portable:
+
+  - the frontmatter block is **valid YAML** (strict `yaml.safe_load`);
+  - `name`: present, string, <= 64 chars, lowercase alphanumeric + single hyphens
+    (no leading/trailing/consecutive hyphen), and free of the reserved tokens
+    `claude` / `anthropic`;
+  - `description`: present, non-empty string, <= 1024 chars, with no XML angle
+    brackets in the value (injection-surface hardening).
+
+This is a repo-CI validator (it lives in `scripts/`, not `skills/*/scripts/`), so it
+is NOT counted as an analysis-integrity detector. Exit 0 when every skill conforms;
+non-zero with a per-skill report on any violation. Requires PyYAML.
+
+Usage:
+  python3 scripts/check_frontmatter_schema.py            # scans skills/
+  python3 scripts/check_frontmatter_schema.py --root DIR  # scans DIR/*/SKILL.md (tests)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+RESERVED_TOKENS = ("claude", "anthropic")
+NAME_MAX = 64
+DESC_MAX = 1024
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.S)
+
+
+def parse_frontmatter(text: str):
+    """Return (mapping, error). error is a string when the block is missing/invalid."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return None, "no '---' frontmatter block at top of file"
+    try:
+        fm = yaml.safe_load(m.group(1))
+    except yaml.YAMLError as exc:
+        first = str(exc).splitlines()[0]
+        return None, f"frontmatter is not valid YAML ({first})"
+    if not isinstance(fm, dict):
+        return None, "frontmatter does not parse to a YAML mapping"
+    return fm, None
+
+
+def check_skill(sk: Path) -> list[str]:
+    errs: list[str] = []
+    fm, err = parse_frontmatter(sk.read_text(encoding="utf-8"))
+    if err:
+        return [err]
+
+    name = fm.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errs.append("missing or empty 'name'")
+    else:
+        if len(name) > NAME_MAX:
+            errs.append(f"name is {len(name)} chars (> {NAME_MAX})")
+        if not NAME_RE.match(name):
+            errs.append(f"name must be lowercase alphanumeric + single hyphens: {name!r}")
+        low = name.lower()
+        for tok in RESERVED_TOKENS:
+            if tok in low:
+                errs.append(f"name contains reserved token {tok!r}")
+
+    desc = fm.get("description")
+    if not isinstance(desc, str) or not desc.strip():
+        errs.append("missing or empty 'description'")
+    else:
+        if len(desc) > DESC_MAX:
+            errs.append(f"description is {len(desc)} chars (> {DESC_MAX})")
+        if "<" in desc or ">" in desc:
+            errs.append("description contains an XML angle bracket ('<' or '>')")
+
+    return errs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Agent Skills frontmatter schema gate.")
+    ap.add_argument("--root", default="skills",
+                    help="directory of <skill>/SKILL.md folders (default: skills)")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    print("=" * 41)
+    print(" Frontmatter Schema (Agent Skills spec)")
+    print("=" * 41)
+
+    n = 0
+    fails = 0
+    for d in sorted(root.iterdir()):
+        sk = d / "SKILL.md"
+        if not (d.is_dir() and sk.exists()):
+            continue
+        n += 1
+        for e in check_skill(sk):
+            print(f"  FAIL  {d.name}: {e}", file=sys.stderr)
+            fails += 1
+
+    print(f"\nchecked {n} SKILL.md frontmatter block(s)")
+    if fails:
+        print(f"\nFRONTMATTER_SCHEMA_VIOLATION: {fails} issue(s).", file=sys.stderr)
+        return 1
+    print("OK: all frontmatter valid YAML and spec-conformant (name, description).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/manage-project/SKILL.md
+++ b/skills/manage-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-project
-description: Research project management for medical manuscripts. Scaffold project structure, track writing progress across phases, maintain project memory files, generate submission checklists and backwards timelines. Commands: init, status, sync-memory, checklist, timeline.
+description: "Research project management for medical manuscripts. Scaffold project structure, track writing progress across phases, maintain project memory files, generate submission checklists and backwards timelines. Commands: init, status, sync-memory, checklist, timeline."
 triggers: manage project, project init, project status, submission checklist, project scaffold, create project, new paper project
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit

--- a/tests/test_frontmatter_schema.sh
+++ b/tests/test_frontmatter_schema.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_frontmatter_schema.py.
+# (1) the real skills/ tree must pass; (2) each spec violation must be caught.
+# Synthetic fixtures are generated in a temp dir — nothing is committed.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+GATE="$REPO/scripts/check_frontmatter_schema.py"
+[[ -f "$GATE" ]] || { echo "ENV-ERR: gate missing: $GATE" >&2; exit 2; }
+
+fail=0
+pass() { printf '  PASS  %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "test_frontmatter_schema:"
+
+# 1. Real tree passes (exit 0).
+if python3 "$GATE" --root "$REPO/skills" >/dev/null 2>&1; then
+  pass "real skills/ tree conforms (exit 0)"
+else
+  bad "real skills/ tree unexpectedly failed the gate"
+fi
+
+# Helper: write a one-skill fixture dir and assert the gate's exit code.
+expect() {  # $1=label  $2=expected_rc  $3=frontmatter-body(+blank+body)
+  local label="$1" want="$2" content="$3"
+  local td; td="$(mktemp -d)"
+  mkdir -p "$td/s"
+  printf '%s' "$content" > "$td/s/SKILL.md"
+  python3 "$GATE" --root "$td" >/dev/null 2>&1; local rc=$?
+  if [[ "$rc" -eq "$want" ]]; then pass "$label (exit $rc)"; else bad "$label (got $rc, want $want)"; fi
+  rm -rf "$td"
+}
+
+GOOD='---
+name: good-skill
+description: A valid skill. Does a thing and another thing for medical manuscripts.
+---
+
+body
+'
+expect "valid frontmatter accepted"        0 "$GOOD"
+
+# invalid YAML: inline description with a colon-space mapping ambiguity
+expect "invalid YAML (colon-space) caught" 1 '---
+name: bad-yaml
+description: Does things. Commands: init, run.
+---
+
+body
+'
+
+# name too long (> 64)
+LONGNAME=$(printf 'a%.0s' {1..70})
+expect "name >64 chars caught"             1 "---
+name: $LONGNAME
+description: ok description here for the test.
+---
+
+body
+"
+
+# name not lowercase-hyphen
+expect "uppercase name caught"             1 '---
+name: Bad_Name
+description: ok description here for the test.
+---
+
+body
+'
+
+# reserved token in name
+expect "reserved token in name caught"     1 '---
+name: claude-helper
+description: ok description here for the test.
+---
+
+body
+'
+
+# angle bracket in description value
+expect "angle bracket in description caught" 1 '---
+name: angle-skill
+description: Use this when the count is < 10 items in the set.
+---
+
+body
+'
+
+# empty description
+expect "empty description caught"          1 '---
+name: empty-desc
+description:
+---
+
+body
+'
+
+if [[ $fail -eq 0 ]]; then echo "  OK"; exit 0; else echo "  $fail check(s) failed"; exit 1; fi


### PR DESCRIPTION
## What

The repo parses SKILL.md frontmatter with a **tolerant line-based reader** (`gen_skills_catalog_json._frontmatter_field`), so a frontmatter block that is **not valid YAML** can pass every existing gate — yet a strict-YAML consumer (the agentskills.io directory validator, or another agent platform loading the skill) would reject it. Now that Agent Skills are a cross-platform standard, that is a real portability gap.

- **New `scripts/check_frontmatter_schema.py` + 2 CI steps** — strictly `yaml.safe_load`s every `skills/*/SKILL.md` frontmatter and enforces the [Agent Skills spec](https://agentskills.io/specification): valid YAML; `name` ≤64 / lowercase-hyphen / no reserved `claude`|`anthropic` token; `description` present / ≤1024 / no XML angle brackets. Self-test (`tests/test_frontmatter_schema.sh`) covers each violation class. Repo-CI validator (in `scripts/`, not `skills/*/scripts/`) → **not a counted detector** (36 unchanged).

- **Fix: `manage-project` frontmatter was invalid YAML** — the inline `description` ended with `Commands: init, status, …` and the `: ` makes a plain inline scalar invalid (`mapping values are not allowed here`). Quoted the value — **text unchanged**; storefront catalog first-sentence and per-skill docs are byte-identical. It was the only non-conforming skill; the other 44 already pass.

## Verification (local CI-mirror, all green)

- `check_frontmatter_schema.py` — OK on all 45 (post-fix); self-test 8/8 (good + 6 violation classes + real-tree)
- `gen_skills_catalog_json.py --check` / `gen_skill_docs.py --check` — **in sync** (manage-project catalog/doc byte-identical after quoting)
- `gen_distribution_manifest.py --check` (regenerated: only manage-project SKILL.md hash; scripts/+tests/ excluded from payload) · `gen_detectors_catalog_json.py --check` (36) · `validate_catalog_consistency.py` · `validate_skills.sh` · `check_version_consistency.py` · `check_locale_inventory.py` · `validate_routing_assets.py --strict`
- `yaml.safe_load(validate.yml)` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)