### PR TITLE
release: v5.8.0 (qualitative-research lane — SRQR + COREQ + QL1–QL8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [5.8.0] - 2026-06-30
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.7.0"
+version: "5.8.0"
 date-released: "2026-06-30"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.7.0",
+  "version": "5.8.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Cuts **v5.8.0** for the qualitative-research lane merged in #240 (reporting guidelines 42→44; review domain-probe modules 21→22).

- CITATION.cff / package.json / distribution_manifest → 5.8.0 (3-source agreement verified).
- CHANGELOG `[Unreleased]` → `[5.8.0] - 2026-06-30`.
- Counts: 51 skills / 42 detectors / **44 reporting guidelines** / **22 review domain-probe modules**. Closes the scored reverse-engineer backlog (G50–G68).

Tag `v5.8.0` on merge triggers release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)