### PR TITLE
feat(find-journal): acceptance-feasibility axis — design-ceiling pre-flight + cascade plan

### DIFF
--- a/docs/skills/find-journal.md
+++ b/docs/skills/find-journal.md
@@ -2,7 +2,7 @@
 
 # find-journal
 
-> Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites.
+> Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 
 **Invoke:** `/find-journal` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
 
@@ -22,10 +22,13 @@
 **Known limitations**
 
 - Coverage is limited to profiled journals; an unprofiled fit may be missed (add via add-journal).
-- Scope-fit ranking is advisory, not an acceptance prediction.
+- Both axes (scope fit and acceptance feasibility) are advisory; the feasibility band is a risk/ceiling estimate with reasons, never an acceptance probability.
+- The Phase 2.5 pre-flight is a lexical/heuristic scan; it surfaces signals to weigh, not a verdict, and its flags are not auto-fixable.
 
 **Validation**
 
+- `python3 scripts/assess_acceptance_readiness.py <manuscript_or_abstract.md>`
+- `bash scripts/acceptance_readiness_challenge/verify.sh  # deterministic, network-free`
 - `verify shortlisted journals' current scope and metrics at their official sites`
 
 **Evidence** — `manual_workflow`
@@ -34,7 +37,13 @@
 
 **References** (`skills/find-journal/references/`):
 
+- `acceptance_signals_schema.md`
 - `journal_profiles/` (73 files)
+
+**Scripts** (`skills/find-journal/scripts/`):
+
+- `acceptance_readiness_challenge/` (6 files)
+- `assess_acceptance_readiness.py`
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1023,13 +1023,18 @@
     },
     {
       "path": "skills/find-journal/POLICY.md",
-      "size": 4486,
-      "sha256": "02de377328f457c57c5edbade8bae40e12c51b4c6ff8ab6293b330c482187ce7"
+      "size": 5255,
+      "sha256": "c2b61b5830844fa3eebe333dc4864acb4d085097e81ba2dbc1ef72dd65bebee3"
     },
     {
       "path": "skills/find-journal/SKILL.md",
-      "size": 14455,
-      "sha256": "48a95f5ee639e59f00241608b23b3e652395bffaa63a6bccba295e5b3d5a49d6"
+      "size": 22072,
+      "sha256": "45074f6499896700bff0eb20bd91c4076b143bcd39521d56559239edaa8b24d8"
+    },
+    {
+      "path": "skills/find-journal/references/acceptance_signals_schema.md",
+      "size": 6869,
+      "sha256": "620ba1c55272908a16125ba69074491df5246d6cf9afa14e6b08a08e8dc4e866"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/AJNR.md",
@@ -1038,8 +1043,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/AJR.md",
-      "size": 1417,
-      "sha256": "ae26a8ea72672a973977a01f7e7a8cdbdc98b5dbcd2a7bc4605bb6eaee1a87fe"
+      "size": 2075,
+      "sha256": "9d9a5ee7b3b2287a6deae8fc06d54dd60b26afa843f5830f7bb5fb2e2ac633f7"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Abdominal_Radiology.md",
@@ -1128,8 +1133,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/European_Radiology.md",
-      "size": 1640,
-      "sha256": "b71a9fe293c985c47f674459b4a613083749bc8d246d062e2c3afddc988e349c"
+      "size": 2350,
+      "sha256": "fa50a9a9d6012b8c6b75d81a69b950dfbe7db29775c8112bf5fe68d6d5655dfa"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Hepatology_Communications.md",
@@ -1158,8 +1163,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Investigative_Radiology.md",
-      "size": 1480,
-      "sha256": "ab740ec46a98b92fc243d4770b2a4f6ed400ea5a1f86e0fdffc121cdb2c98fa9"
+      "size": 2118,
+      "sha256": "c218b4e764a070a3297802076c1e6c68e514160cc1efa038552cc271b01af9ce"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/JACC_Advances.md",
@@ -1248,8 +1253,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/KJR.md",
-      "size": 3036,
-      "sha256": "a0814e6d62288389db7528b73a25db870ab91635dc4b946fb0c8bf8af47150a3"
+      "size": 4061,
+      "sha256": "0849de001a47038b8bfc92b337285372c80ccf4861162cae876295d82ea4f1c8"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Korean_Circulation_Journal.md",
@@ -1348,8 +1353,8 @@
     },
     {
       "path": "skills/find-journal/references/journal_profiles/RYAI.md",
-      "size": 1601,
-      "sha256": "1a6a387ed715a559bb0a7fd535b76ecb9334ff21e43b6c025520ca1167993a5e"
+      "size": 2341,
+      "sha256": "6d85cd675a5e6f395f74865256b7fe937749a4e31cb4c6f8d43d4059cb33a717"
     },
     {
       "path": "skills/find-journal/references/journal_profiles/Radiology.md",
@@ -1397,9 +1402,44 @@
       "sha256": "e2811a46b89f39a7395d98460347ce274ff58ce50138364e8cf96050a05aad91"
     },
     {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_ceiling.txt",
+      "size": 1570,
+      "sha256": "1e84f888350249a3b187d38731a371487232851c6521689e319ef59408ed9448"
+    },
+    {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_clean.txt",
+      "size": 350,
+      "sha256": "40b1a3b94cf15d504fc2c04e25f5aa737410a8b2480118dcd3c9cd1927ee825c"
+    },
+    {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/fixture_ceiling/manuscript.md",
+      "size": 717,
+      "sha256": "557ce5c0607024aebae3375e117b1052acace3d1931a3dc8d015a6b9c6043843"
+    },
+    {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/fixture_clean/manuscript.md",
+      "size": 646,
+      "sha256": "77a215d5c5fe8d09035308f04cdf26ab7c2736c53563b71930a2be1941b7061b"
+    },
+    {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/problem.md",
+      "size": 1981,
+      "sha256": "469b518a373f5bef95016dc866f82b0d05395eb26ae162656abf1303495ed71c"
+    },
+    {
+      "path": "skills/find-journal/scripts/acceptance_readiness_challenge/verify.sh",
+      "size": 1232,
+      "sha256": "0c525f322306fd5229269f155179924d80a419301988fff0171115c3b323d795"
+    },
+    {
+      "path": "skills/find-journal/scripts/assess_acceptance_readiness.py",
+      "size": 10959,
+      "sha256": "32930f970f308d95aaf82c61d809a307685668165df4fe2bf7c2b4f5052b3e87"
+    },
+    {
       "path": "skills/find-journal/skill.yml",
-      "size": 1428,
-      "sha256": "0fdf9fdce505cc1d264bdb9c69a4ad6107ea6d510d186385f854636b9f10e609"
+      "size": 1971,
+      "sha256": "8a4ce35c9fccb8a43de5d06bee09b27fc70d2c735d8fa9fce353ec9467fa9936"
     },
     {
       "path": "skills/fulltext-retrieval/SKILL.md",

--- a/skills/find-journal/POLICY.md
+++ b/skills/find-journal/POLICY.md
@@ -41,6 +41,13 @@ Every public profile must meet **all** of the following. No exceptions, no defau
   not a substitute for checking.
 - `Special Notes` — any "Choose X over Y" decision rule must be defensible from what the
   two journals' own scope statements say, not from general reputation.
+- `Acceptance Signals` (optional block) — every line (selectivity band, desk-reject
+  triggers, design expectations, study-type tolerance, review process, cascade/transfer)
+  must be **generic and traceable to the journal's own public guidance**. Editor-decision
+  patterns learned from confidential peer review (COPE) are **not permitted in a public
+  profile**; abstracted editor-bar notes belong only in the user-local private overlay
+  (`$HOME/.claude/private-journal-profiles/find-journal/`). Selectivity is expressed as a
+  qualitative band, never a fabricated acceptance percentage.
 
 ### Proof of verification
 
@@ -72,6 +79,8 @@ repo) into `skills/*/references/journal_profiles/`, confirm each item:
 - [ ] AI policy sentence transcribed from the journal's or publisher's policy page — no
       sibling-journal copy-paste.
 - [ ] "Choose X over Y" decision rule defensible from each journal's own scope text.
