### PR TITLE
feat(make-figures): tested generators for MRMC ROC, Manhattan, clinical timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- **make-figures render layer extended to MRMC ROC, Manhattan, and clinical timeline.**
+  Three more deterministic generators in `scripts/render_core_figures.py`, each with
+  `assert_structure` invariants: **MRMC ROC** (a curve per reader + the reader-averaged
+  curve + chance diagonal + averaged-AUC annotation — reader studies), **Manhattan**
+  (point scatter + named significance-threshold line + −log10(p) axis — agnostic
+  many-exposure scans), and **clinical timeline** (time baseline + an event marker/label at
+  each event + time axis — case reports). The render-regression challenge now renders all
+  **ten** figures. `imaging_panel` is documented as staying prose-only by design (it
+  composes real images, not computed numbers). Detector count unchanged. Only `imaging_panel`
+  now remains a prose-only exemplar.
+
 - **make-figures render layer extended to forest, Bland–Altman, and confusion matrix.**
   Building on the v5.9.0 tested-generator layer (KM / ROC / calibration / decision-curve),
   `scripts/render_core_figures.py` gains three more deterministic generators from

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2003,8 +2003,8 @@
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/README.md",
-      "size": 6063,
-      "sha256": "e08ff05fe5ade5ced10914637632b1ca4ee59ad72e09b93d8063fc0e5537453e"
+      "size": 6524,
+      "sha256": "6dded03ce2aa6cf81277d4a64fa15e0f6814aa568132fc817e2fc753517d5338"
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/bland_altman.md",
@@ -2168,23 +2168,23 @@
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures.py",
-      "size": 22248,
-      "sha256": "b8a56c25dd1b5069f618e9028d361afb69865aba2d35e2341153230c31a44196"
+      "size": 29667,
+      "sha256": "8c5b8a3b564b74977f25931094e11b55e2d1bad7ec6c05436825bd1bf69dc0b0"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json",
-      "size": 2284,
-      "sha256": "694e7fc00e12d461ddbcc3051f03aed7c50bd3b771ad1ebe1aad6d194902ae1f"
+      "size": 3609,
+      "sha256": "5ca97899b1f61fec1c933039fafdae13dbe20bec175561019a4c947109a9b88f"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/problem.md",
-      "size": 3022,
-      "sha256": "bf8fc8832079a59bebff2e464800d8eebfdd0b2d25e90078d9ff8a35316cde31"
+      "size": 3486,
+      "sha256": "86c57b26720a6ae1112a641f9ef1e1736c1bc3e413452de94d7e25ec298c26ba"
     },
     {
       "path": "skills/make-figures/scripts/render_core_figures_challenge/verify.sh",
-      "size": 2354,
-      "sha256": "bcaeeccef1f3fa795dd696670acb956f45d15cd7bce12028ad08490243b9c5c3"
+      "size": 2378,
+      "sha256": "2961607318f21052d1b1e607b024520ac6a53ebf4afeaf4287199ed252c1c034"
     },
     {
       "path": "skills/make-figures/scripts/validate_pptx_mac_compat.py",

--- a/skills/make-figures/references/exemplar_plots/README.md
+++ b/skills/make-figures/references/exemplar_plots/README.md
@@ -13,18 +13,24 @@ against `critic_rubrics/data_plot.md`; do not copy an image.
 
 ## Runnable render layer (tested)
 
-For the highest-yield clinical figures — **Kaplan–Meier, ROC, calibration, decision-curve,
-forest, Bland–Altman, and confusion matrix** — the prose anatomy here has a matching
-**runnable, deterministic generator** in `../../scripts/render_core_figures.py`. It renders
-already-computed inputs
+Ten of the highest-yield clinical figures — **Kaplan–Meier, ROC, calibration,
+decision-curve, forest, Bland–Altman, confusion matrix, multi-reader ROC (MRMC),
+Manhattan, and clinical timeline** — have a matching **runnable, deterministic generator**
+in `../../scripts/render_core_figures.py`. It renders already-computed inputs
 (the statistical estimation stays in `/analyze-stats`; the render layer never recomputes a
 number) into the canonical anatomy and asserts each figure's load-bearing elements
 (number-at-risk table, chance diagonal, identity line, treat-all/treat-none references,
 no extrapolation past follow-up; forest per-study CI rows + null line + pooled diamond;
 Bland–Altman bias + 95% limits of agreement; confusion Predicted/Actual axes + annotated
-cells). A network-free render-regression challenge
+cells; MRMC per-reader + averaged curves; Manhattan significance-threshold line; timeline
+baseline + event markers). A network-free render-regression challenge
 (`scripts/render_core_figures_challenge/`, wired into `skill.yml` validation) renders all
