### PR TITLE
release: v4.11.0 — v5.0 model-engineering lane Phases 1–4 (6 skills, 5 detectors, 2 probes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [4.11.0] - 2026-06-28
+
 ### Added
 
 - **find-journal:** acceptance-feasibility axis. A Phase 2.5 pre-flight

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "4.10.0"
+version: "4.11.0"
 date-released: "2026-06-28"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "4.10.0",
+  "version": "4.11.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
**v4.11.0** — bundles the additive work merged since v4.10.0 into a tagged release (GitHub Release + npm + Zenodo via `release.yml` on the `v4.11.0` tag).

## Highlights
- **Medical-AI model-engineering lane (v5.0 Phases 1–4)** — the choose → build → validate → evaluate → report chain, clinician-anchored and torch-free:
  - `/architecture-zoo` (choose), `/model-scaffold` (build runnable PyTorch repos), `/model-validation` (validate), `/model-evaluation` + `/mllm-eval` (evaluate), `/model-card` (report).
  - detectors: `check_split_leakage`, `check_training_hygiene`, `check_metric_reporting`, `check_mllm_eval_completeness`, `check_model_card_complete`.
  - reviewer probes: `model_development` (MD0–MD8), `mllm_evaluation` (ME0–ME8); uncounted appraisal ref Metrics Reloaded.
  - integrates MONAI / nnU-Net / TorchIO — does not replace them.
- **`/find-journal` acceptance-feasibility axis** (#215).

## Counts
skills **45 → 51**, integrity detectors **36 → 41**, domain-probe modules **15 → 17**; `reporting_guidelines` **38 unchanged** (Model Card / Datasheet / Metrics Reloaded vendored as uncounted templates / appraisal refs). Additive minor — no breaking change; the dedicated `model_engineering` storefront category + plugin are reserved for v5.0.0.

## Release shape
CITATION.cff / package.json / distribution_manifest.json → 4.11.0; CHANGELOG `[Unreleased]` → `[4.11.0]`. After merge, the `v4.11.0` annotated tag triggers the release workflow (GitHub Release + ZIPs + provenance attestation + npm publish + Zenodo archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)