### PR TITLE
refactor(meta-analysis): move Empirical Lessons to load-on-demand reference (token hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,16 @@
   already enforces before drafting Methods, closing the one observational-pipeline skill that
   lacked it. Guidance only — non-breaking, no new code gate.
 
+- **`/meta-analysis` progressive disclosure (token hygiene)** — the two inline "Empirical
+  Lessons" sections (16 dated SR-MA peer-review lessons, ~45 lines) moved verbatim to
+  load-on-demand `references/empirical_lessons.md`, with an explicit "load before Phase 4
+  extraction-form design and before Phase 8 submission" pointer and a `Reference Files`
+  entry — matching the skill's own established pattern (15 existing reference files). The
+  largest SKILL.md in the bundle drops 804 → 775 lines (less context loaded on every
+  activation); the lessons stay discoverable via the reference list. Content byte-preserved
+  (no rewrite, no renumber — a pre-existing duplicate "9." label is carried over and noted in
+  the reference file). No skill/detector count change.
+
 ### Fixed
 
 - **Public-doc count reconciliation** — `README.md` (MedSci-Audit suite line) and

--- a/docs/skills/meta-analysis.md
+++ b/docs/skills/meta-analysis.md
@@ -41,6 +41,7 @@
 - `ai_pre_screening_template.py`
 - `checklists/` (7 files)
 - `data_integrity_checklist.md`
+- `empirical_lessons.md`
 - `icmje_coi_guide.md`
 - `phase10_recovery.md`
 - `phase4_km_composite.md`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2183,8 +2183,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 55293,
-      "sha256": "d370d5fddffaa5fa26f438a1157d4b96412dbbf7cbe65c9c28cc8474cc736d0b"
+      "size": 49604,
+      "sha256": "4947eae188dc2fcfba68ed991ba126da8315dc79deac0649d2beea558e73025e"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2240,6 +2240,11 @@
       "path": "skills/meta-analysis/references/data_integrity_checklist.md",
       "size": 5538,
       "sha256": "9b2dc03572cb066528e1ef19b0699ec9434ec29cbad8b84f5fbab1492ead5480"
+    },
+    {
+      "path": "skills/meta-analysis/references/empirical_lessons.md",
+      "size": 7616,
+      "sha256": "f49ebc21369095d19661d39186d1c41368811fbe689c77762daf60c74cd73ee8"
     },
     {
       "path": "skills/meta-analysis/references/icmje_coi_guide.md",

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -39,6 +39,7 @@ with specialized support for diagnostic test accuracy (DTA) meta-analyses.
 - **Review orchestration**: `${CLAUDE_SKILL_DIR}/references/review_orchestration.md` -- RO-1~RO-5 circulation discipline (extends phase9_circulation.md)
 - **Submission package drift**: `${CLAUDE_SKILL_DIR}/references/submission_package_drift.md` -- multi-journal folder hygiene, `DO_NOT_EDIT_HERE` gate, `_build.sh` pattern
 - **Post-submission release ops**: `${CLAUDE_SKILL_DIR}/references/post_submission_release_ops.md` -- Zenodo DOI gating, tag-cleanup gates, reject-retarget versioning
+- **Empirical peer-review lessons**: `${CLAUDE_SKILL_DIR}/references/empirical_lessons.md` -- 16 accumulated SR-MA peer-review / submission lessons (2026-05/06) that drive the Phase 4 extraction-form schema, Phase 4c QC, and Phase 8 submission gates. Load before designing the extraction form and before submission.
 
 ### Built-in Templates (`${CLAUDE_SKILL_DIR}/templates/`)
 
@@ -702,48 +703,18 @@ All four scripts are repo-shipped as of 2026-04 (FOLLOWUPS P10). Non-zero exit =
 
 ---
 
-## Empirical Lessons (2026-05)
+## Empirical Lessons (peer-review cycles)
 
-Synthesized from recent SR-MA peer-review cycles. Drives the Phase 4 extraction form schema, Phase 4c QC scripts, and submission-gate enhancements documented above.
-
-1. **Dual-extractor + source-page-reference + verbatim quote** is mandatory for 2x2 cell integrity. Single-extractor without source-page citation invites sens/spec swap that is invisible to forest-plot-level review.
-
-2. **Cohort overlap detection** must cluster by shared public database + institution + author. Independent-cohort assumption for MA pooling fails when multiple included studies use the same public ICU/EHR cohort with overlapping enrollment windows. Sensitivity analysis excluding overlap is the minimum acknowledgment.
-
-3. **Diagnostic subset N transparency** in mixed DTA + prognostic MAs: report `sample_n_dta_pool` separately from `sample_n_prognostic_pool` with explicit prevalence. Aggregate N in Abstract misleads readers about diagnostic-subset power.
-
-4. **Small-k subgroups are not robust (k < 4)**: a subgroup test driven by a single study (k=1) is descriptive-only, and the same caution extends to k=2–3 — heterogeneity and the trend are not estimable from so few strata. Any subgroup with k < 4 must be labelled descriptive / exploratory rather than entered into a formal subgroup interaction test. Post-hoc subgroups require a PROSPERO amendment with a visible record.
-
-5. **Supplementary 8-file package** is the minimum bar for high-impact journals: PRISMA checklist, PROSPERO PDF, full search strategy, full-text exclusion list with reasons, per-study extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication-bias analyses. See `templates/supplementary_8file_checklist.md`.
-
-6. **PROSPERO 14-char ID format** (`^CRD42\d{9}$` = `CRD42` + 4-digit year + 5-digit sequence, e.g. `CRD42024500001`). A 15-character ID is a stray-digit transcription error; pre-2020 IDs may be shorter. Validate with `grep -oE 'CRD42[0-9]+'` + length assert, and request the live registration URL in the cover letter for protocol cross-check.
-
-7. **AI Disclosure presence** for SR-MA submissions to RYAI / Radiology / RSNA / Lancet / JAMA / BMJ / Nature families. Absence triggers MINOR-to-MAJOR finding at peer review.
-
-8. **Sensitivity analyses are recomputed, not copied** (Phase 6b rule 5). Leave-one-out / erosion / alternative-model effect sizes identical to the primary analysis to 2 decimals across ≥4 values means the recomputation did not run. Re-derive from the modified dataset; the inputs (means/SDs/counts) change even when the effect size is close.
-
-9. **Outcome harmonization before pooling.** Studies that report the same-named outcome under different definitions (an imaging-detected event vs a clinically diagnosed one; different thresholds) must not be presented as a single pooled range or pooled estimate. Split by ascertainment method (or pool only the harmonizable subset) and state the definition per stratum — a "6.9–46%" range that silently mixes imaging-detected and clinical events is a heterogeneity artifact, not a finding.
-
-10. **Heterogeneous RoB instruments → no single pooled κ.** When studies are assessed with different risk-of-bias tools (QUADAS-2 for DTA + NOS for cohorts, etc.), do not report one pooled inter-rater κ across the mixed set. Report agreement per instrument, and use an ordinal weighted κ when the domain judgments are ordered (low/some/high). A single κ over a heterogeneous instrument set is uninterpretable.
-
-9. **Prognostic / survival-outcome MAs carry survival-specific concerns** beyond the DTA pitfalls: censoring handling, competing risks (cause-specific vs Fine-Gray), cutoff-derivation optimism, comparator time-horizon alignment, C-index variant transparency (Harrell vs Uno vs IPCW), and calibration beyond discrimination. When pooling prognostic models, pre-specify these in the protocol and report them per study; for the reviewing counterpart see the survival/prognostic 7-probe in `/peer-review`.
-
-
-## Empirical Lessons (2026-06)
-
-From a CBCT lung-ablation SR-MA submission cycle (Springer / CVIR Editorial Manager). Submission-stage; complements the 2026-05 lessons.
-
-11. **Supplementary materials need the same blinding + de-scaffolding + cross-consistency pass as the manuscript.** The largest source of pre-submission defects this cycle was the supplement shipping as raw internal artifacts — `/check-reporting` output carrying an "Assessed by: <AI tool>" line and a JSON verdict block, and a pre-search planning doc with the author's real name, sibling-project cross-references, unresolved `[Check on execution]` placeholders, and estimate tables that contradicted the actual PRISMA counts. Presence (Lesson 5) is not enough; apply the Phase 8 supplementary gate.
-
-12. **A submitted analysis script must reproduce the manuscript and be self-contained.** A hard-coded study-id subset silently drifted (a pool was k=7 in the script vs k=9 in the results table — the manuscript was correct, the script was stale) and the script read a path outside the bundle. Run the bundled code from a clean copy before submission: it must read the bundled dataset, write to cwd, and regenerate every reported pool. Remove stale figures produced by an out-of-sync script.
-
-13. **Re-sync sidecars (cover letter, title-page Word-Counts table) whenever the reference or word count changes.** Adding methodological/software citations took the list from 12 to 24, but the cover letter and title page still said "12 references" — a contradiction visible in the built PDF. Reference/word-count changes are sidecar drift targets (mirror `submission-portal-verification` cover-letter drift).
-
-14. **Methodological + software citations are a routine SR-MA gap.** The reporting standard (PRISMA 2020), each risk-of-bias tool (JBI, ROBINS-I, …), the pooling method (random-effects GLMM / logit, Hartung-Knapp, the choice over Freeman-Tukey arcsine), the certainty framework (GRADE), and the analysis software (R `meta`, `metafor`) should each be cited where named in Methods. Frequently missing from an early draft and an easy reviewer comment to pre-empt. Verify every added citation via PubMed/CrossRef with a first-author cross-check — never from memory.
-
-15. **Wide characteristics tables (≥ ~10 columns) render as character-wrapped gibberish in the journal's built PDF** when the docx uses fixed narrow columns. Put the table in a landscape section with autofit layout and a smaller font, and verify by converting the docx to PDF (`soffice --headless --convert-to pdf`) and viewing the page — the docx alone does not reveal the problem.
-
-16. **Verify the submission portal's journal identity before entering metadata.** A classification taxonomy that does not match the target journal's scope (e.g., a liver/hepatology list at an interventional-radiology journal) is the tell that you are in the wrong journal's Editorial Manager instance.
+Sixteen accumulated SR-MA peer-review / submission lessons (2026-05 and 2026-06) — the
+drivers behind the Phase 4 extraction-form schema, the Phase 4c QC scripts, and the Phase 8
+submission gates. To keep this entry point lean they live load-on-demand in
+`${CLAUDE_SKILL_DIR}/references/empirical_lessons.md`. **Load that file when designing the
+extraction form (before Phase 4) and before submission (Phase 8)** — it covers dual-extractor
+2x2 integrity, cohort-overlap clustering, small-k subgroup caution, the supplementary 8-file
+bar, PROSPERO ID format, AI-disclosure presence, recompute-don't-copy sensitivity analyses,
+outcome harmonization, heterogeneous-RoB κ, survival-specific concerns, supplement blinding /
+de-scaffolding, self-contained reproducible analysis scripts, sidecar re-sync, methodological
++ software citations, wide-table PDF rendering, and submission-portal journal-identity checks.
 
 ---
 

--- a/skills/meta-analysis/references/empirical_lessons.md
+++ b/skills/meta-analysis/references/empirical_lessons.md
@@ -1,0 +1,53 @@
+# Empirical Lessons — SR-MA peer-review cycles
+
+Accumulated, dated lessons from real systematic-review / meta-analysis peer-review and
+submission cycles. They drive the Phase 4 extraction-form schema, the Phase 4c QC scripts,
+and the Phase 8 submission gates. **Load this file when designing the extraction form
+(before Phase 4) and before submission (Phase 8).**
+
+> Note: the 2026-05 list below carries a duplicate "9." (the "Prognostic / survival-outcome"
+> item) inherited from the source; it is the 11th lesson of that batch. Left as-is here to
+> avoid a renumber that would desync any external cross-reference; treat the numbers as labels.
+
+## Empirical Lessons (2026-05)
+
+Synthesized from recent SR-MA peer-review cycles. Drives the Phase 4 extraction form schema, Phase 4c QC scripts, and submission-gate enhancements documented in the skill.
+
+1. **Dual-extractor + source-page-reference + verbatim quote** is mandatory for 2x2 cell integrity. Single-extractor without source-page citation invites sens/spec swap that is invisible to forest-plot-level review.
+
+2. **Cohort overlap detection** must cluster by shared public database + institution + author. Independent-cohort assumption for MA pooling fails when multiple included studies use the same public ICU/EHR cohort with overlapping enrollment windows. Sensitivity analysis excluding overlap is the minimum acknowledgment.
+
+3. **Diagnostic subset N transparency** in mixed DTA + prognostic MAs: report `sample_n_dta_pool` separately from `sample_n_prognostic_pool` with explicit prevalence. Aggregate N in Abstract misleads readers about diagnostic-subset power.
+
+4. **Small-k subgroups are not robust (k < 4)**: a subgroup test driven by a single study (k=1) is descriptive-only, and the same caution extends to k=2–3 — heterogeneity and the trend are not estimable from so few strata. Any subgroup with k < 4 must be labelled descriptive / exploratory rather than entered into a formal subgroup interaction test. Post-hoc subgroups require a PROSPERO amendment with a visible record.
+
+5. **Supplementary 8-file package** is the minimum bar for high-impact journals: PRISMA checklist, PROSPERO PDF, full search strategy, full-text exclusion list with reasons, per-study extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication-bias analyses. See `templates/supplementary_8file_checklist.md`.
+
+6. **PROSPERO 14-char ID format** (`^CRD42\d{9}$` = `CRD42` + 4-digit year + 5-digit sequence, e.g. `CRD42024500001`). A 15-character ID is a stray-digit transcription error; pre-2020 IDs may be shorter. Validate with `grep -oE 'CRD42[0-9]+'` + length assert, and request the live registration URL in the cover letter for protocol cross-check.
+
+7. **AI Disclosure presence** for SR-MA submissions to RYAI / Radiology / RSNA / Lancet / JAMA / BMJ / Nature families. Absence triggers MINOR-to-MAJOR finding at peer review.
+
+8. **Sensitivity analyses are recomputed, not copied** (Phase 6b rule 5). Leave-one-out / erosion / alternative-model effect sizes identical to the primary analysis to 2 decimals across ≥4 values means the recomputation did not run. Re-derive from the modified dataset; the inputs (means/SDs/counts) change even when the effect size is close.
+
+9. **Outcome harmonization before pooling.** Studies that report the same-named outcome under different definitions (an imaging-detected event vs a clinically diagnosed one; different thresholds) must not be presented as a single pooled range or pooled estimate. Split by ascertainment method (or pool only the harmonizable subset) and state the definition per stratum — a "6.9–46%" range that silently mixes imaging-detected and clinical events is a heterogeneity artifact, not a finding.
+
+10. **Heterogeneous RoB instruments → no single pooled κ.** When studies are assessed with different risk-of-bias tools (QUADAS-2 for DTA + NOS for cohorts, etc.), do not report one pooled inter-rater κ across the mixed set. Report agreement per instrument, and use an ordinal weighted κ when the domain judgments are ordered (low/some/high). A single κ over a heterogeneous instrument set is uninterpretable.
+
+9. **Prognostic / survival-outcome MAs carry survival-specific concerns** beyond the DTA pitfalls: censoring handling, competing risks (cause-specific vs Fine-Gray), cutoff-derivation optimism, comparator time-horizon alignment, C-index variant transparency (Harrell vs Uno vs IPCW), and calibration beyond discrimination. When pooling prognostic models, pre-specify these in the protocol and report them per study; for the reviewing counterpart see the survival/prognostic 7-probe in `/peer-review`.
+
+
+## Empirical Lessons (2026-06)
+
+From a CBCT lung-ablation SR-MA submission cycle (Springer / CVIR Editorial Manager). Submission-stage; complements the 2026-05 lessons.
+
+11. **Supplementary materials need the same blinding + de-scaffolding + cross-consistency pass as the manuscript.** The largest source of pre-submission defects this cycle was the supplement shipping as raw internal artifacts — `/check-reporting` output carrying an "Assessed by: <AI tool>" line and a JSON verdict block, and a pre-search planning doc with the author's real name, sibling-project cross-references, unresolved `[Check on execution]` placeholders, and estimate tables that contradicted the actual PRISMA counts. Presence (Lesson 5) is not enough; apply the Phase 8 supplementary gate.
+
+12. **A submitted analysis script must reproduce the manuscript and be self-contained.** A hard-coded study-id subset silently drifted (a pool was k=7 in the script vs k=9 in the results table — the manuscript was correct, the script was stale) and the script read a path outside the bundle. Run the bundled code from a clean copy before submission: it must read the bundled dataset, write to cwd, and regenerate every reported pool. Remove stale figures produced by an out-of-sync script.
+
+13. **Re-sync sidecars (cover letter, title-page Word-Counts table) whenever the reference or word count changes.** Adding methodological/software citations took the list from 12 to 24, but the cover letter and title page still said "12 references" — a contradiction visible in the built PDF. Reference/word-count changes are sidecar drift targets (mirror `submission-portal-verification` cover-letter drift).
+
+14. **Methodological + software citations are a routine SR-MA gap.** The reporting standard (PRISMA 2020), each risk-of-bias tool (JBI, ROBINS-I, …), the pooling method (random-effects GLMM / logit, Hartung-Knapp, the choice over Freeman-Tukey arcsine), the certainty framework (GRADE), and the analysis software (R `meta`, `metafor`) should each be cited where named in Methods. Frequently missing from an early draft and an easy reviewer comment to pre-empt. Verify every added citation via PubMed/CrossRef with a first-author cross-check — never from memory.
+
+15. **Wide characteristics tables (≥ ~10 columns) render as character-wrapped gibberish in the journal's built PDF** when the docx uses fixed narrow columns. Put the table in a landscape section with autofit layout and a smaller font, and verify by converting the docx to PDF (`soffice --headless --convert-to pdf`) and viewing the page — the docx alone does not reveal the problem.
+
+16. **Verify the submission portal's journal identity before entering metadata.** A classification taxonomy that does not match the target journal's scope (e.g., a liver/hepatology list at an interventional-radiology journal) is the tell that you are in the wrong journal's Editorial Manager instance.


### PR DESCRIPTION
## What

The token-waste audit flagged `meta-analysis` as the **largest SKILL.md** in the bundle (804 lines), most of it loaded on every activation. The two inline **"Empirical Lessons"** sections (16 dated SR-MA peer-review lessons, ~45 lines) are reference material, not core procedure — and the skill already follows a load-on-demand pattern (15 existing reference files).

Moved them **verbatim** to `references/empirical_lessons.md`, with an explicit *"load before Phase 4 extraction-form design and before Phase 8 submission"* pointer where the sections were + a `Reference Files` list entry so the skill announces the file at activation. **SKILL.md drops 804 → 775 lines**; the lessons stay discoverable.

This is the repo's own established progressive-disclosure pattern (the diagnosis + external best-practice research both recommend completing it). Conservative scope: only the clearly-archival lessons moved; core Phase procedure stays inline.

## Safety

- **Content byte-preserved** — no rewrite, no renumber. A pre-existing duplicate "9." list label is carried over and called out in the reference file's header rather than silently changed (intent-guess avoided).
- The remaining `CRD42024500001` in SKILL.md is a separate, pre-existing Phase 1 PROSPERO-ID example, not a leftover duplicate.

## Verification (local CI-mirror, all green)

- `validate_routing_assets.py --strict` — the new `references/empirical_lessons.md` reference exists and is referenced (226 asset refs, all present)
- `gen_skill_docs.py --check` — regenerated `docs/skills/meta-analysis.md` (lists the new reference)
- `gen_distribution_manifest.py --check` (739 payload files, +1) · `check_frontmatter_schema.py` · `validate_skills.sh` · `validate_catalog_consistency.py` · `gen_detectors_catalog_json.py` (36 unchanged) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)