### PR TITLE
refactor(sync-submission): de-drift the YAML front-matter splitter into one shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,16 @@
   (no rewrite, no renumber — a pre-existing duplicate "9." label is carried over and noted in
   the reference file). No skill/detector count change.
 
+- **De-drift the `sync-submission` YAML front-matter splitter** — `check_wordcount_cap.py`
+  and `cover_letter_drift_check.py` each carried their own `_strip_yaml_front_matter`, marked
+  "keep in sync" but already drifted (list vs tuple return; subtly different unclosed-fence
+  handling). Extracted one canonical `split_yaml_front_matter()` into a private
+  `scripts/_yaml_frontmatter.py` (leading underscore → not counted as a detector) imported by
+  both — the helper ships in the same skill's `scripts/` dir, so it stays self-contained when
+  vendored/installed. Behavior-preserving (verified normal / no-front-matter / unclosed cases
+  + the wired `test_wordcount_cap` and `test_preflight_gate` subprocess-import path). No
+  skill/detector count change.
+
 ### Fixed
 
 - **Public-doc count reconciliation** — `README.md` (MedSci-Audit suite line) and

--- a/docs/skills/sync-submission.md
+++ b/docs/skills/sync-submission.md
@@ -42,6 +42,7 @@
 
 **Scripts** (`skills/sync-submission/scripts/`):
 
