### PR TITLE
feat(analyze-stats): WARN-level define-variables precondition for observational designs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,17 @@
   fallback when `/analyze-stats` or `/make-figures` is unavailable (emit a checklist, hold
   responses as `BLOCKED — pending analysis/figure`, never invent numbers). Docs only.
 
+- **`/analyze-stats` observational-design precondition** — Phase 2 (Analysis Plan) now opens
+  with a WARN-level precondition: before planning an observational analysis (cohort,
+  case-control, cross-sectional, registry, survey), confirm a literature-grounded
+  `variable_operationalization.md` (from `/define-variables`) or equivalent codebook-backed
+  definition table exists; if not, warn and recommend `/define-variables` first so
+  exposure/outcome/covariate definitions and cutoffs are citation-backed rather than invented
+  ad hoc from the data dictionary. WARN, not a hard block (proceed on explicit confirmation;
+  stricter projects can treat it as a hard stop). Mirrors the precondition `/write-protocol`
+  already enforces before drafting Methods, closing the one observational-pipeline skill that
+  lacked it. Guidance only — non-breaking, no new code gate.
+
 ### Fixed
 
 - **Public-doc count reconciliation** — `README.md` (MedSci-Audit suite line) and

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -153,8 +153,8 @@
     },
     {
       "path": "skills/analyze-stats/SKILL.md",
-      "size": 46340,
-      "sha256": "427b587784ab62562184299f6fcb9625275c42d9191075635be1f31a3f69def3"
+      "size": 47388,
+      "sha256": "12121ea6224d8c75d4aa98a6e2ee2947c95cfc17a3902780e7bb8d7ddb0be052"
     },
     {
       "path": "skills/analyze-stats/references/analysis_guides/mediation.md",

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -55,6 +55,8 @@ from `analysis_guides/` to ensure correct methodology and reporting.
 
 ### Phase 2: Analysis Plan
 
+**Precondition (observational studies).** Before proposing an analysis plan for an observational design (cohort, case-control, cross-sectional, registry, or survey), confirm that a literature-grounded variable operationalization exists — a `variable_operationalization.md` from `/define-variables`, or an equivalent codebook-backed definition table. If none exists, **warn** the user and recommend running `/define-variables` first, so exposure / outcome / covariate definitions and cutoffs are citation-backed rather than invented ad hoc from the data dictionary (ad-hoc phenotype/cutoff definitions are a common reviewer-rejection trigger for observational work — see the dictionary-first discipline). This is a WARN, not a hard block: proceed on explicit user confirmation, recording that the operationalization artifact was not available. For stricter projects, treat the missing artifact as a hard stop until `/define-variables` has run. (This mirrors the same precondition already enforced in `/write-protocol` before drafting Methods.)
+
 Based on the data structure and research question, propose an analysis plan:
 
 1. **Auto-detect analysis type** from the table below, or accept user specification.


### PR DESCRIPTION
## What

The diagnosis flagged `define-variables` as an underdocumented upstream gate for observational research (**P1** — highest non-pass severity). `/write-protocol` (line 46) and the `/orchestrate` pipeline already require it, but `/analyze-stats` did not — so analysis code for a cohort / case-control / cross-sectional / registry / survey study could be generated with **ad-hoc, invented variable definitions** (a common reviewer-rejection trigger).

`/analyze-stats` Phase 2 (Analysis Plan) now opens with a **WARN-level precondition**: confirm a literature-grounded `variable_operationalization.md` (from `/define-variables`) or equivalent codebook-backed table exists before planning an observational analysis; if not, warn and recommend `/define-variables` first. **WARN, not a hard block** (proceed on explicit confirmation; stricter projects can treat it as a hard stop). Mirrors the precondition `/write-protocol` already enforces, closing the one observational-pipeline skill that lacked it. Aligns with the dictionary-first discipline.

**Guidance only — non-breaking, no new code gate, no count change.**

## Verification (local CI-mirror, all green)

- `gen_skill_docs.py --check` (frontmatter-derived; body-only edit) · `check_frontmatter_schema.py` · `validate_skills.sh` · `validate_catalog_consistency.py` · `validate_routing_assets.py --strict` — green
- `gen_distribution_manifest.py --check` — regenerated for the `analyze-stats/SKILL.md` hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)