### PR TITLE
feat(storefront): v5.0.0 — model_engineering category + medsci-modeling plugin + end-to-end repositioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,6 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/architecture-zoo",
         "./skills/calc-sample-size",
         "./skills/clean-data",
         "./skills/define-variables",
@@ -33,12 +32,21 @@
         "./skills/design-ai-benchmarking",
         "./skills/design-study",
         "./skills/generate-codebook",
+        "./skills/version-dataset"
+      ]
+    },
+    {
+      "name": "medsci-modeling",
+      "description": "Clinical AI model research engineering: choose a paper-grounded architecture, scaffold a reproducible PyTorch training repo, validate the model's split and validation design, document it (Model Card / Datasheet), and evaluate models or LLMs/MLLMs on clinical tasks. Integrates MONAI / nnU-Net, never replaces them.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/architecture-zoo",
         "./skills/mllm-eval",
         "./skills/model-card",
         "./skills/model-evaluation",
         "./skills/model-scaffold",
-        "./skills/model-validation",
-        "./skills/version-dataset"
+        "./skills/model-validation"
       ]
     },
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "MedSci Skills: Claude Code Skills for the Medical Research Lifecycle",
-  "description": "An opinionated, physician-built collection of Claude Code skills covering the full medical research workflow — literature search with anti-hallucination citation verification, study design, IRB protocols, statistical analysis, publication-ready figures, IMRAD manuscript drafting, reporting compliance audits against 32 EQUATOR guidelines (STARD, STARD-AI, TRIPOD+AI, CLAIM, PRISMA-DTA, STROBE, CONSORT, etc.), journal selection, peer review, and revision response. Three end-to-end demos with public datasets produce submission-ready manuscripts.",
+  "description": "An opinionated, physician-built collection of Claude Code skills covering the full medical research workflow — literature search with anti-hallucination citation verification, study design, IRB protocols, statistical analysis, publication-ready figures, IMRAD manuscript drafting, reporting compliance audits against 38 EQUATOR reporting guidelines and risk-of-bias tools (STARD, STARD-AI, TRIPOD+AI, CLAIM, PRISMA-DTA, STROBE, STROBE-MR, PGS-RS, CONSORT, etc.), journal selection, peer review, and revision response. As of v5.0 it adds a clinical AI model-engineering lane: choose a paper-grounded architecture, scaffold a reproducible, leakage-safe PyTorch training repo, and validate, document, and evaluate a medical-imaging or LLM/MLLM model — integrating MONAI / nnU-Net, never replacing them. Three end-to-end demos with public datasets produce submission-ready manuscripts.",
   "creators": [
     {
       "name": "Nam, Yoojin",
@@ -26,7 +26,11 @@
     "strobe",
     "pubmed",
     "irb-protocol",
-    "physician-researcher"
+    "physician-researcher",
+    "medical-imaging-ai",
+    "deep-learning",
+    "model-validation",
+    "reproducibility"
   ],
   "communities": [
     {"identifier": "open-research"}
@@ -40,5 +44,5 @@
     }
   ],
   "language": "eng",
