### PR TITLE
feat(make-figures): tested render generators for forest, Bland–Altman, confusion matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **make-figures render layer extended to forest, Bland–Altman, and confusion matrix.**
+  Building on the v5.9.0 tested-generator layer (KM / ROC / calibration / decision-curve),
+  `scripts/render_core_figures.py` gains three more deterministic generators from
+  already-computed inputs, each with `assert_structure` load-bearing-element invariants:
+  **forest** (per-study CI whisker for every study + null reference line + pooled diamond +
+  study/pooled row labels), **Bland–Altman** (difference scatter + bias line + 95% limits of
+  agreement at bias ± 1.96·SD + difference-vs-mean axes), and **confusion matrix** (matrix
+  image + every cell annotated + Predicted/Actual axes). The render-regression challenge now
+  renders all **seven** figures from the synthetic fixture and confirms the gate fails on a
+  non-monotonic KM curve *and* a non-square confusion matrix. Detector count unchanged
+  (render layer is a generator, not a `check_*` detector). Continues closing the suite's
+  self-identified weakest area; forest / Bland–Altman / confusion move from prose-only
+  exemplars to tested generators.
+
 ## [5.9.2] - 2026-07-01
 
 Maintenance patch (no count change).

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2003,8 +2003,8 @@
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/README.md",
-      "size": 5872,
-      "sha256": "32f93f0c65b2fe353b17dd1345267c85d5646fcf7de7adb9f784be551fc900af"
+      "size": 6063,
+      "sha256": "e08ff05fe5ade5ced10914637632b1ca4ee59ad72e09b93d8063fc0e5537453e"
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/bland_altman.md",
@@ -2168,23 +2168,23 @@
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures.py",
-      "size": 14436,
-      "sha256": "35f91147d51dd73b75dc116be9e0a80588fe1daf502966e82468d3c62b12f25d"
+      "size": 22248,
+      "sha256": "b8a56c25dd1b5069f618e9028d361afb69865aba2d35e2341153230c31a44196"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json",
-      "size": 1429,
-      "sha256": "24c0944fcb1384f073988d0f6e28b8f375ba4a7eff62fb4e21bc7066726d5ebc"
+      "size": 2284,
+      "sha256": "694e7fc00e12d461ddbcc3051f03aed7c50bd3b771ad1ebe1aad6d194902ae1f"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/problem.md",
-      "size": 2485,
-      "sha256": "a4e62161806d95b637d9ce984541190e5e9e213e2522d1f8740d847ee10c1a30"
+      "size": 3022,
+      "sha256": "bf8fc8832079a59bebff2e464800d8eebfdd0b2d25e90078d9ff8a35316cde31"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/verify.sh",
-      "size": 1907,
-      "sha256": "7f05fd9cd4e2bfdf6c5b7e8e2a61bee5f8fd44d7d2746e29e2ae77adec84b9c0"
+      "size": 2354,
+      "sha256": "bcaeeccef1f3fa795dd696670acb956f45d15cd7bce12028ad08490243b9c5c3"
     },
     {
       "path": "skills/make-figures/scripts/validate_pptx_mac_compat.py",

--- a/skills/make-figures/references/exemplar_plots/README.md
+++ b/skills/make-figures/references/exemplar_plots/README.md
@@ -13,15 +13,18 @@ against `critic_rubrics/data_plot.md`; do not copy an image.
 
 ## Runnable render layer (tested)
 
-For the four highest-yield clinical figures — **Kaplan–Meier, ROC, calibration, and
-decision-curve** — the prose anatomy here has a matching **runnable, deterministic
-generator** in `../../scripts/render_core_figures.py`. It renders already-computed inputs
+For the highest-yield clinical figures — **Kaplan–Meier, ROC, calibration, decision-curve,
+forest, Bland–Altman, and confusion matrix** — the prose anatomy here has a matching
+**runnable, deterministic generator** in `../../scripts/render_core_figures.py`. It renders
+already-computed inputs
 (the statistical estimation stays in `/analyze-stats`; the render layer never recomputes a
 number) into the canonical anatomy and asserts each figure's load-bearing elements
 (number-at-risk table, chance diagonal, identity line, treat-all/treat-none references,
-no extrapolation past follow-up). A network-free render-regression challenge
+no extrapolation past follow-up; forest per-study CI rows + null line + pooled diamond;
+Bland–Altman bias + 95% limits of agreement; confusion Predicted/Actual axes + annotated
+cells). A network-free render-regression challenge
 (`scripts/render_core_figures_challenge/`, wired into `skill.yml` validation) renders all
