### PR TITLE
docs(architecture-zoo): graph neural net family card (brain connectomes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Documentation
 
+- **`architecture-zoo` graph-neural-net family card** (`references/graph.md`) — closes the last candidate
+  gap in the [model-engineering coverage map](docs/method_coverage_map.md). Covers GNNs for brain
+  **connectomes** and **population graphs** — GCN, GraphSAGE, GAT, GIN, and the brain-specific
+  **BrainGNN** — each with its source paper, when-to-use, medical use, PyTorch Geometric / DGL reference
+  implementation, and validation setup, plus the connectome-specific traps (subject-level split, ComBat
+  site-harmonisation leakage, p ≫ n, interpretability-is-not-proof). States the boundary honestly:
+  `model-scaffold` has no graph template, so integrate PyTorch Geometric / DGL directly while the lane's
+  subject-level gates (`model-validation`, `radiomics-ml`, `explainability`, `uncertainty-imaging`,
+  `check-reporting`) still apply. Reference-only — no skill, no detector, no count change. PR #281.
 - **MLOps wiring reference** (`model-scaffold/references/mlops_guide.md`, Item 6 — the final item of the
   [model-engineering produce-side depth roadmap](docs/roadmap_model_engineering_depth.md)). A
   reproducibility-safe **wiring + reporting** reference — experiment tracking (W&B / MLflow /

--- a/docs/method_coverage_map.md
+++ b/docs/method_coverage_map.md
@@ -30,7 +30,7 @@ Two facts make "all methods" tractable without a skill per algorithm:
 | Self-supervised pretraining | DINO, MAE, SimCLR | `architecture-zoo` | `model-scaffold --task ssl` | `model-validation` | — | — |
 | Generative / synthesis | GAN, **diffusion** | `architecture-zoo` | `model-scaffold --task synthesis`; train-only diffusion augmentation (`finetuning_guide.md`) | `model-validation` | — | `check-reporting` |
 | Vision-language / multimodal | CLIP, BiomedCLIP | `architecture-zoo` | `model-scaffold --task finetune` (transfer learning) | `model-validation` | — | `model-evaluation` |
-| Graph neural nets (connectomes) | GCN, GAT | *candidate* (`architecture-zoo` graph entry) | *candidate* | `model-validation`; tabular graph features → `radiomics-ml` | — | — |
+| Graph neural nets (connectomes) | GCN, GraphSAGE, GAT, GIN, **BrainGNN** | `architecture-zoo` (`graph.md`) | integrate PyTorch Geometric / DGL directly (no `model-scaffold` graph template) | `model-validation` (subject-level split); p≫n rigor → `radiomics-ml` | `explainability` (attention / salient-ROI sanity) | `check-reporting` (TRIPOD+AI) |
 
 ## Classical / statistical ML (radiomics & tabular)
 
@@ -69,7 +69,10 @@ PROBAST-AI reporting from `check-reporting`.
 - **Anything that runs a model on real patient data or fabricates a metric.** Every number comes from
   the researcher's executed code.
 
-*Candidate gaps (open):* a `architecture-zoo` graph-neural-net entry for brain-connectome studies.
-The Item 4 fine-tuning / SAM-adaptation / diffusion-augmentation produce path has landed
-(`model-scaffold --task finetune` + `references/finetuning_guide.md`). See
+*Candidate gaps (open):* none outstanding — the six-item model-engineering produce-side depth
+roadmap is complete, and the `architecture-zoo` graph-neural-net entry for brain-connectome studies
+has landed (`references/graph.md`: GCN / GraphSAGE / GAT / GIN / BrainGNN; integrate PyTorch
+Geometric / DGL, no `model-scaffold` graph template). The fine-tuning / SAM-adaptation /
+diffusion-augmentation produce path landed in `model-scaffold --task finetune` +
+`references/finetuning_guide.md`. See
 [`roadmap_model_engineering_depth.md`](roadmap_model_engineering_depth.md).

--- a/docs/roadmap_model_engineering_depth.md
+++ b/docs/roadmap_model_engineering_depth.md
@@ -178,5 +178,6 @@ in the leakage / validation / calibration / reporting gates that a solo clinicia
 *Update the checkboxes and the top-level ROADMAP pointer as items land. Items 1–2
 shipped in **v5.15.0**; Items 3–4 (the clinical fine-tuning focus) shipped in **v5.16.0**.
 Items 5–6 (deployment safety + the MLOps wiring reference) are staged in `[Unreleased]` for the
-next minor (**v5.17.0**) — the full six-item produce-side depth roadmap is now complete; the only
-remaining candidate is an `architecture-zoo` graph-neural-net entry (brain connectome).*
+next minor (**v5.17.0**), together with the `architecture-zoo` graph-neural-net entry (brain
+connectome, `references/graph.md`) that closes the last candidate gap. The full six-item
+produce-side depth roadmap and its candidate list are now complete.*

--- a/docs/skills/architecture-zoo.md
+++ b/docs/skills/architecture-zoo.md
@@ -2,13 +2,13 @@
 
 # architecture-zoo
 
-> Choose a model architecture for a medical-imaging research question before scaffolding. Maps the task (classification, segmentation, detection, transfer), modality and dimensionality, labelled-data scale, and class imbalance to a shortlist of architectures, each grounded in its source paper with a when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet, ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net, Mask R-CNN; SAM/MedSAM, TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR). It teaches archetypes and the task-to-architecture logic, not a live SOTA leaderboard.
+> Choose a model architecture for a medical-imaging research question before scaffolding. Maps the task (classification, segmentation, detection, transfer), modality and dimensionality, labelled-data scale, and class imbalance to a shortlist of architectures, each grounded in its source paper with a when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet, ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net, Mask R-CNN; SAM/MedSAM, TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN — for brain connectomes). It teaches archetypes and the task-to-architecture logic, not a live SOTA leaderboard.
 
 **Invoke:** `/architecture-zoo` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
 
 ## When to use
 
