### PR TITLE
feat(self-review): supplement-hygiene participant-PII tie (de-anon guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **`check_supplement_hygiene` gains `SUPP_PARTICIPANT_PII_TIE` (Major; no count change).** Flags a reader/participant identity — a pseudonym (`R`+hex) or a named participant — tied to an INDIVIDUAL response on one line of a reader-facing / public supplement (a re-identifiable datum). A byline / roster line with only aggregate responses does not fire. Motivated by a preprint supplement that linked a reader pseudonym to a real name + individual response.
+
 - **Four review domain-probes (no detector-count change).** Canonical in `peer-review`, vendored into `self-review`: **diagnostic_accuracy D9** (confidence-weighted reader study needs an unweighted-baseline AUC + monotonic-encoding check), **D10** (a "no stratum met threshold X" claim vs a per-stratum AUC+CI table that does meet X), **D11** (mixed-normalisation values in one comparison column), and **ai_overclaiming AO7** (a "within/comparable-to X variability" claim whose benchmark X was never quantified). SKILL.md probe ranges updated (D1–D11, AO0–AO7).
 
 - **Three review domain-probes (no detector-count change).** Canonical in `peer-review`, vendored byte-identical into `self-review`: **sr_ma P18** (train-vs-validation pool integrity — an apparent/in-sample estimate smuggled into the "validation" pool), **sr_ma P19** (reviewer-side included-study cell audit — metric-type identity, self-eligibility contradiction, CI provenance), and **observational_confounding O18** (pseudoreplication in multi-rater agreement / reader studies — pooled pairwise vs per-subject). SKILL.md probe ranges/counts updated.

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3738,8 +3738,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_supplement_hygiene.py",
-      "size": 11088,
-      "sha256": "f89027472cdf0258357c3b0f0b0f3fec09b5ea65cc1373292797b818d1acf444"
+      "size": 13579,
+      "sha256": "c61bd5e485d2bce4a6efd7bf2a7980aa0d31ebecb876a7c6895fd12cb6bf7f1c"
     },
     {
       "path": "skills/self-review/skill.yml",

--- a/skills/self-review/scripts/check_supplement_hygiene.py
+++ b/skills/self-review/scripts/check_supplement_hygiene.py
@@ -24,6 +24,10 @@ Verdicts (all Major — each reaches a reviewer/editor as a non-anonymous slip):
                          Reviewer", "Reviewer 2 Comment 4".
   SUPP_PLANNING_RESIDUE  pre-execution planning residue: "Designed by:", "Expected
                          PRISMA Numbers", "Deduplication Plan", "to be executed/run".
+  SUPP_PARTICIPANT_PII_TIE a reader/participant identity (pseudonym R+hex, or a named
+                         participant) tied to an INDIVIDUAL response on one line — a
+                         re-identifiable datum in a reader-facing/public supplement. A
+                         byline/roster without individual responses does not fire.
   SUPP_XREF_UNRESOLVED   (needs --manuscript) a body "Supplementary Table/Figure/
                          Material N" callout with no matching supplement section.
 
@@ -83,6 +87,46 @@ PLANNING_RESIDUE = re.compile(
     r"|\bawaiting\s+(?:data|results|execution)\b",
     re.IGNORECASE)
 
+# Participant-privacy tie: a reader/participant IDENTITY on the same line as an
+# INDIVIDUAL-RESPONSE datum re-identifies that person's answers in a reader-facing /
+# public supplement. Identity = a reader pseudonym token (R + hex) OR a proper "First
+# Last" name accompanied by a participant word on the line. Response datum = an
+# explicit per-trial answer. A byline / roster line (a name with NO individual
+# response) is legitimate and must NOT fire.
+READER_PSEUDONYM = re.compile(r"\bR[0-9a-f]{5,}\b")
+PROPER_NAME = re.compile(r"\b[A-Z][a-z]+(?:\s+[A-Z]\.?)?\s+[A-Z][a-z]+\b")
+PARTICIPANT_WORD = re.compile(r"\b(?:reader|participant|rater|observer|respondent|subject)\b", re.I)
+RESPONSE_DATUM = re.compile(
+    r"\bresponse\s*[=:]|\bconfidence\s*[=:]|\bcue\s*[=:]|\btrial\s+\d+\b"
+    r"|\brated\s+(?:it|this|the\s+\w+)\b|\banswered\s+(?:real|fake|ai|synthetic)\b"
+    r"|\bresponse\s+(?:was\s+)?(?:real|fake|ai|synthetic|authentic)\b",
+    re.IGNORECASE)
+
+
+def lint_pii_tie(path: Path) -> list[dict]:
+    """Flag a line that ties a reader identity to an individual response (de-anon)."""
+    claims: list[dict] = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for i, line in enumerate(text.splitlines(), 1):
+        if not RESPONSE_DATUM.search(line):
+            continue
+        has_pseudonym = READER_PSEUDONYM.search(line)
+        has_named = PROPER_NAME.search(line) and PARTICIPANT_WORD.search(line)
+        if not (has_pseudonym or has_named):
+            continue
+        who = "a reader pseudonym" if has_pseudonym else "a named participant"
+        claims.append({
+            "verdict": "SUPP_PARTICIPANT_PII_TIE",
+            "severity": "Major",
+            "detail": (f"{who} is tied to an individual response on one line in {path.name} — "
+                       f"a re-identifiable participant-level datum in a reader-facing supplement; "
+                       f"de-identify (a byline/roster without individual responses is fine)"),
+            "where": f"{path.name}:{i}: …{line.strip()[:110]}…",
+        })
+        break  # one per file
+    return claims
+
+
 PER_FILE_CHECKS = [
     ("SUPP_INTERNAL_LABEL", INTERNAL_LABEL,
      "a § / §L internal section or SAP label leaked into a reader-facing file"),
@@ -117,6 +161,7 @@ def lint_file(path: Path) -> list[dict]:
             "detail": f"{detail} — {n} occurrence(s) in {path.name}",
             "where": f"{path.name}:{ln}: …{snippet[:120]}…",
         })