+- [ ] Any `Acceptance Signals` lines are generic and traceable to the journal's own public
+      guidance — no confidential editor-corpus content, no fabricated acceptance %.
 - [ ] No `[TODO: verify at journal site]` markers remaining.
 - [ ] Commit message records which pages were opened and on what date.
 

--- a/skills/find-journal/SKILL.md
+++ b/skills/find-journal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-journal
-description: Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites.
+description: Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 triggers: find journal, recommend journal, where to submit, which journal, journal selection, target journal, journal match
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
@@ -77,6 +77,56 @@ From the abstract/key findings, extract:
 
 ---
 
+## Phase 2.5: Acceptance-Readiness & Design-Ceiling Pre-flight
+
+Editors apply two filters in sequence: **(1) importance/novelty + design-ceiling**
+(the desk screen, before review — the #1 desk-rejection driver is lack of
+novelty/importance, ahead of scope) and **(2) scope fit**. Scope matching (Phase 3)
+handles filter 2. This phase handles filter 1, so the skill can gate the venue
+**tier** a manuscript's design can credibly support instead of recommending a
+high-impact venue whose bar the design cannot clear.
+
+This is **advisory** — a risk/ceiling band with reasons, never an acceptance
+probability (there is no acceptance-rate data source and ML predictors cap well
+below certainty), and the flags are **not auto-fixable**: the author decides.
+
+### 2.5.1 Run the deterministic pre-flight (preferred)
+
+If a manuscript or abstract file is available, run the bundled lexical scan:
+
+```
+python3 ${CLAUDE_SKILL_DIR}/scripts/assess_acceptance_readiness.py <manuscript_or_abstract.md>
+# add --json for a machine-readable report
+```
+
+It returns flags in four categories — DESIGN_CEILING, UNFIXABLE_DEFECT,
+IMPORTANCE_RISK, CLAIM_MISMATCH — and a ceiling verdict
+(`NO STRUCTURAL CEILING …` / `IMPORTANCE-FRAMING REVIEW …` /
+`SPECIALTY / TOLERANT-VENUE OR DESIGN FIX …` / `HIGH-IMPACT VENUE UNLIKELY …`).
+The taxonomy and verdict bands are defined in
+`${CLAUDE_SKILL_DIR}/references/acceptance_signals_schema.md`.
+
+### 2.5.2 If only pasted text is available
+
+When the user pasted an abstract with no file to scan, apply the **same taxonomy**
+(`references/acceptance_signals_schema.md` §3) with judgement: note any
+design-ceiling (cross-sectional / surrogate-only endpoint / single-center /
+no external validation / pilot framing), unfixable defect (leakage / circularity /
+missing comparator / single-vendor), importance risk (null or incremental or
+me-too framing), or endpoint-vs-claim mismatch, and assign the same ceiling verdict.
+
+### 2.5.3 Carry the verdict forward
+
+Record the **ceiling verdict + its top flags**. It feeds:
+- Phase 3.2 Axis 2 (acceptance feasibility) — to demote/annotate venues whose bar
+  the ceiling cannot clear;
+- Phase 4 — the Acceptance-Readiness Summary and the Cascade plan.
+
+Do not block the recommendation on a ceiling. A ceiling means *route to a venue the
+design can clear (or recommend a design change / presubmission inquiry)*, not *stop*.
+
+---
+
 ## Phase 3: Profile Loading and Matching (2-Pass)
 
 ### 3.1 Pass 1: Load Compact Profiles
@@ -96,15 +146,23 @@ takes precedence (user override). If the private directory does not exist, proce
 public-only — do not fail.
 
 These are compact profiles (~30 lines each) optimized for matching. Parse each profile's
-Scope, Scope Keywords, Article Types Accepted, Classification (Tier, OA, Field), and
-Special Notes (includes 1-line AI policy summary).
+Scope, Scope Keywords, Article Types Accepted, Classification (Tier, OA, Field),
+Special Notes (includes 1-line AI policy summary), and the optional **Acceptance Signals**
+block (selectivity band, desk-reject triggers, design expectations, cascade/transfer — see
+`${CLAUDE_SKILL_DIR}/references/acceptance_signals_schema.md`). A profile without an
+Acceptance Signals block falls back to its Special Notes plus the Phase 2.5 taxonomy.
 
 Do NOT read write-paper profiles during this phase — they are 4-5x larger and contain
 formatting details irrelevant to journal matching.
 
-### 3.2 Scoring Algorithm
+### 3.2 Two-Axis Scoring (scope fit × acceptance feasibility)
 
-For each journal, compute a composite score:
+Score each journal on **two independent axes**. Scope fit answers "does this journal
+cover my topic?"; acceptance feasibility answers "can this manuscript's design +
+importance clear this journal's bar?" Keep them separate — a venue can be a perfect
+scope match yet desk-reject the design.
+
+**Axis 1 — Scope fit.** Compute a composite scope-fit score:
 
 | Factor | Weight | Description |
 |--------|--------|-------------|
@@ -113,6 +171,18 @@ For each journal, compute a composite score:
 | Tier match | 20% | Alignment with user's preferred tier (if specified) |
 | OA match | 10% | Alignment with user's OA preference (if specified) |
 | Special fit | 5% | Bonus for unique alignment with journal's Special Notes |
+
+**Axis 2 — Acceptance feasibility.** Weigh the Phase 2.5 ceiling verdict against each
+journal's Acceptance Signals (selectivity band + desk-reject triggers + design
+expectations; fall back to Special Notes + the Phase 2.5 taxonomy when no block exists).
+Assign **High / Medium / Low** feasibility:
+- **Low / ceiling-mismatch** when the journal's bar is one the manuscript's ceiling
+  cannot clear (e.g., a `highly-selective` venue that desk-rejects single-center
+  surrogate-endpoint designs, and the manuscript is exactly that).
+- **High** when no ceiling signal collides with the journal's stated bar.
+
+Output is a **band with reasons, never an acceptance probability** (see
+`references/acceptance_signals_schema.md` §4).
 
 ### 3.3 Filtering
 
@@ -123,7 +193,13 @@ Before scoring, exclude:
 
 ### 3.4 Ranking
 