-  "notes": "If you use MedSci Skills in your research, please cite this Zenodo record. The repository contains comprehensive documentation, three end-to-end demos with public datasets (Wisconsin Breast Cancer, BCG meta-analysis, NHANES), and 32 EQUATOR reporting guideline checklists."
+  "notes": "If you use MedSci Skills in your research, please cite this Zenodo record. The repository contains comprehensive documentation, three end-to-end demos with public datasets (Wisconsin Breast Cancer, BCG meta-analysis, NHANES), and 38 EQUATOR reporting guideline and risk-of-bias checklists."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-06-28
+
+### Changed
+
+- **v5.0.0 — storefront repositioning for the medical-AI model-engineering lane.** A material
+  distribution change, not a label bump: the model-engineering lane (built additively across
+  v4.x Phases 1–4 plus the Phase 5 breadth below) now has its own storefront home and the repo's
+  identity is widened to cover it.
+  - **New `model_engineering` storefront category** ("Model Engineering & Validation") and
+    **`medsci-modeling` marketplace plugin**, carved out of "Data & Study Design" (`medsci-data`).
+    The 6 lane skills — `architecture-zoo`, `model-scaffold`, `model-validation`, `model-card`,
+    `model-evaluation`, `mllm-eval` — now group under their own catalog filter and installable
+    plugin (`/plugin` now lists nine category plugins). Both catalog generators
+    (`gen_skills_catalog_json.py` category mapping/order, `gen_marketplace_json.py` plugin
+    name/description) and their self-tests cover the new category.
+  - **README + ROADMAP repositioned to the end-to-end identity**: MedSci Skills is an end-to-end
+    research tool for physician and medical-engineering researchers to design → scaffold →
+    validate → publish — for the clinical manuscript and the medical-AI model alike. "Clinical AI
+    model research engineering is in scope" is now explicit, while "not a general AI-scientist
+    platform" (and not a diagnostic tool or autonomous author) is kept; the lane **integrates**
+    MONAI / nnU-Net and never reimplements them or runs anything autonomously.
+  - Counts unchanged (**51 skills / 41 detectors / 38 reporting guidelines**); CI stays torch-free.
+
 ### Added
 
 - **Medical-AI model-engineering lane — Phase 5 (build-lane breadth).** Expands the existing

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "4.11.0"
+version: "5.0.0"
 date-released: "2026-06-28"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **51 skills that actually work.** Built by a physician-researcher, tested on real publications.
 
