### PR TITLE
docs: by-stage skill index, multi-host framing, star history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Documentation
 
+- **README: by-stage skill index, multi-host framing, and star history.** A scannable "by research
+  stage" grouping of all 51 skills sits above the full table; a Star History chart is added; and the
+  About section now states the toolkit runs on all four verified Agent Skills hosts (Claude Code,
+  Codex, Cursor, GitHub Copilot) rather than Claude Code alone. The GitHub repo description and topics
+  were broadened to match (leads with "Agent Skills"; adds `codex`/`cursor` topics).
+
 - **Copy-paste citation ergonomics** (README § Citation). Adds a ready-to-adapt Methods/Acknowledgement
   sentence (with a version placeholder), BibTeX for the software (Zenodo) and the design preprint,
   a note that the concept DOI resolves to the latest release, and a pointer to the "Used in research"

--- a/README.md
+++ b/README.md
@@ -447,6 +447,21 @@ ma-scout -> search-lit -> fulltext-retrieval -> design-study ──> write-proto
                               └─────────────────────────────────────────────┘
 ```
 
+### By research stage
+
+All 51 skills, grouped by where they fit in the clinical-manuscript and medical-AI lifecycle. Full descriptions are in the table below; one page per skill lives in the [per-skill reference](docs/skills/).
+
+| Stage | Skills |
+|-------|--------|
+| 🔭 **Discover & scope** | `ma-scout` · `find-cohort-gap` · `search-lit` · `fulltext-retrieval` · `lit-sync` · `author-strategy` |
+| 📐 **Design & plan** | `design-study` · `calc-sample-size` · `define-variables` · `write-protocol` · `fill-protocol` · `design-ai-benchmarking` |
+| 🧹 **Data & analysis** | `deidentify` · `clean-data` · `generate-codebook` · `version-dataset` · `analyze-stats` · `batch-cohort` · `cross-national` · `replicate-study` |
+| 🤖 **Medical-AI model engineering** | `architecture-zoo` · `model-scaffold` · `model-validation` · `model-evaluation` · `model-card` · `mllm-eval` |
+| ✍️ **Write & visualize** | `write-paper` · `make-figures` · `review-paper` · `present-paper` · `humanize` · `polish-language` · `academic-aio` |
+| ✅ **Comply & verify** | `check-reporting` · `self-review` · `verify-refs` · `manage-refs` |
+| 📤 **Submit & respond** | `find-journal` · `add-journal` · `sync-submission` · `revise` · `peer-review` · `fill-icmje-coi` |
+| 🧭 **Orchestrate & manage** | `orchestrate` · `intake-project` · `manage-project` · `meta-analysis` · `grant-builder` · `publish-skill` · `render-pdf-doc` · `setup-medsci` |
+
 ### Available Now
 
 | Skill | What It Does |
@@ -844,8 +859,16 @@ Bundled reporting guideline checklists retain their original Creative Commons li
 
 Optional dependency: `pdf_to_md.py` uses [pymupdf4llm](https://pymupdf.readthedocs.io) (AGPL-3.0). Not bundled -- installed separately by the user via `pip install pymupdf4llm`.
 
+## Star History
+
+<a href="https://star-history.com/#Aperivue/medsci-skills&Date">
+  <img src="https://api.star-history.com/svg?repos=Aperivue/medsci-skills&type=Date" alt="MedSci Skills star history" width="640">
+</a>
+
 ## About
 
 Built by [Aperivue](https://aperivue.com) -- tools for medical AI research and education.
+
+**Runs anywhere the [Agent Skills standard](https://agentskills.io) is supported** -- not Claude Code alone. Claude Code, OpenAI Codex, Cursor, and GitHub Copilot are all verified against each host's own docs: one install, four hosts, no per-host fork ([host compatibility](docs/host_compatibility.md)).
 
 If you find this useful, consider giving it a star. It helps other researchers discover these tools.


### PR DESCRIPTION
## Summary

README + About polish inspired by a review against a larger sibling library. Docs-only — records under `[Unreleased]`, no release (per the release-cadence policy).

- **README `### By research stage`** — a scannable grouping of all 51 skills across 8 lifecycle stages (Discover / Design / Data & Analysis / Medical-AI model engineering / Write / Comply / Submit / Orchestrate), placed above the full description table. Closes the one structural gap vs browse-by-stage libraries; verified the table contains exactly 51 distinct skill tokens.
- **README `## Star History`** — star-history chart.
- **README About** — states the toolkit runs on all four verified Agent Skills hosts (Claude Code, OpenAI Codex, Cursor, GitHub Copilot), linking `docs/host_compatibility.md`, rather than reading Claude-Code-only.
- **GitHub repo metadata (already applied out of band)** — description now leads with "Agent Skills" and names the four hosts; topics add `codex`/`cursor` (dropped redundant `strobe`/`tripod-ai` to stay at 20).

## Notes

- No skill / detector / guideline count changes (still 51 / 46 / 44).
- `validate_catalog_consistency.py` passes (README count claims are gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)