-Sort by composite score. Select top 5.
+Rank primarily by the Axis-1 scope-fit score, then apply Axis 2:
+- **Demote** (or, if the mismatch is severe, drop below a better-feasibility peer)
+  any journal whose acceptance feasibility is Low / ceiling-mismatch.
+- **Never silently demote** — always carry the reason so Phase 4 can surface it.
+- Select the top 5 by the feasibility-adjusted order. If a strong scope match is
+  demoted for feasibility, still mention it in the comparison note with the mismatch
+  spelled out (the author may choose to fix the design rather than change venue).
 
 ### 3.5 Pass 2: Enrich Top-5
 
@@ -145,6 +221,9 @@ for the output:
 - Statistical reporting requirements
 - AI Writing Disclosure Policy (full 5-field version)
 - Common rejection reasons
+- Acceptance Signals (selectivity band, desk-reject triggers, design expectations,
+  cascade/transfer targets) — these sharpen the Axis-2 feasibility call and the
+  Phase 4 cascade plan
 
 This enriches the recommendation output without loading all write-paper profiles.
 If no write-paper profile exists, use the compact profile data only.
@@ -236,6 +315,11 @@ Reference specific keywords, disease areas, or methodological preferences from t
 
 **Open Access:** [Full OA / Hybrid / Subscription]
 
+**Acceptance feasibility:** [High / Medium / Low] — [1 line: how the manuscript's
+Phase 2.5 ceiling meets this journal's bar; spell out any mismatch, e.g., "scope fit
+High, but this highly-selective venue desk-rejects single-center surrogate-endpoint
+designs — add external validation or target a selective/accessible venue"]
+
 **Homepage:** [URL]
 **Author guidelines:** [URL]
 
@@ -244,10 +328,47 @@ Reference specific keywords, disease areas, or methodological preferences from t
 
 After all 5 recommendations, add a brief comparison note (2-3 sentences) highlighting
 the key tradeoffs between the top choices (e.g., scope breadth vs. specialty depth,
-tier vs. acceptance likelihood).
+tier vs. acceptance feasibility).
 
-If Phase 3.6 produced a Coverage Advisory, insert it immediately after the comparison
-note and before the Mandatory Disclaimer.
+Then add the two blocks below, then (if Phase 3.6 produced one) the Coverage Advisory,
+then the Mandatory Disclaimer.
+
+### Acceptance-Readiness Summary
+
+```
+---
+### Acceptance-Readiness Summary
+
+**Ceiling verdict:** [from Phase 2.5]
+**Top flags:** [the 2-4 most consequential design-ceiling / unfixable / importance flags, each with its 1-line reason]
+**Implication for venue tier:** [1-2 sentences — e.g., "An unfixable single-center +
+surrogate-endpoint ceiling makes flagship venues unlikely without external validation;
+the recommendations above are routed to venues this design can clear."]
+
+_Advisory only — a risk band, not an acceptance prediction; flags are not auto-fixable._
+```
+
+### Cascade plan
+
+```
+---
+### Cascade plan (primary → reject-fallback)
+
+1. **Primary:** [top recommendation] — [why first]
+2. **If rejected:** [fallback 1] — [same-publisher transfer if applicable, else one tier
+   down / different scope angle]. Following the editor's transfer offer is worth it:
+   across publisher transfer desks more than half of transferred manuscripts are sent
+   to review and over a third are published — both above the average submission.
+3. **Then:** [fallback 2]
+
+[If the Phase 2.5 risk is IMPORTANCE rather than design, recommend a **presubmission
+inquiry** to the primary target before full submission — it lets the editor quick-assess
+contribution/fit and saves a desk-reject cycle.]
+
+[If a confidential corresponding-author editor-bar overlay exists in
+`$HOME/.claude/private-journal-profiles/find-journal/`, its notes have already been
+merged into the per-journal feasibility calls above.]
+```
 
 ---
 
@@ -278,10 +399,23 @@ Recommended verification sources:
 When the user indicates a manuscript was rejected from a specific journal:
 
 1. Exclude the rejecting journal from recommendations
-2. Prioritize journals at the **same tier or one tier lower** than the rejecting journal
-3. If rejected from Q1, recommend mix of Q1 (different scope angle) and strong Q2
-4. In the scope fit explanation, note how the recommendation differs from the rejected journal's focus
-5. Suggest any scope adjustments that might improve fit for the new target
+2. **Distinguish the rejection type — it changes the advice:**
+   - **Desk-reject (no peer review)** — usually an importance/novelty or design-ceiling
+     verdict, not a fixable-revision signal. Re-run Phase 2.5; if a ceiling/importance
+     flag is present, recommending the next same-tier venue will likely desk-reject
+     again. Route **one or two tiers down** (or to a tolerant/`accessible` venue), or
+     advise the design/importance fix first, and consider a **presubmission inquiry**.
+   - **Post-peer-review reject** — there may be a transfer offer and salvageable
+     reviews. Prefer a **same-publisher transfer** (Springer Nature Transfer Desk /
+     Elsevier Article Transfer Service / Wiley / Nature Portfolio) that carries the
+     referee reports; transferred manuscripts are reviewed and published at
+     above-average rates. Otherwise same tier or one down with the fatal flaw addressed.
+3. Prioritize journals at the **same tier or one tier lower** than the rejecting journal
+   (lower if the rejection was a desk-reject on importance/ceiling)
+4. If rejected from Q1, recommend mix of Q1 (different scope angle) and strong Q2
+5. In the scope fit explanation, note how the recommendation differs from the rejected journal's focus
+6. Suggest any scope adjustments — or, when Phase 2.5 found a ceiling, any design
+   changes — that might improve feasibility for the new target
 
 ### Case Report Mode
 