-four from a synthetic fixture and confirms the structural gate fails on a malformed figure.
+seven from a synthetic fixture and confirms the structural gate fails on a malformed figure.
 Use the generator to produce these four directly; use the prose models below to compose
 the figure types that do not yet have a generator.
 

--- a/skills/make-figures/scripts/render_core_figures.py
+++ b/skills/make-figures/scripts/render_core_figures.py
@@ -33,6 +33,7 @@ import matplotlib
 matplotlib.use("Agg")  # headless, deterministic
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+from matplotlib.patches import Polygon  # noqa: E402
 
 
 # --------------------------------------------------------------------------- KM
@@ -164,6 +165,97 @@ def decision_curve(thresholds, net_benefit_model, prevalence: float, *,
     return fig
 
 
+# ------------------------------------------------------------------- forest
+def forest_plot(studies: list[dict], pooled: dict, *, null_value: float = 1.0,
+                effect_label: str = "Effect (95% CI)", title: str = "",
+                log_x: bool = True) -> plt.Figure:
+    """Meta-analysis forest plot from already-computed per-study estimates.
+
+    studies: [{name, est, lo, hi, weight?}] — each study's point estimate + CI.
+    pooled:  {est, lo, hi, label}          — the pooled estimate + CI + model name.
+    Draws a weight-scaled marker + CI whisker per study, the null reference line, and a
+    pooled diamond; the pooled row is always last. For a ratio measure keep log_x=True and
+    null_value=1.0; for a mean difference pass log_x=False, null_value=0.0."""
+    n = len(studies)
+    fig, ax = plt.subplots(figsize=(6.6, 0.5 * n + 2.0))
+    ys = list(range(n, 0, -1))  # top study at the highest y
+    weights = np.asarray([s.get("weight", 1.0) for s in studies], float)
+    wnorm = weights / weights.max() if weights.max() > 0 else np.ones(n)
+    for y, s, w in zip(ys, studies, wnorm):
+        ax.plot([s["lo"], s["hi"]], [y, y], color="0.3")             # CI whisker
+        ax.scatter([s["est"]], [y], s=30 + 120 * w, marker="s",
+                   color="steelblue", zorder=4)                       # weight-scaled box
+    ax.axvline(null_value, linestyle="--", color="0.5")               # null reference
+    # pooled diamond on a row below the studies
+    yd = 0
+    d = pooled
+    ax.add_patch(Polygon([[d["lo"], yd], [d["est"], yd + 0.35],
+                          [d["hi"], yd], [d["est"], yd - 0.35]],
+                         closed=True, facecolor="crimson", edgecolor="black", zorder=5))
+    labels = [s["name"] for s in studies] + [pooled.get("label", "Pooled")]
+    ax.set_yticks(ys + [yd])
+    ax.set_yticklabels(labels)
+    ax.set_ylim(-1, n + 1)
+    if log_x:
+        ax.set_xscale("log")
+    ax.set_xlabel(effect_label)
+    ax.set_title(title or "Meta-analysis forest plot")
+    fig.tight_layout()
+    fig._mf_kind = "forest"
+    fig._mf_n_studies = n
+    fig._mf_null = null_value
+    return fig
+
+
+# -------------------------------------------------------------- Bland–Altman
+def bland_altman(mean_vals, diff_vals, *, bias: float, sd_diff: float,
+                 title: str = "") -> plt.Figure:
+    """Bland–Altman agreement plot: difference vs mean, with the bias line and the
+    95% limits of agreement (bias ± 1.96·SD) — the load-bearing agreement elements."""
+    mean_vals = np.asarray(mean_vals, float)
+    diff_vals = np.asarray(diff_vals, float)
+    loa_hi, loa_lo = bias + 1.96 * sd_diff, bias - 1.96 * sd_diff
+    fig, ax = plt.subplots(figsize=(6.0, 5.0))
+    ax.scatter(mean_vals, diff_vals, s=25, color="steelblue", alpha=0.8)
+    ax.axhline(bias, color="crimson", label=f"Bias {bias:.2f}")
+    ax.axhline(loa_hi, linestyle="--", color="0.4", label=f"+1.96 SD {loa_hi:.2f}")
+    ax.axhline(loa_lo, linestyle="--", color="0.4", label=f"−1.96 SD {loa_lo:.2f}")
+    ax.set_xlabel("Mean of the two measurements")
+    ax.set_ylabel("Difference between measurements")
+    ax.set_title(title or "Bland–Altman agreement")
+    ax.legend(loc="upper right", frameon=False)
+    fig.tight_layout()
+    fig._mf_kind = "bland_altman"
+    fig._mf_loa = (loa_lo, loa_hi)
+    return fig
+
+
+# ---------------------------------------------------------- confusion matrix
+def confusion_matrix(matrix, labels, *, title: str = "") -> plt.Figure:
+    """Confusion matrix from an already-computed count grid. Rows = actual, cols =
+    predicted; every cell is annotated with its count (for a 2×2, TN/FP/FN/TP)."""
+    m = np.asarray(matrix, float)
+    k = m.shape[0]
+    if m.shape[0] != m.shape[1] or k != len(labels):
+        raise AssertionError("confusion matrix must be square and match the label count")
+    fig, ax = plt.subplots(figsize=(1.4 * k + 2, 1.4 * k + 2))
+    ax.imshow(m, cmap="Blues")
+    thresh = m.max() / 2.0 if m.max() else 0.5
+    for i in range(k):
+        for j in range(k):
+            ax.text(j, i, str(int(m[i, j])), ha="center", va="center",
+                    color="white" if m[i, j] > thresh else "black")
+    ax.set_xticks(range(k)); ax.set_xticklabels(labels)
+    ax.set_yticks(range(k)); ax.set_yticklabels(labels)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Actual")
+    ax.set_title(title or "Confusion matrix")
+    fig.tight_layout()
+    fig._mf_kind = "confusion"
+    fig._mf_k = k
+    return fig
+
+
 # ----------------------------------------------------- structural invariants
 def assert_structure(fig: plt.Figure) -> list[str]:
     """Assert the load-bearing elements for the figure's kind. Returns the list of
@@ -241,6 +333,52 @@ def assert_structure(fig: plt.Figure) -> list[str]:
             "DCA: treat-all / treat-none not labelled"
         passed.append("DCA reference strategies labelled")
 
+    elif kind == "forest":
+        ax = fig.axes[0]
+        n = getattr(fig, "_mf_n_studies")
+        # one horizontal CI whisker (2-point line, equal y) per study
+        whiskers = [ln for ln in ax.lines
+                    if len(ln.get_xdata()) == 2 and np.allclose(np.diff(ln.get_ydata()), 0.0)]
+        assert len(whiskers) >= n, "forest: missing per-study CI whiskers"
+        passed.append(f"forest per-study CI rows present ({n})")
+        null = getattr(fig, "_mf_null")
+        assert any(len(ln.get_xdata()) == 2 and np.allclose(ln.get_xdata(), [null, null])
+                   for ln in ax.lines), "forest: null reference line missing"
+        passed.append("forest null reference line present")
+        assert any(isinstance(p, Polygon) and len(p.get_xy()) >= 4 for p in ax.patches), \
+            "forest: pooled diamond missing"
+        passed.append("forest pooled diamond present")
+        assert len(ax.get_yticklabels()) >= n + 1, "forest: study/pooled row labels missing"
+        passed.append("forest study + pooled row labels present")
+
+    elif kind == "bland_altman":
+        ax = fig.axes[0]
+        assert ax.collections, "Bland–Altman: scatter of differences missing"
+        passed.append("Bland–Altman difference scatter present")
+        hlines = [ln for ln in ax.lines if np.allclose(np.diff(ln.get_ydata()), 0.0)]
+        assert len(hlines) >= 3, "Bland–Altman: need bias + two limits-of-agreement lines"
+        passed.append("Bland–Altman bias + 2 LoA lines present")
+        loa_lo, loa_hi = getattr(fig, "_mf_loa")
+        yvals = [float(ln.get_ydata()[0]) for ln in hlines]
+        assert any(abs(y - loa_hi) < 1e-6 for y in yvals) and any(abs(y - loa_lo) < 1e-6 for y in yvals), \
+            "Bland–Altman: LoA lines not at bias ± 1.96·SD"
+        passed.append("Bland–Altman LoA at bias ± 1.96·SD")
+        assert "difference" in ax.get_ylabel().lower() and "mean" in ax.get_xlabel().lower(), \
+            "Bland–Altman: axes not difference-vs-mean"
+        passed.append("Bland–Altman difference-vs-mean axes")
+
+    elif kind == "confusion":
+        ax = fig.axes[0]
+        k = getattr(fig, "_mf_k")
+        assert ax.images, "confusion: matrix image missing"
+        passed.append("confusion matrix image present")
+        cells = [t for t in ax.texts if t.get_text().strip().lstrip("-").isdigit()]
+        assert len(cells) >= k * k, f"confusion: expected {k * k} annotated cells"
+        passed.append(f"confusion all {k}×{k} cells annotated")
+        assert "predicted" in ax.get_xlabel().lower() and "actual" in ax.get_ylabel().lower(), \
+            "confusion: axes not Predicted/Actual"
+        passed.append("confusion Predicted/Actual axes")
+
     else:
         raise AssertionError(f"unknown figure kind: {kind!r}")
     return passed
@@ -248,7 +386,7 @@ def assert_structure(fig: plt.Figure) -> list[str]:
 
 # ----------------------------------------------------------------- driver
 def render_all(inputs: dict, out_dir: Path) -> dict:
-    """Render all four figures from ``inputs``, save PNGs, and assert structure.
+    """Render each figure kind present in ``inputs``, save PNGs, and assert structure.
     Returns {kind: [passed checks]}. Raises on any structural violation."""
     out_dir.mkdir(parents=True, exist_ok=True)
     results: dict[str, list[str]] = {}
@@ -261,6 +399,13 @@ def render_all(inputs: dict, out_dir: Path) -> dict:
             ci_low=d.get("ci_low"), ci_high=d.get("ci_high")),
         "dca": lambda d: decision_curve(d["thresholds"], d["net_benefit_model"],
                                         d["prevalence"]),
