### PR TITLE
feat(self-review): claim_artifact --scripts code-label reconcile (PRIMARY_LABEL_CODE_DRIFT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **`check_claim_artifact` gains `--scripts` + `PRIMARY_LABEL_CODE_DRIFT` (advisory; no count change).** When the manuscript asserts a SINGLE primary model/analysis but an analysis script annotates a model as `co-primary`, the code label (a third SSOT) has drifted — reconcile it with the declared estimand. Advisory, since code comments can lag.
+
 - **`check_cv_leakage` (self-review, `data_preparation`; integrity detectors 45 → 46).** `CV_SELECTION_LEAKAGE` (Major): for a classifier / NLP / tabular manuscript, a data-driven selection step (feature selection, log-odds / univariate filtering, vocabulary construction, a threshold) that co-occurs with cross-validation without any fold-nesting disclosure ('within each fold', 'nested CV') — if the selection was fit on the full dataset the CV metric is optimistically inflated. Distinct from patient-vs-image split leakage.
 - **peer-review §1C contribution-gate: salvage-reframe sub-rule.** A fix that *narrows* a claim to survive a construct/validity flaw is Reject-leaning, not an encourage-major-revision, when novelty/importance is already weak — a shrunk contribution is the product, not addressable-in-revision.
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3668,8 +3668,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",
-      "size": 15879,
-      "sha256": "1daa64eaabe493f05ae7e2129a2056b673ec588487d5b6c73f41f10104822935"
+      "size": 18475,
+      "sha256": "c99c8090205734b0eae981550ed09e6275d94add608e66df78f4533c35f20924"
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",

--- a/skills/self-review/scripts/check_claim_artifact.py
+++ b/skills/self-review/scripts/check_claim_artifact.py
@@ -83,6 +83,16 @@ EVALUE_RE = re.compile(
 NONPRIMARY_KW = ("secondary", "exploratory", "subgroup", "sensitivity", "supporting",
                  "cause-specific", "cancer-specific", "post-hoc", "post hoc", "non-primary")
 
+# The manuscript asserts exactly ONE primary model/analysis (so a script annotating a
+# model as "co-primary" is a third-SSOT drift).
+SINGLE_PRIMARY = re.compile(
+    r"\bsingle\s+primary\b|\ba\s+single\s+primary\b|\bone\s+primary\s+(?:model|analysis|endpoint|outcome)\b"
+    r"|\bthe\s+primary\s+(?:model|analysis|endpoint|outcome)\b[^.]{0,70}?"
+    r"(?:consistent\s+with\s+the\s+(?:registered|pre-?specified)|registered\s+analysis\s+plan)",
+    re.I)
+# A model annotated "co-primary" in analysis code (a comment, string, or variable).
+CO_PRIMARY_CODE = re.compile(r"\bco[-\s]?primary\b", re.I)
+
 STOP = set("the a an of for in on to and or with by is was were are be been being this that "
            "between association associated estimated using model analysis primary outcome "
            "endpoint study patients group as at from".split())
@@ -271,6 +281,45 @@ def check_evalue(manuscript: str) -> list[dict]:
 # manual confirmation against the registration before either is acted on, and a P0
 # that needs hand-confirmation is not a P0. Only explicit re-designation and a
 # non-recomputing E-value are Major.
+def check_code_labels(manuscript: str, scripts_dir: str | None) -> list[dict]:
+    """Reconcile the manuscript's declared primary against analysis-script labels.
+
+    Fires only the specific conflict: the manuscript asserts a SINGLE primary while an
+    analysis script annotates a model as 'co-primary' — the code label is a third SSOT
+    that drifts across revisions. Advisory (code comments can lag)."""
+    claims: list[dict] = []
+    if not scripts_dir:
+        return claims
+    d = Path(scripts_dir)
+    if not d.exists() or not SINGLE_PRIMARY.search(manuscript):
+        return claims
+    for p in sorted(d.rglob("*")):
+        if p.suffix.lower() not in (".r", ".py"):
+            continue
+        try:
+            txt = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = CO_PRIMARY_CODE.search(txt)
+        if not m:
+            continue
+        ln = txt[:m.start()].count("\n") + 1
+        snippet = txt.splitlines()[ln - 1].strip()[:80] if ln - 1 < len(txt.splitlines()) else ""
+        claims.append({
+            "claim_id": "EST-code-label",
+            "type": "estimand",
+            "prose_value": "manuscript asserts a single primary model/analysis",
+            "artifact_source": f"{p.name}:{ln} labels a model 'co-primary'",
+            "verdict": "PRIMARY_LABEL_CODE_DRIFT",
+            "detail": (f"the manuscript declares a SINGLE primary while an analysis script "
+                       f"annotates a model as co-primary ({p.name}:{ln}: '{snippet}'); reconcile "
+                       f"the code's primary/co-primary label with the declared estimand — code "
+                       f"labels are a third SSOT that can drift across revisions. ADVISORY."),
+        })
+        break  # one is enough to prompt a reconcile
+    return claims
+
+
 MAJOR = {"PRIMARY_REASSIGNED", "EVALUE_ARITHMETIC"}
 
 
@@ -278,6 +327,7 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Claim-vs-artifact cross-check (estimand + E-value).")
     ap.add_argument("--manuscript", required=True, help="manuscript markdown/text")
     ap.add_argument("--prereg", help="pre-registration / protocol / project.yaml text")
+    ap.add_argument("--scripts", help="analysis-scripts directory (reconcile code primary/co-primary labels)")
     ap.add_argument("--out", help="write JSON artifact to this path")
     ap.add_argument("--strict", action="store_true", help="exit 1 if any Major verdict")
     args = ap.parse_args()
@@ -302,7 +352,8 @@ def main() -> int:
         else:
             sys.stderr.write(f"WARN: prereg not found: {args.prereg} (estimand provenance limited)\n")
 
-    claims = check_estimand(manuscript, prereg, prereg_raw) + check_evalue(manuscript)
+    claims = (check_estimand(manuscript, prereg, prereg_raw) + check_evalue(manuscript)
+              + check_code_labels(manuscript, args.scripts))
     n_major = sum(1 for c in claims if c["verdict"] in MAJOR)
     n_flag = sum(1 for c in claims if c["verdict"] not in MAJOR and c["verdict"] != "OK")
 

--- a/skills/self-review/tests/fixtures/claim_manuscript_single_primary.md
+++ b/skills/self-review/tests/fixtures/claim_manuscript_single_primary.md
@@ -1,0 +1,3 @@
+## Methods
+Model 3 is the single primary model, consistent with the registered analysis plan.
+The E-value for the primary association (HR 1.34) was 2.02.

--- a/skills/self-review/tests/fixtures/claim_scripts_consistent/05_primary_cox.R
+++ b/skills/self-review/tests/fixtures/claim_scripts_consistent/05_primary_cox.R
@@ -1,0 +1,3 @@
+# 05_primary_cox.R
+model3 <- coxph(Surv(t, e) ~ x + covars)   # the single primary model
+model5 <- coxph(Surv(t, e) ~ x + covars2)  # secondary sensitivity analysis

--- a/skills/self-review/tests/fixtures/claim_scripts_coprimary/05_primary_cox.R
+++ b/skills/self-review/tests/fixtures/claim_scripts_coprimary/05_primary_cox.R
@@ -1,0 +1,3 @@
+# 05_primary_cox.R
+model3 <- coxph(Surv(t, e) ~ x + covars)   # PRIMARY model
+model4 <- coxph(Surv(t, e) ~ x2 + covars)  # CO-PRIMARY model (added at revision)

--- a/skills/self-review/tests/test_claim_artifact.sh
+++ b/skills/self-review/tests/test_claim_artifact.sh
@@ -86,5 +86,20 @@ raise SystemExit(0 if not any(c['verdict']=='ESTIMAND_DRIFT' for c in d['claims'
 python3 "$SCRIPT" --manuscript "$SMAN" --prereg "$SPRE" --strict >/dev/null 2>&1
 check "exit 0 on structured consistent prereg (no Major)" test "$?" -eq 0
 
+# Code-label reconciliation (--scripts): a manuscript asserting a SINGLE primary vs an
+# analysis script annotating a model 'co-primary' -> PRIMARY_LABEL_CODE_DRIFT (advisory,
+# not Major). A consistent scripts dir and the no-flag backward-compatible default.
+SP="$HERE/fixtures/claim_manuscript_single_primary.md"
+python3 "$SCRIPT" --manuscript "$SP" --scripts "$HERE/fixtures/claim_scripts_coprimary" --out "$OUT" >/dev/null 2>&1
+check "PRIMARY_LABEL_CODE_DRIFT on code co-primary vs single-primary manuscript" has_verdict PRIMARY_LABEL_CODE_DRIFT
+python3 "$SCRIPT" --manuscript "$SP" --scripts "$HERE/fixtures/claim_scripts_coprimary" --strict >/dev/null 2>&1
+check "code-label drift is advisory (exit 0 under --strict)" test "$?" -eq 0
+python3 "$SCRIPT" --manuscript "$SP" --scripts "$HERE/fixtures/claim_scripts_consistent" --out "$OUT" >/dev/null 2>&1
+check "no drift when scripts carry no co-primary label" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='PRIMARY_LABEL_CODE_DRIFT' for c in d['claims']) else 1)
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
`check_claim_artifact` gains **`--scripts`** and an advisory **`PRIMARY_LABEL_CODE_DRIFT`** — **no detector-count change**, backward-compatible.

When the manuscript asserts a **single** primary model/analysis but an analysis script annotates a model as `co-primary`, the code label (a third SSOT alongside manuscript + prereg) has drifted from the declared estimand. Fires only that specific conflict; advisory, since code comments can lag across revisions.

pos+neg fixtures (a co-primary-labelled script dir + a consistent one); existing claim_artifact regression preserved (ALL PASS); CI-mirror green locally. Source: review-harvest inbox 2026-06-29 (`05_primary_cox.R` labelled Model 4 "CO-PRIMARY" while the manuscript stated a single primary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)