--- a/skills/find-journal/references/acceptance_signals_schema.md
+++ b/skills/find-journal/references/acceptance_signals_schema.md
@@ -1,0 +1,126 @@
+# Acceptance Signals — schema & taxonomy
+
+This reference defines the **acceptance-feasibility** layer that `/find-journal`
+adds alongside scope fit. Scope fit answers *"does this journal cover my topic?"*
+Acceptance feasibility answers *"can this manuscript's design + importance clear
+this journal's bar?"* — the filter editors apply **first** (the #1 desk-rejection
+driver is lack of novelty/importance, ahead of scope).
+
+Three pieces live here:
+1. the `## Acceptance Signals` block a journal profile may carry,
+2. the **selectivity bands** vocabulary (qualitative — never a fabricated %), and
+3. the **unfixable-defect taxonomy** the Phase 2.5 pre-flight scans for.
+
+---
+
+## 1. The `## Acceptance Signals` profile block (optional, source-traceable)
+
+A compact or detail profile may add this block. Every line must be **generic and
+traceable to the journal's own public guidance** (same bar as the rest of the
+profile — see `POLICY.md`). Journal-specific editor behaviour learned from a
+private review corpus is **confidential** and belongs ONLY in the user-local
+private overlay (`$HOME/.claude/private-journal-profiles/find-journal/`), never in
+a public profile.
+
+```
+## Acceptance Signals
+- **Selectivity band:** highly-selective | selective | accessible | fast-track
+- **Desk-reject triggers:** <bullet list of what this journal commonly desk-rejects on,
+  from its scope/guidelines — e.g., single-center without external validation;
+  case series; out-of-scope clinical specialty>
+- **Design expectations:** <sample-size / multi-center / external-validation expectations
+  stated or implied by the journal>
+- **Study-type tolerance:** <which designs the journal values vs deprioritises>
+- **Review process:** <statistical reviewer; double-blind; mandatory reporting guideline;
+  presubmission inquiry accepted?>
+- **Cascade / transfer:** <same-publisher transfer targets and tier-down fallbacks>
+```
+
+All fields are optional; include only what the journal's own pages support. Absence
+of the block ≠ "anything goes" — it just means the feasibility axis falls back to
+the LLM-applied taxonomy below plus the profile's existing Special Notes.
+
+### Selectivity bands (qualitative — no fake percentages)
+There is **no database of journal acceptance rates** (homepage/editor only), and
+cached IF/acceptance numbers go stale and are paywalled. So we use bands, not %:
+
+| Band | Meaning |
+|------|---------|
+| `highly-selective` | flagship/high-impact; desk-rejects most; expects definitive multi-center / external-validation designs |
+| `selective` | strong specialty/society journal; expects solid single- or multi-center originals with clear contribution |
+| `accessible` | sound-science or broad-scope journal; methodology/incremental work accepted if rigorous and well-reported |
+| `fast-track` | rapid / continuous-publication venue; speed-oriented, scientific bar still applies |
+
+---
+
+## 2. Unfixable vs fixable defects (why the ceiling matters)
+
+Across editor decisions the decisive lever is **fixable vs unfixable**:
+
+- **Fixable** (reporting, extraction, measurement, presentation, missing analysis)
+  → Major → Minor → Accept trajectory. These do **not** cap the venue tier.
+- **Unfixable** (a design-level validity or importance ceiling) → an editor rejects
+  even when everything fixable is addressed, and is frequently **more severe than
+  the reviewers**. These **cap the venue tier** the design can support.
+
+The pre-flight surfaces unfixable/ceiling signals so the skill stops recommending a
+high-impact venue whose bar the design cannot clear, and instead routes to a
+tolerant venue or recommends a design change (or a presubmission inquiry).
+
+## 3. Pre-flight taxonomy (what `assess_acceptance_readiness.py` scans)
+
+Four categories. The script does a deterministic lexical scan; the LLM phase
+applies the same taxonomy with judgement when only an abstract is available.
+
+- **DESIGN_CEILING** — the design cannot support the claimed altitude:
+  cross-sectional vs prognostic/causal/surveillance claim; surrogate/non-invasive
+  marker as the sole endpoint; single-center; no external validation for a
+  prediction/diagnostic model; pilot/preliminary/proof-of-concept framing.
+- **UNFIXABLE_DEFECT** — validity threats editors reject on, not revisable:
+  data/information leakage (target-derived, train/test overlap); circular
+  design/validation; missing field-standard comparator/baseline;
+  single-vendor / single-scanner generalizability ceiling.
+- **IMPORTANCE_RISK** — the novelty/importance gate (top desk-reject cause):
+  null/negative framing without an importance argument; incremental/marginal gain;
+  me-too positioning ("consistent with prior literature").
+- **CLAIM_MISMATCH** — an action verb the endpoint may not support
+  (recommend / defer / guide management / surveillance / actionable), emitted only
+  when the document also carries a design-ceiling signal.
+
+### Verdict bands (from the script + LLM judgement)
+- `NO STRUCTURAL CEILING DETECTED BY LEXICAL SCAN` → feasibility does not cap tier.
+- `IMPORTANCE-FRAMING REVIEW RECOMMENDED` → tighten the contribution/novelty argument.
+- `SPECIALTY / TOLERANT-VENUE OR DESIGN FIX RECOMMENDED` → one ceiling/claim signal.
+- `HIGH-IMPACT VENUE UNLIKELY WITHOUT A DESIGN CHANGE` → unfixable defect, or ≥2
+  design-ceiling signals.
+
+---
+
+## 4. How the two axes combine (Phase 3 ranking)
+
+For each candidate journal report **two independent axes**:
+
+- **Scope fit** (existing composite: scope 40 / study-type 25 / tier 20 / OA 10 / special 5).
+- **Acceptance feasibility** = the manuscript's ceiling verdict weighed against the
+  journal's Acceptance Signals (selectivity band + desk-reject triggers + design
+  expectations).
+
+Rules of thumb:
+- Rank primarily by **scope fit**, but **demote or annotate** any journal where
+  feasibility is Low / ceiling-mismatch.
+- Always **surface the mismatch explicitly** — e.g., *"scope fit High, but
+  feasibility Low: this `highly-selective` venue desk-rejects single-center
+  surrogate-endpoint designs; consider a `selective`/`accessible` venue or add
+  external validation."* A silent demotion teaches the author nothing.
+- Output is a **risk/feasibility band with reasons, never an acceptance
+  probability** — ML acceptance predictors cap well below certainty and ride
+  surface features, so a number here would be false precision.
+
+## 5. Confidentiality
+
+Public Acceptance-Signals lines must be generic and traceable to the journal's own
+public guidance. Specific editor-decision patterns learned from confidential peer
+review (COPE) are abstracted and kept in the **private overlay only**. The private
+tier wins on filename collision, so a user's local profile can enrich any public
+profile with their own corresponding-author editor-bar notes without those notes
+ever entering the shared library.

--- a/skills/find-journal/references/journal_profiles/AJR.md
+++ b/skills/find-journal/references/journal_profiles/AJR.md
@@ -28,3 +28,11 @@ diagnostic radiology, body imaging, CT, MRI, ultrasound, abdominal imaging, thor
 
 ## Special Notes
 AJR is one of the oldest and most widely read general radiology journals, published by ARRS since 1906. It requires both a "What Does This Article Add?" box and "Key Points" for original research. Strong emphasis on clinical relevance and practical applicability of findings. AI policy: follows ICMJE — disclose AI use in Methods.
+
+## Acceptance Signals
+- **Selectivity band:** selective
+- **Desk-reject triggers:** limited clinical relevance or practical applicability; incremental work that cannot fill a concrete "What Does This Article Add?" statement
+- **Design expectations:** clinically grounded diagnostic-accuracy or imaging studies with a clearly articulated contribution
+- **Study-type tolerance:** original research, brief reports, and technical innovations valued when clinically actionable
+- **Review process:** mandatory "What Does This Article Add?" box + Key Points; ICMJE AI disclosure
+- **Cascade / transfer:** tier-down to a specialty or subspecialty radiology journal

--- a/skills/find-journal/references/journal_profiles/European_Radiology.md
+++ b/skills/find-journal/references/journal_profiles/European_Radiology.md
@@ -27,3 +27,11 @@ diagnostic radiology, interventional radiology, CT, MRI, ultrasound, radiomics, 
 
 ## Special Notes
 European Radiology is the official journal of the European Society of Radiology (ESR) and one of the highest-impact general radiology journals. Requires 3 Key Points (max 85 characters each) as declarative statements. Uses British English throughout. Strongly prefers multi-center studies with N >= 200 for original articles. AI policy: follows ICMJE — disclose AI use in Methods. **Graphical abstract mandatory** from first revision for all Original Articles (Jan 2025). Official template: EURA-GA-Jan2025.pptx.
+
+## Acceptance Signals
+- **Selectivity band:** highly-selective
+- **Desk-reject triggers:** small single-center series; case reports unless highly unusual; studies whose only novelty is a larger sample of an already-validated technique
+- **Design expectations:** multi-center (international) cohorts; original articles generally expected at N ≥ 200
+- **Study-type tolerance:** favors multi-center clinical and AI/radiomics validation; deprioritizes small single-center work
+- **Review process:** British English; 3 Key Points; graphical abstract mandatory from first revision; ICMJE AI disclosure
+- **Cascade / transfer:** Springer Nature Transfer Desk; tier-down to a specialty or society radiology journal

