### PR TITLE
docs(connectors): research-connector registry + optional email/NCBI-key env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Research-connector registry (`docs/connectors.md`).** A declarative registry of the
+  external research APIs the skills call — PubMed / NCBI E-utilities, CrossRef, OpenAlex
+  (verification) and Unpaywall / Europe PMC / PMC (open-access full text) — with what uses
+  each, its keyless/legitimate boundary, and a plain "how you authorize" guide. The
+  clinical-manuscript analogue of a curated connector panel: **keyless public APIs (nothing
+  to paste in the common case)**, a `.claude/settings.json` permission-allowlist snippet as
+  the "call these domains without asking each time" mechanism, and an explicit boundary
+  (metadata + open access only; no paywalled-publisher scraping, no institution-auth
+  connectors, no omics/cheminformatics databases). Linked from the README intro.
+
 ### Changed
+
+- **Optional contact-email / NCBI key via environment (never required).**
+  `fetch_oa.py --email` now falls back to `MEDSCI_CONTACT_EMAIL` (and errors clearly if a
+  contact email is set nowhere — Unpaywall requires one). `verify_refs.py` E-utilities
+  calls now send NCBI-recommended `tool`/`email` courtesy params and honour an optional
+  `NCBI_API_KEY` (raising the PubMed rate limit from 3 → 10 req/s); absent the key the calls
+  stay keyless, so behaviour is unchanged by default. All verify-refs + fulltext-retrieval
+  tests pass.
 
 - **Competitive positioning — adjacent-not-competing note for hosted AI-for-science
   workbenches (Claude Science).** `docs/competitive_positioning.md` gains an "Adjacent

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ rather than reimplementing the ecosystem. Clinical AI model research
 engineering is in scope; it is **not** a diagnostic tool, an autonomous author, or a
 general AI-scientist platform, and every output requires human-expert verification.
 New here? See the [3 workflows below](#start-here-3-workflows), the
-[FAQ](docs/faq.md), and the
+[FAQ](docs/faq.md), the
+[research connectors it calls](docs/connectors.md) (keyless public APIs — nothing to set
+up in the common case), and the
 [scope boundary](ROADMAP.md#not-planned--explicitly-out-of-scope).
 
 ---

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -75,8 +75,8 @@ Set these only if you want them; every one has a working default or fallback.
 | `NCBI_API_KEY` | raises the PubMed rate limit from 3 → 10 requests/s | keyless (3 req/s) |
 | `GEMINI_API_KEY` | only for `make-figures` optional AI-image generation | AI images off (non-AI illustration is the default) |
 
-`fulltext-retrieval` also accepts the contact email directly: `fetch_oa.py … --email you@lab.org`
-(Unpaywall rejects `example.com`). If `--email` is omitted it falls back to
+`fulltext-retrieval` also accepts the contact email directly: `fetch_oa.py … --email <your-contact-email>`
+(a real address — Unpaywall rejects `example.com`). If `--email` is omitted it falls back to
 `MEDSCI_CONTACT_EMAIL`.
 
 ## Reference manager (separate mechanism)

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,102 @@
+# Research connectors
+
+The external research APIs MedSci Skills calls, what uses them, and — importantly —
+**what you have to set up (almost nothing).** This is the clinical-manuscript analogue of a
+curated connector registry: it is intentionally small, keyless where possible, and limited
+to **metadata and legitimate open-access** sources. It never scrapes paywalled publisher
+full text.
+
+## What actually gets called
+
+Every connector below is a **free, public API — no account, no API key** for the core
+workflow. The only per-user input is a **contact email** (etiquette for the OA services,
+not a credential) and, optionally, authorising the domains so your agent stops asking on
+each fetch.
+
+| Connector | Endpoint | Purpose | Used by | Auth |
+|---|---|---|---|---|
+| **PubMed / NCBI E-utilities** | `eutils.ncbi.nlm.nih.gov` | authoritative author/title/PMID verification (esummary / efetch / esearch) | verify-refs, search-lit, manage-refs, lit-sync, meta-analysis | keyless (optional `NCBI_API_KEY` for higher rate limit) |
+| **CrossRef** | `api.crossref.org` | DOI ↔ publisher metadata (title, authors, journal) | verify-refs, search-lit | keyless |
+| **OpenAlex** | `api.openalex.org` | conference / non-DOI recovery, tertiary author cross-check | verify-refs | keyless |
+| **Unpaywall** | `api.unpaywall.org` | legal open-access location for a DOI | fulltext-retrieval, lit-sync | keyless; **requires a contact `email`** |
+| **Europe PMC** | `europepmc.org` | open-access full-text render | fulltext-retrieval | keyless |
+| **PMC (NCBI)** | `www.ncbi.nlm.nih.gov/pmc` | open-access PDF via idconv / OA service | fulltext-retrieval | keyless |
+
+**"Publisher connection" in practice** = CrossRef (the publisher DOI/metadata registry) +
+Unpaywall / OpenAlex / PMC / Europe PMC (open-access full text). That is the entire,
+legitimate publisher surface — there is no login to Elsevier/Springer/Wiley, and no
+paywall bypass.
+
+Separately, the `find-journal` / `write-paper` journal **profiles** cite publisher
+homepages and author-guideline pages (thelancet.com, sciencedirect.com, …). Those are
+**documentation references a human reads**, not live API connectors — the toolkit does not
+call them programmatically.
+
+## How you "enter an API" — three tiers
+
+### Tier 0 — nothing (the default)
+
+PubMed, CrossRef, OpenAlex, Europe PMC, and PMC are keyless. Install the skills and they
+work. There is no key to paste, no account to create.
+
+### Tier 1 — authorise the domains (so your agent stops asking every fetch)
+
+MedSci Skills runs inside your coding agent (Claude Code / Codex / Cursor), so the analogue
+of a hosted "Allowed domains" panel is your agent's **tool-permission allowlist**. Either
+approve each fetch when prompted, or pre-authorise once. In Claude Code, add to
+`.claude/settings.json` (or use the `/update-config` skill):
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:eutils.ncbi.nlm.nih.gov)",
+      "WebFetch(domain:api.crossref.org)",
+      "WebFetch(domain:api.openalex.org)",
+      "WebFetch(domain:api.unpaywall.org)",
+      "WebFetch(domain:europepmc.org)",
+      "WebFetch(domain:www.ncbi.nlm.nih.gov)",
+      "Bash(curl:*)"
+    ]
+  }
+}
+```
+
+That is the whole "input" for most users: paste this once. (Exact matcher syntax is
+host-specific; the intent — allow these research domains — is the same across hosts.)
+
+### Tier 2 — optional environment variables (never required)
+
+Set these only if you want them; every one has a working default or fallback.
+
+| Variable | Effect | Default if unset |
+|---|---|---|
+| `MEDSCI_CONTACT_EMAIL` | polite contact email sent to Unpaywall / PMC / NCBI (a courtesy, not a credential) | falls back to `fetch_oa.py --email`, then a generic UA |
+| `NCBI_API_KEY` | raises the PubMed rate limit from 3 → 10 requests/s | keyless (3 req/s) |
+| `GEMINI_API_KEY` | only for `make-figures` optional AI-image generation | AI images off (non-AI illustration is the default) |
+
+`fulltext-retrieval` also accepts the contact email directly: `fetch_oa.py … --email you@lab.org`
+(Unpaywall rejects `example.com`). If `--email` is omitted it falls back to
+`MEDSCI_CONTACT_EMAIL`.
+
+## Reference manager (separate mechanism)
+
+Zotero is **not** one of the connectors above — it is a local reference manager reached
+through an MCP server, configured with `ZOTERO_API_KEY` / `ZOTERO_LIBRARY_ID` in your MCP
+settings, not through these research APIs. See
+[`docs/setup/mcp-setup.md`](setup/mcp-setup.md).
+
+## Boundaries (what is deliberately not a connector)
+
+- **No paywalled-publisher full-text scraping.** `fulltext-retrieval` is open-access only
+  (Unpaywall / OpenAlex / PMC / Europe PMC); it does not, and will not, bypass paywalls.
+- **No institution-authenticated connectors** (EZproxy, licensed databases) are bundled —
+  those stay on the user's own infrastructure.
+- **No omics / cheminformatics databases** (UniProt, PDB, Ensembl, ChEMBL, …). That is the
+  domain of a bench-science workbench; see
+  [`competitive_positioning.md`](competitive_positioning.md).
+
+---
+
+*Part of [MedSci Skills](../README.md). Reference integrity policy lives in
+[`docs/citations.md`](citations.md).*

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1578,8 +1578,8 @@
     },
     {
       "path": "skills/fulltext-retrieval/fetch_oa.py",
-      "size": 24503,
-      "sha256": "768f95a30737e67b7f9edee72fe8815a795c9f83451b46551bbe25fc36094f4b"
+      "size": 24810,
+      "sha256": "12bfbf094d338ac461267cea133c0a63a66bc0d2dadd28727921149bc5b72855"
     },
     {
       "path": "skills/fulltext-retrieval/fetch_oa_report_challenge/expected/projection.json",
@@ -3853,8 +3853,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 40629,
-      "sha256": "ca762e7f294cf90aa1675129a8c152304b48ba7340982c09a64204babc53c674"
+      "size": 41415,
+      "sha256": "4377e25e6b125ace31fd35df9ffdd21a413f0f70ba1e429e5bfcf50c0a29510e"
     },
     {
       "path": "skills/verify-refs/skill.yml",

--- a/skills/fulltext-retrieval/fetch_oa.py
+++ b/skills/fulltext-retrieval/fetch_oa.py
@@ -21,6 +21,7 @@ import csv
 import io
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -562,14 +563,19 @@ def main():
                              "with a DOI column (optional PMID, Title)")
     parser.add_argument("-o", "--output", type=Path, default=Path("pdfs"),
                         help="Output directory (default: pdfs/)")
-    parser.add_argument("-e", "--email", required=True,
-                        help="Contact email (required by Unpaywall TOS)")
+    parser.add_argument("-e", "--email", default=os.environ.get("MEDSCI_CONTACT_EMAIL"),
+                        help="Contact email (required by Unpaywall TOS). "
+                             "Falls back to the MEDSCI_CONTACT_EMAIL environment variable.")
     parser.add_argument("--report", type=Path, default=None,
                         help="Path for the JSON retrieval report "
                              "(default: <output>/retrieval_report.json)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Show debug messages")
     args = parser.parse_args()
+
+    if not args.email:
+        parser.error("a contact email is required (Unpaywall TOS): pass --email you@lab.org "
+                     "or set MEDSCI_CONTACT_EMAIL")
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import html
 import json
+import os
 import re
 import sys
 import time
@@ -372,8 +373,30 @@ def guess_title(raw: str) -> str:
     return ""
 
 
+def _contact_email() -> str:
+    """User-supplied contact email (courtesy for NCBI/CrossRef), never a credential."""
+    return (os.environ.get("MEDSCI_CONTACT_EMAIL")
+            or os.environ.get("NCBI_EMAIL")
+            or "medsci-skills@users.noreply.github.com")
+
+
+def _user_agent() -> str:
+    return f"medsci-skills/verify-refs (mailto:{_contact_email()})"
+
+
+def _ncbi_extras() -> dict:
+    """Optional NCBI E-utilities etiquette / rate-limit params, all from env.
+    Setting NCBI_API_KEY raises the PubMed rate limit from 3 to 10 requests/s;
+    absent it, the calls stay keyless. `tool`/`email` are NCBI-recommended courtesy."""
+    extra = {"tool": "medsci-skills", "email": _contact_email()}
+    key = os.environ.get("NCBI_API_KEY")
+    if key:
+        extra["api_key"] = key
+    return extra
+
+
 def http_json(url: str, timeout: int) -> dict | None:
-    req = urllib.request.Request(url, headers={"User-Agent": "medsci-skills/verify-refs (mailto:example@example.com)"})
+    req = urllib.request.Request(url, headers={"User-Agent": _user_agent()})
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read().decode("utf-8", "replace"))
@@ -421,7 +444,7 @@ def verify_pubmed_pmid(pmid: str, timeout: int) -> tuple[str, str, list]:
     verify_pubmed_efetch().
     """
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?" + urllib.parse.urlencode(
-        {"db": "pubmed", "id": pmid, "retmode": "json"}
+        {"db": "pubmed", "id": pmid, "retmode": "json", **_ncbi_extras()}
     )
     data = http_json(url, timeout)
     if not data:
@@ -458,11 +481,11 @@ def verify_pubmed_efetch(pmid: str, timeout: int) -> tuple[str, str, list, list]
     case: CrossRef "Vasileios" vs PubMed "Victoria" — PubMed is authoritative).
     """
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?" + urllib.parse.urlencode(
-        {"db": "pubmed", "id": pmid, "retmode": "xml"}
+        {"db": "pubmed", "id": pmid, "retmode": "xml", **_ncbi_extras()}
     )
     req = urllib.request.Request(
         url,
-        headers={"User-Agent": "medsci-skills/verify-refs (mailto:example@example.com)"},
+        headers={"User-Agent": _user_agent()},
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -496,7 +519,7 @@ def verify_pubmed_title(title: str, timeout: int) -> tuple[str, str, list]:
     if not title:
         return "UNVERIFIED", "No DOI, PMID, or usable title", []
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?" + urllib.parse.urlencode(
-        {"db": "pubmed", "term": title, "retmode": "json", "retmax": "3"}
+        {"db": "pubmed", "term": title, "retmode": "json", "retmax": "3", **_ncbi_extras()}
     )
     data = http_json(url, timeout)
     if not data:


### PR DESCRIPTION
Answers *"how do users enter the API?"* — for the core workflow, **they don't**: the research APIs the skills call are keyless public services.

## Added
- **`docs/connectors.md`** — a declarative registry of the external APIs the skills actually call: **PubMed / NCBI E-utilities, CrossRef, OpenAlex** (verification) and **Unpaywall / Europe PMC / PMC** (open-access full text). For each: what uses it, its keyless/legitimate boundary, and a plain **"how you authorize"** guide.
  - **Tier 0** — nothing (keyless public APIs).
  - **Tier 1** — a `.claude/settings.json` `permissions.allow` snippet as the *"call these domains without asking each time"* mechanism (the clinical analogue of a hosted connector panel's *Allowed domains*).
  - **Tier 2** — optional env vars (`MEDSCI_CONTACT_EMAIL`, `NCBI_API_KEY`), never required.
  - Explicit **boundary**: metadata + open access only — no paywalled-publisher scraping, no institution-auth connectors, no omics/cheminformatics DBs.

## Changed
- `fetch_oa.py --email` falls back to `MEDSCI_CONTACT_EMAIL` (clear error if a contact email is set nowhere — Unpaywall requires one).
- `verify_refs.py` E-utilities calls send NCBI-recommended `tool`/`email` courtesy params and honour an optional `NCBI_API_KEY` (PubMed rate limit 3 → 10 req/s); **keyless by default, behaviour unchanged**.

Verify-refs (3 tests) + fulltext-retrieval challenge pass; detector count unchanged (42); all CI-mirror gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)