### PR TITLE
docs(changelog): record find-journal acceptance-feasibility axis (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- **find-journal:** acceptance-feasibility axis. A Phase 2.5 pre-flight
+  (`assess_acceptance_readiness.py`, deterministic + reproducible challenge card)
+  scans a manuscript for design-ceiling / unfixable-defect / importance-risk /
+  claim-mismatch signals and a ceiling verdict (advisory risk band, never a
+  probability). Adds two-axis ranking (scope fit × acceptance feasibility) with
+  explicit mismatch surfacing, an `Acceptance Signals` profile schema
+  (`references/acceptance_signals_schema.md`, populated for European Radiology, AJR,
+  KJR, RYAI, Investigative Radiology), a reject-fallback cascade plan, and a
+  desk-reject vs post-review distinction in Post-Rejection Mode. Helper named
+  `assess_*` (not a detector-catalog member); counts unchanged (additive). (#215)
+
 ## [4.10.0] - 2026-06-28
 
 ### Added


### PR DESCRIPTION
Adds the `[Unreleased]` CHANGELOG entry for #215 (find-journal acceptance-feasibility axis), which merged **after** the v4.10.0 tag and so is captured in no release notes yet. This lets the next release (v5.0.0 in flight in a parallel session) **absorb it on rebase** without the release author hand-copying it.

CHANGELOG-only — version (4.10.0) and counts (45 skills / 36 detectors / 38 guidelines) unchanged; distribution manifest, skill docs, and catalog consistency all unaffected (verified `--check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)