-*MedSci Skills is a submission-grade clinical manuscript workflow, not a generic biomedical skill catalog. Its moat is the compliance layer — 38 reporting guidelines and risk-of-bias tools, reference/citation verification, and deterministic integrity gates, before peer review sees the manuscript. It competes on clinical submission reliability, not skill count.*
+*MedSci Skills is an end-to-end research tool for physician and medical-engineering researchers — design → scaffold → validate → publish — for the clinical manuscript and the medical-AI model behind it. Its moat is the compliance layer — 38 reporting guidelines and risk-of-bias tools, reference/citation verification, and deterministic integrity gates before peer review — now extended by a model-engineering lane that scaffolds reproducible, leakage-safe training repos and audits model validation. Clinical AI model research engineering is in scope; a general AI-scientist platform is not. It competes on clinical submission reliability, not skill count.*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Aperivue/medsci-skills?style=flat-square&color=blue)](https://github.com/Aperivue/medsci-skills/releases/latest)
@@ -42,14 +42,20 @@
 ## What is MedSci Skills?
 
 MedSci Skills is an open-source Claude Code skill collection for **clinical
-manuscript preparation**. It helps physician-researchers and biomedical
-investigators move from literature search, study design, statistics, and figures to
-reporting-guideline compliance, citation/reference auditing, numerical-consistency
-checks, and response-to-reviewer workflows — combining agentic writing with
-**deterministic integrity gates** for submission-grade biomedical research. It is
-**not** a diagnostic tool, an autonomous author, or a general AI-scientist platform;
-every output requires human-expert verification. New here? See the
-[3 workflows below](#start-here-3-workflows), the [FAQ](docs/faq.md), and the
+research — the manuscript and the medical-AI model alike**. It helps
+physician-researchers and biomedical/medical-engineering investigators move from
+literature search, study design, statistics, and figures to reporting-guideline
+compliance, citation/reference auditing, numerical-consistency checks, and
+response-to-reviewer workflows — combining agentic writing with **deterministic
+integrity gates** for submission-grade biomedical research. As of **v5.0** it adds a
+**model-engineering lane**: choose a paper-grounded architecture, scaffold a
+reproducible, leakage-safe PyTorch training repo, and validate, document, and
+evaluate a medical-imaging or LLM/MLLM model so the work reaches a paper — it
+**integrates** MONAI / nnU-Net, never reimplements them. Clinical AI model research
+engineering is in scope; it is **not** a diagnostic tool, an autonomous author, or a
+general AI-scientist platform, and every output requires human-expert verification.
+New here? See the [3 workflows below](#start-here-3-workflows), the
+[FAQ](docs/faq.md), and the
 [scope boundary](ROADMAP.md#not-planned--explicitly-out-of-scope).
 
 ---
@@ -82,17 +88,18 @@ Restart Claude Code, then start with **`/orchestrate`** — it classifies your r
 
 ### Install as a Claude Code plugin
 
-Prefer plugins? One line adds the marketplace; `/plugin` then lets you browse eight category plugins and enable the ones you want:
+Prefer plugins? One line adds the marketplace; `/plugin` then lets you browse nine category plugins and enable the ones you want:
 
 ```text
 /plugin marketplace add Aperivue/medsci-skills
-/plugin            # browse eight category plugins; enable the ones you want
+/plugin            # browse nine category plugins; enable the ones you want
 ```
 
 | Plugin | Covers |
 |--------|--------|
 | `medsci-literature` | Literature search, full-text retrieval, Zotero sync, reference-integrity audits |
 | `medsci-data` | Study design, variable operationalization, sample size, data cleaning, de-identification, codebooks, dataset versioning |
+| `medsci-modeling` | Architecture selection, reproducible model-scaffold repos, model-validation audits, Model Card/Datasheet, model & LLM/MLLM evaluation |
 | `medsci-analysis` | Statistics, figures, batch/cross-national/replication analysis, meta-analysis |
 | `medsci-writing` | IMRAD & protocol drafting, AI-pattern removal, AI-search optimization, reviewer responses |
 | `medsci-review` | Self-review, peer review, reporting-guideline compliance |
@@ -452,7 +459,7 @@ ma-scout -> search-lit -> fulltext-retrieval -> design-study ──> write-proto
 | **design-study** | Study design review: identifies analysis unit, cohort logic, data leakage risks, comparator design, validation strategy, and reporting guideline fit. |
 | **design-ai-benchmarking** | Design and validity review for benchmarking AI system(s) against a human-expert panel: evaluation-question and arm definition, decoupled multi-dimensional rubrics with anchors, planted calibration probes (positive-control / known-bad / instability / mechanism-contradiction), reviewer-panel construction with per-reviewer randomization, inter-rater reliability targets with separate control-item reliability, LLM-as-judge vs human-as-judge adjudication, construct-independence guards, and a structured JSON rating-export schema. Locks the rubric before data collection. |
 | **model-validation** | Design or audit the clinical-validation study for an engineer-built medical-imaging model (segmentation / classification / detection): patient-level split disjointness and the data-leakage taxonomy, tuning-on-test, internal vs genuine external validation, comparator design, single-run vs multi-seed variance, task-correct metric selection (Metrics Reloaded), test-set sizing, and CLAIM 2024 / TRIPOD+AI / STARD-AI reporting fit. Ships a deterministic split-leakage gate that proves patient disjointness by set arithmetic on the emitted split table. Integrates with MONAI / nnU-Net — does not replace them. |
-| **model-scaffold** | Generate a reproducible, runnable PyTorch training repo for a medical-imaging segmentation task — the missing middle link between choosing an architecture and validating a trained model. Emits a patient-level seed-locked split as an auditable artifact, a configurable U-Net, train/evaluate scripts that seed every RNG and infer under eval mode, a config, requirements, a reproducibility record, and a Methods stub with VERIFY placeholders (no fabricated numbers). Reproducibility holds by construction; ships a `check_training_hygiene` AST gate + a network-free build→validate challenge. Integrates with MONAI / nnU-Net / TorchIO — does not reimplement them. |
+| **model-scaffold** | Generate a reproducible, runnable PyTorch training repo for a medical-imaging task — segmentation (U-Net), classification, detection, image-to-image synthesis, or self-supervised pretraining — the missing middle link between choosing an architecture and validating a trained model. Emits a patient-level seed-locked split as an auditable artifact, a task-appropriate model, train/evaluate scripts that seed every RNG and infer under eval mode, a config, requirements, a reproducibility record, and a Methods stub with VERIFY placeholders (no fabricated numbers). Reproducibility holds by construction; ships a `check_training_hygiene` AST gate + a network-free build→validate challenge. Integrates with MONAI / nnU-Net / TorchIO / timm / torchvision — does not reimplement them. |
 | **architecture-zoo** | "Which architecture for which research question" decision tool: maps task (classification / segmentation / detection / transfer), modality, data scale, and class imbalance to a paper-grounded architecture shortlist. Curates the foundational curriculum (ResNet / DenseNet / EfficientNet / ViT / Swin; U-Net / 3-D U-Net / Attention & Residual U-Net / nnU-Net / Mask R-CNN; SAM/MedSAM / TotalSegmentator / BiomedCLIP / DINO / MAE / SimCLR) — each with core idea, when-to-use, medical-imaging use, reference implementation, validation setup, and the matching model-scaffold template. Advisory; teaches archetypes, not a live SOTA leaderboard. |
 | **model-card** | Generate the documentation an engineer-built medical-imaging model must carry — a Model Card (Mitchell et al. 2019), a Datasheet for its dataset (Gebru et al. 2021), and a METRIC-informed data-quality pass — filled from user-supplied facts (never fabricated), then verify every required section is present and non-empty with a deterministic completeness gate (`check_model_card_complete`). Model Card / Datasheet are documentation standards vendored as templates, not counted reporting checklists. |
 | **model-evaluation** | Compute and report task-correct held-out metrics for a trained medical-imaging model — segmentation (Dice + a boundary metric HD95/NSD, per structure), classification (AUROC + AUPRC + sensitivity/specificity with bootstrap CIs at the deployment prevalence), or detection (FROC/mAP with a stated IoU criterion) — plus calibration and subgroup slices. Emits a per-case table for analyze-stats and gates the metric choice against Metrics Reloaded / CLAIM 2024 (`check_metric_reporting`). Numbers come only from executed code. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,12 +48,21 @@ MedSci Skills is **narrow on purpose**. It will not become:
 - an **autonomous manuscript generator** that replaces human authors,
   statisticians, reviewers, IRBs, or journal requirements;
 - a broad **general AI-scientist** platform spanning chemistry / drug discovery /
-  bench biology;
+  bench biology, or one that runs experiments autonomously;
 - a source of **unsupported guideline interpretation** or **clinical-validation**
   claims about the toolkit itself.
 
-These boundaries are a feature: the value comes from doing clinical-manuscript
-workflow well, with human experts in the loop, not from breadth.
+**In scope (as of v5.0):** *clinical AI model research engineering* — choosing a
+paper-grounded architecture, scaffolding a reproducible training repo, and
+validating, documenting, and evaluating a medical-imaging or LLM/MLLM model so the
+work reaches a manuscript. This is the model-engineering lane; it **integrates**
+MONAI / nnU-Net and never reimplements them, and it never trains or claims results
+autonomously — a human expert runs and verifies everything. That is different from a
+general autonomous AI-scientist, which remains out of scope.
+
+These boundaries are a feature: the value comes from doing clinical research
+workflow — manuscript and model alike — well, with human experts in the loop, not
+from breadth.
 
 ## How priorities are set
 

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "4.11.0",
+  "version": "5.0.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/metadata/skills_catalog.json
+++ b/metadata/skills_catalog.json
@@ -17,7 +17,6 @@
       "key": "data_study_design",
       "label": "Data & Study Design",
       "slugs": [
-        "architecture-zoo",
         "calc-sample-size",
         "clean-data",
         "define-variables",
@@ -25,12 +24,19 @@
         "design-ai-benchmarking",
         "design-study",
         "generate-codebook",
+        "version-dataset"
+      ]
+    },
+    {
+      "key": "model_engineering",
+      "label": "Model Engineering & Validation",
+      "slugs": [
+        "architecture-zoo",
         "mllm-eval",
         "model-card",
         "model-evaluation",
         "model-scaffold",
-        "model-validation",
-        "version-dataset"
+        "model-validation"
       ]
     },
     {
@@ -132,8 +138,8 @@
     },
     {
       "slug": "architecture-zoo",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "D",
       "owner_domain": "architecture_reference",
       "maturity": "official",
@@ -366,8 +372,8 @@
     },
     {
       "slug": "mllm-eval",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "D",
       "owner_domain": "model_evaluation",
       "maturity": "official",
@@ -375,8 +381,8 @@
     },
     {
       "slug": "model-card",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "C",
       "owner_domain": "model_reporting",
       "maturity": "official",
@@ -384,8 +390,8 @@
     },
     {
       "slug": "model-evaluation",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "B",
       "owner_domain": "model_evaluation",
       "maturity": "official",
@@ -393,8 +399,8 @@
     },
     {
       "slug": "model-scaffold",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "B",
       "owner_domain": "model_development",
       "maturity": "official",
@@ -402,8 +408,8 @@
     },
     {
       "slug": "model-validation",
-      "category": "data_study_design",
-      "category_label": "Data & Study Design",
+      "category": "model_engineering",
+      "category_label": "Model Engineering & Validation",
       "layer": "D",
       "owner_domain": "model_validation",
       "maturity": "official",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "4.11.0",
+  "version": "5.0.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",

--- a/scripts/gen_marketplace_json.py
+++ b/scripts/gen_marketplace_json.py
@@ -62,6 +62,7 @@ OWNER = {"name": "Aperivue"}  # public org; no personal email (PII-safe)
 PLUGIN_NAME_BY_CATEGORY: dict[str, str] = {
     "literature_references": "medsci-literature",
     "data_study_design": "medsci-data",
+    "model_engineering": "medsci-modeling",
     "analysis_figures": "medsci-analysis",
     "writing_manuscript": "medsci-writing",
     "review_compliance": "medsci-review",
@@ -80,6 +81,12 @@ PLUGIN_DESC_BY_CATEGORY: dict[str, str] = {
         "Study design and validity review, literature-grounded variable "
         "operationalization, sample-size planning, data cleaning, de-identification, "
         "codebook generation, and dataset versioning."
+    ),
+    "model_engineering": (
+        "Clinical AI model research engineering: choose a paper-grounded architecture, "
+        "scaffold a reproducible PyTorch training repo, validate the model's split and "
+        "validation design, document it (Model Card / Datasheet), and evaluate models or "
+        "LLMs/MLLMs on clinical tasks. Integrates MONAI / nnU-Net, never replaces them."
     ),
     "analysis_figures": (
         "Reproducible statistical analysis, publication-ready figures, "

--- a/scripts/gen_skills_catalog_json.py
+++ b/scripts/gen_skills_catalog_json.py
@@ -50,13 +50,14 @@ CATEGORY_BY_OWNER_DOMAIN: dict[str, tuple[str, str]] = {
     "data_preparation": ("data_study_design", "Data & Study Design"),
     "data_documentation": ("data_study_design", "Data & Study Design"),
     "dataset_versioning": ("data_study_design", "Data & Study Design"),
-    # Model engineering & validation (v5.0 lane — interim home; carves its own
-    # "Model Engineering & Validation" storefront category at the v5.0.0 major).
-    "model_validation": ("data_study_design", "Data & Study Design"),
-    "model_development": ("data_study_design", "Data & Study Design"),
-    "architecture_reference": ("data_study_design", "Data & Study Design"),
-    "model_reporting": ("data_study_design", "Data & Study Design"),
-    "model_evaluation": ("data_study_design", "Data & Study Design"),
+    # Model engineering & validation (v5.0 lane — its own storefront category as of
+    # the v5.0.0 major: design an architecture, scaffold a reproducible repo, validate
+    # the model, report it, and evaluate models / LLMs-MLLMs on clinical tasks).
+    "model_validation": ("model_engineering", "Model Engineering & Validation"),
+    "model_development": ("model_engineering", "Model Engineering & Validation"),
+    "architecture_reference": ("model_engineering", "Model Engineering & Validation"),
+    "model_reporting": ("model_engineering", "Model Engineering & Validation"),
+    "model_evaluation": ("model_engineering", "Model Engineering & Validation"),
     # Analysis & figures
     "statistical_analysis": ("analysis_figures", "Analysis & Figures"),
     "figure_generation": ("analysis_figures", "Analysis & Figures"),
@@ -99,6 +100,7 @@ CATEGORY_BY_OWNER_DOMAIN: dict[str, tuple[str, str]] = {
 CATEGORY_ORDER = [
     "literature_references",
     "data_study_design",
+    "model_engineering",
     "analysis_figures",
     "writing_manuscript",
     "review_compliance",

--- a/tests/test_marketplace_json.sh
+++ b/tests/test_marketplace_json.sh
@@ -77,7 +77,7 @@ root=Path('$REPO_ROOT')
 mk=json.load(open(root/'.claude-plugin'/'marketplace.json'))
 cat=json.load(open(root/'metadata'/'skills_catalog.json'))
 errs=[]
-# marketplace identity + 8 plugins
+# marketplace identity + one plugin per catalog category
 if mk.get('name')!='medsci-skills': errs.append('name != medsci-skills')
 if len(mk['plugins'])!=len(cat['categories']):
     errs.append('plugin count != category count')


### PR DESCRIPTION
## v5.0.0 — storefront major for the medical-AI model-engineering lane

A **material distribution change**, not a label bump. The model-engineering lane was built additively across v4.x (Phases 1–4) plus Phase 5 (build-lane breadth, now in this release); v5.0.0 gives it a dedicated storefront home and widens the repo identity to cover it.

### Storefront carve
- **New category `model_engineering`** ("Model Engineering & Validation") and **new marketplace plugin `medsci-modeling`**, carved out of "Data & Study Design" (`medsci-data`).
- The 6 lane skills — `architecture-zoo`, `model-scaffold`, `model-validation`, `model-card`, `model-evaluation`, `mllm-eval` — now group under their own catalog filter and installable plugin (`/plugin` now lists **nine** category plugins).
- Both catalog generators updated with their self-tests: `gen_skills_catalog_json.py` (category mapping + order) → 9 categories; `gen_marketplace_json.py` (plugin name + description) → 9 plugins. Generator self-tests assert plugin-per-category coverage dynamically (6/6 + 7/7 pass).

### Repositioning
- README masthead + ROADMAP rewritten to the **end-to-end identity**: an end-to-end research tool to **design → scaffold → validate → publish** — for the clinical manuscript **and** the medical-AI model behind it.
- **"Clinical AI model research engineering is in scope"** is now explicit, while **"not a general AI-scientist platform"** (nor a diagnostic tool / autonomous author) is kept. The lane **integrates** MONAI / nnU-Net and never reimplements them or runs anything autonomously.

### Release bookkeeping
- Version **4.11.0 → 5.0.0**: `CITATION.cff`, `package.json`, `metadata/distribution_manifest.json` (all three agree; `check_version_consistency` green).
- `CHANGELOG.md` cut `[5.0.0] - 2026-06-28` (Phase 5 content moved under it).
- `.zenodo.json` release record refreshed (stale "32 EQUATOR guidelines" → 38 + model-lane clause + discovery keywords).
- **Counts unchanged: 51 skills / 41 detectors / 38 reporting guidelines.** CI stays torch-free.

### Gates (all green locally, CI-mirror)
`validate_skills.sh` (PII clean) · all `gen_*` `--check` (catalog/marketplace/detectors/skill_docs/distribution_manifest) · `validate_catalog_consistency` · `check_version_consistency` · `check_domain_probe_sync --strict` (17 modules) · `check_frontmatter_schema` · `validate_routing_assets --strict` · `check_locale_inventory` · `check_npm_package_contents` · catalog/marketplace/detectors/hero self-tests (6/7/7/28).

### Deferred (separate, outward-facing — needs explicit auth)
- **Hero mirror** for a lane skill: creating a public `Aperivue/<skill>` repo is a publish action; not bundled here to keep this PR strictly in-repo and non-publishing.
- **aperivue-web** homepage lane section (separate repo PR).
- **Release publication** (tag + GitHub Release + npm + Zenodo) held for explicit per-release authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)