### PR TITLE
release: v4.10.0 (reverse-eng reviewer coverage — domain-probes 12→15, guidelines 36→38 + clinician update UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [4.10.0] - 2026-06-28
+
 ### Added
 
 - **Three new reviewer domain-probe modules** (`/peer-review` + `/self-review`, vendored

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "4.9.0"
-date-released: "2026-06-22"
+version: "4.10.0"
+date-released: "2026-06-28"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 ## What's New
 
+**v4.10** — reviewer-coverage expansion reverse-engineered from high-IF, CC-BY papers (learn-only under the `reverse_engineer/` license firewall), plus a clinician-friendly update path. Additive and backward-compatible; 45 skills / **38 guidelines** / 36 detectors / **15 domain-probe modules** (was 12):
+
+- **Three new reviewer domain-probe modules** (`/peer-review` + `/self-review`, vendored byte-identical): **Mendelian randomization** (MR1–MR8 — IV assumptions, pleiotropy-robust sensitivity suite, Steiger, sample overlap, NLMR, drug-target colocalization), **polygenic risk score** (PG1–PG8 — ancestry portability, base/target leakage, incremental value over the clinical model, screening-vs-discrimination, calibration), and **network meta-analysis** (NM1–NM8 — transitivity, incoherence, SUCRA over-interpretation, CINeMA/GRADE-NMA, component-NMA additivity). Plus observational **O17** (agnostic many-exposure-scan multiplicity: ExWAS/EWAS/MWAS).
+- **Two reporting-guideline checklists** (36 → 38): **STROBE-MR** and **PGS-RS / PRS-RS**, with study-type routing. Four new `/analyze-stats` analysis guides (multiplicity, MR, PRS, NMA) and a `/clean-data` implausible-value + cross-field validity reference.
+- **Clinician-friendly update reminders** — the classroom installers enable the in-app "update available" notice + one-click Desktop updater by default; the `npx`/manual paths print how to turn it on; the install guide recommends `npx medsci-skills install --enable-update-notify`.
+
 **v4.9** — analysis-integrity hardening promoted from real review cycles, plus journal-mechanics additions. Additive and backward-compatible; still 45 skills / 38 guidelines, analysis-integrity detectors **32 → 36**:
 
 - **Four new gates** — a **duplicate-bibliography** check (`check_reference_duplication.py`) for the hybrid `[@key]` + hand-typed `## References` build that renders the list twice; a **cross-script binning / composite-indicator** consistency check (`check_binning_consistency.py`, `BINNING_DRIFT` / `DERIVED_DEF_DRIFT`) for a derived categorical or composite indicator defined inconsistently across analysis scripts; a **float citation-order** check (`check_citation_order.py`) for numbered Tables/Figures not first cited in ascending order per series; and an **audit-dump leak** gate (`/sync-submission`) that blocks a `/check-reporting` output mistakenly attached as a submission file.

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "4.9.0",
+  "version": "4.10.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Release commit for **v4.10.0** (MINOR, additive — no breaking change). Bundles this session's merged work (#207–#213):

- 3 new vendored domain-probe modules (Mendelian randomization, polygenic risk score, network meta-analysis) + observational O17 → domain-probes 12→15
- STROBE-MR + PGS-RS reporting checklists → guidelines 36→38
- 4 analyze-stats guides (multiplicity, MR, PRS, NMA) + clean-data implausible-value reference
- clinician-friendly update reminders (classroom default-on + npx nudge + install guide)

Skills 45 / detectors 36 unchanged. Files: CHANGELOG `[Unreleased]`→`[4.10.0]`, CITATION + package.json + distribution_manifest 4.9.0→4.10.0, README What's New.

Gates green: check_version_consistency (all 4.10.0), validate_catalog_consistency, distribution-manifest --check, gen_skill_docs --check, test_distribution_manifest 8/0, release-zip round-trip. **Tag v4.10.0 after merge → release.yml (GitHub Release + ZIPs + attest + npm publish + Zenodo).**