+        "forest": lambda d: forest_plot(d["studies"], d["pooled"],
+                                        null_value=d.get("null_value", 1.0),
+                                        effect_label=d.get("effect_label", "Effect (95% CI)"),
+                                        log_x=d.get("log_x", True)),
+        "bland_altman": lambda d: bland_altman(d["mean_vals"], d["diff_vals"],
+                                               bias=d["bias"], sd_diff=d["sd_diff"]),
+        "confusion": lambda d: confusion_matrix(d["matrix"], d["labels"]),
     }
     for kind, build in builders.items():
         if kind not in inputs:
@@ -287,7 +432,7 @@ def main(argv=None) -> int:
         return 1
     for kind, checks in results.items():
         print(f"OK [{kind}] {len(checks)} structural invariants: {'; '.join(checks)}")
-    print(f"PASS: {len(results)}/4 core figures rendered + structurally verified.")
+    print(f"PASS: {len(results)} figure(s) rendered + structurally verified.")
     return 0
 
 

--- a/skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json
+++ b/skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json
@@ -38,5 +38,27 @@
     "thresholds": [0.05, 0.10, 0.20, 0.30, 0.40, 0.50],
     "net_benefit_model": [0.34, 0.30, 0.22, 0.15, 0.09, 0.04],
     "prevalence": 0.35
