### PR TITLE
release: v5.2.0 (model-lane reference grounding + detection metric-gate fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-06-29
+
+### Added
+
+- **Model-engineering lane — reference grounding for three thin lane skills.** New load-on-demand
+  reference docs, grounded in named public standards (cross-checked against the repo's own
+  check-reporting SSOT, e.g. STARD-AI *Nat Med* 2025, PROBAST+AI *BMJ* 2025), wired into each
+  SKILL.md:
+  - `model-validation/references/validation_design.md` — data-leakage taxonomy, internal vs
+    genuine-external validation, comparator/variance/test-set sizing, CLAIM 2024 / TRIPOD+AI /
+    STARD-AI reporting map.
+  - `mllm-eval/references/evaluation_axes.md` — clinical-efficacy metrics beyond n-gram overlap,
+    faithfulness/hallucination, benchmark contamination, prompt-sensitivity, answer-matching,
+    reader study.
+  - `model-evaluation/references/metric_selection_grounding.md` — Metrics Reloaded task-fingerprint
+    principle, calibration vs discrimination, disaggregated reporting, CLAIM 2024 reporting fit.
+
+### Fixed
+
+- **`model-evaluation` metric-reporting gate false positive.** `check_metric_reporting.py`'s
+  `iou_crit` proximity window used `[^.\n]`, so a hard-wrapped IoU match criterion (the IoU and its
+  threshold on different physical lines) was undetectable and the gate fired a spurious
+  `DETECTION_METRIC_MISSING` on a legitimately formatted detection report. Changed to `[^.]`
+  (newline-tolerant, still period-bounded); locked by a load-bearing `det_good_wrapped` regression
+  case plus `det_no_iou` detection-branch coverage in the CI-wired `metric_reporting_challenge`.
+
+- Counts unchanged (**51 skills / 41 detectors / 38 reporting guidelines / 14 probes**); reference
+  docs are uncounted.
+
 ## [5.1.0] - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.1.0"
+version: "5.2.0"
 date-released: "2026-06-29"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.1.0",
+  "version": "5.2.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
## Summary
Version bump **5.1.0 → 5.2.0** to ship the already-merged PR #228 as a rolling release. CITATION.cff + package.json + `metadata/distribution_manifest.json` all declare **5.2.0** (3-source gate green); CHANGELOG `[5.2.0]` added.

### What 5.2.0 ships (PR #228)
- Three model-engineering-lane **reference-grounding docs** (model-validation / mllm-eval / model-evaluation), grounded in named public standards (cross-checked vs the repo's check-reporting SSOT), wired load-on-demand into each SKILL.md.
- **Fix**: `model-evaluation` `check_metric_reporting.py` `iou_crit` newline-tolerance — a hard-wrapped IoU match criterion no longer fires a spurious `DETECTION_METRIC_MISSING`; locked by a load-bearing regression case + detection-branch coverage in the CI-wired `metric_reporting_challenge`.

**Additive** — counts unchanged (51 / 41 / 38 / 14). After merge: tag `v5.2.0` → release.yml (GitHub Release + classroom ZIPs + provenance attest + npm publish + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)