### PR TITLE
feat(installer): clinician-friendly update reminders (classroom default-on + npx nudge + README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Three new reviewer domain-probe modules** (`/peer-review` + `/self-review`, vendored
+  byte-identical), reverse-engineered from high-IF CC-BY papers under the `reverse_engineer/`
+  license firewall: **`mendelian_randomization.md`** (MR1–MR8: the three IV assumptions, a
+  pleiotropy-robust sensitivity suite rather than IVW alone, Steiger/direction, sample overlap,
+  non-linear-MR caution, drug-target colocalization); **`polygenic_risk_score.md`** (PG1–PG8:
+  ancestry transferability/portability, base/target leakage, incremental value over the clinical
+  model, screening detection-rate-vs-discrimination, target-population calibration);
+  **`network_meta_analysis.md`** (NM1–NM8: transitivity, global+local incoherence, SUCRA/P-score
+  over-interpretation, CINeMA/GRADE-NMA certainty, component-NMA additivity). Domain-probe modules
+  12 → 15.
+- **Observational probe O17** (`observational_confounding.md`) — agnostic many-exposure-scan
+  multiplicity (ExWAS / EWAS / MWAS): correction matched to claim against the honest test-count
+  denominator, independent replication as the real safeguard, correlated-exposure conservatism,
+  selective top-hit reporting.
+- **Two reporting-guideline checklists** (`/check-reporting`): **STROBE-MR** (Mendelian
+  randomization) and **PGS-RS / PRS-RS** (polygenic-score risk prediction), with study-type
+  routing + aliases. Reporting guidelines 36 → 38.
+- **Four `/analyze-stats` analysis guides**: multiple-testing/high-dimensional screening,
+  Mendelian randomization, polygenic risk score, and network meta-analysis.
+- **`/clean-data` implausible-value & cross-field validity rules** reference — organ-system
+  compatible-with-life bounds + cross-field logical-consistency rules (temporal ordering,
+  derived-vs-source, sex-/state-specific), flag-not-auto-fix.
+
+### Changed
+
+- **Clinician-friendly update reminders.** The classroom installers
+  (`install-macos.command` / `install-windows.cmd` / `install-windows.ps1`) now enable the in-app
+  "update available" notice and the one-click Desktop updater by default (turnkey path; disable
+  with `--disable-update-notify` or `MEDSCI_NO_UPDATE_CHECK=1`). For the `npx`/manual paths the
+  installer prints a one-time nudge showing how to turn reminders on (`--enable-update-notify`),
+  and the README Quick Start recommends it. New read-only `update.session_hook_enabled()` gates the
+  nudge; the `npx`/manual paths stay opt-in (no silent SessionStart hook).
+
 ## [4.9.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ every output requires human-expert verification. New here? See the
 npx medsci-skills install        # copies every skill into your agent's folder
 ```
 
+**Recommended (especially for clinicians):** add `--enable-update-notify` so Claude Code shows a one-line *"update available"* notice when a new version ships — otherwise you stay on the version you installed and are never told. (No terminal at all? The classroom installer below turns this on for you.)
+
+```bash
+npx medsci-skills install --enable-update-notify        # install + in-app update reminders
+```
+
 **Have git?** Install every skill in three commands:
 
 ```bash
@@ -497,6 +503,8 @@ After unzipping:
 - Windows: double-click `installers/install-windows.cmd`
 - macOS: double-click `installers/install-macos.command`
 
+This turnkey install also **turns on in-app update reminders** and adds an **"Update MedSci Skills"** Desktop icon, so you are told when a new version ships and can update with one click — no terminal needed (see [Updating](#updating)).
+
 Then restart Claude Code Desktop, Codex Desktop, or Cursor and test with:
 
 ```text
@@ -548,19 +556,22 @@ See [docs/classroom_distribution_plan.md](docs/classroom_distribution_plan.md) a
 
 MedSci Skills updates often. You do **not** need GitHub, git, or the command line to stay current.
 
-- **One click (recommended for the classroom install).** After installing, an updater is placed at
-  `~/.medsci-skills/updater/` (and, if you chose `--desktop-launcher`, an **"Update MedSci Skills"**
-  icon on your Desktop). Double-click it: it downloads the latest release from GitHub, verifies it,
-  and re-installs — transactionally, so an interrupted update never corrupts your install.
+- **One click (recommended for the classroom install).** The classroom installer (Option 1) now
+  sets this up for you automatically — it places an updater at `~/.medsci-skills/updater/`, drops an
+  **"Update MedSci Skills"** icon on your Desktop (`--desktop-launcher`), and **turns on the in-app
+  update reminder** (below). Double-click the icon: it downloads the latest release from GitHub,
+  verifies it, and re-installs — transactionally, so an interrupted update never corrupts your install.
 - **Already installed an old copy?** Re-download the latest classroom ZIP **once** and double-click
   the installer; from then on the one-click updater is in place for every future update.
 - **Terminal users:** `npx medsci-skills@latest install` always installs the latest.
 - **Just checking:** `python3 installers/install.py --check-update` reports whether a newer version
   is available and installs nothing.
-- **Get reminded (opt-in, Claude Code):** `python3 installers/install.py --enable-update-notify`
-  shows a one-line *"update available"* notice when a Claude Code session starts. It is **off by
-  default**, checks at most once a day, reads nothing about your session, and never installs
-  anything. Turn it off with `--disable-update-notify`, or silence it with `MEDSCI_NO_UPDATE_CHECK=1`.
+- **Get reminded (Claude Code):** `python3 installers/install.py --enable-update-notify` (or
+  `npx medsci-skills install --enable-update-notify`) shows a one-line *"update available"* notice
+  when a Claude Code session starts. **The classroom installer enables this for you;** for the
+  `npx`/manual paths it is **off by default** (the installer prints how to turn it on). It checks at
+  most once a day, reads nothing about your session, and never installs anything. Turn it off with
+  `--disable-update-notify`, or silence it with `MEDSCI_NO_UPDATE_CHECK=1`.
 - **Claude Code plugin marketplace:** third-party marketplace **auto-update is off by default** —
   enable it in Claude Code or run a manual plugin update.
 

--- a/installers/install-macos.command
+++ b/installers/install-macos.command
@@ -6,10 +6,19 @@ cd "$(dirname "$0")/.."
 echo "MedSci Skills Installer for macOS"
 echo
 
+PY=""
 if command -v python3 >/dev/null 2>&1; then
-  python3 installers/install.py --target all
+  PY=python3
 elif command -v python >/dev/null 2>&1; then
-  python installers/install.py --target all
+  PY=python
+fi
+
+if [ -n "$PY" ]; then
+  "$PY" installers/install.py --target all --desktop-launcher
+  # Turn on the in-app "update available" reminder for this turnkey install so you are told when a
+  # new version is out (no terminal needed afterward). Best-effort; turn off later with
+  # `install.py --disable-update-notify` or MEDSCI_NO_UPDATE_CHECK=1.
+  "$PY" installers/install.py --enable-update-notify || true
 else
   echo "Python was not found."
   echo "Install Python 3 from https://www.python.org/downloads/ and run this installer again."

--- a/installers/install-windows.cmd
+++ b/installers/install-windows.cmd
@@ -7,13 +7,17 @@ echo.
 
 where py >nul 2>nul
 if %errorlevel%==0 (
-  py -3 installers\install.py --target all
+  py -3 installers\install.py --target all --desktop-launcher
+  rem Turn on the in-app "update available" reminder for this turnkey install (disable later with --disable-update-notify).
+  py -3 installers\install.py --enable-update-notify
   goto done
 )
 
 where python >nul 2>nul
 if %errorlevel%==0 (
-  python installers\install.py --target all
+  python installers\install.py --target all --desktop-launcher
+  rem Turn on the in-app "update available" reminder for this turnkey install (disable later with --disable-update-notify).
+  python installers\install.py --enable-update-notify
   goto done
 )
 

--- a/installers/install-windows.ps1
+++ b/installers/install-windows.ps1
@@ -5,9 +5,12 @@ Write-Host "MedSci Skills Installer for Windows"
 Write-Host ""
 
 if (Get-Command py -ErrorAction SilentlyContinue) {
-    py -3 installers/install.py --target all
+    py -3 installers/install.py --target all --desktop-launcher
+    # Turn on the in-app "update available" reminder for this turnkey install (disable later with --disable-update-notify).
+    try { py -3 installers/install.py --enable-update-notify } catch {}
 } elseif (Get-Command python -ErrorAction SilentlyContinue) {
-    python installers/install.py --target all
+    python installers/install.py --target all --desktop-launcher
+    try { python installers/install.py --enable-update-notify } catch {}
 } else {
     Write-Host "Python was not found."
     Write-Host "Please install Python 3 from https://www.python.org/downloads/ and run this installer again."

--- a/installers/install.py
+++ b/installers/install.py
@@ -286,6 +286,19 @@ def main() -> int:
         except Exception as exc:  # noqa: BLE001
             log(f"\n[updater] could not install the one-click updater ({exc}); updates still work via re-running the installer.", log_lines)
 
+    # One-time nudge: if the in-app update reminder is not enabled, surface how to turn it on.
+    # (The classroom installers enable it automatically; this covers npx / manual installs so a
+    # clinician who installed via "install this repo" is told how to get update notices.) Read-only.
+    if not args.dry_run:
+        try:
+            import update  # noqa: PLC0415
+            if not update.session_hook_enabled(medsci_txn.state_home(), update.default_settings_path()):
+                log("\n[update reminders] OFF — Claude Code will not tell you when a new version is out.", log_lines)
+                log("  Turn on with:  npx medsci-skills install --enable-update-notify", log_lines)
+                log("  (or:           python3 installers/install.py --enable-update-notify)", log_lines)
+        except Exception:  # noqa: BLE001 - nudge is best-effort, never block the install
+            pass
+
     if failures:
         log(f"\nCompleted with errors on: {', '.join(failures)}. Other targets are fully installed.", log_lines)
         log("If this happened during class, send the install log to the instructor.", log_lines)

--- a/installers/update.py
+++ b/installers/update.py
@@ -517,6 +517,25 @@ def register_session_hook(home: Path, settings_path: Path) -> str:
     return "enabled"
 
 
+def session_hook_enabled(home: Path, settings_path: Path) -> bool:
+    """Read-only: True iff our SessionStart update-notify hook is currently registered in
+    settings.json. Never writes; tolerant of an absent/empty/unreadable settings file (False).
+    Used by the installer to decide whether to print the one-time enable-reminders nudge."""
+    try:
+        if not settings_path.is_file():
+            return False
+        settings = _load_settings(settings_path)
+        if not isinstance(settings, dict):
+            return False
+        hooks = settings.get("hooks")
+        ss = hooks.get("SessionStart") if isinstance(hooks, dict) else None
+        if not isinstance(ss, list):
+            return False
+        return any(_entry_owns_hook(e, home) for e in ss)
+    except Exception:  # noqa: BLE001 - read-only nudge gate, never block install
+        return False
+
+
 def unregister_session_hook(home: Path, settings_path: Path) -> str:
     """Opt-out: remove ONLY our SessionStart hook (even if it shares an entry with other hooks),
     preserving everything else; drop emptied containers. Returns 'disabled' or 'not-enabled'."""

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -8,23 +8,23 @@
     },
     {
       "path": "installers/install-macos.command",
-      "size": 455,
-      "sha256": "abc4ed71a42e0e87ef20332a9bcad840d84e50032cbf77999d703eebe3084bd9"
+      "size": 803,
+      "sha256": "4071582be11c467f48fe9f4684dcc9b7a115a5361479fdfbd7a10c74d3309a52"
     },
     {
       "path": "installers/install-windows.cmd",
-      "size": 438,
-      "sha256": "96cce0caf63a2936de769d4a01720a2fc1de946379d04259876272474e07d574"
+      "size": 831,
+      "sha256": "3204da065979a2b060a5170b5c542e5ccd2ede4ecc172fcee7eafac3c0bfd003"
     },
     {
       "path": "installers/install-windows.ps1",
-      "size": 554,
-      "sha256": "2e025ffce1079a2a8be442ccccbd65711780423bcf68be9cc12bf29c015e3621"
+      "size": 861,
+      "sha256": "1f44ec21dfd828979445dc9ab76b4e2015cec573911d843d9416f3302aa8183d"
     },
     {
       "path": "installers/install.py",
-      "size": 13319,
-      "sha256": "9467880b2efdc5c71ed280aa1e17e4c785fe7d80078c3666d5047fb9ac267c89"
+      "size": 14230,
+      "sha256": "f1a092bbc5ea676a3bfca3dcb724e9e64a07dc1e1e2414ff696fc21cf4f7f8c0"
     },
     {
       "path": "installers/medsci_txn.py",
@@ -48,8 +48,8 @@
     },
     {
       "path": "installers/update.py",
-      "size": 25500,
-      "sha256": "6a632a88617889a1ac36418822b8af3f2bcab75bfa28169e99ae4fdf0b810365"
+      "size": 26375,
+      "sha256": "9ed283deea2e9bf10c17bbbbc1d75ae64703ecd587326583a17d0600d8bf0ca3"
     },
     {
       "path": "skills/MAINTENANCE.md",


### PR DESCRIPTION
## Clinician-friendly update reminders

**Problem (real-world install flow):** most clinicians install by handing Claude the GitHub repo and saying "install it." That path almost never enables the update notice, because the in-app "update available" notice is **opt-in and off by default** (`--enable-update-notify` early-returns as a standalone mode). So clinicians install once and are **never told about updates** — they silently stay on whatever version they got.

### Changes
1. **Classroom installers default-on** (`install-macos.command` / `install-windows.cmd` / `install-windows.ps1`): now install with `--desktop-launcher` **and** enable the in-app update notice by default (2-call, since `--enable-update-notify` early-returns). The turnkey non-programmer path now gets: one-click Desktop "Update MedSci Skills" icon + a session-start "update available" notice. Disable with `--disable-update-notify` / `MEDSCI_NO_UPDATE_CHECK=1`.
2. **npx/manual one-time nudge** (`install.py`): after any install where the notice is not enabled, prints how to turn it on (`npx medsci-skills install --enable-update-notify`). Gated by a new **read-only** `update.session_hook_enabled()` (never writes). This covers the Claude-driven `npx` flow — the install output now tells Claude/the user how to enable reminders.
3. **README**: Quick Start recommends `--enable-update-notify` (with a clinician note that without it you're never told); Installing/Updating sections document the classroom default-on.

**Design:** `npx`/manual paths stay **opt-in** (no silent SessionStart hook — preserves the deliberate no-surprise-hook design); only the explicit turnkey **classroom** path defaults reminders on, which is appropriate for a non-programmer who chose a managed install.

Also **backfilled `CHANGELOG [Unreleased]`** with the reverse-engineering batch already on main but unrecorded (#207–#212: O17 + MR/PRS/NMA probes + STROBE-MR/PGS-RS checklists + 4 analyze-stats guides + clean-data ref), so the next release (v4.10.0) cuts accurate notes.

### Gates (local, green)
- Installer tests: `test_session_hook` 38/0, `test_update` 20/0, `test_txn` 19/0, `install.py --self-test` 45/45, `test_release_zip` pass
- `gen_distribution_manifest --check` in sync; `validate_catalog_consistency` green; `validate_skills.sh` ALL PASS; version consistency 4.9.0
- No skill/detector/guideline count change; no version bump.

Stops at the merge gate (public README + installer behavior change).