-seven from a synthetic fixture and confirms the structural gate fails on a malformed figure.
+ten from a synthetic fixture and confirms the structural gate fails on a malformed figure.
+
+`imaging_panel.md` stays a **prose-only** exemplar by design: it composes real medical
+images with panel labels, scale bars, and arrows — an image-arrangement task, not a plot of
+computed numbers — so a synthetic generator would only draw placeholder boxes. Use the
+prose model to compose it against real images.
 Use the generator to produce these four directly; use the prose models below to compose
 the figure types that do not yet have a generator.
 

--- a/skills/make-figures/scripts/render_core_figures.py
+++ b/skills/make-figures/scripts/render_core_figures.py
@@ -256,6 +256,97 @@ def confusion_matrix(matrix, labels, *, title: str = "") -> plt.Figure:
     return fig
 
 
+# ------------------------------------------------------------------ MRMC ROC
+def mrmc_roc(readers: list[dict], averaged: dict, *, delta_auc: dict | None = None,
+             title: str = "") -> plt.Figure:
+    """Multi-reader multi-case ROC: each reader's ROC curve plus the reader-averaged
+    curve and the chance diagonal (the load-bearing MRMC-reader-study elements).
+
+    readers:  [{name, fpr, tpr, auc}]  — per-reader ROC coordinates.
+    averaged: {fpr, tpr, auc, label}   — the reader-averaged curve.
+    delta_auc (optional): {value, margin} — a ΔAUC-vs-margin annotation."""
+    fig, ax = plt.subplots(figsize=(5.4, 5.2))
+    for r in readers:
+        ax.plot(np.asarray(r["fpr"], float), np.asarray(r["tpr"], float),
+                color="0.7", linewidth=1)                              # thin per-reader
+    a = averaged
+    ax.plot(np.asarray(a["fpr"], float), np.asarray(a["tpr"], float),
+            color="crimson", linewidth=2.4,
+            label=f"{a.get('label', 'Reader-averaged')} (AUC = {a['auc']:.3f})")
+    ax.plot([0, 1], [0, 1], linestyle="--", color="0.5", label="Chance")
+    ax.set_xlim(0, 1); ax.set_ylim(0, 1.02)
+    ax.set_xlabel("1 − specificity (false-positive rate)")
+    ax.set_ylabel("Sensitivity (true-positive rate)")
+    ax.set_title(title or "Multi-reader multi-case ROC")
+    txt = f"averaged AUC = {a['auc']:.3f}"
+    if delta_auc:
+        txt += f"\nΔAUC = {delta_auc['value']:.3f} (margin {delta_auc['margin']:.3f})"
+    ax.text(0.55, 0.08, txt, fontsize=10,
+            bbox=dict(boxstyle="round", fc="white", ec="0.7"))
+    ax.legend(loc="lower right", frameon=False)
+    fig.tight_layout()
+    fig._mf_kind = "mrmc_roc"
+    fig._mf_n_readers = len(readers)
+    return fig
+
+
+# ------------------------------------------------------------------ Manhattan
+def manhattan(x, neglogp, threshold: float, *, labels=None,
+              ylabel: str = "−log10(p)", xlabel: str = "Exposure / position",
+              title: str = "") -> plt.Figure:
+    """Manhattan / *-wide-scan plot: −log10(p) vs position with the significance
+    threshold line (the two load-bearing elements of an agnostic many-test scan)."""
+    x = np.asarray(x, float)
+    y = np.asarray(neglogp, float)
+    fig, ax = plt.subplots(figsize=(7.0, 4.4))
+    ax.scatter(x, y, s=14, color="steelblue", alpha=0.8)
+    ax.axhline(threshold, color="crimson", linestyle="--",
+               label=f"significance threshold (−log10 = {threshold:.2f})")
+    if labels:  # sparse labelling of hits above the threshold
+        for xi, yi, lab in zip(x, y, labels):
+            if lab and yi >= threshold:
+                ax.annotate(lab, (xi, yi), fontsize=8,
+                            xytext=(0, 4), textcoords="offset points", ha="center")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title or "Manhattan plot")
+    ax.legend(loc="upper right", frameon=False)
+    fig.tight_layout()
+    fig._mf_kind = "manhattan"
+    fig._mf_threshold = threshold
+    return fig
+
+
+# --------------------------------------------------------- clinical timeline
+def clinical_timeline(events: list[dict], *, time_unit: str = "days from admission",
+                      title: str = "") -> plt.Figure:
+    """Case-report clinical timeline: an event marker + label at each time on a single
+    time axis (the load-bearing elements of a longitudinal case figure)."""
+    times = [float(e["time"]) for e in events]
+    fig, ax = plt.subplots(figsize=(max(6.0, 0.9 * len(events)), 3.4))
+    lo, hi = (min(times), max(times)) if times else (0, 1)
+    pad = max(1.0, (hi - lo) * 0.08)
+    ax.axhline(0, color="0.4")                                        # the timeline
+    for i, e in enumerate(events):
+        t = float(e["time"])
+        up = 1 if i % 2 == 0 else -1
+        ax.plot([t, t], [0, up * 0.6], color="0.6")                  # stem
+        ax.scatter([t], [0], s=40, color="crimson", zorder=5)         # event marker
+        ax.annotate(str(e["label"]), (t, up * 0.65), ha="center",
+                    va="bottom" if up > 0 else "top", fontsize=8)
+    ax.set_xlim(lo - pad, hi + pad)
+    ax.set_ylim(-1.3, 1.3)
+    ax.get_yaxis().set_visible(False)
+    for spine in ("left", "right", "top"):
+        ax.spines[spine].set_visible(False)
+    ax.set_xlabel(f"Time ({time_unit})")
+    ax.set_title(title or "Clinical timeline")
+    fig.tight_layout()
+    fig._mf_kind = "timeline"
+    fig._mf_n_events = len(events)
+    return fig
+
+
 # ----------------------------------------------------- structural invariants
 def assert_structure(fig: plt.Figure) -> list[str]:
     """Assert the load-bearing elements for the figure's kind. Returns the list of
@@ -379,6 +470,51 @@ def assert_structure(fig: plt.Figure) -> list[str]:
             "confusion: axes not Predicted/Actual"
         passed.append("confusion Predicted/Actual axes")
 
+    elif kind == "mrmc_roc":
+        ax = fig.axes[0]
+        n = getattr(fig, "_mf_n_readers")
+        curves = [ln for ln in ax.lines
+                  if len(ln.get_xdata()) > 2]                          # multi-point ROC curves
+        assert len(curves) >= n + 1, "MRMC-ROC: fewer curves than readers + averaged"
+        passed.append(f"MRMC-ROC per-reader + averaged curves present ({n}+1)")
+        diag = [ln for ln in ax.lines
+                if len(ln.get_xdata()) == 2 and np.allclose(ln.get_xdata(), [0, 1])
+                and np.allclose(ln.get_ydata(), [0, 1])]
+        assert diag, "MRMC-ROC: chance diagonal missing"
+        passed.append("MRMC-ROC chance diagonal present")
+        assert has_text(ax, "auc"), "MRMC-ROC: averaged-AUC annotation missing"
+        passed.append("MRMC-ROC averaged-AUC annotation present")
+        assert "sensitiv" in ax.get_ylabel().lower(), "MRMC-ROC: y-label not sensitivity"
+        passed.append("MRMC-ROC sensitivity y-label")
+
+    elif kind == "manhattan":
+        ax = fig.axes[0]
+        assert ax.collections, "Manhattan: point scatter missing"
+        passed.append("Manhattan scatter present")
+        thr = getattr(fig, "_mf_threshold")
+        assert any(np.allclose(ln.get_ydata(), thr) for ln in ax.lines
+                   if np.allclose(np.diff(ln.get_ydata()), 0.0)), \
+            "Manhattan: significance threshold line missing"
+        passed.append("Manhattan significance threshold line present")
+        yl = ax.get_ylabel().lower()
+        assert "log" in yl and ("10" in yl or "log10" in yl or "−log" in yl or "-log" in yl), \
+            "Manhattan: y-label not −log10(p)"
+        passed.append("Manhattan −log10(p) y-label")
+
+    elif kind == "timeline":
+        ax = fig.axes[0]
+        ne = getattr(fig, "_mf_n_events")
+        assert any(np.allclose(ln.get_ydata(), 0.0) for ln in ax.lines), \
+            "timeline: baseline axis missing"
+        passed.append("timeline baseline present")
+        assert ax.collections, "timeline: event markers missing"
+        passed.append("timeline event markers present")
+        assert len([t for t in ax.texts if t.get_text().strip()]) >= ne, \
+            "timeline: an event label is missing"
+        passed.append(f"timeline all {ne} event labels present")
+        assert "time" in ax.get_xlabel().lower(), "timeline: x-axis not a time axis"
+        passed.append("timeline time x-axis")
+
     else:
         raise AssertionError(f"unknown figure kind: {kind!r}")
     return passed
@@ -406,6 +542,13 @@ def render_all(inputs: dict, out_dir: Path) -> dict:
         "bland_altman": lambda d: bland_altman(d["mean_vals"], d["diff_vals"],
                                                bias=d["bias"], sd_diff=d["sd_diff"]),
         "confusion": lambda d: confusion_matrix(d["matrix"], d["labels"]),
+        "mrmc_roc": lambda d: mrmc_roc(d["readers"], d["averaged"],
+                                       delta_auc=d.get("delta_auc")),
+        "manhattan": lambda d: manhattan(d["x"], d["neglogp"], d["threshold"],
+                                         labels=d.get("labels"),
+                                         xlabel=d.get("xlabel", "Exposure / position")),
+        "timeline": lambda d: clinical_timeline(d["events"],
+                                                time_unit=d.get("time_unit", "days from admission")),
     }
     for kind, build in builders.items():
         if kind not in inputs:

--- a/skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json
+++ b/skills/make-figures/scripts/render_core_figures_challenge/fixture/synthetic_inputs.json
@@ -60,5 +60,32 @@
   "confusion": {
     "matrix": [[85, 15], [10, 90]],
     "labels": ["Negative", "Positive"]
+  },
+  "mrmc_roc": {
+    "readers": [
+      {"name": "Reader 1", "fpr": [0.0, 0.10, 0.25, 0.50, 1.0], "tpr": [0.0, 0.55, 0.72, 0.88, 1.0], "auc": 0.80},
+      {"name": "Reader 2", "fpr": [0.0, 0.08, 0.20, 0.45, 1.0], "tpr": [0.0, 0.62, 0.78, 0.90, 1.0], "auc": 0.84},
+      {"name": "Reader 3", "fpr": [0.0, 0.12, 0.30, 0.55, 1.0], "tpr": [0.0, 0.50, 0.68, 0.85, 1.0], "auc": 0.77}
+    ],
+    "averaged": {"fpr": [0.0, 0.10, 0.25, 0.50, 1.0], "tpr": [0.0, 0.56, 0.73, 0.88, 1.0], "auc": 0.805, "label": "Reader-averaged"},
+    "delta_auc": {"value": 0.06, "margin": 0.05}
+  },
+  "manhattan": {
+    "xlabel": "Candidate exposure (index)",
+    "threshold": 2.6,
+    "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    "neglogp": [0.4, 1.2, 0.8, 3.5, 0.6, 1.1, 2.1, 0.9, 4.2, 0.5, 1.3, 0.7, 2.8, 1.0, 0.4, 5.1, 0.9, 1.4, 0.6, 2.2],
+    "labels": ["", "", "", "Exposure D", "", "", "", "", "Exposure I", "", "", "", "Exposure M", "", "", "Exposure P", "", "", "", ""]
+  },
+  "timeline": {
+    "time_unit": "days from admission",
+    "events": [
+      {"time": 0, "label": "Admission"},
+      {"time": 2, "label": "CT scan"},
+      {"time": 5, "label": "Biopsy"},
+      {"time": 9, "label": "Diagnosis"},
+      {"time": 14, "label": "Treatment start"},
+      {"time": 30, "label": "Follow-up"}
+    ]
   }
 }

--- a/skills/make-figures/scripts/render_core_figures_challenge/problem.md
+++ b/skills/make-figures/scripts/render_core_figures_challenge/problem.md
@@ -33,13 +33,22 @@ elements are present:
 - **Bland–Altman** — the difference scatter, the bias line, and the 95% limits of
   agreement (bias ± 1.96·SD); difference-vs-mean axes.
 - **Confusion matrix** — a matrix image with every cell annotated and Predicted/Actual axes.
+- **MRMC ROC** — a curve per reader + the reader-averaged curve, the chance diagonal, and
+  the averaged-AUC annotation.
+- **Manhattan** — the point scatter, the named significance-threshold line, and a
+  −log10(p) y-axis.
+- **Clinical timeline** — the time baseline, an event marker + label at each event, and a
+  time x-axis.
+
+(`imaging_panel` stays a prose-only exemplar — it composes real images, not computed
+numbers, so it has no synthetic generator.)
 
 ## Fixture (synthetic only — no real data)
 - `fixture/synthetic_inputs.json` — hand-authored coordinates and summary statistics for
-  all seven figures.
+  all ten figures.
 
 ## Expected (`verify.sh`, network-free)
-- All seven figures render to PNGs (each > 2 KB) **and** every structural invariant holds
+- All ten figures render to PNGs (each > 2 KB) **and** every structural invariant holds
   → exit 0.
 - Mutated inputs that drop a load-bearing element (a non-monotonic KM curve; a non-square
   confusion matrix) raise `AssertionError` → the negative cases in `verify.sh` confirm the

--- a/skills/make-figures/scripts/render_core_figures_challenge/verify.sh
+++ b/skills/make-figures/scripts/render_core_figures_challenge/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Deterministic verifier for the core-figure render challenge (make-figures).
-# Network-free. Renders the seven canonical clinical figures from a synthetic fixture and
+# Network-free. Renders the ten canonical clinical figures from a synthetic fixture and
 # asserts each figure's load-bearing elements; then confirms the structural gate FAILS on
 # mutated inputs (so the assertions are proven to bite). Exit 0 = all expectations hold.
 set -euo pipefail
@@ -13,13 +13,13 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 python3 -c "import matplotlib, numpy" 2>/dev/null \
   || { echo "SKIP: matplotlib/numpy unavailable on this host"; exit 0; }
 
-# (1) Positive: all seven figures render + every structural invariant holds.
+# (1) Positive: all ten figures render + every structural invariant holds.
 python3 "$GEN" --inputs "$FIX" --out-dir "$TMP/out" >"$TMP/log" 2>&1 \
   || { echo "FAIL: valid fixture did not render/verify" >&2; cat "$TMP/log" >&2; exit 1; }
-for k in km roc calibration dca forest bland_altman confusion; do
+for k in km roc calibration dca forest bland_altman confusion mrmc_roc manhattan timeline; do
   [ -s "$TMP/out/$k.png" ] || { echo "FAIL: $k.png not written" >&2; exit 1; }
 done
-grep -q "PASS: 7 figure" "$TMP/log" || { echo "FAIL: not all seven figures verified" >&2; cat "$TMP/log" >&2; exit 1; }
+grep -q "PASS: 10 figure" "$TMP/log" || { echo "FAIL: not all ten figures verified" >&2; cat "$TMP/log" >&2; exit 1; }
 
 # (2) Negative — the assertions must actually fire on malformed inputs.
 # (2a) a KM survival curve mutated to be non-monotonic.
@@ -43,4 +43,4 @@ if python3 "$GEN" --inputs "$TMP/bad_cm.json" --out-dir "$TMP/bc" >/dev/null 2>&
   echo "FAIL: a non-square confusion matrix was NOT caught" >&2; exit 1
 fi
 
-echo "PASS: 7 core figures render + structurally verify; the gate fails on a non-monotonic KM curve and a non-square confusion matrix."
+echo "PASS: 10 core figures render + structurally verify; the gate fails on a non-monotonic KM curve and a non-square confusion matrix."


### PR DESCRIPTION
Finishes the make-figures render-test build-out. Adds three more deterministic generators (same pattern: render **already-computed inputs**, then `assert_structure` checks the load-bearing elements):

- **MRMC ROC** — a curve per reader + the reader-averaged curve + chance diagonal + averaged-AUC annotation (reader studies).
- **Manhattan** — point scatter + named significance-threshold line + −log10(p) axis (agnostic many-exposure / *-wide scans).
- **clinical timeline** — time baseline + an event marker/label at each event + time axis (case reports).

The render-regression challenge now renders all **10** figures from the synthetic fixture and still catches the 2 negatives (non-monotonic KM, non-square confusion).

**Scoping call:** `imaging_panel` is documented as **staying prose-only by design** — it composes real medical images with panel labels/scale bars/arrows (an image-arrangement task, not a plot of computed numbers), so a synthetic generator would only draw placeholder boxes. It is now the only remaining prose-only exemplar.

Detector count unchanged (42 — generators, not `check_*` detectors). All CI-mirror gates green; challenge 10/10 + 2 negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)