+  },
+  "forest": {
+    "effect_label": "Odds ratio (95% CI)",
+    "null_value": 1.0,
+    "log_x": true,
+    "studies": [
+      {"name": "Study A 2019", "est": 1.20, "lo": 0.90, "hi": 1.60, "weight": 25},
+      {"name": "Study B 2020", "est": 1.45, "lo": 1.10, "hi": 1.92, "weight": 30},
+      {"name": "Study C 2021", "est": 0.95, "lo": 0.70, "hi": 1.29, "weight": 20},
+      {"name": "Study D 2022", "est": 1.60, "lo": 1.15, "hi": 2.22, "weight": 25}
+    ],
+    "pooled": {"est": 1.30, "lo": 1.10, "hi": 1.54, "label": "Random-effects pooled"}
+  },
+  "bland_altman": {
+    "mean_vals": [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+    "diff_vals": [0.2, -0.5, 0.8, 1.1, -0.3, 0.6, -1.2, 0.9, 0.1, 1.5, -0.7, 0.4],
+    "bias": 0.24,
+    "sd_diff": 0.80
+  },
+  "confusion": {
+    "matrix": [[85, 15], [10, 90]],
+    "labels": ["Negative", "Positive"]
   }
 }

--- a/skills/make-figures/scripts/render_core_figures_challenge/problem.md
+++ b/skills/make-figures/scripts/render_core_figures_challenge/problem.md
@@ -1,15 +1,17 @@
 # Challenge card — core clinical-figure render regression (make-figures)
 
 ## Problem
