### PR TITLE
fix(contrib): un-trap the first-PR on-ramp (#115) + drive-by quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Thank you for helping make medical research workflows more reproducible and less brittle. Contributions are welcome through GitHub issues and pull requests.
 
+## Quickstart: your first PR (5 minutes)
+
+Most contributions are **one small, self-contained file** (a CSL style, a de-identification locale, a figure exemplar, a journal profile, a README translation). You do **not** need to read the rest of this document, understand the whole pipeline, or run the full validator suite locally for one of these. The path is:
+
+1. **Fork** the repo and **clone** your fork.
+2. **Branch**: `git checkout -b add-<what-you-are-adding>`.
+3. **Add one file** in the folder the [good-first-issue](https://github.com/Aperivue/medsci-skills/contribute) or the README's "Contributing" table points to. Copy the nearest existing file as your template.
+4. **Open a PR.** CI runs for you — you do not need to run it locally, and you do **not** need the worktree discipline, the release process, or any catalog-count bump. The catalog-consistency check auto-derives journal-profile counts from disk, so adding a profile will not flag you; a maintainer handles any bookkeeping in review.
+
+**Claiming an issue:** you don't need to. **No assignment is required — just open a PR.** The first PR that passes CI and review wins. If you want to signal intent, comment on the issue; that soft-claim lapses after **7 days** so an issue never sits blocked on someone who moved on.
+
+The heavier **Pull Request Checklist**, **Skill Addition Workflow**, and validator steps below apply to **maintainers and larger PRs** (new skills, detectors, or anything touching a medical/research claim) — not to a one-file drive-by contribution.
+
 ## What to Contribute
 
 - New skills for recurring medical research workflows.

--- a/README.md
+++ b/README.md
@@ -783,12 +783,18 @@ from one of these:
 
 | Want to add… | How | Issue |
 |---|---|---|
-| **A journal profile** (submission rules for a journal we don't cover) | `/add-journal`, or copy an existing `journal_profiles/*.md` | [#115](https://github.com/Aperivue/medsci-skills/issues/115) |
+| **A CSL citation style** for a journal that lacks one | drop one `.csl` into `manage-refs/citation_styles/` | [#117](https://github.com/Aperivue/medsci-skills/issues/117) |
+| **A de-identification locale pack** for one more country | add one patterns file under `deidentify/` | [#116](https://github.com/Aperivue/medsci-skills/issues/116) |
+| **A README translation** (e.g., zh-CN) | one translated `README` file | [#119](https://github.com/Aperivue/medsci-skills/issues/119) |
 | **A figure exemplar** (ROC, KM, forest, Bland–Altman, confusion matrix…) | one `make-figures/references/exemplar_plots/*.md` anatomy model | [#118](https://github.com/Aperivue/medsci-skills/issues/118) |
-| **A CSL citation style** for a journal that lacks one | drop a `.csl` into `manage-refs/citation_styles/` | [#117](https://github.com/Aperivue/medsci-skills/issues/117) |
-| **A de-identification locale pack** for one more country | add patterns to `deidentify/` | [#116](https://github.com/Aperivue/medsci-skills/issues/116) |
+| **A journal profile** (submission rules for a journal we don't cover) | `/add-journal`, or copy an existing `journal_profiles/*.md` | [#115](https://github.com/Aperivue/medsci-skills/issues/115) |
 | **A reporting checklist or peer-review exemplar** | one reference file in the matching skill | [#120](https://github.com/Aperivue/medsci-skills/issues/120) |
-| **A README translation** (e.g., zh-CN) | a translated `README` | [#119](https://github.com/Aperivue/medsci-skills/issues/119) |
+
+Each of these adds **exactly one new file** — none requires editing a count, a generated
+page, or the build config, and the catalog-consistency check auto-derives profile counts from
+disk so it won't flag you. **No assignment needed: just open a PR — the first one that passes
+CI wins, and a maintainer handles any bookkeeping in review.** See the
+[5-minute first-PR quickstart](CONTRIBUTING.md#quickstart-your-first-pr-5-minutes) to get going.
 
 Every contribution is gated the same way the maintainers are: it must be a self-contained
 file, pass the CI (`validate.yml` — PII scan, structure, catalog consistency), and carry no

--- a/metadata/catalog_counts.json
+++ b/metadata/catalog_counts.json
@@ -1,8 +1,6 @@
 {
-  "_comment": "Single source of truth for catalog counts cited in public docs (README, orchestrate, check-reporting). scripts/validate_catalog_consistency.py recomputes every value from disk, asserts this file matches, and asserts the doc claims match. Do not hand-edit a value without running that script \u2014 CI fails on drift.",
+  "_comment": "Single source of truth for maintainer-scoped catalog counts cited in public docs (README, orchestrate, check-reporting). scripts/validate_catalog_consistency.py recomputes every value from disk, asserts this file matches, and asserts the doc claims match. Do not hand-edit a value without running that script \u2014 CI fails on drift. Journal-profile counts are deliberately NOT tracked here: they are auto-derived from disk by the validator so that adding one profile (good-first-issue #115) never requires a contributor to bump a count.",
   "skills": 55,
   "reporting_guidelines": 44,
-  "journal_profiles_find": 73,
-  "journal_profiles_write": 55,
   "integrity_detectors": 50
 }

--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -10,6 +10,12 @@ the counts a single source of truth and fails CI on drift.
 Three layers:
   1. Recompute every count from disk (the real ground truth).
   2. Assert metadata/catalog_counts.json matches disk — the SSOT cannot lie.
+     Exception: the journal-profile counts (``AUTO_DERIVED_KEYS``) are recomputed
+     from disk but never asserted against the JSON, so that adding one profile —
+     the single-file change the "add a journal profile" good-first-issue (#115)
+     invites from a first-time contributor — can never fail on a count bump they
+     have no reason to know about. Those counts are cited in no checked doc claim,
+     so disk is their sole source of truth.
   3. Assert the count claims in README / orchestrate / check-reporting match the
      SSOT. Guideline claims are matched (case-insensitively, so a "### 33 Reporting
      Guidelines" heading is caught) by the word "guideline"; the skill self-count by
@@ -30,6 +36,16 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SSOT = ROOT / "metadata" / "catalog_counts.json"
+
+# Counts that a drive-by contributor legitimately changes with a single-file PR
+# (adding one journal profile). These are AUTO-DERIVED from disk and deliberately
+# NOT asserted against catalog_counts.json — otherwise the flagship "add a journal
+# profile" good-first-issue (#115) would fail CATALOG_COUNT_DRIFT for the exact
+# newcomer it targets, who has no reason to touch the SSOT JSON. No public doc
+# cross-checks these counts, so disk is their sole source of truth. Maintainer-
+# scoped counts (skills, reporting_guidelines, integrity_detectors) stay hard-
+# asserted below and in catalog_counts.json.
+AUTO_DERIVED_KEYS = ("journal_profiles_find", "journal_profiles_write")
 
 
 def disk_counts() -> dict[str, int]:
@@ -159,6 +175,8 @@ def main() -> int:
         return 1
     ssot = json.loads(SSOT.read_text(encoding="utf-8"))
     for key, val in truth.items():
+        if key in AUTO_DERIVED_KEYS:
+            continue  # disk is truth; a profile-add PR must never need a JSON bump
         if ssot.get(key) != val:
             print(f"\nFAIL: SSOT {key}={ssot.get(key)} != disk {val}", file=sys.stderr)
             failures += 1


### PR DESCRIPTION
## Why

The flagship **"add a journal profile"** good-first-issue (#115) was booby-trapped. Adding one
profile makes the on-disk profile count drift from the hardcoded `metadata/catalog_counts.json`,
so `scripts/validate_catalog_consistency.py` fails CI with `CATALOG_COUNT_DRIFT`. The local
validator the issue tells contributors to run (`validate_skills.sh`) passes green — so a first-time
contributor who follows the instructions gets a red-X they cannot diagnose. This is the most likely
reason the good-first-issues have not converted.

## What

- **`scripts/validate_catalog_consistency.py`** — journal-profile counts are now auto-derived from
  disk and never asserted against the JSON. No public doc claim cross-checks them, so disk is their
  sole source of truth; adding a profile can no longer fail this gate. Maintainer-scoped counts
  (skills, reporting guidelines, integrity detectors) stay hard-asserted. **Verified:** dropping a
  dummy profile into the folder keeps the validator at exit 0.
- **`metadata/catalog_counts.json`** — drop the two journal-profile keys (only this validator read
  them) and document why in the comment.
- **README "Contributing"** — lead the funnel with the count-safe issues (CSL #117, locale #116,
  translation #119), add a count-safety + no-assignment note, and link the new quickstart.
- **`CONTRIBUTING.md`** — add a **"Quickstart: your first PR (5 minutes)"** that separates the
  one-file drive-by path (fork → one file → PR; CI runs for you; no worktree discipline, no count
  bump) from the maintainer-grade checklist, and states the claim policy: no assignment needed —
  first passing PR wins, soft-claim lapses after 7 days.

## Test

`validate_skills.sh`, `check_locale_inventory.py`, `validate_catalog_consistency.py`, and all five
`gen_*.py --check` pass locally. The drive-by simulation (add one profile → re-run the consistency
check → exit 0) is described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