--- a/skills/find-journal/references/journal_profiles/Investigative_Radiology.md
+++ b/skills/find-journal/references/journal_profiles/Investigative_Radiology.md
@@ -23,3 +23,11 @@ contrast agents, imaging physics, MRI techniques, CT technology, molecular imagi
 
 ## Special Notes
 Investigative Radiology is a highly selective journal focused on imaging science and technology rather than clinical case series. It does not accept case reports, reviews, or technical notes — only original research. Known for rapid publication of novel contrast agent studies and imaging physics advances. AI policy: AI use discouraged, must disclose in cover letter and Acknowledgments.
+
+## Acceptance Signals
+- **Selectivity band:** highly-selective
+- **Desk-reject triggers:** clinical case series; case reports, reviews, or technical notes (not accepted — original research only); work without a methodologically novel imaging-science contribution
+- **Design expectations:** high methodological rigor; a novel imaging technique, contrast agent, or physics advance
+- **Study-type tolerance:** original research only
+- **Review process:** AI use discouraged — disclose in cover letter and Acknowledgments
+- **Cascade / transfer:** tier-down to a general radiology or applied-imaging journal for clinically oriented work

--- a/skills/find-journal/references/journal_profiles/KJR.md
+++ b/skills/find-journal/references/journal_profiles/KJR.md
@@ -33,6 +33,14 @@ diagnostic radiology, AI in radiology, radiomics, deep learning, Korean radiolog
 ## Special Notes
 KJR is the leading English-language radiology journal in Asia, fully open access (USD 100 APC for accepted manuscripts; invited articles, Uncover This Tech Term, Emerging Rad Dx, and Letters are exempt). Indexed in PubMed/MEDLINE, SCIE, and Scopus. Particularly receptive to AI/radiomics studies and Korean population data. Faster turnaround than Western journals (Minor Revision within 30 days; Major Revision within 60 days). A pre-review "technical check" can *unsubmit* a manuscript for deterministic desk items — ascending float citation order (Tables / Supplementary Tables / Figures), demographics in Materials and Methods, one-decimal percentages, double spacing, Acknowledgments on the Title Page only, reporting checklist cited as "Supplementary Material 1", IRB number in Methods even when blinded, and ICMJE forms only after acceptance (see the write-paper profile's Technical-Check Conventions). References: Vancouver style with first six authors listed, then "et al." (≥7 authors). AI policy follows the journal's "Ethical and Responsible Use of Generative AI" statement (KJR 2026; https://doi.org/10.3348/kjr.2026.0166): AI cannot be author or primary scholarly source; AI use beyond routine language assistance must be disclosed in the relevant section or Acknowledgments; AI as study subject must be described in Materials and Methods; reviewers/editors must preserve confidentiality and disclose AI use beyond routine language assistance.
 
+## Acceptance Signals
+- **Selectivity band:** selective
+- **Desk-reject triggers:** out-of-scope topics (radiation oncology, dentistry/dental radiology, basic nuclear medicine); pre-review "technical check" can *unsubmit* for deterministic format items (ascending float citation order, demographics in Materials and Methods, one-decimal percentages, double spacing, Acknowledgments on Title Page only, reporting checklist as "Supplementary Material 1", IRB number in Methods even when blinded)
+- **Design expectations:** solid original studies; particularly receptive to AI/radiomics and Korean / East Asian population data
+- **Study-type tolerance:** broad (Original Article, Brief Research Report, plus short formats such as Uncover This Tech Term and Emerging Rad Dx)
+- **Review process:** pre-review technical-check desk gate; fast turnaround (Minor ≤30 d, Major ≤60 d); ICMJE forms only after acceptance
+- **Cascade / transfer:** full-OA society journal; peer Asian / society radiology journals as tier-equivalents
+
 ## Verification
 - **Source:** KJR-Instructions-202603.pdf (March 2026 official author instructions)
 - **Date:** 2026-05-21

--- a/skills/find-journal/references/journal_profiles/RYAI.md
+++ b/skills/find-journal/references/journal_profiles/RYAI.md
@@ -26,3 +26,11 @@ artificial intelligence, deep learning, machine learning, medical imaging AI, co
 
 ## Special Notes
 Radiology: Artificial Intelligence is the premier AI-focused radiology journal (IF ~8), a sister journal to Radiology. CLAIM checklist is mandatory for all AI studies. Strong emphasis on reproducibility, requiring code availability statements and model cards. Accepts AI studies at any development stage (unlike flagship Radiology which requires full clinical validation). AI policy: language editing only, dual disclosure required, AI images banned.
+
+## Acceptance Signals
+- **Selectivity band:** highly-selective
+- **Desk-reject triggers:** AI study without CLAIM compliance, code-availability statement, or model card; claims that exceed the study's validation stage; reproducibility gaps
+- **Design expectations:** validation rigor proportional to the claim (external validation strengthens deployment-stage claims); methodology and leakage controls clearly reported
+- **Study-type tolerance:** AI/ML methodology and validation at any development stage
+- **Review process:** CLAIM checklist mandatory; code availability + model card; dual AI disclosure; AI-generated images banned
+- **Cascade / transfer:** RSNA family; tier-down to a general radiology-AI or imaging-informatics journal

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_ceiling.txt
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_ceiling.txt
@@ -1,0 +1,18 @@
+ACCEPTANCE-READINESS PRE-FLIGHT
+file: manuscript.md
+note: advisory lexical scan — flags cap the venue tier a design can support;
+      not an acceptance prediction and not auto-fixable.
+
+flags:
+  L4  [DESIGN_CEILING] cross-sectional design :: cross-sectional data cannot support prognostic, causal, or surveillance claims
+  L4  [DESIGN_CEILING] single-center :: high-impact venues expect multi-center cohorts or external validation
+  L6  [DESIGN_CEILING] surrogate / non-invasive marker as endpoint :: a surrogate endpoint without a hard clinical or histologic endpoint caps clinical-impact claims
+  L7  [DESIGN_CEILING] no external validation :: a prediction/diagnostic model without external validation rarely clears a top venue
+  L7  [DESIGN_CEILING] pilot / preliminary framing :: appropriate for tolerant venues; high-impact originals expect a definitive design
+  L8  [UNFIXABLE_DEFECT] single-vendor / single-scanner :: vendor-locked acquisition is a hard generalizability ceiling
+  L11  [IMPORTANCE_RISK] negative / null framing :: a null/negative result needs explicit importance justification; low-impact nulls are desk-rejected
+  L12  [IMPORTANCE_RISK] incremental-gain framing :: incremental contribution is the single most common desk-rejection reason (~52%)
+  L15  [CLAIM_MISMATCH] management / surveillance claim :: verify the endpoint supports this action verb; a cross-sectional/surrogate design cannot
+
+summary: design_ceiling=5 unfixable_defect=1 importance_risk=2 claim_mismatch=1 total=9
+ceiling: HIGH-IMPACT VENUE UNLIKELY WITHOUT A DESIGN CHANGE

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_clean.txt
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/expected/report_clean.txt
@@ -1,0 +1,10 @@
+ACCEPTANCE-READINESS PRE-FLIGHT
+file: manuscript.md
+note: advisory lexical scan — flags cap the venue tier a design can support;
+      not an acceptance prediction and not auto-fixable.
+
+flags:
+  (none)
+
+summary: design_ceiling=0 unfixable_defect=0 importance_risk=0 claim_mismatch=0 total=0
+ceiling: NO STRUCTURAL CEILING DETECTED BY LEXICAL SCAN

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/fixture_ceiling/manuscript.md
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/fixture_ceiling/manuscript.md
@@ -1,0 +1,16 @@
+# Resolved HBV and Hepatic Steatosis: a Screening-Cohort Analysis
+
+## Abstract
+This single-center study used a cross-sectional design to examine the interplay
+between resolved hepatitis B, hepatic steatosis, and liver fibrosis.
+Fibrosis was assessed only by the FIB-4 surrogate index, a non-invasive marker.
+This is a preliminary pilot analysis; no external validation was performed.
+Imaging was acquired on a single-scanner protocol from one vendor.
+
+## Results
+The two conditions showed no synergy on the fibrosis index.
+The incremental value over age alone was marginal.
+
+## Conclusion
+We recommend annual surveillance for these patients, and the index is actionable
+for management decisions at the point of care.

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/fixture_clean/manuscript.md
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/fixture_clean/manuscript.md
@@ -1,0 +1,15 @@
+# Multi-Center External Validation of a Mortality Risk Model
+
+## Abstract
+We developed and externally validated a prognostic model for one-year mortality
+in a prospective multi-center cohort enrolled across multiple vendors and sites.
+The model was compared against the established clinical comparator, and a
+pre-registered statistical analysis plan governed all endpoints.
+
+## Results
+Discrimination held over the comparator with a hard clinical endpoint,
+and calibration was maintained in two independent external cohorts.
+
+## Conclusion
+We recommend the model guide management at discharge, with routine surveillance
+as part of standard care.

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/problem.md
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/problem.md
@@ -1,0 +1,38 @@
+# Challenge card — acceptance-readiness pre-flight
+
+**Tool under test:** `skills/find-journal/scripts/assess_acceptance_readiness.py`
+
+## What it guards
+`/find-journal` ranks journals by *scope fit*. But editors apply an earlier,
+decisive filter: **importance/novelty + design-ceiling**. The #1 desk-rejection
+driver is lack of novelty/importance (~52%), ahead of scope; and across editor
+decisions an *unfixable* design-ceiling defect floors the outcome at REJECT no
+matter how polished everything fixable is. This script supplies that missing
+**acceptance-feasibility** axis as a deterministic lexical pre-flight so the skill
+can gate the venue TIER a manuscript's design can credibly support.
+
+It is advisory (a risk/ceiling band with reasons), never an acceptance probability,
+and never auto-fixable.
+
+## Fixtures
+- `fixture_ceiling/manuscript.md` — seeded with one signal per category:
+  cross-sectional + single-center + surrogate (FIB-4) + no-external-validation +
+  pilot (DESIGN_CEILING ×5), single-vendor/single-scanner (UNFIXABLE_DEFECT),
+  null/negative + incremental framing (IMPORTANCE_RISK ×2), and a
+  management/surveillance claim (CLAIM_MISMATCH ×1). Expected: 9 flags, verdict
+  `HIGH-IMPACT VENUE UNLIKELY WITHOUT A DESIGN CHANGE`.
+- `fixture_clean/manuscript.md` — a multi-center, externally-validated, prospective
+  design with a hard endpoint and a comparator. It *deliberately* contains the
+  management/surveillance verbs ("we recommend … guide management … surveillance")
+  but **no** ceiling trigger, so the gated CLAIM_MISMATCH must stay silent.
+  Expected: 0 flags, verdict `NO STRUCTURAL CEILING DETECTED BY LEXICAL SCAN`
+  (the negative fixture — proves no false positives).
+
+## Pass criterion
+`verify.sh` runs the tool on both fixtures and diffs against the golden masters in
+`expected/`. Exit 0 iff both match. Deterministic and network-free.
+
+## Run
+```
+bash skills/find-journal/scripts/acceptance_readiness_challenge/verify.sh
+```

--- a/skills/find-journal/scripts/acceptance_readiness_challenge/verify.sh
+++ b/skills/find-journal/scripts/acceptance_readiness_challenge/verify.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Deterministic, network-free verifier for the acceptance-readiness challenge card.
+# Runs assess_acceptance_readiness.py on two synthetic manuscripts:
+#   - fixture_ceiling: seeded with design-ceiling / unfixable / importance / claim
+#     signals -> must flag all four categories (9 flags) and the HIGH-impact verdict.
+#   - fixture_clean: a strong multi-center externally-validated design that carries
+#     management/surveillance verbs but NO ceiling trigger -> must flag nothing
+#     (negative fixture: proves the gated CLAIM_MISMATCH does not false-fire).
+# Exit 0 = both reports match their golden masters.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TOOL="$HERE/../assess_acceptance_readiness.py"
+
+status=0
+for case in ceiling clean; do
+  actual="$(python3 "$TOOL" "$HERE/fixture_${case}/manuscript.md")"
+  if diff -u "$HERE/expected/report_${case}.txt" <(printf '%s\n' "$actual"); then
+    echo "PASS: ${case} report matches expected."
+  else
+    echo "FAIL: ${case} report drifted from expected/report_${case}.txt" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "PASS: acceptance-readiness pre-flight matches both golden masters (positive + negative)."
+fi
+exit "$status"

--- a/skills/find-journal/scripts/assess_acceptance_readiness.py
+++ b/skills/find-journal/scripts/assess_acceptance_readiness.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Acceptance-readiness pre-flight for /find-journal (Phase 2.5).
+
+A deterministic, stdlib-only lexical scan of a manuscript (or abstract) markdown
+file that surfaces the signals editors actually reject on BEFORE scope is even
+considered: design-ceiling, unfixable validity defects, importance/novelty risk,
+and endpoint-vs-claim mismatch.
+
+Why this exists
+---------------
+Empirically the #1 desk-rejection driver is lack of novelty/importance (~52%),
+ahead of scope mismatch; and across a curated editor-decision corpus the recurring
+pattern is that an *unfixable* design-ceiling defect floors the outcome at REJECT
+regardless of how polished everything fixable is. `/find-journal` already optimises
+scope fit; this script supplies the missing **acceptance-feasibility** axis so the
+skill can gate the venue TIER a manuscript's design can credibly support.
+
+This is an ADVISORY heuristic, not an acceptance prediction and not auto-fixable.
+It flags lexical signals for a human (or the skill's LLM phase) to weigh; it never
+rewrites the manuscript. Acceptance likelihood has no reliable data source and ML
+predictors cap well below certainty, so the output is a risk/ceiling band with
+reasons — never a probability.
+
+Usage
+-----
+  python3 assess_acceptance_readiness.py MANUSCRIPT.md
+  python3 assess_acceptance_readiness.py --json MANUSCRIPT.md
+
+Exit code is always 0 (advisory). Output is deterministic (sorted, stable) so it
+can be golden-mastered in a network-free challenge card.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Category display order (also the tie-break order in the sorted flag list).
+CATEGORIES = ("DESIGN_CEILING", "UNFIXABLE_DEFECT", "IMPORTANCE_RISK", "CLAIM_MISMATCH")
+CAT_ORDER = {c: i for i, c in enumerate(CATEGORIES)}
+
+# Each detector: (category, compiled regex, label, rationale).
+# Regexes are case-insensitive and intentionally conservative — a flag is a
+# prompt to verify, so a miss is safer than a false alarm. Keep them lexical and
+# stable; do not depend on sentence parsing.
+_D = lambda p: re.compile(p, re.IGNORECASE)
+
+DETECTORS = [
+    # --- DESIGN_CEILING: the design cannot support the claimed altitude ---
+    ("DESIGN_CEILING", _D(r"\bcross[-\s]?sectional\b"),
+     "cross-sectional design",
+     "cross-sectional data cannot support prognostic, causal, or surveillance claims"),
+    ("DESIGN_CEILING", _D(r"\b(?:surrogate|proxy)\b|\bFIB[-\s]?4\b|\bnon[-\s]?invasive (?:surrogate|marker)\b"),
+     "surrogate / non-invasive marker as endpoint",
+     "a surrogate endpoint without a hard clinical or histologic endpoint caps clinical-impact claims"),
+    ("DESIGN_CEILING", _D(r"\bsingle[-\s]?cent(?:er|re)\b"),
+     "single-center",
+     "high-impact venues expect multi-center cohorts or external validation"),
+    ("DESIGN_CEILING", _D(r"\b(?:no|without|lack(?:ing|ed|s)?(?: of)?) (?:an? )?external validation\b"
+                          r"|\bexternal validation (?:was )?(?:not|never) (?:performed|done|available|conducted)\b"),
+     "no external validation",
+     "a prediction/diagnostic model without external validation rarely clears a top venue"),
+    ("DESIGN_CEILING", _D(r"\b(?:pilot|preliminary|proof[-\s]?of[-\s]?concept|feasibility)\b"),
+     "pilot / preliminary framing",
+     "appropriate for tolerant venues; high-impact originals expect a definitive design"),
+
+    # --- UNFIXABLE_DEFECT: validity threats editors reject on, not revisable ---
+    ("UNFIXABLE_DEFECT", _D(r"\b(?:data|information) leakage\b|\btrain(?:ing)?[-/\s]test (?:overlap|contamination)\b"
+                            r"|\btarget[-\s]?derived\b"),
+     "possible data leakage",
+     "leakage is an unfixable validity threat; in-sample performance becomes uninterpretable"),
+    ("UNFIXABLE_DEFECT", _D(r"\bcircular(?:ity)?\b|\bself[-\s]?fulfilling\b"),
+     "circular design / validation",
+     "predicting a label from inputs that encode it is structurally guaranteed, not a finding"),
+    ("UNFIXABLE_DEFECT", _D(r"\bno (?:comparator|baseline)\b|\bwithout (?:a )?(?:comparator|baseline)\b"
+                            r"|\bno (?:standard|established) baseline\b"),
+     "missing comparator / baseline",
+     "without a field-standard comparator the contribution cannot be judged"),
+    ("UNFIXABLE_DEFECT", _D(r"\bsingle[-\s]?vendor\b|\bsingle[-\s]?scanner\b|\bone (?:vendor|scanner|device)\b"
+                            r"|\bvendor[-\s]?locked\b"),
+     "single-vendor / single-scanner",
+     "vendor-locked acquisition is a hard generalizability ceiling"),
+
+    # --- IMPORTANCE_RISK: the novelty/importance gate (top desk-reject cause) ---
+    ("IMPORTANCE_RISK", _D(r"\bshow(?:ed|s|n)? no\b|\bno (?:significant )?(?:association|difference|synerg(?:y|ies)|effect|benefit)\b"
+                           r"|\bdid not (?:differ|improve|change|increase|reduce)\b|\bnull (?:result|finding)\b"),
+     "negative / null framing",
+     "a null/negative result needs explicit importance justification; low-impact nulls are desk-rejected"),
+    ("IMPORTANCE_RISK", _D(r"\bincremental\b|\bmarginal\b|\bmodest improvement\b|\bslight(?:ly)? (?:better|higher|improved)\b"),
+     "incremental-gain framing",
+     "incremental contribution is the single most common desk-rejection reason (~52%)"),
+    ("IMPORTANCE_RISK", _D(r"\bsimilar to (?:previous|prior)\b|\bconsistent with (?:existing|prior) (?:work|literature)\b"
+                           r"|\bme[-\s]?too\b"),
+     "me-too positioning",
+     "framing the work as confirmatory of prior literature signals weak novelty"),
+
+    # --- CLAIM_MISMATCH: action verb that the endpoint may not support ---
+    # Emitted only when a DESIGN_CEILING signal also appears in the document
+    # (computed below), so the manuscript that legitimately earns the claim is
+    # not flagged.
+    ("CLAIM_MISMATCH", _D(r"\b(?:we )?recommend\b|\bdefer\b|\bwithhold\b|\bguide(?:s|d)? (?:management|treatment|therapy)\b"
+                          r"|\bsurveillance\b|\brescreen\b|\binitiate (?:treatment|therapy)\b|\bchange(?:s|d)? management\b"
+                          r"|\bactionable\b|\bpersonalized risk\b"),
+     "management / surveillance claim",
+     "verify the endpoint supports this action verb; a cross-sectional/surrogate design cannot"),
+]
+
+# Detectors whose presence marks the document as having a design ceiling, which
+# in turn enables CLAIM_MISMATCH emission.
+_CEILING_TRIGGER_LABELS = {
+    "cross-sectional design",
+    "surrogate / non-invasive marker as endpoint",
+    "pilot / preliminary framing",
+}
+
+VERDICT_NONE = "NO STRUCTURAL CEILING DETECTED BY LEXICAL SCAN"
+VERDICT_IMPORTANCE = "IMPORTANCE-FRAMING REVIEW RECOMMENDED"
+VERDICT_SPECIALTY = "SPECIALTY / TOLERANT-VENUE OR DESIGN FIX RECOMMENDED"
+VERDICT_HIGH = "HIGH-IMPACT VENUE UNLIKELY WITHOUT A DESIGN CHANGE"
+
+
+def scan(text: str):
+    """Return a sorted list of flags: (line_no, category, label, rationale)."""
+    lines = text.splitlines()
+    raw = []
+    doc_has_ceiling = False
+    # First pass: every detector except CLAIM_MISMATCH, and learn doc_has_ceiling.
+    for lineno, line in enumerate(lines, start=1):
+        for category, rx, label, rationale in DETECTORS:
+            if category == "CLAIM_MISMATCH":
+                continue
+            if rx.search(line):
+                raw.append((lineno, category, label, rationale))
+                if label in _CEILING_TRIGGER_LABELS:
+                    doc_has_ceiling = True
+    # Second pass: CLAIM_MISMATCH only when the document carries a ceiling signal.
+    if doc_has_ceiling:
+        for lineno, line in enumerate(lines, start=1):
+            for category, rx, label, rationale in DETECTORS:
+                if category != "CLAIM_MISMATCH":
+                    continue
+                if rx.search(line):
+                    raw.append((lineno, category, label, rationale))
+    # Dedupe identical (line, category, label) and sort deterministically.
+    seen = set()
+    flags = []
+    for lineno, category, label, rationale in raw:
+        key = (lineno, category, label)
+        if key in seen:
+            continue
+        seen.add(key)
+        flags.append((lineno, category, label, rationale))
+    flags.sort(key=lambda f: (f[0], CAT_ORDER[f[1]], f[2]))
+    return flags
+
+
+def verdict(counts):
+    if counts["UNFIXABLE_DEFECT"] > 0 or counts["DESIGN_CEILING"] >= 2:
+        return VERDICT_HIGH
+    if counts["DESIGN_CEILING"] >= 1 or counts["CLAIM_MISMATCH"] >= 1:
+        return VERDICT_SPECIALTY
+    if counts["IMPORTANCE_RISK"] >= 1:
+        return VERDICT_IMPORTANCE
+    return VERDICT_NONE
+
+
+def render_text(basename: str, flags, counts, verd) -> str:
+    out = []
+    out.append("ACCEPTANCE-READINESS PRE-FLIGHT")
+    out.append(f"file: {basename}")
+    out.append("note: advisory lexical scan — flags cap the venue tier a design can support;")
+    out.append("      not an acceptance prediction and not auto-fixable.")
+    out.append("")
+    out.append("flags:")
+    if flags:
+        for lineno, category, label, rationale in flags:
+            out.append(f"  L{lineno}  [{category}] {label} :: {rationale}")
+    else:
+        out.append("  (none)")
+    out.append("")
+    out.append(
+        "summary: design_ceiling={DESIGN_CEILING} unfixable_defect={UNFIXABLE_DEFECT} "
+        "importance_risk={IMPORTANCE_RISK} claim_mismatch={CLAIM_MISMATCH} total={total}".format(
+            total=sum(counts.values()), **counts
+        )
+    )
+    out.append(f"ceiling: {verd}")
+    return "\n".join(out)
+
+
+def build_report(path: Path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    flags = scan(text)
+    counts = {c: 0 for c in CATEGORIES}
+    for _lineno, category, _label, _rationale in flags:
+        counts[category] += 1
+    verd = verdict(counts)
+    return flags, counts, verd
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Acceptance-readiness pre-flight (advisory).")
+    ap.add_argument("manuscript", help="path to a manuscript / abstract markdown file")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = ap.parse_args(argv)
+
+    path = Path(args.manuscript)
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+
+    flags, counts, verd = build_report(path)
+
+    if args.json:
+        payload = {
+            "file": path.name,
+            "advisory": True,
+            "fixable_by_ai": False,
+            "flags": [
+                {"line": ln, "category": cat, "label": lab, "rationale": rat}
+                for ln, cat, lab, rat in flags
+            ],
+            "summary": {**counts, "total": sum(counts.values())},
+            "ceiling": verd,
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=False))
+    else:
+        print(render_text(path.name, flags, counts, verd))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/find-journal/skill.yml
+++ b/skills/find-journal/skill.yml
@@ -12,6 +12,7 @@ inputs:
   - "study type"
 outputs:
   - "ranked journal recommendations with scope rationale and AI-policy notes"
+  - "acceptance-readiness pre-flight (design-ceiling / unfixable-defect / importance-risk flags) and a reject-fallback cascade plan"
 side_effects:
   - reads_journal_profiles
 downstream_consumers:
@@ -29,7 +30,10 @@ safety_boundaries:
   - "Recommendations are drawn from the curated profile library, not invented venues."
 known_limitations:
   - "Coverage is limited to profiled journals; an unprofiled fit may be missed (add via add-journal)."
-  - "Scope-fit ranking is advisory, not an acceptance prediction."
+  - "Both axes (scope fit and acceptance feasibility) are advisory; the feasibility band is a risk/ceiling estimate with reasons, never an acceptance probability."
+  - "The Phase 2.5 pre-flight is a lexical/heuristic scan; it surfaces signals to weigh, not a verdict, and its flags are not auto-fixable."
 validation_commands:
+  - "python3 scripts/assess_acceptance_readiness.py <manuscript_or_abstract.md>"
+  - "bash scripts/acceptance_readiness_challenge/verify.sh  # deterministic, network-free"
   - "verify shortlisted journals' current scope and metrics at their official sites"
 evidence_surface: manual_workflow


### PR DESCRIPTION
## What
Adds an **acceptance-feasibility** axis to `/find-journal`, which until now ranked candidate journals on **scope fit only**. Editors apply an earlier, decisive filter — importance/novelty + design-ceiling — and this PR models it.

## Why
- The most common desk-rejection driver is **lack of novelty/importance**, ahead of scope.
- An **unfixable design-ceiling** defect (cross-sectional / surrogate endpoint, single-center, no external validation, leakage / circularity, vendor-lock) tends to floor the editor's outcome at reject regardless of how much fixable polish is added.
- Scope-fit recommenders (and the prior `/find-journal`) are blind to this, so they can recommend a high-impact venue whose bar the design cannot clear.

## Changes
- **Phase 2.5 acceptance-readiness pre-flight** — `scripts/assess_acceptance_readiness.py` (deterministic, stdlib-only) scans a manuscript for `DESIGN_CEILING` / `UNFIXABLE_DEFECT` / `IMPORTANCE_RISK` / `CLAIM_MISMATCH` signals and emits a ceiling verdict. **Advisory risk band, never a probability; flags are not auto-fixable.**
- **Reproducible challenge card** — positive (ceiling) + negative (clean) synthetic fixtures + a network-free `verify.sh`, wired into `skill.yml` `validation_commands`. The negative fixture carries management/surveillance verbs but no ceiling trigger, proving the gated `CLAIM_MISMATCH` does not false-fire.
- **Two-axis ranking** (scope fit × acceptance feasibility) with explicit mismatch surfacing — low-feasibility venues are demoted/annotated, never silently dropped.
- **New output** — Acceptance-Readiness Summary + Cascade plan (same-publisher transfer + tier-down + presubmission-inquiry when the risk is importance). Post-Rejection Mode now distinguishes desk-reject (importance/ceiling) from post-peer-review reject (transfer offer).
- **`Acceptance Signals` profile schema** (`references/acceptance_signals_schema.md`) populated for European_Radiology, AJR, KJR, RYAI, Investigative_Radiology — every line generic and traceable to the journal's own public guidance.
- **POLICY.md** — confidentiality-gated verification bar + promotion-checklist item (qualitative selectivity bands, no fabricated acceptance %).

## Counts / CI
- Helper named `assess_*` (not `check_*`) → **not** a detector-catalog member. Counts unchanged: **45 skills / 36 detectors / 38 reporting guidelines / 73 find-profiles**.
- CI-mirror regenerated and green: `gen_skill_docs` + `gen_distribution_manifest`; `validate_skills.sh` ALL CHECKS PASSED; catalog consistency, domain-probe sync (`--strict`), routing assets, skill contracts, locale inventory, version consistency; challenge `verify.sh` passes.

## Design notes
- IF / acceptance-rate are deliberately **not cached** (no acceptance-rate database exists; IF is paywalled and stale). Feasibility is a qualitative band with reasons.
- Confidential, per-journal editor-bar knowledge stays in the **user-local private overlay** (never in this repo) — the public `Acceptance Signals` lines are generic and source-traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
