### PR TITLE
release: v5.6.0 (/self-review editorial-impression counterweight — 42nd detector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [5.6.0] - 2026-06-30
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.5.0"
-date-released: "2026-06-29"
+version: "5.6.0"
+date-released: "2026-06-30"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.5.0",
+  "version": "5.6.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Cuts **v5.6.0** for the editorial-impression counterweight detector merged in #235 (integrity_detectors 41→42).

- Bumps CITATION.cff / package.json / distribution_manifest to 5.6.0 (3-source agreement verified).
- CHANGELOG `[Unreleased]` → `[5.6.0] - 2026-06-30`.
- Counts: 51 skills / **42 detectors** / 41 reporting guidelines / 20 review domain-probe modules.

Tag `v5.6.0` on merge triggers release.yml (GitHub Release + classroom ZIPs + provenance attest + npm publish + Zenodo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)