### PR TITLE
fix(self-review): four detector precision fixes (df-alias, null per-site, meta-document guards)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Four self-review detector precision fixes (no count change, no schema change).**
+  Field-observed false positives / masking on already-shipped gates, each with a
+  positive+negative regression fixture:
+  - `check_binning_consistency` (`DERIVED_DEF_DRIFT`) no longer fires on a legitimately
+    **parallel sensitivity cohort** — the SAME derivation rule expressed against a
+    different dataframe-receiver object (`v0['col']` vs `lenient_cohort['col']`). The
+    clause-set now compares on column+operator+rhs; the Python `df['col']` subscript is
+    dropped from each atom, matching the existing base-R `df$col` normalisation.
+  - `check_null_calibration` (`CONFIRM_NULL_NO_MDE`) is now **per-claim-site**: a
+    power/CI caveat co-located with one null no longer masks a bare "equivalence within
+    the bound" claim in a different region. Each unqualified claim site is evaluated on
+    its own neighbourhood.
+  - `check_scope_coherence` (`CROSS_SECTIONAL_PROGNOSTIC`) no longer fires on a
+    **meta-document** — a QC/methods/detector paper (or review) whose SUBJECT is the
+    anti-pattern and that NAMES it rather than committing it.
+  - `check_classical_style` (`INBODY_AI_DISCLOSURE`) no longer fires on a paper whose
+    SUBJECT is AI-use disclosure and that carries disclosure phrasing as an object of
+    study. All meta-document guards are kept tight (they require the meta-framing
+    structure) so a genuine overclaim / in-body disclosure is never suppressed.
+
 ## [5.10.0] - 2026-07-01
 
 Figures enablement — the make-figures **render-test layer** grows from 4 to **10** tested,

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3658,8 +3658,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_binning_consistency.py",
-      "size": 19541,
-      "sha256": "e3bf7dd2e0871ce6905abc1d33a26c7afac76a93d184bfe2d431af97d0622f74"
+      "size": 20076,
+      "sha256": "c6467eb4a1d954d67da87e283d8a628604a9ec7558c966f8b20c1b661e23b9c9"
     },
     {
       "path": "skills/self-review/scripts/check_citation_order.py",
@@ -3673,8 +3673,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",
-      "size": 12210,
-      "sha256": "c973ee8b776f28515439fb185e1254e08e62c2e1410e260f18a824241a331af0"
+      "size": 13124,
+      "sha256": "941d90559cdcdd24f3eba58daf00eb34a7d227c3fe44267b93b65b80b6092989"
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
@@ -3693,8 +3693,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_null_calibration.py",
-      "size": 7594,
-      "sha256": "9ddff01722c34efb6ffd757ae762c6ee12f5993bf13b11313c2e20b60b26cab3"
+      "size": 8585,
+      "sha256": "e5bd71c515554b3acbaefd3807e584364a536dc6e1101bec5b524bc26b341309"
     },
     {
       "path": "skills/self-review/scripts/check_panel_diversity.py",
@@ -3718,8 +3718,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_scope_coherence.py",
-      "size": 10818,
-      "sha256": "820dfc264c2a4f62c79c0c7123a3e1a8b59a100b89654617a08ff55deeb25a75"
+      "size": 11920,
+      "sha256": "e600e54fcbe308060a8dadd871ec274b6ae19f89456ae0194490e152c0d09a91"
     },
     {
       "path": "skills/self-review/scripts/check_supplement_hygiene.py",

--- a/skills/self-review/scripts/check_binning_consistency.py
+++ b/skills/self-review/scripts/check_binning_consistency.py
@@ -286,13 +286,19 @@ def _strip_wrap_parens(a: str) -> str:
 
 
 def _norm_atom(a: str) -> str:
-    """Whitespace-free canonical form of one OR-clause. Dataframe qualifiers
-    (`df$col`, `sub$col`) are dropped so a bare `mutate()` reference and a base-R
-    `df$` reference to the same column compare equal, and a top-level `&`-group is
-    sorted so operand order inside an AND does not matter
-    (`x==1 & y>=2` == `y>=2 & x==1`)."""
+    """Whitespace-free canonical form of one OR-clause. Dataframe-receiver
+    qualifiers are dropped so the SAME derivation rule expressed against different
+    dataframe objects compares equal — a base-R `df$col`, a bare `mutate()`
+    reference, and a Python `df['col']` / `df["col"]` subscript all reduce to the
+    column `col`. This matters for a legitimately-parallel sensitivity cohort:
+    `v0['end_date'] >= x` in the primary script and `lenient_cohort['end_date'] >= x`
+    in the sensitivity script are the SAME rule on two df objects and must not read
+    as DERIVED_DEF_DRIFT. A top-level `&`-group is sorted so operand order inside an
+    AND does not matter (`x==1 & y>=2` == `y>=2 & x==1`)."""
     a = re.sub(r"\s+", "", _strip_wrap_parens(a))
-    a = re.sub(r"[A-Za-z_]\w*\$", "", a)  # df$col / sub$col -> col
+    a = re.sub(r"[A-Za-z_]\w*\$", "", a)  # base-R df$col / sub$col -> col
+    # Python df['col'] / df["col"] receiver subscript -> col (receiver alias dropped)
+    a = re.sub(r"[A-Za-z_]\w*\[\s*(['\"])([^'\"]+)\1\s*\]", r"\2", a)
     if "&" in a:
         andparts = _split_top_level(a, "&")
         if len(andparts) > 1:

--- a/skills/self-review/scripts/check_classical_style.py
+++ b/skills/self-review/scripts/check_classical_style.py
@@ -66,6 +66,17 @@ INBODY_AI_DISCLOSURE = re.compile(
     r"(?:used|use[d]?|employed)[^.]{0,60}?(?:ai|gpt|chatgpt|claude|copilot|gemini|language model)",
     re.IGNORECASE)
 
+# A paper whose SUBJECT is AI-use disclosure (a reporting-methods / QC paper about
+# disclosure statements) contains such phrasing as an object of study, not as its
+# own disclosure. When the match sits next to disclosure-as-subject framing, do not
+# fire INBODY_AI_DISCLOSURE. Kept tight so a genuine in-body disclosure still fires.
+AI_DISCLOSURE_SUBJECT = re.compile(
+    r"ai[-\s]?disclosure|disclosure (?:statement|practice|policy|policies|requirement|item)|"
+    r"reporting of ai (?:use|tools|assistance)|MI[-\s]?CLEAR|"
+    r"(?:this|the present) (?:paper|study|work|review|analysis)\b[^.]{0,60}?"
+    r"(?:disclosure|ai use|ai tools|ai assistance|reporting)",
+    re.IGNORECASE)
+
 ELIGIBILITY_LEAD = re.compile(
     r"(?:studies|articles|records|participants|patients|trials)\s+were\s+eligible\s+if|"
     r"eligibility criteria were|inclusion criteria (?:were|included)|"
@@ -99,8 +110,11 @@ def check(text: str, em_dash_max: int) -> list[dict]:
             "where": text[max(0, first - 30):first + 20].replace("\n", " ").strip()[:120],
         })
 