+- `_yaml_frontmatter.py`
 - `assemble_supplement.py`
 - `author_registry_example.yaml`
 - `blind_sweep.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3087,6 +3087,11 @@
       "sha256": "6d278675d7c734aa3589165817f5413cc46c44402ea15039e51052ab2f52c0a8"
     },
     {
+      "path": "skills/sync-submission/scripts/_yaml_frontmatter.py",
+      "size": 1669,
+      "sha256": "028fa8c4f7a4440c72d693a2ba6d4799410de0c565c61bd30d68eb0e7c208c78"
+    },
+    {
       "path": "skills/sync-submission/scripts/assemble_supplement.py",
       "size": 8979,
       "sha256": "ab6549a295b37df059f83d97c50c41e3ea373d797d52b2978ae60e9cc78e6458"
@@ -3123,13 +3128,13 @@
     },
     {
       "path": "skills/sync-submission/scripts/check_wordcount_cap.py",
-      "size": 10053,
-      "sha256": "7d47c194bdde03accbb6fab6347621cb3efdec17131651d7e58b4a69b4f0f0c6"
+      "size": 9788,
+      "sha256": "16fecbceae672e4192a138a0509321ea367f61079ca4ef4d630667b1e64eda58"
     },
     {
       "path": "skills/sync-submission/scripts/cover_letter_drift_check.py",
-      "size": 16554,
-      "sha256": "3188551ea2557ec7445f668a4d4b64396e94c5d691114b3d5bf52a16ef27cd7b"
+      "size": 16001,
+      "sha256": "347c5b702fbe9375899795791a34e8a60e246253bafb53b15ebb59d51dd45e7d"
     },
     {
       "path": "skills/sync-submission/scripts/cross_document_n_check.py",

--- a/skills/sync-submission/scripts/_yaml_frontmatter.py
+++ b/skills/sync-submission/scripts/_yaml_frontmatter.py
@@ -1,0 +1,35 @@
+"""Shared YAML front-matter splitter for sync-submission scripts.
+
+Both `check_wordcount_cap.py` and `cover_letter_drift_check.py` need to peel the
+`---`-fenced YAML front matter off a manuscript before counting body words. The
+two had drifted (one returned just the body as a list, the other returned a
+(yaml, body) tuple, with subtly different unclosed-fence handling) despite a
+"keep in sync" intent. This is the single canonical implementation, imported by
+both. It is a private helper (leading underscore) so the detector-catalog glob
+(`check_*` / `detect_*` / `derive_*` / `verify_refs`) never counts it.
+
+Self-contained within this skill's scripts/ dir: both consumers run with their
+own directory on sys.path[0] (invoked as `python3 .../scripts/<name>.py`), so a
+sibling import resolves wherever the skill is installed/vendored.
+"""
+from __future__ import annotations
+
+import re
+
+YAML_FENCE_RE = re.compile(r"^---\s*$")
+
+
+def split_yaml_front_matter(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split ``lines`` into (yaml_lines, body_lines) on the first two ``---`` fences.
+
+    If there is no opening fence, or the front matter is never closed, the whole
+    input is treated as body and ``([], lines)`` is returned. Callers that only
+    need the body can discard the first element: ``_, body = split_yaml_front_matter(lines)``.
+    """
+    if not lines or not YAML_FENCE_RE.match(lines[0].rstrip()):
+        return [], lines
+    for i, line in enumerate(lines[1:], start=1):
+        if YAML_FENCE_RE.match(line.rstrip()):
+            return lines[1:i], lines[i + 1:]
+    # Unclosed front matter — treat as no front matter.
+    return [], lines

--- a/skills/sync-submission/scripts/check_wordcount_cap.py
+++ b/skills/sync-submission/scripts/check_wordcount_cap.py
@@ -46,7 +46,9 @@ import re
 import sys
 from pathlib import Path
 
-# --- measurement (vendored from cover_letter_drift_check.py; keep in sync) -----
+from _yaml_frontmatter import split_yaml_front_matter
+
+# --- measurement (shares the skip set + YAML splitter with cover_letter_drift_check.py) -----
 
 SKIP_SECTION_RE = re.compile(
     r"^#{1,3}\s+\*{0,2}\s*("
@@ -58,26 +60,16 @@ SKIP_SECTION_RE = re.compile(
     r")\s*\*{0,2}\s*:?\s*$",
     re.IGNORECASE,
 )
-YAML_FENCE_RE = re.compile(r"^---\s*$")
 WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'./%\-]*")
 # pandoc inline citations: [@key], [@k1; @k2], [-@k]. Count each @key.
 CITE_RE = re.compile(r"@[A-Za-z0-9_][A-Za-z0-9_:.\-]*")
 HEADER_RE = re.compile(r"^#{1,3}\s")
 
 
-def _strip_yaml_front_matter(lines: list[str]) -> list[str]:
-    if not lines or not YAML_FENCE_RE.match(lines[0].rstrip()):
-        return lines
-    for i, line in enumerate(lines[1:], start=1):
-        if YAML_FENCE_RE.match(line.rstrip()):
-            return lines[i + 1:]
-    return lines
-
-
 def measure_body(manuscript_path: Path) -> tuple[int, int]:
     """Return (body_words, n_inline_citations) over the non-skipped body."""
     lines = manuscript_path.read_text(encoding="utf-8").splitlines()
-    body_lines = _strip_yaml_front_matter(lines)
+    _, body_lines = split_yaml_front_matter(lines)
     in_skip = False
     in_code_fence = False
     words = 0

--- a/skills/sync-submission/scripts/cover_letter_drift_check.py
+++ b/skills/sync-submission/scripts/cover_letter_drift_check.py
@@ -57,6 +57,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from _yaml_frontmatter import split_yaml_front_matter
+
 
 # ---------------------------------------------------------------------------
 # Manuscript measurement helpers
@@ -79,26 +81,10 @@ ABSTRACT_START_RE = re.compile(
     r"^#{1,3}\s+\*{0,2}\s*Abstract\s*\*{0,2}\s*:?\s*$", re.IGNORECASE
 )
 
-# YAML frontmatter delimiters.
-YAML_FENCE_RE = re.compile(r"^---\s*$")
-
 # Word-counting tokenizer: splits on whitespace, drops markdown punctuation-only
 # tokens (e.g., "—", "•", standalone "1." numbering) so prose density isn't
 # inflated.
 WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'./%\-]*")
-
-
-def _strip_yaml_front_matter(lines: list[str]) -> tuple[list[str], list[str]]:
-    """Return (yaml_lines, body_lines) splitting on first two `---` fences."""
-    if not lines or not YAML_FENCE_RE.match(lines[0].rstrip()):
-        return [], lines
-    yaml_block: list[str] = []
-    for i, line in enumerate(lines[1:], start=1):
-        if YAML_FENCE_RE.match(line.rstrip()):
-            return lines[1:i], lines[i + 1 :]
-        yaml_block.append(line)
-    # Unclosed front matter — treat as no front matter.
-    return [], lines
 
 
 def _next_section_boundary(lines: list[str], start: int) -> int:
@@ -115,7 +101,7 @@ def count_body_words(manuscript_path: Path) -> int:
     references, tables, figures, supplementary, acknowledgments, and
     declaration sections."""
     lines = manuscript_path.read_text(encoding="utf-8").splitlines()
-    _, body_lines = _strip_yaml_front_matter(lines)
+    _, body_lines = split_yaml_front_matter(lines)
 
     in_skip = False
     in_code_fence = False
@@ -144,7 +130,7 @@ def count_body_words(manuscript_path: Path) -> int:
 def extract_abstract_text(manuscript_path: Path) -> str:
     """Extract abstract section text from manuscript (best-effort)."""
     lines = manuscript_path.read_text(encoding="utf-8").splitlines()
-    yaml_lines, body_lines = _strip_yaml_front_matter(lines)
+    yaml_lines, body_lines = split_yaml_front_matter(lines)
 
     # First try YAML `abstract:` field.
     yaml_text = "\n".join(yaml_lines)


### PR DESCRIPTION
## What

Closes the last open code-health duplication finding from the diagnosis (`VENDORED_CODE_DRIFT_YAML_STRIP`). `check_wordcount_cap.py` and `cover_letter_drift_check.py` each carried their own `_strip_yaml_front_matter`, commented *"keep in sync"* but already drifted (one returned the body as a `list`, the other a `(yaml, body)` tuple, with subtly different unclosed-fence handling).

Extracted a single canonical `split_yaml_front_matter()` into a private `scripts/_yaml_frontmatter.py` and imported it in both. **Behavior-preserving**, no count change.

- The helper is **underscore-prefixed** → not matched by the detector-catalog glob (`check_*`/`detect_*`/`derive_*`/`verify_refs`), so `integrity_detectors` stays **36**.
- It ships in the **same skill's `scripts/` dir**, so each consumer stays self-contained when vendored/installed (both run with their own dir on `sys.path[0]`).

## Verification (local CI-mirror, all green)

- Behaviour equivalence asserted for normal / no-front-matter / unclosed-fence inputs (matches the prior logic)
- Wired tests pass: `test_wordcount_cap.sh` (A7) and **`test_preflight_gate.sh`** — the latter invokes `cover_letter_drift_check.py` as a **subprocess**, exercising the sibling-import path
- `gen_detectors_catalog_json.py --check` (36 unchanged) · `gen_distribution_manifest.py --check` (740, +1 helper) · `gen_skill_docs.py --check` (regenerated: helper listed) · `validate_catalog_consistency.py` · `validate_skills.sh` · `check_frontmatter_schema.py` · `validate_routing_assets.py --strict` · `check_locale_inventory.py` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)