### PR TITLE
docs: comprehensive ML/DL method coverage (broaden radiomics-ml + method map)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`radiomics-ml` broadened to the full classical / statistical-ML family** (not just RF / XGBoost).
+  The skill description, triggers, workflow, and `references/radiomics_ml_guide.md` now enumerate
+  penalised regression (LASSO / ridge / elastic-net), SVM, k-NN, naive Bayes, LDA/QDA, trees, bagging,
+  boosting (XGBoost / LightGBM / CatBoost / HistGBM / AdaBoost), shallow MLP, stacked ensembles, plus
+  unsupervised reduction/clustering — and make explicit that the `check_radiomics_ml` gate is
+  **learner-agnostic** (it audits the pipeline, not the algorithm). No code or count change.
+
+### Documentation
+
+- **ML / DL method coverage map** (`docs/method_coverage_map.md`, linked from README and `ROADMAP.md`).
+  A single matrix showing every common ML/DL method family — imaging deep learning (CNN / transformer /
+  segmentation / detection / foundation-SAM / diffusion / SSL / multimodal), the full classical/tabular
+  family, and LLM/MLLM — mapped to the skills that select, produce, validate, interpret, and report it,
+  with the integrate-not-reimplement boundary and open candidate gaps (graph neural nets, Item 4
+  fine-tuning) stated explicitly.
+
 ### Added
 
 - **`radiomics-ml` skill + `check_radiomics_ml` detector** (Item 3 of the

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ MedSci Skills is **opinionated and narrow on purpose**: a single physician-resea
 
 📖 **Per-skill reference:** [`docs/skills/`](docs/skills/) — one page per skill (what it does, when it activates, its Quality Card — purpose, safety boundaries, known limitations, validation, evidence — and bundled resources), generated from each `SKILL.md` + `skill.yml`. See [`docs/skills/AUDIT.md`](docs/skills/AUDIT.md) for how the skills are validated.
 
+🧠 **ML / DL method coverage:** [`docs/method_coverage_map.md`](docs/method_coverage_map.md) — which machine-learning and deep-learning method families (CNN / transformer / segmentation / detection / foundation / diffusion / SSL for imaging; the full classical family — penalised regression, SVM, k-NN, trees, boosting [XGBoost / LightGBM / CatBoost], MLP, ensembles, clustering — for radiomics/tabular; LLM/MLLM) map to which skills for selection, production, validation, interpretation, and reporting.
+
 ```
                               ┌─────────────────────────────────┐
                               │  orchestrate: single entry point │

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,9 @@ demoted to a sustaining floor, not the strategic direction.
   target-trial-emulation specifications, DAG-derived adjustment sets, and
   prediction-model-appropriate sample sizes, shaping a study *before* data
   collection — the highest-leverage point in the pipeline.
-- **Model-engineering produce-side depth** — fill the thin produce stages of the
+- **Model-engineering produce-side depth** — the full ML/DL method coverage (imaging DL + the
+  classical/tabular family + LLM/MLLM) is mapped in
+  [`docs/method_coverage_map.md`](docs/method_coverage_map.md); fill the thin produce stages of the
   in-scope model-engineering lane: imaging data pipeline + data-stage leakage,
   interpretability/explainability production, and uncertainty/OOD reporting — each
   a rigor gate, never a training-framework reimplementation. Sequenced in

--- a/docs/method_coverage_map.md
+++ b/docs/method_coverage_map.md
@@ -1,0 +1,72 @@
+# ML / DL method coverage map
+
+Which machine-learning and deep-learning method families the toolkit covers, and **how** — by
+*selecting*, *producing*, *validating*, *interpreting*, and *reporting* each, integrating the standard
+frameworks (timm / MONAI / nnU-Net / TorchIO / scikit-learn / xgboost / pyradiomics) rather than
+reimplementing them. The target user **fine-tunes existing models and builds classical-ML on collected
+clinical data to derive clinical results and write papers** — not novel architecture development
+(that stays [out of scope](../ROADMAP.md)).
+
+Two facts make "all methods" tractable without a skill per algorithm:
+
+1. **Produce paths integrate whole libraries.** `model-scaffold` wires **timm** (hundreds of pretrained
+   backbones) + MONAI / nnU-Net / torchvision; `radiomics-ml` wires **scikit-learn** + xgboost /
+   lightgbm / catboost + pyradiomics. Any learner in those libraries is in scope.
+2. **The rigor gates are learner-agnostic.** `check_radiomics_ml`, `check_split_leakage`,
+   `check_preprocessing_leakage`, `check_metric_reporting`, and `check_explainability_report` audit the
+   *pipeline* (leakage, nested CV, calibration, metric choice, saliency rigor) — not the specific
+   algorithm — so they apply to every method in the same family.
+
+## Deep learning (imaging)
+
+| Family | Examples | Select | Produce / fine-tune | Validate | Interpret | Report / evaluate |
+|---|---|---|---|---|---|---|
+| Classification CNN / transformer | ResNet, DenseNet, EfficientNet, ViT, Swin (timm) | `architecture-zoo` | `model-scaffold --task classification` (+ fine-tune, Item 4) | `model-validation`, `preprocess-imaging` | `explainability` | `model-evaluation`, `check-reporting` (CLAIM / TRIPOD+AI) |
+| Segmentation | U-Net, 3D U-Net, Attention/Residual U-Net, **nnU-Net** | `architecture-zoo` | `model-scaffold --task segmentation` | `model-validation` | `explainability` | `model-evaluation` |
+| Detection | Faster R-CNN, RetinaNet, YOLO, Mask R-CNN | `architecture-zoo` | `model-scaffold --task detection` | `model-validation` | — | `model-evaluation` (FROC / mAP) |
+| Promptable / foundation segmentation | **SAM, MedSAM**, TotalSegmentator | `architecture-zoo` | fine-tune / adapt (Item 4) | `model-validation` | `explainability` | `model-evaluation` |
+| Self-supervised pretraining | DINO, MAE, SimCLR | `architecture-zoo` | `model-scaffold --task ssl` | `model-validation` | — | — |
+| Generative / synthesis | GAN, **diffusion** | `architecture-zoo` | `model-scaffold --task synthesis`; diffusion augmentation (Item 4) | `model-validation` | — | `check-reporting` |
+| Vision-language / multimodal | CLIP, BiomedCLIP | `architecture-zoo` | fine-tune (Item 4) | `model-validation` | — | `model-evaluation` |
+| Graph neural nets (connectomes) | GCN, GAT | *candidate* (`architecture-zoo` graph entry) | *candidate* | `model-validation`; tabular graph features → `radiomics-ml` | — | — |
+
+## Classical / statistical ML (radiomics & tabular)
+
+All of the below are produced and gated by **`radiomics-ml`** (learner-agnostic `check_radiomics_ml`
++ nested-CV recipe), with calibration / clinical-utility from `analyze-stats` and CLEAR / TRIPOD+AI /
+PROBAST-AI reporting from `check-reporting`.
+
+| Family | Examples |
+|---|---|
+| Penalised regression | LASSO, ridge, **elastic-net** logistic |
+| Margin / kernel | linear & RBF **SVM** |
+| Instance-based | **k-NN** |
+| Probabilistic / discriminant | **naive Bayes**, LDA, QDA |
+| Single tree | decision tree, CART |
+| Bagging | **random forest**, extra-trees |
+| Boosting | **XGBoost**, **LightGBM**, **CatBoost**, HistGBM, AdaBoost |
+| Shallow neural | **MLP** |
+| Meta / ensemble | **stacking**, voting, blending |
+| Dimensionality reduction | PCA, UMAP, t-SNE, LASSO-selection |
+| Unsupervised / clustering | k-means, hierarchical, GMM |
+| Survival ML | random survival forest, Cox-net, DeepSurv (+ `analyze-stats` survival) |
+| Probability calibration | Platt, isotonic (+ `analyze-stats` calibration) |
+
+## LLM / MLLM
+
+| Family | Select / produce | Evaluate | Report |
+|---|---|---|---|
+| Clinical LLM / multimodal LLM (API or open weights) | prompt-driven; `design-ai-benchmarking` for reader panels | **`mllm-eval`** (faithfulness, hallucination, contamination, clinical-efficacy metrics) | `check-reporting` (TRIPOD-LLM / MI-CLEAR-LLM / CLAIM) |
+
+## What is deliberately NOT here
+
+- **Novel architecture development / a new training framework.** We wire and report MONAI / nnU-Net /
+  timm / scikit-learn; we do not reimplement them or invent architectures.
+- **Autonomous training / experiment tracking (MLOps).** Left to the frameworks + W&B / MLflow; a thin
+  integration reference is roadmap Item 6.
+- **Anything that runs a model on real patient data or fabricates a metric.** Every number comes from
+  the researcher's executed code.
+
+*Candidate gaps (open):* a `architecture-zoo` graph-neural-net entry for brain-connectome studies, and
+the Item 4 fine-tuning / SAM-adaptation / diffusion-augmentation produce path. See
+[`roadmap_model_engineering_depth.md`](roadmap_model_engineering_depth.md).

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -45,7 +45,7 @@ One reference page per skill, generated from each skill's `SKILL.md` and `skill.
 - [preprocess-imaging](preprocess-imaging.md) — Design or audit the data-preparation stage of a medical-imaging model — DICOM/NIfTI intake, resampling and intensity normalisation, and the augmentation plan — so the pipeline is leakage-safe before m… _(evidence: ci_validator)_
 - [present-paper](present-paper.md) — Academic presentation preparation — paper-driven (journal club, grand rounds, seminar) and lecture/teaching decks (course material, workshop slides, conference talks). _(evidence: bundled_script)_
 - [publish-skill](publish-skill.md) — Convert a personal agent skill into a distributable, open-source-ready skill. _(evidence: bundled_script)_
-- [radiomics-ml](radiomics-ml.md) — Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → random forest / XGBoost / regularised logistic → a clinical outcome — so it clears the rigor bar reviewers exp… _(evidence: ci_validator)_
+- [radiomics-ml](radiomics-ml.md) — Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → any classical learner (penalised logistic [LASSO / ridge / elastic-net], SVM, k-NN, naive Bayes, LDA/QDA, deci… _(evidence: ci_validator)_
 - [render-pdf-doc](render-pdf-doc.md) — Render academic Markdown documents (English or Korean) to publication-quality PDF via pandoc + xelatex. _(evidence: bundled_script)_
 - [replicate-study](replicate-study.md) — Replicate an existing cohort study's methodology on a different database. _(evidence: manual_workflow)_
 - [review-paper](review-paper.md) — Scaffold and draft medical/AI literature reviews (narrative, scoping PRISMA-ScR, or systematic).

--- a/docs/skills/radiomics-ml.md
+++ b/docs/skills/radiomics-ml.md
@@ -2,13 +2,13 @@
 
 # radiomics-ml
 
-> Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → random forest / XGBoost / regularised logistic → a clinical outcome — so it clears the rigor bar reviewers expect: nested cross-validation (tuning never on the reported folds), dimensionality control for the features-far-exceed-events regime, feature selection inside the fold, feature-stability (ICC / test-retest) filtering, calibration, and external/temporal validation. Emits a pipeline manifest and a deterministic rigor gate. The most common solo-doable clinical-ML workflow — no GPU, no engineer. Integrates scikit-learn / xgboost / pyradiomics; it does not reimplement them.
+> Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → any classical learner (penalised logistic [LASSO / ridge / elastic-net], SVM, k-NN, naive Bayes, LDA/QDA, decision tree, random forest, gradient boosting [XGBoost / LightGBM / CatBoost], shallow MLP, stacked ensembles) → a clinical outcome — so it clears the rigor bar reviewers expect: nested cross-validation (tuning never on the reported folds), dimensionality control for the features-far-exceed-events regime, feature selection inside the fold, feature-stability (ICC / test-retest) filtering, calibration, and external/temporal validation. The deterministic gate is learner-agnostic (it audits the pipeline, not the algorithm). Emits a pipeline manifest and the gate. The most common solo-doable clinical-ML workflow — no GPU, no engineer. Integrates scikit-learn / xgboost / lightgbm / catboost / pyradiomics; it does not reimplement them.
 
 **Invoke:** `/radiomics-ml` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 
-`radiomics-ml` activates on requests such as: radiomics, radiomic features, pyradiomics, tabular ML, clinical prediction model, random forest, XGBoost, gradient boosting, tree ensemble, feature selection, nested cross-validation, nested CV, ICC feature stability, SHAP, machine learning model, classical ML, clinical machine learning, LASSO, feature stability, decision curve, calibration, TRIPOD, CLEAR, PROBAST.
+`radiomics-ml` activates on requests such as: radiomics, radiomic features, pyradiomics, tabular ML, clinical prediction model, random forest, XGBoost, LightGBM, CatBoost, gradient boosting, tree ensemble, SVM, support vector machine, k-NN, KNN, naive Bayes, LDA, QDA, elastic net, ridge, LASSO, logistic regression, MLP, stacking, ensemble, clustering, k-means, PCA, UMAP, dimensionality reduction, feature selection, nested cross-validation, nested CV, ICC feature stability, SHAP, machine learning model, classical ML, clinical machine learning, feature stability, decision curve, calibration, TRIPOD, CLEAR, PROBAST.
 
 ## Quality Card
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3413,13 +3413,13 @@
     },
     {
       "path": "skills/radiomics-ml/SKILL.md",
-      "size": 6946,
-      "sha256": "d957750dd8e2a16327eb0fda05a0b442f2592383f122267b485b38493301bce3"
+      "size": 8273,
+      "sha256": "cc65bfd50db2b6e9b6681e1c9649b306490cd5dd74192bfdf5316362b71f141b"
     },
     {
       "path": "skills/radiomics-ml/references/radiomics_ml_guide.md",
-      "size": 4882,
-      "sha256": "f6333fabdfddce9bb16181215e9a3e6f33da86af3d28e8d426bbe0881e45677d"
+      "size": 6707,
+      "sha256": "29bf2b2b847c488ddb33e50cd21ea0e2cd4937a1a62ab2655f31227a0e42215a"
     },
     {
       "path": "skills/radiomics-ml/scripts/check_radiomics_ml.py",

--- a/metadata/skills_catalog.json
+++ b/metadata/skills_catalog.json
@@ -488,7 +488,7 @@
       "layer": "D",
       "owner_domain": "model_validation",
       "maturity": "official",
-      "description": "Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → random forest / XGBoost / regularised logistic → a clinical outcome — so it clears the rigor bar reviewers exp…"
+      "description": "Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → any classical learner (penalised logistic [LASSO / ridge / elastic-net], SVM, k-NN, naive Bayes, LDA/QDA, deci…"
     },
     {
       "slug": "render-pdf-doc",

--- a/skills/radiomics-ml/SKILL.md
+++ b/skills/radiomics-ml/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: radiomics-ml
 description: >
-  Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → random
-  forest / XGBoost / regularised logistic → a clinical outcome — so it clears the rigor bar reviewers
-  expect: nested cross-validation (tuning never on the reported folds), dimensionality control for the
+  Produce or audit a radiomics / tabular clinical-ML study — imaging or clinical features → any
+  classical learner (penalised logistic [LASSO / ridge / elastic-net], SVM, k-NN, naive Bayes,
+  LDA/QDA, decision tree, random forest, gradient boosting [XGBoost / LightGBM / CatBoost], shallow
+  MLP, stacked ensembles) → a clinical outcome — so it clears the rigor bar reviewers expect: nested
+  cross-validation (tuning never on the reported folds), dimensionality control for the
   features-far-exceed-events regime, feature selection inside the fold, feature-stability (ICC /
-  test-retest) filtering, calibration, and external/temporal validation. Emits a pipeline manifest and
-  a deterministic rigor gate. The most common solo-doable clinical-ML workflow — no GPU, no engineer.
-  Integrates scikit-learn / xgboost / pyradiomics; it does not reimplement them.
-triggers: radiomics, radiomic features, pyradiomics, tabular ML, clinical prediction model, random forest, XGBoost, gradient boosting, tree ensemble, feature selection, nested cross-validation, nested CV, ICC feature stability, SHAP, machine learning model, classical ML, clinical machine learning, LASSO, feature stability, decision curve, calibration, TRIPOD, CLEAR, PROBAST
+  test-retest) filtering, calibration, and external/temporal validation. The deterministic gate is
+  learner-agnostic (it audits the pipeline, not the algorithm). Emits a pipeline manifest and the gate.
+  The most common solo-doable clinical-ML workflow — no GPU, no engineer. Integrates scikit-learn /
+  xgboost / lightgbm / catboost / pyradiomics; it does not reimplement them.
+triggers: radiomics, radiomic features, pyradiomics, tabular ML, clinical prediction model, random forest, XGBoost, LightGBM, CatBoost, gradient boosting, tree ensemble, SVM, support vector machine, k-NN, KNN, naive Bayes, LDA, QDA, elastic net, ridge, LASSO, logistic regression, MLP, stacking, ensemble, clustering, k-means, PCA, UMAP, dimensionality reduction, feature selection, nested cross-validation, nested CV, ICC feature stability, SHAP, machine learning model, classical ML, clinical machine learning, feature stability, decision curve, calibration, TRIPOD, CLEAR, PROBAST
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
@@ -67,7 +70,20 @@ patient/subject ID and the outcome. See `references/radiomics_ml_guide.md`.
 - **Nested cross-validation** — outer folds estimate performance, inner folds tune; do **feature
   selection and scaling inside each training fold** (never on the whole dataset).
 - **Dimensionality** — with features ≥ events, use LASSO / a stability+redundancy filter / PCA.
-- **Model** — random forest / XGBoost / regularised logistic (a simple baseline is mandatory).
+- **Model** — pick from the full classical family for the task; a simple baseline (penalised logistic)
+  is mandatory alongside any complex learner:
+  - *penalised regression* — LASSO / ridge / elastic-net logistic (also the baseline)
+  - *margin / kernel* — linear or RBF SVM
+  - *instance-based* — k-NN
+  - *probabilistic / discriminant* — naive Bayes, LDA / QDA
+  - *trees & bagging* — decision tree, random forest, extra-trees
+  - *boosting* — XGBoost, LightGBM, CatBoost, HistGBM, AdaBoost
+  - *shallow neural* — MLP
+  - *meta* — stacking / voting ensembles
+  - *unsupervised (upstream)* — PCA / UMAP for reduction, k-means / hierarchical / GMM for phenotyping
+  The gate below is **learner-agnostic** — it audits the pipeline (nested CV, leakage, dimensionality,
+  calibration), so it applies identically to any of these. See the full method map in
+  [`docs/method_coverage_map.md`](../../docs/method_coverage_map.md).
 - **Report** — discrimination **and** calibration (slope/intercept + flexible curve, via the
   `/analyze-stats` calibration guide) and clinical utility (decision curve). SHAP for interpretation.
 

--- a/skills/radiomics-ml/references/radiomics_ml_guide.md
+++ b/skills/radiomics-ml/references/radiomics_ml_guide.md
@@ -63,10 +63,32 @@ grid  = GridSearchCV(pipe, param_grid, cv=inner, scoring="roc_auc")
 auc   = cross_val_score(grid, X, y, cv=outer, scoring="roc_auc")  # outer = unbiased estimate
 ```
 
-## 5. Models
+## 5. Models — the full classical family (not just RF / XGBoost)
 
-Report a **simple baseline** (regularised logistic) alongside random forest / XGBoost — a tree ensemble
-that does not beat penalised logistic on your data is a finding, not a failure. Fix the seed.
+Always report a **simple baseline** (penalised logistic) alongside any complex learner — a model that
+does not beat penalised logistic on your data is a finding, not a failure. Fix the seed. Pick by task
+and sample size; the pipeline rigor in §2–§4 is identical across all of them (the gate is
+learner-agnostic).
+
+| Family | Learner (scikit-learn / library) | When |
+|---|---|---|
+| Penalised regression | `LogisticRegression(penalty=l1/l2/elasticnet)` — LASSO / ridge / elastic-net | baseline; small n; interpretable coefficients |
+| Margin / kernel | `SVC` (linear / RBF) | moderate n, clear margin; scale features first |
+| Instance-based | `KNeighborsClassifier` | small feature set, local structure |
+| Probabilistic / discriminant | `GaussianNB`, `LinearDiscriminantAnalysis`, `QuadraticDiscriminantAnalysis` | fast baselines; LDA when classes ~Gaussian |
+| Single tree | `DecisionTreeClassifier` | interpretability demo (rarely final) |
+| Bagging | `RandomForestClassifier`, `ExtraTreesClassifier` | robust default, low tuning |
+| Boosting | `XGBClassifier`, `LGBMClassifier`, `CatBoostClassifier`, `HistGradientBoostingClassifier`, `AdaBoost` | usually top tabular performance; tune with the inner CV |
+| Shallow neural | `MLPClassifier` | non-linear, enough samples; scale + early-stop |
+| Meta / ensemble | `StackingClassifier`, `VotingClassifier` | squeeze marginal gain; guard overfitting |
+| Survival ML | random survival forest, Cox-net, DeepSurv | time-to-event outcome (+ `/analyze-stats` survival) |
+
+**Unsupervised (upstream, not the endpoint):** PCA / UMAP for dimensionality reduction (fit inside the
+fold, §4), and k-means / hierarchical / Gaussian-mixture for phenotype discovery — report cluster
+stability, never as a supervised performance claim.
+
+For imbalanced outcomes prefer probability-calibrated models + threshold analysis over resampling that
+distorts prevalence; calibrate with Platt / isotonic (`/analyze-stats` calibration).
 
 ## 6. Report discrimination AND calibration AND utility
 


### PR DESCRIPTION
## Summary

Answers "reflect **all** ML/DL, not just RF/XGBoost" — without reimplementing anything. Two facts make full coverage tractable: the **produce paths integrate whole libraries** (timm / MONAI / nnU-Net for DL; scikit-learn / xgboost / lightgbm / catboost / pyradiomics for classical), and the **rigor gates are learner-agnostic** (they audit the pipeline — leakage, nested CV, calibration, metric choice — not the algorithm).

## What changed

- **`radiomics-ml` broadened to the full classical / statistical-ML family.** Description, triggers, workflow, and `references/radiomics_ml_guide.md` now enumerate: penalised regression (LASSO / ridge / elastic-net), SVM, k-NN, naive Bayes, LDA/QDA, decision tree, random forest / extra-trees, boosting (**XGBoost / LightGBM / CatBoost** / HistGBM / AdaBoost), shallow MLP, stacking/voting ensembles, plus unsupervised reduction (PCA/UMAP) and clustering (k-means/hierarchical/GMM) and survival ML. Made explicit that `check_radiomics_ml` is **learner-agnostic**. No code or count change (the gate already applied to any learner).
- **New `docs/method_coverage_map.md`** — a matrix mapping every common ML/DL method family to the skills that **select → produce → validate → interpret → report** it:
  - imaging DL: CNN / transformer, segmentation (U-Net / nnU-Net), detection, foundation (SAM / MedSAM), diffusion / GAN, self-supervised, multimodal
  - classical / tabular: the full family above
  - LLM / MLLM: `mllm-eval`
  - with the integrate-not-reimplement boundary and **open candidate gaps** stated (graph neural nets for connectomes; Item 4 fine-tuning / SAM-adaptation / diffusion-augmentation).
- Linked from README (🧠 ML / DL method coverage) and `ROADMAP.md`.

## Verification (all green)

- `validate_skills.sh` ALL PASS · catalog consistency (54 skills / 49 detectors, **unchanged**) · `gen_skill_docs` + `gen_distribution_manifest` `--check` in sync · version + locale green · `test_radiomics_ml.sh` still 14/14.

Recorded under `[Unreleased]`; released with the batch (Item 4 next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)