### PR TITLE
release: v4.9.0 (detectors 32→36 + quality/portability/token hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [4.9.0] - 2026-06-26
+
 ### Added
 
 - **Duplicate-bibliography gate** — new `check_reference_duplication.py`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "4.8.0"
+version: "4.9.0"
 date-released: "2026-06-22"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 ## What's New
 
-**Unreleased** — analysis-integrity hardening promoted from real review cycles, plus journal-mechanics additions. Additive and backward-compatible; still 45 skills / 36 guidelines, analysis-integrity detectors **32 → 36**:
+**v4.9** — analysis-integrity hardening promoted from real review cycles, plus journal-mechanics additions. Additive and backward-compatible; still 45 skills / 36 guidelines, analysis-integrity detectors **32 → 36**:
 
 - **Four new gates** — a **duplicate-bibliography** check (`check_reference_duplication.py`) for the hybrid `[@key]` + hand-typed `## References` build that renders the list twice; a **cross-script binning / composite-indicator** consistency check (`check_binning_consistency.py`, `BINNING_DRIFT` / `DERIVED_DEF_DRIFT`) for a derived categorical or composite indicator defined inconsistently across analysis scripts; a **float citation-order** check (`check_citation_order.py`) for numbered Tables/Figures not first cited in ascending order per series; and an **audit-dump leak** gate (`/sync-submission`) that blocks a `/check-reporting` output mistakenly attached as a submission file.
 - **KJR technical-check conventions + percentage-decimal style**, reader-allocation-under-burden and generative-image-as-study-object reporting (`/design-ai-benchmarking`, `/check-reporting`), and a **Liver International** CSL with that journal's submission mechanics (`/manage-refs`).

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "4.8.0",
+  "version": "4.9.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
## Release v4.9.0

Bundles the post-v4.8 `[Unreleased]` work — additive and backward-compatible (**SemVer MINOR**, no breaking change). Catalog: **45 skills / 36 reporting guidelines / 36 analysis-integrity detectors**.

**Added (detectors 32 → 36):** duplicate-bibliography, cross-script binning/composite-indicator consistency, float citation-order, audit-dump leak; KJR technical-check conventions + percentage-decimal style; reader-allocation-under-burden + generative-image-as-study-object reporting; Liver International CSL; a new **frontmatter schema CI gate** (Agent Skills cross-platform portability).

**Changed:** README "Skill boundaries" block + language pass order; `/revise` unavailable-skill fallback; `/analyze-stats` WARN-level define-variables precondition; `/meta-analysis` Empirical Lessons → load-on-demand reference (804→775); sync-submission YAML splitter de-drifted.

**Fixed:** public-doc count reconciliation (28/32 → 36/36); `check_csl_render.py` 5 latent bugs + CI test; **15 dormant skill tests wired into CI**; **dormant PRISMA Figure 1 detector activated**; `manage-project` invalid-YAML frontmatter.

## Release commit shape

CITATION.cff + package.json + distribution_manifest.json → 4.9.0; CHANGELOG `[Unreleased]` → `[4.9.0] - 2026-06-26`; README "What's New" Unreleased → v4.9. `check_version_consistency.py` green (all three 4.9.0).

## Pre-tag verification (local, all green)

Full CI-mirror (10 generators/validators) + installer self-test (45/45) + test_distribution_manifest (8) / test_txn (19) / test_update (20) / test_session_hook (38) + **release-zip build→safe-extract round-trip**.

On merge, tag `v4.9.0` triggers `release.yml` → GitHub Release + 2 classroom ZIPs + npm publish + Zenodo archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)