### PR TITLE
docs: copy-paste citation ergonomics in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Documentation
 
+- **Copy-paste citation ergonomics** (README § Citation). Adds a ready-to-adapt Methods/Acknowledgement
+  sentence (with a version placeholder), BibTeX for the software (Zenodo) and the design preprint,
+  a note that the concept DOI resolves to the latest release, and a pointer to the "Used in research"
+  issue → `docs/citations.md`. Lowers the friction to legitimately cite the toolkit.
+
 - **Release-cadence policy** (`docs/maintainer_workflow.md` § Release cadence). Codifies that
   `[Unreleased]` is a staging area a release drains, that a minor release must be a coherent
   user-noticeable batch (not internal symmetry-completion), and a guardrail of at most ~one minor

--- a/README.md
+++ b/README.md
@@ -787,15 +787,44 @@ It helps other researchers find the toolkit — and we list it (with your permis
 
 ## Citation
 
-If you use MedSci Skills in your research, please cite the software via
-[`CITATION.cff`](CITATION.cff) (Zenodo concept DOI
-[10.5281/zenodo.20155321](https://doi.org/10.5281/zenodo.20155321)).
+If MedSci Skills helped produce your manuscript, protocol, or analysis, please cite it —
+software citation is how a tool like this earns academic recognition, and it takes one line.
 
-The design and evaluation of the toolkit are described in a preprint:
+**In your manuscript** (Methods or Acknowledgements — cite the version you actually used):
 
-> Nam Y, Kim N. *Agentic Skills for Auditable and Reproducible Medical Research
-> Writing: An Integrity-gated Architecture for LLM-Assisted Clinical Manuscripts.*
-> arXiv:2606.09500 (2026). https://arxiv.org/abs/2606.09500
+> Reporting-guideline compliance, reference verification, and pre-submission integrity checks
+> were assisted by MedSci Skills (version X.Y.Z; https://github.com/Aperivue/medsci-skills;
+> archived at Zenodo, https://doi.org/10.5281/zenodo.20155321).
+
+**BibTeX** (the software, and the preprint describing its design):
+
+```bibtex
+@software{nam_medsci_skills,
+  author    = {Nam, Yoojin},
+  title     = {{MedSci Skills: Claude Code Skills for the Medical Research Lifecycle}},
+  year      = {2026},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20155321},
+  url       = {https://github.com/Aperivue/medsci-skills}
+}
+
+@article{nam2026agentic,
+  author  = {Nam, Yoojin and Kim, Namkug},
+  title   = {{Agentic Skills for Auditable and Reproducible Medical Research Writing:
+             An Integrity-gated Architecture for LLM-Assisted Clinical Manuscripts}},
+  year    = {2026},
+  journal = {arXiv preprint arXiv:2606.09500},
+  url     = {https://arxiv.org/abs/2606.09500}
+}
+```
+
+The Zenodo **concept DOI** [10.5281/zenodo.20155321](https://doi.org/10.5281/zenodo.20155321)
+always resolves to the latest release; [`CITATION.cff`](CITATION.cff) carries the machine-readable
+metadata (GitHub's "Cite this repository" button reads it).
+
+**Used it in published or in-review work?** Tell us via the
+["Used in research" issue template](https://github.com/Aperivue/medsci-skills/issues/new?template=used-in-research.yml)
+— with your permission it is added to [`docs/citations.md`](docs/citations.md).
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary

Enriches the README `## Citation` section with **copy-paste artifacts** — the missing friction-reducer that stops legitimate users from actually citing the tool:

- a ready-to-adapt **Methods/Acknowledgement sentence** (with a version placeholder),
- **BibTeX** for the software (Zenodo DOI) and the design preprint,
- a note that the Zenodo concept DOI resolves to the latest release,
- a pointer to the **"Used in research"** issue → `docs/citations.md`.

## Why

Adoption-direction work (chosen with the founder): the strong-evidence column for this project — **confirmed downstream use + citations** — is currently empty, while stars grow steadily. Software gets cited when citing is one copy-paste away; this removes that friction. No feature added.

## Note

Docs-only. **No version bump, no release** — accumulates under `[Unreleased]` per the release-cadence policy (#269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)