-`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone.
+`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone.
 
 ## Quality Card
 
@@ -21,7 +21,7 @@
 
 **Known limitations**
 
-- The literature moves fast; this is a curated archetype map (classification, segmentation, detection, synthesis, foundation/SSL families), not an exhaustive or current SOTA ranking.
+- The literature moves fast; this is a curated archetype map (classification, segmentation, detection, synthesis, foundation/SSL, and graph/GNN families), not an exhaustive or current SOTA ranking.
 - A sound architecture choice is necessary, not sufficient; validity still depends on the split, validation design, and metrics (/model-validation, /model-evaluation).
 
 **Validation**
@@ -37,6 +37,7 @@
 - `classification.md`
 - `detection.md`
 - `foundation_models.md`
+- `graph.md`
 - `index.md`
 - `segmentation.md`
 - `synthesis.md`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -423,8 +423,8 @@
     },
     {
       "path": "skills/architecture-zoo/SKILL.md",
-      "size": 5712,
-      "sha256": "ffb9a52d417f309a3b22c8d0f74e6700b67350c0d7a2a2e2c785f0cb4cb066bc"
+      "size": 6094,
+      "sha256": "abb4656f36e0ef068508269ce2ec87c832b7c8fb13c4cbc44af27b2dc8058bff"
     },
     {
       "path": "skills/architecture-zoo/references/classification.md",
@@ -442,9 +442,14 @@
       "sha256": "495453b025f1cb13d5ba0bac9be6d3b0d63dd958ea48d2b9e55bc222e9c26786"
     },
     {
+      "path": "skills/architecture-zoo/references/graph.md",
+      "size": 6913,
+      "sha256": "d6bea2d61a2f1d515810d1bf96bef80f156d816998134a3c911e6c4585728c2e"
+    },
+    {
       "path": "skills/architecture-zoo/references/index.md",
-      "size": 4024,
-      "sha256": "d2360eb8635347f0f22be0b0e337a540db865aafdc12678455cf32bc49fd9d3d"
+      "size": 4334,
+      "sha256": "f812ec9afe2ba06c42da8de851cea08632d61eb98e87cd3edd7cdd17f39e226e"
     },
     {
       "path": "skills/architecture-zoo/references/segmentation.md",
@@ -458,8 +463,8 @@
     },
     {
       "path": "skills/architecture-zoo/skill.yml",
-      "size": 2836,
-      "sha256": "7d7c727a9fc75383e775feac14faf1c4caad90307ed8ca20859ef499ac17deb0"
+      "size": 2851,
+      "sha256": "c9e03a47973bab737587d22ebac4cd7b27b5c5af55a271efb8f71abba7fa70cf"
     },
     {
       "path": "skills/author-strategy/SKILL.md",

--- a/skills/architecture-zoo/SKILL.md
+++ b/skills/architecture-zoo/SKILL.md
@@ -7,9 +7,10 @@ description: >
   when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the
   matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet,
   ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net, Mask R-CNN; SAM/MedSAM,
-  TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR). It teaches archetypes and the task-to-architecture
-  logic, not a live SOTA leaderboard.
-triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone
+  TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN —
+  for brain connectomes). It teaches archetypes and the task-to-architecture logic, not a live SOTA
+  leaderboard.
+triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
 ---
