### PR TITLE
fix(manifest): exclude installers/.logs/ from the distribution scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`gen_distribution_manifest.py` no longer scans `installers/.logs/`.** The gitignored,
+  per-machine install logs `install.py` writes there were picked up by the manifest scan,
+  so running `install.py` locally and regenerating would add a machine-specific log path
+  to the inventory (local `--check` drift, or an accidental committed log path). `.logs` is
+  added to the generator's excluded directory names; a regression assertion in
+  `installers/tests/test_distribution_manifest.py` (CI-wired) locks it — a stray
+  `installers/.logs/*.txt` is excluded and a normal installer file is still included.
+
 ## [5.9.1] - 2026-07-01
 
 Documentation + connector-transparency patch (no count change; behaviour unchanged by

--- a/installers/tests/test_distribution_manifest.py
+++ b/installers/tests/test_distribution_manifest.py
@@ -37,7 +37,7 @@ def run(*args: str) -> int:
 
 
 def classroom_payload() -> set[str]:
-    excl = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules", ".git", "tests"}
+    excl = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules", ".git", "tests", ".logs"}
     exclf = {".DS_Store"}
     payload: set[str] = set()
     for root in ("README_FIRST.md", "installers", "skills"):
@@ -71,6 +71,20 @@ def main() -> int:
           "metadata/distribution_files.json" not in inv and "metadata/distribution_manifest.json" not in inv)
     # the transactional installer module must be in the payload (install.py imports it)
     check("installers/medsci_txn.py is in the inventory", "installers/medsci_txn.py" in inv)
+
+    # regression (durable fix): gitignored installer logs under installers/.logs/ are
+    # excluded from the inventory, so running install.py locally never drifts the manifest.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "gdm_under_test", ROOT / "scripts" / "gen_distribution_manifest.py")
+    gdm = importlib.util.module_from_spec(spec)
+    sys.modules["gdm_under_test"] = gdm
+    spec.loader.exec_module(gdm)
+    log_name = "20260101-000000-medsci-skills-install-log.txt"
+    check("installer .logs/ path is excluded from the inventory",
+          gdm._included(f"installers/.logs/{log_name}", log_name) is False)
+    check("a normal installer file is still included",
+          gdm._included("installers/install.py", "install.py") is True)
 
     print("----")
     print(f"test_distribution_manifest: {PASS} passed, {FAIL} failed")

--- a/scripts/gen_distribution_manifest.py
+++ b/scripts/gen_distribution_manifest.py
@@ -61,7 +61,11 @@ EXCLUDE_RELPATHS = {
     "provenance.json",
     "metadata/provenance.json",
 }
-EXCLUDE_DIR_NAMES = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules", ".git", "tests"}
+# ".logs" excludes installers/.logs/ — the gitignored, per-machine install logs
+# install.py writes; without this, running install.py locally then regenerating would
+# add a machine-specific log path to the manifest (local `--check` drift, or an
+# accidental commit of a log path).
+EXCLUDE_DIR_NAMES = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules", ".git", "tests", ".logs"}
 EXCLUDE_SUFFIXES = (".pyc",)
 EXCLUDE_NAMES = {".DS_Store"}
 


### PR DESCRIPTION
Durable fix for the manifest-drift gotcha from the v5.9.1 cycle.

**Problem:** `install.py` writes gitignored per-machine logs to `installers/.logs/`. `gen_distribution_manifest.py` scanned `installers/` and picked those up, so running `install.py` locally and regenerating would add a machine-specific log path to `distribution_files.json` — local `--check` drift, or an accidental committed log path.

**Fix:** add `.logs` to the generator's `EXCLUDE_DIR_NAMES`. A CI-wired regression assertion in `installers/tests/test_distribution_manifest.py` locks it: a stray `installers/.logs/*.txt` is excluded, and a normal installer file is still included.

Verified end-to-end: with a stray `installers/.logs/*.txt` present, `gen_distribution_manifest.py --check` stays green. Test suite 10/10; all CI-mirror gates green; no inventory change (scripts/tests aren't in the payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)