-The four highest-yield clinical figures — Kaplan–Meier, ROC, calibration, and
-decision-curve — were documented only as **prose anatomy** in
+The highest-yield clinical figures — Kaplan–Meier, ROC, calibration, decision-curve,
+forest, Bland–Altman, and confusion matrix — were documented only as **prose anatomy** in
 `references/exemplar_plots/`, and the actual matplotlib rendering had **no deterministic
 test of any kind**. A regression in figure code (a dropped number-at-risk table, a
 missing chance diagonal, a calibration plot without its identity line, a DCA without the
-treat-all / treat-none references, or a KM curve extrapolated past follow-up) would pass
-every prose read and only be caught by a reviewer — the gap that left the suite's
-self-identified weakest area with the same defense/enablement asymmetry the rest of the
-repo has closed (42 integrity detectors vs ~0 generative render tests).
+treat-all / treat-none references, a KM curve extrapolated past follow-up, a forest without
+its pooled diamond or null line, a Bland–Altman without its limits of agreement, or a
+confusion matrix without annotated cells) would pass every prose read and only be caught by
+a reviewer — the gap that left the suite's self-identified weakest area with the same
+defense/enablement asymmetry the rest of the repo has closed (integrity detectors have
+challenge fixtures; the figure generators did not).
 
 ## What the generator does
 `scripts/render_core_figures.py` is the **render** layer for the exemplar anatomies. It
@@ -26,17 +28,22 @@ elements are present:
   predicted-vs-observed axes.
 - **Decision curve** — model + treat-all + treat-none strategies, the treat-none
   (net benefit = 0) reference, a net-benefit y-axis.
+- **Forest** — a per-study CI whisker for every study, the null reference line, and the
+  pooled diamond; study + pooled row labels.
+- **Bland–Altman** — the difference scatter, the bias line, and the 95% limits of
+  agreement (bias ± 1.96·SD); difference-vs-mean axes.
+- **Confusion matrix** — a matrix image with every cell annotated and Predicted/Actual axes.
 
 ## Fixture (synthetic only — no real data)
-- `fixture/synthetic_inputs.json` — hand-authored step/curve coordinates and summary
-  statistics for all four figures.
+- `fixture/synthetic_inputs.json` — hand-authored coordinates and summary statistics for
+  all seven figures.
 
 ## Expected (`verify.sh`, network-free)
-- All four figures render to PNGs (each > 2 KB) **and** every structural invariant holds
+- All seven figures render to PNGs (each > 2 KB) **and** every structural invariant holds
   → exit 0.
-- A mutated input that drops a load-bearing element (e.g. a KM curve extended past
-  follow-up, or a DCA missing the treat-none reference) raises `AssertionError` → the
-  negative cases in `verify.sh` confirm the gate actually fails when it should.
+- Mutated inputs that drop a load-bearing element (a non-monotonic KM curve; a non-square
+  confusion matrix) raise `AssertionError` → the negative cases in `verify.sh` confirm the
+  gate actually fails when it should.
 
 Requires matplotlib + numpy (already make-figures runtime deps); the verifier skips with
 a clear message if matplotlib is unavailable, so it never hard-fails a minimal host.

--- a/skills/make-figures/scripts/render_core_figures_challenge/verify.sh
+++ b/skills/make-figures/scripts/render_core_figures_challenge/verify.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Deterministic verifier for the core-figure render challenge (make-figures).
-# Network-free. Renders the four canonical clinical figures from a synthetic fixture and
+# Network-free. Renders the seven canonical clinical figures from a synthetic fixture and
 # asserts each figure's load-bearing elements; then confirms the structural gate FAILS on
-# a mutated input (so the assertions are proven to bite). Exit 0 = all expectations hold.
+# mutated inputs (so the assertions are proven to bite). Exit 0 = all expectations hold.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 GEN="$HERE/../render_core_figures.py"
@@ -13,25 +13,34 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 python3 -c "import matplotlib, numpy" 2>/dev/null \
   || { echo "SKIP: matplotlib/numpy unavailable on this host"; exit 0; }
 
