### PR TITLE
fix(self-review): scope_coherence — suppress enumerated-defect-label false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`self-review` scope-coherence: enumerated-defect-label false positive.** `check_scope_coherence`
+  no longer fires `CROSS_SECTIONAL_PROGNOSTIC` on a sentence that *names* the anti-pattern as a defect
+  in a list (e.g. "… flags … an unsupported prognostic claim in a cross-sectional study, a fabricated
+  citation, …"), which the existing meta-document guard missed. A new `ANTIPATTERN_LABEL` guard treats
+  a prognostic/surveillance token preceded by a defect adjective (unsupported/unwarranted/…) or
+  followed by overclaim/overreach/fallacy/error as a label, not a claim — high-precision, no genuine
+  overclaim suppressed. Field-harvested from real-project precision tracking; regression test added.
+  No detector count change (46).
+
 ### Documentation
 
 - **README: by-stage skill index, multi-host framing, and star history.** A scannable "by research

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_scope_coherence.py",
-      "size": 11920,
-      "sha256": "e600e54fcbe308060a8dadd871ec274b6ae19f89456ae0194490e152c0d09a91"
+      "size": 12989,
+      "sha256": "2444bce9c5bd2fc088c43eae97c1fc5791ae4da44f428a2caa0559b976dbe622"
     },
     {
       "path": "skills/self-review/scripts/check_supplement_hygiene.py",

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -87,6 +87,22 @@ META_DOC_FRAME = re.compile(
     r"(?:as|is) an? (?:example|illustration|instance|case) of",
     re.IGNORECASE)
 
+# A sentence that LABELS a prognostic/surveillance claim as a defect — "an
+# unsupported prognostic claim in a cross-sectional study", "prognostic
+# overreach", "an unwarranted surveillance recommendation" — is naming the
+# anti-pattern, not committing it. This catches the enumerated-defect framing
+# (a defect listed as an appositive in a list of things a tool flags) that
+# META_DOC_FRAME misses because the framing verb ("flags"/"detects") sits far
+# from the match. Stays high-precision: a manuscript making a real prognostic
+# claim never precedes it with "unsupported"/"unwarranted", nor calls it an
+# "overreach"/"overclaim" — so no genuine overclaim is suppressed.
+ANTIPATTERN_LABEL = re.compile(
+    r"(?:unsupported|unwarranted|unjustified|inappropriate|spurious|invalid|"
+    r"overreaching|erroneous|illegitimate)\s+(?:\w+\s+){0,2}?"
+    r"(?:prognostic|surveillance|longitudinal)|"
+    r"(?:prognostic|surveillance|longitudinal)\s+(?:overclaim|overreach|fallacy|error)",
+    re.IGNORECASE)
+
 DIRECTIVE_VERB = re.compile(
     r"\bdefer(?:ral|red|ring)?\b|\bwithhold\b|\bforgo\b|\binitiat(?:e|ed|ion)\b|"
     r"\bdiscontinu(?:e|ed|ation)\b|start(?:ing)?\s+(?:statin|therapy|treatment|pharmacotherapy)|"
@@ -142,7 +158,8 @@ def check(text: str) -> list[dict]:
         # conclusion still fires even if an earlier mention was a disclaimer.
         for pm in PROGNOSTIC_VERB.finditer(concl):
             window = concl[max(0, pm.start() - 120):pm.end() + 120]
-            if PROGNOSTIC_DISCLAIMER.search(window) or META_DOC_FRAME.search(window):
+            if (PROGNOSTIC_DISCLAIMER.search(window) or META_DOC_FRAME.search(window)
+                    or ANTIPATTERN_LABEL.search(window)):
                 continue
             claims.append({
                 "verdict": "CROSS_SECTIONAL_PROGNOSTIC",

--- a/skills/self-review/tests/fixtures/scope_antipattern_list.md
+++ b/skills/self-review/tests/fixtures/scope_antipattern_list.md
@@ -1,0 +1,13 @@
+# A reproducible toolkit for scope-coherence defects in cross-sectional imaging studies
+
+## Abstract
+
+We present a deterministic gate that scans manuscripts built on a
+cross-sectional, single-visit design and reports a compact list of defects.
+
+## Conclusion
+
+Across a public corpus, the gate flags a non-portable analysis script, an
+unsupported prognostic claim in a cross-sectional study, a fabricated citation,
+and a silently dropped exclusion. Each defect is deterministic and
+reviewer-visible, and authors can resolve every one before submission.

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -83,5 +83,19 @@ assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']),
 python3 "$SCRIPT" --manuscript "$METADOC" --strict --quiet >/dev/null 2>&1
 check "exit 0 on meta-document" test "$?" -eq 0
 
+# (8) an enumerated-defect list ("... flags ..., an unsupported prognostic claim
+#     in a cross-sectional study, a fabricated citation, ...") LABELS the anti-pattern
+#     as a defect rather than committing it. META_DOC_FRAME misses it (the framing
+#     verb sits far from the match); ANTIPATTERN_LABEL suppresses it. -> no fire.
+APLIST="$HERE/fixtures/scope_antipattern_list.md"
+python3 "$SCRIPT" --manuscript "$APLIST" --out "$OUT" --quiet >/dev/null 2>&1
+check "no CROSS_SECTIONAL_PROGNOSTIC on an enumerated-defect list" python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']), 'enumerated-defect label flagged as prognostic overclaim'
+"
+python3 "$SCRIPT" --manuscript "$APLIST" --strict --quiet >/dev/null 2>&1
+check "exit 0 on enumerated-defect list" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## Summary

Field-harvested precision fix for the `check_scope_coherence` gate (self-review §D). It fired `CROSS_SECTIONAL_PROGNOSTIC` on a **meta-sentence that names the anti-pattern as a defect** — e.g. "… the gate flags a non-portable analysis script, an unsupported prognostic claim in a cross-sectional study, a fabricated citation, …" — rather than an actual overclaim. The existing `META_DOC_FRAME` guard keys on the "this paper/tool … detects/flags" structure and misses this **appositive-list** framing where the framing verb sits far from the `prognostic` match.

## Fix

- New `ANTIPATTERN_LABEL` guard: a `prognostic`/`surveillance`/`longitudinal` token **immediately preceded by a defect adjective** (`unsupported`/`unwarranted`/`unjustified`/…) or **followed by** `overclaim`/`overreach`/`fallacy`/`error` is a *label*, not a claim → suppress. Applied alongside the existing disclaimer + meta-doc guards.
- High-precision by construction: a manuscript making a real prognostic claim never precedes it with "unsupported"/"unwarranted", nor calls its own claim an "overreach". Verified the positive fixture (`scope_bad.md`) **still fires**.
- New negative fixture `scope_antipattern_list.md` + regression case (8) in `test_scope_coherence.sh` (already CI-wired at `validate.yml:249`).

## Provenance

Surfaced by the real-project detector-precision harvest (`check_scope_coherence` showed 0.00 precision on the one labeled fire — the MedSci Skills methods paper, which *discusses* the anti-patterns). This is the only genuine repo-level FP that survived the audit; the other "prune candidates" were project-local qc filename noise or detectors simply not exercised by the sample.

## Verification

- `test_scope_coherence.sh`: 14/14 PASS (12 existing + 2 new).
- `validate_skills.sh`, catalog consistency, detectors catalog `--check`, skill docs `--check`, version consistency, locale inventory: all green.
- `distribution_files.json` regenerated (script hash changed); manifest `--check` in sync.
- No detector added — **46 unchanged**.

Not a release trigger (staged under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)