### PR TITLE
docs: clarify skill boundaries + ordering; revise unavailable-skill fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,20 @@
   directory validator or another agent platform). Self-test (`tests/test_frontmatter_schema.sh`)
   covers each violation class. This is a repo-CI validator, not a counted detector.
 
+### Changed
+
+- **Skill-boundary documentation** — a diagnostic pass confirmed the 45 skills are
+  deliberately specialized (no consolidation warranted), but several boundaries were
+  easy to confuse. README's "Skills Work Together" now carries a **Skill boundaries**
+  block spelling out the reference pipeline (`search-lit` → `lit-sync` → `manage-refs` →
+  `verify-refs`), the language pass order (`humanize` → `polish-language` → `academic-aio`),
+  manuscript-type selection (`write-paper` / `review-paper` / `revise`), author-vs-reviewer
+  (`self-review` / `peer-review`), project entry (`intake-project` / `orchestrate`), study
+  design (`design-study` perceptual ceiling gate / `design-ai-benchmarking`), and content
+  vs template (`write-protocol` / `fill-protocol`). `/revise` now documents the manual
+  fallback when `/analyze-stats` or `/make-figures` is unavailable (emit a checklist, hold
+  responses as `BLOCKED — pending analysis/figure`, never invent numbers). Docs only.
+
 ### Fixed
 
 - **Public-doc count reconciliation** — `README.md` (MedSci-Audit suite line) and

--- a/README.md
+++ b/README.md
@@ -606,6 +606,17 @@ Projects declare their source-of-truth layout in `SSOT.yaml`, and a `qc/migratio
 ### Skills Work Together
 Skills call each other. `check-reporting` invokes `make-figures` for PRISMA diagrams. `write-paper` calls `search-lit` for citation verification. `self-review` delegates reporting compliance to `check-reporting`. `calc-sample-size` output feeds directly into `write-protocol`'s IRB justification section.
 
+### Skill boundaries — which to use, and in what order
+The skill set is deliberately *specialized, not consolidated* — each skill owns a distinct artifact or lifecycle step, so the routing stays precise. The boundaries that are easy to confuse:
+
+- **Reference pipeline** — `search-lit` (discover candidates) → `lit-sync` (sole writer of `refs.bib`, syncs Zotero/Obsidian) → `manage-refs` (render CSL / inject CWYW / cross-ref QC, sole writer of the rendered DOCX) → `verify-refs` (read-only audit; never edits `refs.bib`). They are one pipeline, not four overlapping tools.
+- **Language passes run in order** — `humanize` (remove AI-writing tells) → `polish-language` (deterministic ESL/house-style consistency: abbreviations, spelling, en-dashes, p-value case) → `academic-aio` (AI-search/GEO visibility). Three sequential passes with non-overlapping jobs.
+- **Manuscript type picks the skill** — `write-paper` (original/IMRAD articles, case reports, MAs) vs `review-paper` (narrative / scoping / systematic literature reviews) vs `revise` (reviewer-response + tracked changes). Different structures and reporting guidelines.
+- **Author vs external reviewer** — `self-review` is your own pre-submission check (anticipated comments); `peer-review` drafts a journal-facing review as an external reviewer. Same domain probes, different user and output.
+- **Project entry** — `intake-project` classifies and scaffolds a *new or messy folder*; `orchestrate` routes a *goal or task* ("help me write a paper"). Start with `intake-project` when you have files but no structure, `orchestrate` when you have a task but no plan.
+- **Study design** — `design-study` covers general validity (analysis unit, leakage, comparator, validation) **and** carries a design-stage ceiling gate for perceptual / observer / reader / visual-Turing-test / image-provenance studies; `design-ai-benchmarking` specializes in AI-vs-human-expert evaluation (rubrics, calibration probes, LLM-as-judge).
+- **Content vs template** — `write-protocol` drafts IRB/ethics scientific content; `fill-protocol` renders that content into an institutional Word template without breaking its formatting.
+
 ### Validation status — available vs CI-gated vs evaluated
 Be precise about what "validated" means here — the three tiers are different facts:
 - **Available** — every bundled skill and deterministic detector. The current totals are the single source of truth in [`metadata/catalog_counts.json`](metadata/catalog_counts.json) and [`MEDSCI_AUDIT.md`](MEDSCI_AUDIT.md).

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2798,8 +2798,8 @@
     },
     {
       "path": "skills/revise/SKILL.md",
-      "size": 27309,
-      "sha256": "80d274dbca054955c1f4953e9db4f2bf0a02aaf91a26a54ecedd855546dbaceb"
+      "size": 27775,
+      "sha256": "2da4f80e879c2d3ff31d2af435cb27ecae0ba09f1014b8ebbd799ac2472ff1ea"
     },
     {
       "path": "skills/revise/references/r2r_voice.md",

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -81,6 +81,8 @@ Before writing responses, identify which comments require external action:
 
 Output: "The following comments require statistical analysis before responses can be finalized: R1-1, R2-3. Run /analyze-stats with these tasks, then return to /revise."
 
+**If `/analyze-stats` or `/make-figures` is not installed in this environment**, do not invent numbers or figures. Emit the same routing list as an explicit checklist for the author to run manually (the named analysis or figure per comment) and hold those responses as `BLOCKED — pending analysis/figure` until the committed script + CSV (or figure file) returns. The reviewer-response numbers must always trace to a produced artifact, never to a model estimate.
+
 ---
 
 ## Step 2.5: Revision Numerical Lineage Check (MANDATORY)


### PR DESCRIPTION
## What

The diagnosis confirmed the 45 skills are **deliberately specialized — no consolidation warranted**. This documents the boundaries that are easy to confuse, so the answer to "why aren't these merged?" is visible, and adds the one genuine gap (a fallback when a delegated skill is absent). **Docs only** — no frontmatter/description/triggers change.

- **README "Skills Work Together"** gains a **Skill boundaries** block: the reference pipeline (`search-lit` → `lit-sync` → `manage-refs` → `verify-refs`), the language pass order (`humanize` → `polish-language` → `academic-aio`), manuscript-type selection (`write-paper` / `review-paper` / `revise`), author-vs-reviewer (`self-review` / `peer-review`), project entry (`intake-project` / `orchestrate`), study design (`design-study` perceptual ceiling gate / `design-ai-benchmarking`), content-vs-template (`write-protocol` / `fill-protocol`).
- **`revise/SKILL.md`** documents the manual fallback when `/analyze-stats` or `/make-figures` is not installed: emit the routing list as an author checklist, hold those responses as `BLOCKED — pending analysis/figure`, never invent numbers/figures.

## Verification (local CI-mirror, all green)

- `gen_skill_docs.py --check` — in sync (body-only edit; docs derive from frontmatter)
- `check_frontmatter_schema.py` / `validate_skills.sh` / `validate_catalog_consistency.py` / `validate_routing_assets.py --strict` / `check_locale_inventory.py` — green
- `gen_distribution_manifest.py --check` — regenerated for the `revise/SKILL.md` hash (README not in payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)