### PR TITLE
docs(model-scaffold): MLOps wiring reference (Item 6, roadmap complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **MLOps wiring reference** (`model-scaffold/references/mlops_guide.md`, Item 6 — the final item of the
+  [model-engineering produce-side depth roadmap](docs/roadmap_model_engineering_depth.md)). A
+  reproducibility-safe **wiring + reporting** reference — experiment tracking (W&B / MLflow /
+  TensorBoard), config / data / environment versioning, pipeline orchestration via the framework's own
+  (nnU-Net / MONAI bundles), CI-for-ML (gate the network-free properties, never a real training run),
+  and an MLOps reporting checklist for TRIPOD+AI / CLAIM. Deliberately **not** a training-loop,
+  hyperparameter-search, or experiment-tracking reimplementation — it points to the frameworks and never
+  replaces them (the ROADMAP out-of-scope clause). Cross-linked from `model-scaffold` Phase 5 and
+  `training_guide.md`. No skill, no detector, no count change. PR #280.
+
 ### Added
 
 - **`uncertainty-imaging` skill + `check_uncertainty_reporting` detector** (Item 5 of the

--- a/docs/roadmap_model_engineering_depth.md
+++ b/docs/roadmap_model_engineering_depth.md
@@ -171,9 +171,12 @@ in the leakage / validation / calibration / reporting gates that a solo clinicia
   `PRETRAINED_PROVENANCE_MISSING` verdict added to the existing `check_training_hygiene` — no new
   skill, no new detector). Chosen build-time form: **extend** `model-scaffold` (not a sibling skill).
 - [x] **Item 5** — uncertainty/OOD + `check_uncertainty_reporting` (skill `uncertainty-imaging`, PR #279)
-- [ ] **Item 6** — MLOps integration reference (`model-scaffold/training_guide.md`)
+- [x] **Item 6** — MLOps integration reference (`model-scaffold/references/mlops_guide.md` — experiment
+  tracking / config / data / environment versioning, CI-for-ML, reporting checklist; wiring-only,
+  points to MONAI / nnU-Net / W&B / MLflow, reimplements nothing; no skill, no detector). PR #280
 
 *Update the checkboxes and the top-level ROADMAP pointer as items land. Items 1–2
 shipped in **v5.15.0**; Items 3–4 (the clinical fine-tuning focus) shipped in **v5.16.0**.
-Item 5 (`uncertainty-imaging`) is staged in `[Unreleased]` for the next minor — accumulate with
-Item 6 (or a candidate) rather than releasing per skill (release-cadence policy).*
+Items 5–6 (deployment safety + the MLOps wiring reference) are staged in `[Unreleased]` for the
+next minor (**v5.17.0**) — the full six-item produce-side depth roadmap is now complete; the only
+remaining candidate is an `architecture-zoo` graph-neural-net entry (brain connectome).*

--- a/docs/skills/model-scaffold.md
+++ b/docs/skills/model-scaffold.md
@@ -38,6 +38,7 @@
 **References** (`skills/model-scaffold/references/`):
 
 - `finetuning_guide.md`
+- `mlops_guide.md`
 - `training_guide.md`
 
 **Scripts** (`skills/model-scaffold/scripts/`):

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2868,8 +2868,8 @@
     },
     {
       "path": "skills/model-scaffold/SKILL.md",
-      "size": 9237,
-      "sha256": "d7e736178cb60d2d13cef9174474297bd54bc6d4d1f3862023d802ff0c034a95"
+      "size": 9527,
+      "sha256": "8fcf4060f064a1924d4bec278e0c0c628c99caf6ea75f617f8b9748cbb207ed8"
     },
     {
       "path": "skills/model-scaffold/references/finetuning_guide.md",
@@ -2877,9 +2877,14 @@
       "sha256": "b7817d53eeeb506b573beaae1889fa863dd81286d474ab99b46b38ad046b32e7"
     },
     {
+      "path": "skills/model-scaffold/references/mlops_guide.md",
+      "size": 5171,
+      "sha256": "cc9b62ed588daf97b40b6d7a8e27f9b6de96b9f5752ad2baa8e180e01d3d4973"
+    },
+    {
       "path": "skills/model-scaffold/references/training_guide.md",
-      "size": 2661,
-      "sha256": "4a3197a89b8d3473071051f67a7bcf40f71ecf007e942f81e9c40dc48fce1a9c"
+      "size": 2840,
+      "sha256": "9a7f7b5dda65e71d8007cb6539cda0cfb9c6b1f2c877aedee4646f368686e96f"
     },
     {
       "path": "skills/model-scaffold/scripts/check_training_hygiene.py",

--- a/skills/model-scaffold/SKILL.md
+++ b/skills/model-scaffold/SKILL.md
@@ -100,7 +100,10 @@ adaptation and train-only diffusion augmentation). Run `python train.py` (best m
 ### Phase 5 — Validate, evaluate, publish
 Hand off to `/model-validation` (validation-tier + comparator + metric-selection audit),
 `/model-evaluation` + `/analyze-stats` (Dice + HD95/NSD with CIs), `/make-figures`, and `/write-paper`
-(fill the `methods_stub.md` `[VERIFY]` placeholders) + `/check-reporting` (CLAIM 2024 / TRIPOD+AI).
+(fill the `methods_stub.md` `[VERIFY]` placeholders) + `/check-reporting` (CLAIM 2024 / TRIPOD+AI). For
+reproducibility-safe wiring of experiment tracking (W&B / MLflow), config / data / environment
+versioning, and the MLOps reporting checklist, see `${CLAUDE_SKILL_DIR}/references/mlops_guide.md`
+(a wiring + reporting reference — it points to the frameworks, it does not replace them).
 
 ## Runnability — honest contract
 The generated repo is **runnable**, but runnability is **not a CI guarantee**. The default gates prove

--- a/skills/model-scaffold/references/mlops_guide.md
+++ b/skills/model-scaffold/references/mlops_guide.md
@@ -1,0 +1,77 @@
+# MLOps wiring guide (model-scaffold)
+
+Load-on-demand notes for taking a scaffolded repo through a **reproducible, reportable**
+training run. This is a **wiring and reporting** reference, **not** a training-loop,
+hyperparameter-search, or experiment-tracking reimplementation. Training and tracking stay
+with the frameworks — MONAI / nnU-Net / timm for the model, Weights & Biases / MLflow /
+TensorBoard for tracking, DVC / git-lfs for data — and this guide covers how to wire them so
+the run is reproducible and what to record so a reviewer can trust it. Everything here points
+to a framework; nothing here replaces one (the [ROADMAP out-of-scope clause](../../../ROADMAP.md)).
+
+## The reproducibility contract (what a run must be able to reproduce)
+A training run is reproducible when, from the recorded artifacts alone, someone else can
+re-derive the same result. That needs five things pinned, all of which the scaffold already
+emits a slot for:
+1. **Code** — the git commit of the repo (dirty trees are not reproducible; commit first).
+2. **Config** — `config.yaml` as the single source of truth (task, arch, channels, split
+   fractions, seed). Do not scatter hyperparameters across the CLI and the code.
+3. **Data** — a content hash of the exact dataset (see `/version-dataset`), not just a path.
+4. **Seed + determinism** — the scaffold's `seed_everything` seeds Python / NumPy / torch /
+   CUDA and sets cuDNN deterministic; record the seed in the tracker and `REPRODUCIBILITY.md`.
+5. **Environment** — a pinned `requirements.txt` (exact versions), CUDA / driver, GPU model.
+
+## Experiment tracking (integrate, don't build one)
+Log to **W&B**, **MLflow**, or **TensorBoard** — pick one, do not write a tracker. At run
+start, log the whole `config.yaml`, the git commit, the dataset hash, and the seed as the run
+config; during training log per-epoch train/val loss + the val metric; at the end log the best
+checkpoint as an artifact. The tracker's run URL / ID becomes part of the Methods record. Keep
+the scaffold's contract intact — the best model is still selected on the **val** split, the
+**test** split is still touched once by `evaluate.py`.
+
+## Config management
+The emitted `config.yaml` is the SSOT for one run. For sweeps, drive them with **Hydra /
+OmegaConf** (or the tracker's sweep feature) that *reads* this config — never hand-edit values
+into `train.py`. A hyperparameter that isn't in the config isn't reproducible.
+
+## Data & model versioning
+- **Data** — hash the training set with `/version-dataset` and record the manifest hash in the
+  run config, so "trained on dataset X" is verifiable, not asserted. For large data use **DVC**
+  or **git-lfs**; commit the pointer, not the pixels.
+- **Model** — document the trained model with `/model-card` (Model Card + Datasheet); for a
+  fine-tune, the pretrained-weight provenance lives in `PRETRAINED.md`
+  (see `references/finetuning_guide.md`).
+
+## Environment capture
+Pin `requirements.txt` to exact versions before publishing (`pip freeze`, or a `conda env
+export`). For a hard reproducibility guarantee, a Dockerfile / container digest removes "works
+on my machine". Record the CUDA / driver / GPU — some GPU ops are non-deterministic even with
+cuDNN deterministic set, which is why metrics are reported as **mean ± SD over ≥ 3 seeds**, not
+a single run.
+
+## Pipeline orchestration — use the framework's, not a new one
+For segmentation, **nnU-Net** owns preprocessing → training → inference as a pipeline; build
+its `dataset.json` folds from the scaffold's `splits/split_assignment.csv` so the patient-level
+split is preserved end to end. **MONAI bundles** package a model + transforms + metadata the
+same way. Orchestrate with the framework's own pipeline; do not rebuild one.
+
+## CI for an ML repo (what is worth gating)
+CI should gate the **network-free, deterministic** properties — not full training. The scaffold
+already ships these: `check_training_hygiene` (seeds, eval-mode inference, train-only loaders,
+pretrained provenance) and the split-leakage proof (`/model-validation`). Add a **forward-pass
+smoke** (build the model, one batch, check output shape) as a fast job. Do **not** put a real
+training run in CI — it is slow, non-deterministic, and not what CI is for.
+
+## What to report (the MLOps reporting checklist)
+State, in Methods or a reproducibility appendix: the **compute environment** (framework +
+versions, CUDA / driver, GPU), the **seed(s)** and that metrics are mean ± SD over ≥ 3 seeds,
+the **config** (as a supplement or a tracker link), the **dataset version** (`/version-dataset`
+hash), and the **tracking run** URL / ID. This is the reproducibility half of TRIPOD+AI /
+CLAIM 2024; `/check-reporting` covers the items.
+
+## Hand-offs
+- Dataset hash / reproducibility-lock → `/version-dataset`.
+- Model + dataset documentation → `/model-card`.
+- Split / validation-design audit → `/model-validation`.
+- Held-out metrics + CIs → `/model-evaluation` → `/analyze-stats`.
+- Deployment uncertainty / OOD / monitoring → `/uncertainty-imaging`.
+- Reporting fit → `/check-reporting` (TRIPOD+AI / CLAIM / DECIDE-AI).

--- a/skills/model-scaffold/references/training_guide.md
+++ b/skills/model-scaffold/references/training_guide.md
@@ -34,7 +34,9 @@ with cuDNN deterministic set).
 Before publishing, complete `REPRODUCIBILITY.md`: pinned `requirements.txt`
 (torch/monai/... exact versions), CUDA/driver, GPU model, the git commit of the repo,
 and the seed. Pair with `/version-dataset` to hash the exact dataset the model trained
-on.
+on. For reproducibility-safe wiring of experiment tracking (W&B / MLflow), config / data
+/ environment versioning, CI-for-ML, and the MLOps reporting checklist, see
+`mlops_guide.md`.
 
 ## Hand-offs
 - Split / validation-design audit → `/model-validation` (run `check_split_leakage.py`


### PR DESCRIPTION
## Item 6 — MLOps wiring reference (final roadmap item)

Adds `model-scaffold/references/mlops_guide.md`: a reproducibility-safe **wiring + reporting** reference for taking a scaffolded repo through a trackable, reportable training run. Roadmap [Item 6](docs/roadmap_model_engineering_depth.md).

### What lands
- **Experiment tracking** (W&B / MLflow / TensorBoard) — what to log for reproducibility (config, git commit, dataset hash, seed, per-epoch metrics, best-checkpoint artifact), not how to build a tracker.
- **The reproducibility contract** — code / config / data / seed+determinism / environment, each mapped to a slot the scaffold already emits.
- **Config, data & model, environment versioning** — Hydra/OmegaConf reads `config.yaml`; `/version-dataset` hashes the data; `/model-card` documents the model; pin `requirements.txt` + container digest.
- **Pipeline orchestration** — use nnU-Net's / MONAI bundle's own pipeline, built off the scaffold's `split_assignment.csv`; don't rebuild one.
- **CI-for-ML** — gate the network-free deterministic properties (`check_training_hygiene`, split-leakage, forward-pass smoke); never a real training run in CI.
- **MLOps reporting checklist** — compute environment, seeds (mean ± SD over ≥3), config, dataset version, tracking run — the reproducibility half of TRIPOD+AI / CLAIM.

### Design
- **Off-moat, reframed thin** per the roadmap: this is wiring + reporting, **not** a training-loop / hyperparameter-search / experiment-tracking reimplementation. It points to MONAI / nnU-Net / timm / W&B / MLflow and replaces none of them (ROADMAP out-of-scope clause).
- **Reference-only**: no skill, no detector, **no count change** (skills stay 55, detectors stay 50). Cross-linked from `model-scaffold` Phase 5 + `training_guide.md`.

### Verification
All 5 generators `--check` in sync + `validate_catalog_consistency` (counts unchanged) + `validate_skills.sh` (ALL PASS) — green locally.

### Release
Staged in `[Unreleased]` with **Item 5** — the six-item produce-side depth roadmap is now **complete**. Next minor (**v5.17.0**) batches Items 5–6. **No release cut** in this PR.