### PR TITLE
release: v5.5.0 (survey-research CROSS/CHERRIES reporting lane)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [5.5.0] - 2026-06-29
+
+### Added
+
+- **Survey-research lane (CROSS / CHERRIES).** The third study-genre lane of the autonomous
+  reverse-engineer cycle (after CHEERS and RECORD), filling the most common uncovered manuscript type:
+  - `check-reporting/references/checklists/CROSS.md` — an in-house faithful summary of the CROSS 2021
+    reportable elements (paraphrased item intents; CROSS is ©SGIM, so not reproduced verbatim — DOI
+    cited) integrating the CC-BY CHERRIES internet-survey items. Routed via the study-type table +
+    `cross` alias. **Reporting guidelines 40 → 41.**
+  - `peer-review` + `self-review` `domain-probes/survey_research.md` (SV1–SV8; vendored byte-identical,
+    review domain-probe modules 19 → 20): sampling-frame representativeness, sampling method +
+    sample-size justification, response rate (defined denominator) + non-response bias, instrument
+    development/validation/reliability, CHERRIES e-survey specifics, question design,
+    weighting/denominators/missingness, generalisability/ethics.
+- Counts: 51 skills / 41 detectors / **41 reporting guidelines** / 20 review domain-probe modules.
+
 ## [5.4.0] - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.4.0"
+version: "5.5.0"
 date-released: "2026-06-29"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.4.0",
+  "version": "5.5.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Version bump **5.4.0 → 5.5.0** to ship the already-merged PR #234 (survey-research lane). 3-source gate green; CHANGELOG `[5.5.0]`. Ships CROSS/CHERRIES checklist (**reporting guidelines 40→41**) + SV1–SV8 probe (modules 19→20). After merge: tag `v5.5.0` → release.yml (GitHub Release + ZIPs + attest + npm + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)