@@ -62,6 +63,8 @@ a family card.
   VAE / fastMRI reconstruction.
 - `${CLAUDE_SKILL_DIR}/references/foundation_models.md` — SAM / MedSAM / MedSAM2 / TotalSegmentator /
   SegVol / BiomedCLIP / DINO / MAE / SimCLR / MoCo.
+- `${CLAUDE_SKILL_DIR}/references/graph.md` — GCN / GraphSAGE / GAT / GIN / BrainGNN for brain
+  connectomes & population graphs (integrate PyTorch Geometric / DGL; not scaffolded by model-scaffold).
 Each card gives the paper, core idea, when-to-use, medical-imaging use, reference implementation, and the
 **typical validation/experiment setup** for that architecture class.
 

--- a/skills/architecture-zoo/references/graph.md
+++ b/skills/architecture-zoo/references/graph.md
@@ -1,0 +1,110 @@
+# Graph neural networks — brain connectomes & population graphs (architecture-zoo)
+
+For when the data is a **graph, not an image grid**: a brain **connectome** (nodes = ROIs /
+parcels, edges = structural connectivity from DTI tractography or functional connectivity
+from fMRI correlation), or a **population graph** (nodes = subjects, edges = phenotypic /
+imaging similarity). The task is usually **graph-level classification** (diagnose a subject
+from their connectome), **node-level** (flag abnormal ROIs, or classify subjects on a
+population graph), or **link prediction** (connectivity changes).
+
+This is a distinct family because a CNN/U-Net assumes a regular pixel grid; a connectome has
+no grid — permuting the ROI order must not change the prediction, which is exactly the
+symmetry a GNN respects. Each card: **paper → core idea → when to use → medical use →
+reference impl → validation/experiment setup.**
+
+---
+
+## The general-purpose message-passing GNNs
+
+### GCN (graph convolutional network)
+- **Paper**: Kipf & Welling, "Semi-Supervised Classification with Graph Convolutional
+  Networks", *ICLR* 2017.
+- **Core idea**: each layer averages a node's features with its neighbours' (a first-order
+  spectral-graph approximation), stacking to widen the receptive field over the graph.
+- **When to use**: the transparent baseline for any connectome / population-graph task — try
+  it before anything fancier.
+- **Medical use**: connectome classification; **Parisot et al.** (*Medical Image Analysis*
+  2018) put subjects on a **population graph** (phenotypic-similarity edges) for autism
+  (ABIDE) and Alzheimer's (ADNI) prediction — a semi-supervised node-classification framing.
+- **Reference impl**: **PyTorch Geometric** (`GCNConv`) or **DGL**; do not reimplement.
+- **Validation setup**: split at the **subject level** (a subject's graph — or, on a
+  population graph, a subject node's label — never spans train/test); with a small cohort,
+  report a **permutation test** and cross-validated CIs, not a single split.
+
+### GraphSAGE (inductive aggregation)
+- **Paper**: Hamilton, Ying & Leskovec, "Inductive Representation Learning on Large Graphs",
+  *NeurIPS* 2017.
+- **Core idea**: learn an **aggregator** over a sampled neighbourhood so the model generalises
+  to **unseen** nodes/graphs (inductive), unlike transductive GCN.
+- **When to use**: a **new subject** must be classified without retraining (the realistic
+  clinical setting), or the graph is too large to process whole.
+- **Medical use**: inductive connectome classification where test subjects are genuinely held
+  out (the honest deployment framing for a population-graph model).
+- **Reference impl**: PyTorch Geometric (`SAGEConv`) / DGL.
+- **Validation setup**: exploit the inductive setup to keep the test subjects fully out of
+  message passing during training (transductive leakage is a real trap on population graphs).
+
+### GAT (graph attention)
+- **Paper**: Veličković et al., "Graph Attention Networks", *ICLR* 2018.
+- **Core idea**: learn **attention weights** over neighbours, so the model decides which
+  connections matter instead of averaging uniformly.
+- **When to use**: when *which edges/connections drive the prediction* is itself a finding
+  (edge importance is a built-in interpretability signal).
+- **Medical use**: connectome studies that report the most-attended edges/ROIs as candidate
+  biomarkers.
+- **Reference impl**: PyTorch Geometric (`GATConv` / `GATv2Conv`) / DGL.
+- **Validation setup**: treat attention as a **hypothesis-generating** attribution, not proof
+  — sanity-check it (does it survive label permutation?) as `/explainability` requires of any
+  saliency.
+
+### GIN (graph isomorphism network)
+- **Paper**: Xu et al., "How Powerful are Graph Neural Networks?", *ICLR* 2019.
+- **Core idea**: an aggregation as discriminative as the Weisfeiler-Lehman test — the most
+  **expressive** simple GNN for **graph-level** classification.
+- **When to use**: graph-level diagnosis where subtle topology differences separate classes
+  and GCN/GAT underfit.
+- **Reference impl**: PyTorch Geometric (`GINConv`).
+- **Validation setup**: expressiveness raises overfitting risk on small connectome cohorts —
+  pair with heavy regularisation and nested CV (as `/radiomics-ml` does for the p ≫ n regime).
+
+---
+
+## The brain-specific model
+
+### BrainGNN (ROI-aware, interpretable)
+- **Paper**: Li et al., "BrainGNN: Interpretable Brain Graph Neural Network for fMRI Analysis",
+  *Medical Image Analysis* 2021.
+- **Core idea**: ROI-aware convolution + a pooling layer that scores and selects the most
+  informative ROIs, so the model is **interpretable at the region level** by construction.
+- **When to use**: fMRI connectome classification where you must report **which ROIs** drove
+  the decision (the usual neuroimaging reviewer demand).
+- **Medical use**: task-fMRI / resting-state connectome diagnosis (ASD, disorders) with a
+  salient-ROI readout.
+- **Reference impl**: the authors' released BrainGNN repo (on PyTorch Geometric).
+- **Validation setup**: report salient ROIs with **stability across folds** (not one split);
+  keep site-harmonisation (**ComBat**) fit on the **training** fold only.
+
+---
+
+## Connectome-specific validation traps (read before publishing)
+- **Subject-level split.** A subject's connectome must not appear in more than one split; on a
+  population graph, hold test-subject **labels** out of training and (ideally, inductive)
+  their **nodes** out of message passing. This is `/model-validation`'s split-leakage discipline
+  at the subject level.
+- **Site / scanner harmonisation leakage.** Multi-site connectome data (ABIDE, ADNI) is
+  harmonised with **ComBat** — fit it on the **training** fold only, never the whole cohort
+  (the graph analogue of `/preprocess-imaging`'s `NORMALIZATION_LEAKAGE`).
+- **p ≫ n.** A connectome has thousands of edges on tens–hundreds of subjects; treat it like
+  radiomics — nested CV, regularisation, a **permutation test** for tiny cohorts, and don't
+  over-read a single fold (`/radiomics-ml`).
+- **Interpretability ≠ proof.** Attention / ROI-saliency is hypothesis-generating; sanity-check
+  it (`/explainability`).
+
+## Boundary — this family is not scaffolded by `/model-scaffold`
+`/model-scaffold` builds **image-grid** repos (CNN / U-Net / transformer); it has **no graph
+task template**. For GNNs, **integrate PyTorch Geometric / DGL directly** — they own the graph
+layers, loaders, and training loop; the lane does not reimplement them. The lane's
+**subject-level** gates still apply: `/model-validation` (split leakage), `/radiomics-ml`
+(nested-CV rigor for p ≫ n), `/explainability` (attribution sanity), `/uncertainty-imaging`
+(deployment uncertainty), and `/check-reporting` (TRIPOD+AI). Record the choice + paper in the
+decision note; validate the built model with `/model-validation`.

--- a/skills/architecture-zoo/references/index.md
+++ b/skills/architecture-zoo/references/index.md
@@ -14,12 +14,16 @@ per-paper detail and the `/model-scaffold` template to instantiate.
 | "I have few labels / want to pretrain on unlabelled scans" | **self-supervised pretraining → fine-tune** | `foundation_models.md` |
 | "adapt a released medical foundation model" | **transfer / prompt a foundation model** | `foundation_models.md` |
 | "synthesise / translate a modality" (MRI→CT, denoise) | **image-to-image / generative** | `synthesis.md` |
+| "classify from a brain connectome / graph" (ROI connectivity, DTI/fMRI) | **graph neural network** | `graph.md` |
 | "generate a report / answer a visual question" | **multimodal LLM** | *(use `/mllm-eval`; not a CNN choice)* |
 
 ## Step 2 — let the constraints narrow it
 - **Modality / dimensionality**: 2-D (CXR, fundus, path tiles, single CT/MR slices) →
   2-D backbones / 2-D U-Net. 3-D volumes (CT, MR) → **3-D U-Net / SegResNet / nnU-Net**
-  (3-D context matters; do not collapse to slices if the structure is volumetric).
+  (3-D context matters; do not collapse to slices if the structure is volumetric). A
+  **graph** (brain connectome, ROI-connectivity matrix — no pixel grid) → a **GNN**
+  (`graph.md`); integrate PyTorch Geometric / DGL directly (`/model-scaffold` has no graph
+  template).
 - **Labelled data scale** (events/structures, not just images):
   - **small** (hundreds) → a **pretrained** backbone fine-tuned (ImageNet / a medical
     foundation model), strong augmentation, heavy regularisation; prefer **nnU-Net**

--- a/skills/architecture-zoo/skill.yml
+++ b/skills/architecture-zoo/skill.yml
@@ -29,7 +29,7 @@ safety_boundaries:
   - "Advisory only: it writes a decision note, never code or weights; the build is /model-scaffold."
   - "Every recommendation names its source paper; benchmark numbers are cited, never invented; the zoo describes archetypes, not a live leaderboard."
 known_limitations:
-  - "The literature moves fast; this is a curated archetype map (classification, segmentation, detection, synthesis, foundation/SSL families), not an exhaustive or current SOTA ranking."
+  - "The literature moves fast; this is a curated archetype map (classification, segmentation, detection, synthesis, foundation/SSL, and graph/GNN families), not an exhaustive or current SOTA ranking."
   - "A sound architecture choice is necessary, not sufficient; validity still depends on the split, validation design, and metrics (/model-validation, /model-evaluation)."
 validation_commands:
   - "carry the decision note into /model-scaffold to instantiate the chosen template, then /model-validation"


### PR DESCRIPTION
## GNN family card — closes the last candidate gap

Adds `architecture-zoo/references/graph.md`: a family card for **graph neural networks** on brain **connectomes** and **population graphs** — the one open candidate in the [model-engineering coverage map](docs/method_coverage_map.md), and directly relevant to neuroimaging (connectome diagnosis from DTI/fMRI).

### What lands
- **GCN / GraphSAGE / GAT / GIN** (Kipf & Welling 2017; Hamilton 2017; Veličković 2018; Xu 2019) — the general message-passing family, each with when-to-use (baseline / inductive / edge-attention / max-expressive).
- **BrainGNN** (Li et al., *Medical Image Analysis* 2021) — the brain-specific, ROI-interpretable model.
- **Population-graph framing** (Parisot et al., *Medical Image Analysis* 2018 — ABIDE/ADNI) alongside per-subject connectomes.
- **Connectome-specific validation traps**: subject-level split, ComBat site-harmonisation fit on train only (the graph analogue of `NORMALIZATION_LEAKAGE`), p ≫ n → treat like radiomics (nested CV + permutation test), attention/saliency is hypothesis-generating not proof.

### Design
- **Honest boundary**: `model-scaffold` builds image-grid repos and has **no graph template** — integrate **PyTorch Geometric / DGL** directly; the lane doesn't reimplement them. The subject-level gates (`model-validation`, `radiomics-ml`, `explainability`, `uncertainty-imaging`, `check-reporting`) still apply.
- **Reference-only**: no skill, no detector, **no count change** (55 / 50). Wired into the decision `index.md` (task table + modality note) + SKILL curriculum; `method_coverage_map` GNN row candidate → landed; every recommendation names its source paper (no invented benchmarks).

### Verification
All 5 generators `--check` in sync + `validate_catalog_consistency` (counts unchanged) + `validate_skills.sh` (ALL PASS) — green locally.

### Release
Staged in `[Unreleased]` with Items 5–6 for the next minor (**v5.17.0**). The six-item produce-side depth roadmap **and** its candidate list are now complete. **No release cut** in this PR.