### PR TITLE
release: v5.4.0 (RECORD routinely-collected-data reporting lane)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-06-29
+
+### Added
+
+- **RECORD lane — routinely-collected / registry / claims / EHR observational reporting.** The second
+  lane of the autonomous reverse-engineer cycle (after CHEERS), chosen by the same CC-BY-cleanliness
+  logic and directly relevant to the suite's heavy NHIS/KNHANES/health-checkup-DB cohort emphasis:
+  - `check-reporting/references/checklists/RECORD.md` — faithful 13-item RECORD summary (base STROBE +
+    RECORD extension; RECORD-PE noted for drug studies; CC BY 4.0, Benchimol et al. *PLoS Med* 2015).
+    Routed via the study-type table + `record` alias. **Reporting guidelines 39 → 40.**
+  - `peer-review` + `self-review` `domain-probes/record_routinely_collected_data.md` (RD1–RD8; vendored
+    byte-identical, review domain-probe modules 18 → 19): database fitness-for-purpose, phenotype
+    code-lists & validation, data linkage & linkage-quality, participant-selection flow incl.
+    data-quality filtering, misclassification, informative missingness, unmeasured confounding +
+    immortal-time/prevalent-user (RECORD-PE), eligibility drift + code/protocol availability.
+- Counts: 51 skills / 41 detectors / **40 reporting guidelines** / 19 review domain-probe modules.
+
 ## [5.3.0] - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.3.0"
+version: "5.4.0"
 date-released: "2026-06-29"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.3.0",
+  "version": "5.4.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Version bump **5.3.0 → 5.4.0** to ship the already-merged PR #232 (RECORD lane). 3-source version gate green; CHANGELOG `[5.4.0]`. Ships RECORD checklist (**reporting guidelines 39→40**, CC BY 4.0) + RD1–RD8 probe (modules 18→19). After merge: tag `v5.4.0` → release.yml (GitHub Release + ZIPs + attest + npm + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)