### PR TITLE
docs: codify a release-cadence policy (batch, don't release per PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Documentation
+
+- **Release-cadence policy** (`docs/maintainer_workflow.md` § Release cadence). Codifies that
+  `[Unreleased]` is a staging area a release drains, that a minor release must be a coherent
+  user-noticeable batch (not internal symmetry-completion), and a guardrail of at most ~one minor
+  release per week under additive work — bundle otherwise; only a broken-install/CI/correctness/security
+  patch ships immediately. Content creation (merge when ready, demand-driven) and releasing
+  (batch-driven) are decoupled. ROADMAP "honest versioning" now links it; the release checklist
+  clarifies draining `[Unreleased]` in place.
+
 ## [5.14.0] - 2026-07-02
 
 Research enablement: a fourth executable-depth produce-guide and completion of the worked-exemplar

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,8 +49,9 @@ These stay green but are no longer the strategic direction:
   OpenAlex before a reference is trusted; no references written from model memory.
 - **Numerical, cohort, and cross-artifact consistency** — counts, denominators,
   and submission-package artifacts that agree across the manuscript lifecycle.
-- **Release stability and documentation clarity** — honest versioning, a clear
-  "start here", and reproducible public demos.
+- **Release stability and documentation clarity** — honest versioning and a batched
+  [release cadence](docs/maintainer_workflow.md#release-cadence) (no per-PR version
+  inflation), a clear "start here", and reproducible public demos.
 - **Maintainability and governance** — lightweight contributor and maintainer
   process so the project can accept help without diluting clinical scope
   (see [`MAINTAINERS.md`](MAINTAINERS.md)).

--- a/docs/maintainer_workflow.md
+++ b/docs/maintainer_workflow.md
@@ -42,7 +42,10 @@ it simply does not gate.)
 
 1. **Decide the version** honestly (see "Versioning" below).
 2. **Sync versions in one commit:**
-   - `CHANGELOG.md` — move `[Unreleased]` to `[x.y.z]` with today's date.
+   - `CHANGELOG.md` — rename the `## [Unreleased]` header **in place** to `## [x.y.z] - <date>`
+     so the accumulated items stay under it; do **not** insert a new `## [x.y.z]` header *above*
+     `## [Unreleased]` (that orphans the items under a stale Unreleased heading). Verify with
+     `grep '^## \[' CHANGELOG.md`.
    - `CITATION.cff` — `version` + `date-released`.
    - `package.json` — `version` (npm).
    - `README.md` — "What's New" entry.
@@ -86,3 +89,40 @@ Semantic versioning, read honestly:
 
 Release notes distinguish: **Added / Changed / Fixed / Deprecated /
 Validation-Evidence / Breaking changes / Documentation.**
+
+## Release cadence
+
+Semver above says *what a bump means*; this says *how often to cut one*. The default
+failure mode for an actively-developed toolkit — especially one worked on by an
+autonomous agent — is **releasing per pull request**, which inflates the version number
+until it no longer communicates anything. `[Unreleased]` racing several minors in a few
+days is a credibility tell to an academic audience, the same way an unjustified major bump
+is.
+
+**Rules:**
+
+1. **`[Unreleased]` is the staging area; a release drains it.** Merged PRs accumulate under
+   `## [Unreleased]` in `CHANGELOG.md`. Do **not** cut a release for every 1–2 merged PRs.
+   Let the section fill up, then release once.
+
+2. **A minor release must be a coherent, user-noticeable batch** — not internal
+   symmetry-completion. "The N-pillar set is now complete" or "the arc is finished" is an
+   *aesthetic* trigger, not a release trigger. Release when `[Unreleased]` holds something a
+   user would actually notice or act on.
+
+3. **Cadence guardrail: at most ~one minor release per week** under normal additive work. If
+   several minors would otherwise land in the same week, **bundle them into one**. More than
+   one minor release in a single work session is almost always over-granular — accumulate
+   instead.
+
+4. **The only "release now" trigger is a patch for a broken install / CI / correctness or
+   security fix.** Those ship immediately (see the Versioning policy for what counts as a
+   patch). Everything else waits for the next batch.
+
+5. **Content creation and releasing are decoupled.** New skills/detectors/guides should be
+   **demand-driven** (a real reviewer comment, a user request, a desk-reject, or a
+   review-harvest promotion), and *merged* whenever ready; *releasing* is **batch-driven** on
+   the cadence above. Finishing a PR is a reason to merge, never by itself a reason to tag.
+
+When in doubt, **do not release** — an extra week in `[Unreleased]` costs nothing, while an
+extra version number spends credibility that is hard to earn back.


### PR DESCRIPTION
## Summary

Adds a **Release cadence** section to `docs/maintainer_workflow.md`. The existing *Versioning policy* defines *what a bump means* (patch/minor/major); this defines *how often to cut one*.

**Rules codified:**
1. `[Unreleased]` is a staging area a release drains — do **not** release per 1–2 PRs.
2. A minor release must be a coherent, **user-noticeable batch** — not internal symmetry/arc/"N-pillar-set" completion (an *aesthetic* trigger, not a release trigger).
3. Guardrail: **at most ~one minor release per week** under additive work; bundle otherwise.
4. Only a broken-install/CI/correctness/security **patch** ships immediately.
5. **Content creation (merge when ready, demand-driven) and releasing (batch-driven) are decoupled** — finishing a PR is never by itself a reason to tag.

## Why

An autonomous cycle cut **three minor releases in one session** (v5.12→v5.14), part of 10 minor releases in 4 days (v5.5→v5.14). That is version-number inflation that dilutes what a release communicates — the same credibility tell the Versioning policy already warns about for unjustified major bumps. This closes the gap by governing cadence explicitly.

## Changes

- `docs/maintainer_workflow.md` — new `## Release cadence` section; release checklist clarifies renaming `## [Unreleased]` → `## [x.y.z]` **in place** (an orphaning gotcha hit this cycle).
- `ROADMAP.md` — "honest versioning" now links the batched-cadence policy.
- `CHANGELOG.md` — `[Unreleased]` Documentation entry.

## Note

Docs-only; **no version bump and no release** — this change accumulates under `[Unreleased]` per the very policy it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)