+    claims.extend(lint_pii_tie(path))
     return claims
 
 

--- a/skills/self-review/tests/fixtures/supplement_pii_clean.md
+++ b/skills/self-review/tests/fixtures/supplement_pii_clean.md
@@ -1,0 +1,5 @@
+# Supplementary Appendix. Reader panel
+
+The reader panel comprised Kyung Eun Lee, Pa Hong, and Min Su Yoon (members listed
+in the Supplementary Appendix). Aggregate response rates were 0.71 across readers.
+Overall, responses to real images were more accurate than to synthetic ones.

--- a/skills/self-review/tests/fixtures/supplement_pii_tie.md
+++ b/skills/self-review/tests/fixtures/supplement_pii_tie.md
@@ -1,0 +1,6 @@
+# Supplementary Table S3. Post-lock reader timeline
+
+| Reader | Name | Status | Response |
+|---|---|---|---|
+| Rfe75ca | Kyung Eun Lee | analyzed | response=real, confidence=4, cue=texture |
+| R0a1b2c | (quarantined) | replaced | response=fake, confidence=2 |

--- a/skills/self-review/tests/test_supplement_hygiene.sh
+++ b/skills/self-review/tests/test_supplement_hygiene.sh
@@ -59,5 +59,22 @@ assert len(x)==1 and '9' in x[0]['detail'], x
 python3 "$SCRIPT" --manuscript "$XBODY" --quiet >/dev/null 2>&1
 check "exit 2 when no --supplement given" test "$?" -eq 2
 
+# (5) participant-PII tie: a pseudonym + name tied to an individual response row ->
+#     SUPP_PARTICIPANT_PII_TIE; a byline/roster with only aggregate responses -> clean.
+PIILEAK="$HERE/fixtures/supplement_pii_tie.md"
+PIICLEAN="$HERE/fixtures/supplement_pii_clean.md"
+python3 "$SCRIPT" --supplement "$PIILEAK" --out "$OUT" --quiet >/dev/null 2>&1
+check "SUPP_PARTICIPANT_PII_TIE on identity+individual-response row" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert any(c['verdict']=='SUPP_PARTICIPANT_PII_TIE' for c in d['claims']), 'not flagged'
+"
+python3 "$SCRIPT" --supplement "$PIICLEAN" --out "$OUT" --quiet >/dev/null 2>&1
+check "no PII tie on a byline/roster with aggregate responses" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='SUPP_PARTICIPANT_PII_TIE' for c in d['claims']), 'roster false positive'
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
`check_supplement_hygiene` gains **`SUPP_PARTICIPANT_PII_TIE`** (Major) — **no detector-count change** (extends an existing detector).

Flags a line in a reader-facing / public supplement that ties a **reader/participant identity** — a pseudonym (`R`+hex, e.g. `Rfe75ca`) or a **named** participant (First Last + a participant word on the line) — to an **individual response** (`response=`, `confidence=`, `cue=`, `trial N`, "rated…", "answered real/fake"). That is a re-identifiable participant-level datum.

A **byline / roster** line — names with only *aggregate* responses, no individual answer — does **not** fire.

pos+neg fixtures; existing supplement-hygiene regression preserved (ALL PASS); CI-mirror green locally. Source: review-harvest inbox 2026-06-25 (a preprint supplement linked a reader pseudonym → real name → individual response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)