-    # INBODY_AI_DISCLOSURE (Major)
+    # INBODY_AI_DISCLOSURE (Major) — unless the paper's SUBJECT is AI disclosure
+    # (a reporting-methods paper naming the pattern, not committing it).
     m = INBODY_AI_DISCLOSURE.search(text)
+    if m and AI_DISCLOSURE_SUBJECT.search(text[max(0, m.start() - 200):m.end() + 200]):
+        m = None
     if m:
         claims.append({
             "verdict": "INBODY_AI_DISCLOSURE",

--- a/skills/self-review/scripts/check_null_calibration.py
+++ b/skills/self-review/scripts/check_null_calibration.py
@@ -17,8 +17,13 @@ Verdict:
                                compatibility token anywhere in those regions.
 
 Conservative by construction: it fires only when a headline negative claim is
-present AND no precision token appears anywhere in the title+abstract+conclusion
-regions (a single MDE/power/equivalence/CI-compatibility sentence suppresses it).
+present AND no precision token is CO-LOCATED with that claim (a MDE / power /
+equivalence / CI-compatibility statement within the claim's own sentence
+neighbourhood suppresses it). The check is per-claim-SITE, not per-region: a
+power-aware caveat next to the Abstract-Results null does NOT license a bare
+"equivalence within +/-0.10" in the Conclusions. Each unqualified claim site is
+flagged on its own; a caveat in one region no longer masks an uncaveated
+equivalence claim in another.
 
 Exit codes: 0 clean (or report-only), 1 with --strict when any Major exists, 2 usage.
 Stdlib-only (json / re / argparse / pathlib).
@@ -94,22 +99,35 @@ def headline_region(text: str) -> str:
     return "\n".join(spans)
 
 
+# Neighbourhood (chars each side of a claim) searched for a co-located precision
+# statement. Wide enough to cover the same sentence / adjacent clause, narrow
+# enough that a caveat in a different paragraph/region does not mask this claim.
+_COLOCATE_WINDOW = 160
+
+
 def check(text: str) -> list[dict]:
     region = headline_region(text)
-    nm = NEGATIVE_CLAIM.search(region)
-    if not nm:
-        return []
-    if PRECISION_TOKEN.search(region):
-        return []  # a precision/MDE/equivalence/CI-compatibility sentence is present
-    return [{
-        "verdict": "CONFIRM_NULL_NO_MDE",
-        "severity": "Major",
-        "detail": (f"a headline negative/equivalence claim ('{nm.group(0).strip()}') in the "
-                   f"Title/Abstract/Conclusion is not accompanied by a minimum-detectable-"
-                   f"effect, power, equivalence-margin/TOST, or CI-compatibility statement; a "
-                   f"non-significant result is not evidence of no effect without one"),
-        "where": region[max(0, nm.start() - 40):nm.end() + 60].replace("\n", " ").strip()[:160],
-    }]
+    claims: list[dict] = []
+    seen: set[str] = set()
+    for nm in NEGATIVE_CLAIM.finditer(region):
+        window = region[max(0, nm.start() - _COLOCATE_WINDOW):nm.end() + _COLOCATE_WINDOW]
+        if PRECISION_TOKEN.search(window):
+            continue  # a precision statement is co-located with THIS claim site
+        key = re.sub(r"\s+", " ", nm.group(0).strip().lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        claims.append({
+            "verdict": "CONFIRM_NULL_NO_MDE",
+            "severity": "Major",
+            "detail": (f"a headline negative/equivalence claim ('{nm.group(0).strip()}') in the "
+                       f"Title/Abstract/Conclusion has no co-located minimum-detectable-"
+                       f"effect, power, equivalence-margin/TOST, or CI-compatibility statement; a "
+                       f"non-significant result is not evidence of no effect without one "
+                       f"(a caveat elsewhere in the manuscript does not cover this claim site)"),
+            "where": region[max(0, nm.start() - 40):nm.end() + 60].replace("\n", " ").strip()[:160],
+        })
+    return claims
 
 
 def analyze(manuscript: str) -> dict:

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -71,6 +71,22 @@ PROGNOSTIC_DISCLAIMER = re.compile(
     r"beyond the scope|no (?:prognostic|surveillance|longitudinal) (?:claim|inference|conclusion)",
     re.IGNORECASE)
 
+# A methods / QC / detector paper — or a review — whose SUBJECT is this very
+# anti-pattern NAMES the pattern rather than committing it ("this paper detects
+# manuscripts that make a prognostic claim in a cross-sectional setting"). When the
+# match sits inside such a meta-framing, it is a description, not an overclaim; do
+# not fire. Kept tight (requires the meta-framing structure, not a bare "detect")
+# so a real prognostic overclaim is never suppressed.
+META_DOC_FRAME = re.compile(
+    r"anti[-\s]?pattern|such (?:patterns|claims|conclusions|overclaims)\b|"
+    r"(?:papers?|manuscripts?|studies|authors) (?:that|which|who) "
+    r"(?:commit|make|assert|report|conflate|claim|treat|use)\b|"
+    r"we (?:report|show|find|note|observe) that (?:papers|manuscripts|studies|authors|some|many)|"
+    r"(?:this|the present) (?:paper|study|work|review|tool|detector|gate|framework|probe)\b"
+    r"[^.]{0,40}?(?:discuss|describ|detect|flag|identif|examin|review|illustrat|catalog)|"
+    r"(?:as|is) an? (?:example|illustration|instance|case) of",
+    re.IGNORECASE)
+
 DIRECTIVE_VERB = re.compile(
     r"\bdefer(?:ral|red|ring)?\b|\bwithhold\b|\bforgo\b|\binitiat(?:e|ed|ion)\b|"
     r"\bdiscontinu(?:e|ed|ation)\b|start(?:ing)?\s+(?:statin|therapy|treatment|pharmacotherapy)|"
@@ -126,7 +142,7 @@ def check(text: str) -> list[dict]:
         # conclusion still fires even if an earlier mention was a disclaimer.
         for pm in PROGNOSTIC_VERB.finditer(concl):
             window = concl[max(0, pm.start() - 120):pm.end() + 120]
-            if PROGNOSTIC_DISCLAIMER.search(window):
+            if PROGNOSTIC_DISCLAIMER.search(window) or META_DOC_FRAME.search(window):
                 continue
             claims.append({
                 "verdict": "CROSS_SECTIONAL_PROGNOSTIC",

--- a/skills/self-review/tests/fixtures/classical_metadoc.md
+++ b/skills/self-review/tests/fixtures/classical_metadoc.md
@@ -1,0 +1,8 @@
+# Reporting of AI-use disclosure in radiology manuscripts
+
+## Introduction
+
+This study analyzes AI-disclosure statements across published radiology papers.
+A frequently reused template reads: "During the preparation of this manuscript the
+authors used a large language model to assist with editing." We examine how often
+such disclosure statements meet MI-CLEAR-LLM requirements and where they fall short.

--- a/skills/self-review/tests/fixtures/derived_clean_dfalias/03_cohort.py
+++ b/skills/self-review/tests/fixtures/derived_clean_dfalias/03_cohort.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+# primary cohort `v0`: metabolic-syndrome blood-pressure component
+v0['mets_bp'] = np.where(
+    (v0['bl_he_sbp'] >= 130) | (v0['bl_he_dbp'] >= 85) | (v0['bl_tx_htn_med'] == 1),
+    1, 0,
+)

--- a/skills/self-review/tests/fixtures/derived_clean_dfalias/08_sensitivity.py
+++ b/skills/self-review/tests/fixtures/derived_clean_dfalias/08_sensitivity.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+# parallel sensitivity cohort `lenient_cohort`: IDENTICAL derivation rule, only the
+# dataframe-receiver object differs (by design — a second cohort, not a drift).
+lenient_cohort['mets_bp'] = np.where(
+    (lenient_cohort['bl_he_sbp'] >= 130) | (lenient_cohort['bl_he_dbp'] >= 85) | (lenient_cohort['bl_tx_htn_med'] == 1),
+    1, 0,
+)

--- a/skills/self-review/tests/fixtures/null_region_masked.md
+++ b/skills/self-review/tests/fixtures/null_region_masked.md
@@ -1,0 +1,15 @@
+# Reader detection of synthetic radiologic images
+
+## Abstract
+
+**Results:** In the primary reader analysis the two generators performed comparably
+(AUC 0.71 vs 0.73). The study was powered to detect a between-generator difference
+of 0.10 in AUC, and the observed interval was compatible with a difference of that
+magnitude, so formal equivalence at the pre-specified bound was not demonstrated by
+these data alone.
+
+## Conclusion
+
+Taken together, the two image generators were equivalent within the pre-specified
+bound, and radiologists could not reliably tell them apart during routine
+interpretation, supporting interchangeable use in practice.

--- a/skills/self-review/tests/fixtures/scope_metadoc.md
+++ b/skills/self-review/tests/fixtures/scope_metadoc.md
@@ -1,0 +1,12 @@
+# A detector for scope-coherence anti-patterns in cross-sectional imaging studies
+
+## Abstract
+
+This paper describes a deterministic gate for manuscripts built on a
+cross-sectional, single-visit design.
+
+## Conclusion
+
+The present tool detects papers that assert a surveillance interval from
+prevalence data; such patterns are a recurrent reviewer-fatal overclaim that
+methods work should catalog so that authors can avoid them.

--- a/skills/self-review/tests/test_binning_consistency.sh
+++ b/skills/self-review/tests/test_binning_consistency.sh
@@ -63,5 +63,15 @@ check "no DERIVED_DEF_DRIFT on clean composite fixtures" bash -c "
 python3 -c \"import json; d=json.load(open('$OUT')); assert not d['claims']\"
 "
 
+# (5) parallel sensitivity cohort: SAME derived rule, different dataframe-receiver
+#     object (v0[...] vs lenient_cohort[...]) -> NO DERIVED_DEF_DRIFT (regression).
+DALIAS="$HERE/fixtures/derived_clean_dfalias"
+python3 "$SCRIPT" --root "$DALIAS" --strict --quiet >/dev/null 2>&1
+check "exit 0 on parallel df-alias cohort" test "$?" -eq 0
+python3 "$SCRIPT" --root "$DALIAS" --out "$OUT" --quiet >/dev/null 2>&1
+check "no DERIVED_DEF_DRIFT on parallel df-alias cohort" bash -c "
+python3 -c \"import json; d=json.load(open('$OUT')); assert not any(c['verdict']=='DERIVED_DEF_DRIFT' for c in d['claims'])\"
+"
+
 if [[ "$fail" -eq 0 ]]; then echo "  ALL PASS"; else echo "  $fail FAILED"; fi
 exit "$fail"

--- a/skills/self-review/tests/test_classical_style.sh
+++ b/skills/self-review/tests/test_classical_style.sh
@@ -71,5 +71,17 @@ assert not any(c['verdict']=='SECTION_SYMBOL' for c in d['claims']), 'dagger § 
 python3 "$SCRIPT" --manuscript "$DAGGER" --strict --quiet >/dev/null 2>&1
 check "exit 0 on dagger-footnote manuscript" test "$?" -eq 0
 
+# (5) a paper whose SUBJECT is AI-use disclosure carries disclosure phrasing as an
+#     object of study, not as its own disclosure -> no INBODY_AI_DISCLOSURE.
+METADOC="$HERE/fixtures/classical_metadoc.md"
+python3 "$SCRIPT" --manuscript "$METADOC" --out "$OUT" --quiet >/dev/null 2>&1
+check "no INBODY_AI_DISCLOSURE on an AI-disclosure-methods paper" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='INBODY_AI_DISCLOSURE' for c in d['claims']), 'meta-document flagged as in-body disclosure'
+"
+python3 "$SCRIPT" --manuscript "$METADOC" --strict --quiet >/dev/null 2>&1
+check "exit 0 on AI-disclosure-methods paper" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_null_calibration.sh
+++ b/skills/self-review/tests/test_null_calibration.sh
@@ -43,5 +43,13 @@ assert not any(c['verdict']=='CONFIRM_NULL_NO_MDE' for c in d['claims']), 'fired
 python3 "$SCRIPT" --manuscript "$CLEAN" --strict --quiet >/dev/null 2>&1
 check "exit 0 on power-aware null" test "$?" -eq 0
 
+# (3) region-blind masking: a power/CI caveat co-located with the Abstract-Results
+#     null does NOT license a bare "equivalence within the bound" in a far
+#     Conclusion -> CONFIRM_NULL_NO_MDE still fires on the uncaveated claim site.
+MASKED="$HERE/fixtures/null_region_masked.md"
+python3 "$SCRIPT" --manuscript "$MASKED" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1: masked equivalence in a far Conclusion still flagged" test "$?" -eq 1
+check "CONFIRM_NULL_NO_MDE on the uncaveated claim site" has_verdict CONFIRM_NULL_NO_MDE
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -71,5 +71,17 @@ assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']),
 python3 "$SCRIPT" --manuscript "$DISC" --strict --quiet >/dev/null 2>&1
 check "exit 0 on disclaimer manuscript" test "$?" -eq 0
 
+# (7) a methods/QC/detector paper whose SUBJECT is this anti-pattern NAMES the
+#     cross-sectional+prognostic pattern rather than committing it -> no fire.
+METADOC="$HERE/fixtures/scope_metadoc.md"
+python3 "$SCRIPT" --manuscript "$METADOC" --out "$OUT" --quiet >/dev/null 2>&1
+check "no CROSS_SECTIONAL_PROGNOSTIC on a meta-document" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']), 'meta-document flagged as prognostic overclaim'
+"
+python3 "$SCRIPT" --manuscript "$METADOC" --strict --quiet >/dev/null 2>&1
+check "exit 0 on meta-document" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
Four field-observed false-positive / masking fixes on already-shipped self-review gates. Each carries a positive+negative regression fixture. **No detector count change, no verdict/schema change** — pure precision.

| Gate | Was | Now |
|---|---|---|
| `check_binning_consistency` `DERIVED_DEF_DRIFT` | fired on a parallel sensitivity cohort (`v0['col']` vs `lenient_cohort['col']`) | Python `df['col']` subscript dropped from each clause atom (matches base-R `df$col`); compares column+operator+rhs |
| `check_null_calibration` `CONFIRM_NULL_NO_MDE` | any precision token in the whole title+abstract+conclusion region suppressed every null | per-claim-**site**: a caveat co-located with one null no longer masks a bare equivalence claim elsewhere |
| `check_scope_coherence` `CROSS_SECTIONAL_PROGNOSTIC` | fired on a QC/methods/detector paper that *describes* the anti-pattern | meta-document guard: cleared when the match names the pattern as an object of study |
| `check_classical_style` `INBODY_AI_DISCLOSURE` | fired on a paper whose *subject* is AI-use disclosure | meta-document guard on AI-disclosure-as-subject |

Meta-document guards are kept tight (require the meta-framing structure) so a genuine overclaim / in-body disclosure is never suppressed.

Source: review-harvest inbox candidates (2026-06-24 meta-document; 2026-06-28 binning df-alias; 2026-06-29 null region-blind). Prune-before-add: precision on shipped detectors.

All four `tests/test_*.sh` pass (new + existing regression). CI-mirror green locally (generators `--check`, `validate_skills`, `validate_catalog_consistency`, `check_domain_probe_sync --strict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)