-# (1) Positive: all four figures render + every structural invariant holds.
+# (1) Positive: all seven figures render + every structural invariant holds.
 python3 "$GEN" --inputs "$FIX" --out-dir "$TMP/out" >"$TMP/log" 2>&1 \
   || { echo "FAIL: valid fixture did not render/verify" >&2; cat "$TMP/log" >&2; exit 1; }
-for k in km roc calibration dca; do
+for k in km roc calibration dca forest bland_altman confusion; do
   [ -s "$TMP/out/$k.png" ] || { echo "FAIL: $k.png not written" >&2; exit 1; }
 done
-grep -q "PASS: 4/4" "$TMP/log" || { echo "FAIL: not all four figures verified" >&2; cat "$TMP/log" >&2; exit 1; }
+grep -q "PASS: 7 figure" "$TMP/log" || { echo "FAIL: not all seven figures verified" >&2; cat "$TMP/log" >&2; exit 1; }
 
-# (2) Negative: a KM survival curve mutated to be non-monotonic must make the structural
-# gate FAIL — proves the load-bearing-element assertions actually fire.
-python3 - "$FIX" "$TMP/bad.json" <<'PY'
+# (2) Negative — the assertions must actually fire on malformed inputs.
+# (2a) a KM survival curve mutated to be non-monotonic.
+python3 - "$FIX" "$TMP/bad_km.json" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1]))
 d["km"]["groups"][0]["surv"] = [1.0, 0.92, 0.95, 0.74, 0.68]  # 0.81 -> 0.95 (increasing)
 json.dump(d, open(sys.argv[2], "w"))
 PY
-if python3 "$GEN" --inputs "$TMP/bad.json" --out-dir "$TMP/bad" >/dev/null 2>&1; then
-  echo "FAIL: a non-monotonic KM survival curve was NOT caught by the structural gate" >&2
-  exit 1
+if python3 "$GEN" --inputs "$TMP/bad_km.json" --out-dir "$TMP/bk" >/dev/null 2>&1; then
+  echo "FAIL: a non-monotonic KM survival curve was NOT caught" >&2; exit 1
+fi
+# (2b) a non-square confusion matrix (label/shape mismatch).
+python3 - "$FIX" "$TMP/bad_cm.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["confusion"]["matrix"] = [[85, 15, 0], [10, 90, 0]]  # 2x3, not square
+json.dump(d, open(sys.argv[2], "w"))
+PY
+if python3 "$GEN" --inputs "$TMP/bad_cm.json" --out-dir "$TMP/bc" >/dev/null 2>&1; then
+  echo "FAIL: a non-square confusion matrix was NOT caught" >&2; exit 1
 fi
 
-echo "PASS: 4/4 core figures render + structurally verify; the gate fails on a non-monotonic KM curve."
+echo "PASS: 7 core figures render + structurally verify; the gate fails on a non-monotonic KM curve and a non-square confusion matrix."


### PR DESCRIPTION
Continues closing the suite's self-identified weakest area. Extends the v5.9.0 tested render-test layer (KM / ROC / calibration / decision-curve) with three more high-frequency clinical figures — same pattern: render **already-computed inputs** (estimation stays in `/analyze-stats`), then `assert_structure` introspects the matplotlib artists for the load-bearing elements.

- **forest** — per-study CI whisker for every study + null reference line + pooled diamond + study/pooled row labels
- **Bland–Altman** — difference scatter + bias line + 95% limits of agreement (bias ± 1.96·SD) + difference-vs-mean axes
- **confusion matrix** — matrix image + every cell annotated + Predicted/Actual axes

The network-free render-regression challenge now renders all **7** figures from the synthetic fixture and confirms the gate fails on a **non-monotonic KM curve** *and* a **non-square confusion matrix**. `exemplar_plots/README` + challenge `problem.md` updated.

Detector count unchanged (42 — the render layer is a generator, not a `check_*` detector). All CI-mirror gates green; challenge passes 7/7 + 2 negatives.

Moves forest / Bland–Altman / confusion from prose-only exemplars to tested generators (remaining prose-only: mrmc_roc, manhattan, clinical_timeline, imaging_panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)