### PR TITLE
release: v5.3.0 (CHEERS 2022 health-economic-evaluation lane)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-06-29
+
+### Added
+
+- **Health economic evaluation lane (CHEERS 2022).** A new study-genre lane filling the suite's
+  largest open reporting gap (absent from medsci-skills and from competing toolkits), surfaced by an
+  EQUATOR-grounded competitor + reporting-standard research scan:
+  - `check-reporting/references/checklists/CHEERS_2022.md` — faithful 28-item CHEERS 2022 summary
+    (CC BY 4.0, Husereau et al. *BMJ* 2022); routed via the study-type table + `cheers`/`cheers2022`
+    aliases. **Reporting guidelines 38 → 39.**
+  - `peer-review` + `self-review` `domain-probes/health_economic_evaluation.md` (HE1–HE8; vendored
+    byte-identical, review domain-probe modules 17 → 18): comparator/perspective, time-horizon &
+    discounting, effectiveness source + QALY valuation, costing/currency/price-year, model structure
+    + validation, deterministic and **probabilistic** uncertainty (PSA/CEAC, not a point ICER), ICER
+    vs a stated willingness-to-pay threshold + dominance, equity/generalisability/funding-COI.
+  - `analyze-stats` `analysis_guides/health_economic_evaluation.md` + SKILL entry — ICER/net-benefit,
+    decision-analytic models (Markov/DES), PSA → plane + CEAC, `heemod`/`dampack`/`BCEA`.
+- Counts: 51 skills / 41 detectors / **39 reporting guidelines** / 18 review domain-probe modules.
+
 ## [5.2.0] - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.2.0"
+version: "5.3.0"
 date-released: "2026-06-29"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.2.0",
+  "version": "5.3.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Version bump **5.2.0 → 5.3.0** to ship the already-merged PR #230 (health economic evaluation lane). CITATION.cff + package.json + distribution_manifest all **5.3.0** (3-source gate green); CHANGELOG `[5.3.0]` added.

Ships: CHEERS 2022 checklist (**reporting guidelines 38→39**, CC BY 4.0) + HE1–HE8 review domain-probe (modules 17→18) + analyze-stats health-economic guide. After merge: tag `v5.3.0` → release.yml (GitHub Release + ZIPs + attest + npm publish + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)