### PR TITLE
docs: sequenced roadmap for model-engineering produce-side depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 
 ### Documentation
 
+- **Model-engineering produce-side depth roadmap** (`docs/roadmap_model_engineering_depth.md`,
+  linked from `ROADMAP.md` § Research throughput). Sequences the three thin produce stages of the
+  in-scope model-engineering lane — imaging data pipeline + data-stage leakage, interpretability/
+  explainability production, uncertainty/OOD reporting — each as a rigor gate with a challenge card,
+  never a training-framework reimplementation, released as one batch. Working checklist for the
+  next expansion cycle.
+
 - **README: by-stage skill index, multi-host framing, and star history.** A scannable "by research
   stage" grouping of all 51 skills sits above the full table; a Star History chart is added; and the
   About section now states the toolkit runs on all four verified Agent Skills hosts (Claude Code,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,11 @@ demoted to a sustaining floor, not the strategic direction.
   target-trial-emulation specifications, DAG-derived adjustment sets, and
   prediction-model-appropriate sample sizes, shaping a study *before* data
   collection — the highest-leverage point in the pipeline.
+- **Model-engineering produce-side depth** — fill the thin produce stages of the
+  in-scope model-engineering lane: imaging data pipeline + data-stage leakage,
+  interpretability/explainability production, and uncertainty/OOD reporting — each
+  a rigor gate, never a training-framework reimplementation. Sequenced in
+  [`docs/roadmap_model_engineering_depth.md`](docs/roadmap_model_engineering_depth.md).
 
 ### Sustaining (the reliability floor)
 

--- a/docs/roadmap_model_engineering_depth.md
+++ b/docs/roadmap_model_engineering_depth.md
@@ -1,0 +1,124 @@
+# Model-Engineering Lane — Produce-Side Depth Roadmap
+
+A sequenced build plan for deepening the **produce** side of the medical-AI
+model-engineering lane. This is a working checklist, executed one item at a time;
+it is a companion to the top-level [`ROADMAP.md`](../ROADMAP.md) (§ Research
+throughput), not a delivery commitment.
+
+## Where the lane stands
+
+The lane today is a **design → scaffold → validate → evaluate → document** loop:
+
+| Stage | Skill(s) |
+|-------|----------|
+| Choose architecture | `architecture-zoo` |
+| Scaffold training repo | `model-scaffold` (+ `check_training_hygiene`) |
+| Validate | `model-validation` (+ `check_split_leakage`) |
+| Evaluate | `model-evaluation` (+ `check_metric_reporting`) |
+| Document | `model-card` (+ `check_model_card_complete`) |
+| LLM/MLLM eval | `mllm-eval` (+ `check_mllm_eval_completeness`) |
+| AI-vs-expert design | `design-ai-benchmarking` |
+
+Plus an **audit companion** in `self-review` domain-probes (`model_development`,
+`clinical_prediction_model`, `ai_overclaiming`, `image_synthesis`).
+
+By design this is a *rigor / reproducibility / reporting* lane — it **integrates**
+MONAI / nnU-Net / timm and never reimplements a training framework. Three
+produce-side stages are genuinely thin; this roadmap fills them, in order.
+
+## Guardrails (every item)
+
+- **On-moat only.** Rigor / reproducibility / reporting for medical imaging —
+  never generic MLOps. Training loops, hyperparameter search, and experiment
+  tracking stay with MONAI / nnU-Net / timm / W&B; we wire and report, not rebuild
+  (this is the [ROADMAP out-of-scope clause](../ROADMAP.md)).
+- **Human-in-loop.** Nothing trains, tunes, or claims a result autonomously.
+- **Every addition ships a deterministic gate + a network-free challenge card +
+  a CI-wired test** (the reproducible-challenge pattern), and no fabricated
+  numbers (VERIFY placeholders where a real run is required).
+- **Wire bidirectionally.** Each produce skill pairs with its `self-review`
+  audit probe and, where relevant, a `check-reporting` item (CLAIM 2024 /
+  TRIPOD+AI).
+- **Catalog discipline.** A new skill bumps `metadata/catalog_counts.json`
+  (skills) + the README tagline + the four count-claim files; a new detector
+  bumps the detectors-catalog family map + count. Run `gen_*` `--check` +
+  `validate_catalog_consistency.py` before every push.
+- **Batched release.** Merge each item to `[Unreleased]`; release the lane as
+  **one** user-noticeable batch once ≥2 items land (per the
+  [release-cadence policy](maintainer_workflow.md#release-cadence)) — not per skill.
+
+## Sequence
+
+### Item 1 — Imaging data pipeline + data-stage leakage  ·  foundation, do first
+
+- **Why first.** Everything downstream depends on leakage-safe, correctly
+  preprocessed data. It extends the existing split-leakage moat
+  (`model-validation`) **upstream** to the data-preparation stage.
+- **Form.** New skill (`preprocess-imaging`) — a distinct produce stage that
+  `model-scaffold` consumes; not an extension.
+- **Produces.** DICOM/NIfTI I/O, resampling / spacing normalization, intensity
+  windowing/normalization, a patient-level split at slice/volume granularity, and
+  augmentation-appropriateness guidance per modality (physiology-preserving vs
+  breaking) — integrating MONAI transforms / TorchIO, not reimplementing them.
+- **Gate — `check_preprocessing_leakage`.** Flags: (a) normalization/scaler
+  statistics fit on full data or the test split (train-only fit required);
+  (b) augmentation or resampling applied before the split; (c) patient IDs
+  crossing train/val/test at the slice level (set-arithmetic on the
+  slice→patient map, extending `check_split_leakage`); (d) test-time augmentation
+  folded into training metrics.
+- **Wiring.** Feeds `model-scaffold`'s split; `self-review` `model_development`
+  probe gains a data-leakage audit back-link; CLAIM data-preprocessing item.
+- **Catalog.** +1 skill, +1 detector.
+
+### Item 2 — Interpretability / explainability (produce + pitfalls)  ·  reviewer-demand, do second
+
+- **Why second.** Highest reviewer-demand and adoption pull; independent of Item 1.
+  Currently only *audited* in `self-review`, never produced.
+- **Form.** New skill (`explainability`).
+- **Produces.** Grad-CAM / Grad-CAM++ / attention-rollout / saliency wired to a
+  trained model (integrating captum / pytorch-grad-cam), quantitative
+  localization metrics (pointing game, IoU with ground-truth masks), and
+  **mandatory sanity checks** (Adebayo et al. model-parameter and data
+  randomization tests).
+- **Gate — `check_explainability_report`.** Flags: saliency presented as causal
+  or as validation of correctness; missing sanity check; no quantitative
+  localization metric; single cherry-picked example without a cohort-level result.
+- **Wiring.** `self-review` `ai_overclaiming` / `image_synthesis` probes (audit)
+  ↔ produce; CLAIM / TRIPOD+AI explainability items in `check-reporting`.
+- **Catalog.** +1 skill, +1 detector.
+
+### Item 3 — Uncertainty / OOD / selective prediction  ·  deployment-safety, do third
+
+- **Why third.** Deployment-safety flavored; builds on evaluation + calibration.
+- **Form.** New skill (`uncertainty-imaging`) — decide vs extending
+  `model-evaluation` at build time (lean new skill for discoverability).
+- **Produces.** MC-dropout / deep-ensemble / conformal-prediction intervals, OOD
+  detection (energy / Mahalanobis), selective prediction (abstention at a
+  coverage target), calibration-under-shift.
+- **Gate — `check_uncertainty_reporting`.** Flags: point predictions without
+  uncertainty in a deployment-framed claim; conformal intervals without coverage
+  validation; an OOD claim without a held-out OOD test set.
+- **Wiring.** `model-evaluation` (calibration / subgroup) + `analyze-stats`
+  calibration guide; DECIDE-AI monitoring seam in `model-validation`.
+- **Catalog.** +1 skill, +1 detector.
+
+### Item 4 — MLOps integration reference (off-moat, reframed thin)  ·  last, reference-only
+
+- **Why last / reframed.** Honors "grow all of it" without scope creep. **Not** a
+  training-loop or experiment-tracking reimplementation. A reference that
+  documents reproducibility-safe wiring of MONAI / nnU-Net / timm + W&B / MLflow,
+  seed discipline, and what to report — pointing to the frameworks, never
+  replacing them, bounded by the ROADMAP out-of-scope clause.
+- **Form.** Reference extension of `model-scaffold` (`training_guide.md`), not a
+  new skill → **no count bump**.
+
+## Progress
+
+- [ ] **Item 1** — imaging data pipeline + `check_preprocessing_leakage`
+- [ ] **Item 2** — interpretability/explainability + `check_explainability_report`
+- [ ] **Item 3** — uncertainty/OOD + `check_uncertainty_reporting`
+- [ ] **Item 4** — MLOps integration reference (`model-scaffold/training_guide.md`)
+
+*Update the checkboxes and the top-level ROADMAP pointer as items land. Release
+the lane as one batch (e.g. a `model-engineering produce-side depth` minor) once
+Items 1–2 are merged.*


### PR DESCRIPTION
## Summary

Adds `docs/roadmap_model_engineering_depth.md` — a working, sequenced checklist for growing the **produce** side of the in-scope model-engineering lane, and links it from `ROADMAP.md` § Research throughput. Docs-only; recorded under `[Unreleased]`, no release.

The lane today is a design→scaffold→validate→evaluate→document *rigor* loop that integrates MONAI/nnU-Net (never reimplements). Three produce stages are genuinely thin; this roadmap sequences filling them, each as a **deterministic gate + challenge card**, on-moat:

1. **Imaging data pipeline + data-stage leakage** (`check_preprocessing_leakage`) — extends the split-leakage moat upstream to preprocessing/augmentation/normalization. *Foundation, first.*
2. **Interpretability/explainability production** (`check_explainability_report`) — Grad-CAM/saliency done right + Adebayo sanity checks + localization metrics; currently only audited in `self-review`, never produced.
3. **Uncertainty / OOD / selective prediction** (`check_uncertainty_reporting`).
4. **MLOps integration reference** — reframed thin (a `model-scaffold` reference, not a new skill), honoring "grow all of it" without reimplementing torch/MONAI/W&B (bounded by the ROADMAP out-of-scope clause).

Guardrails codified in the doc: on-moat only, human-in-loop, gate+challenge+CI-test per addition, bidirectional wiring to the `self-review` audit probes and CLAIM/TRIPOD+AI items, catalog discipline, and **batched release** (release the lane once Items 1–2 land, not per skill).

## Verification
- `validate_catalog_consistency.py` green; distribution manifest `--check` in sync (docs not in payload; no count change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)