### PR TITLE
release: v5.1.0 (lit-sync fulltext-retrieval phase + OA cascade consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-06-29
+
+### Added
+
+- **`/lit-sync` fulltext-retrieval phase (opt-in, owner-only).** A new Phase 2.7 orchestrates two
+  complementary full-text routes and reconciles them into `references/fulltext_retrieval.json`:
+  disk open-access PDFs by delegating to the `/fulltext-retrieval` engine, and in-library
+  Zotero-native PDFs via a user-run `find_available_pdf.js` snippet that triggers Zotero's own
+  `addAvailablePDF` / `addAvailablePDFs` — reusing the user's own proxy / OpenURL configuration, so
+  no credentials or institutional identifiers ever enter the skill. Adds a DOI/PMID/Title worklist
+  entry mode.
+- **`fetch_oa.py` (the single authored open-access cascade) enhancements:** TSV/CSV/Markdown-table +
+  `Title` worklist parsing; direct **arXiv** resolution for `10.48550/arXiv.*` DOIs (new/old-style,
+  version suffixes); a `--report retrieval_report.json` (schema_version + per-DOI
+  `status`/`source`/`title_match` tri-state); and pure, offline-testable report/title-match helpers
+  with a best-effort `pdftotext` title cross-check that **flags** mislabeled PDFs without
+  auto-rejecting them. New network-free `fetch_oa_report_challenge` wired into CI.
+
+### Changed
+
+- **DRY consolidation.** `/search-lit` Phase 5 now delegates full-text retrieval to
+  `/fulltext-retrieval` and drops the duplicated inline open-access code (and the unsafe Sci-Hub
+  env-var wording) — the OA cascade now lives in exactly one authored place.
+- Counts unchanged (**51 skills / 41 detectors / 38 reporting guidelines / 14 probes**).
+
 ## [5.0.0] - 2026-06-28
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.0.0"
-date-released: "2026-06-28"
+version: "5.1.0"
+date-released: "2026-06-29"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.0.0",
+  "version": "5.1.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
## Summary

Version bump **5.0.0 → 5.1.0** to ship the already-merged PR #226 as a rolling release.

CITATION.cff + package.json + `metadata/distribution_manifest.json` all declare **5.1.0** (3-source version gate green). CHANGELOG `[5.1.0]` entry added.

### What 5.1.0 ships (PR #226)
- `/lit-sync` **Phase 2.7** opt-in fulltext retrieval: disk OA (delegates to `/fulltext-retrieval`) + in-library Zotero-native `find_available_pdf.js` (proxy-aware, zero institutional info), reconciled into `references/fulltext_retrieval.json`.
- `fetch_oa.py`: TSV/CSV/MD + Title worklist, direct arXiv resolution, `--report retrieval_report.json` (per-DOI `title_match` tri-state), offline-testable helpers + CI-wired `fetch_oa_report_challenge`.
- DRY: `/search-lit` Phase 5 delegates to `/fulltext-retrieval`; Sci-Hub wording removed.

**Additive** — counts unchanged (51 skills / 41 detectors / 38 guidelines / 14 probes). No catalog/probe changes.

After merge: tag `v5.1.0` → release.yml (GitHub Release + classroom ZIPs + provenance attest + npm publish + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)