### PR TITLE
fix(render-pdf-doc): Windows support — Malgun Gothic default + MiKTeX PATH probe (#68)

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3478,8 +3478,8 @@
     },
     {
       "path": "skills/render-pdf-doc/SKILL.md",
-      "size": 7490,
-      "sha256": "2de13f525ab617dc3a5d67403f8668c26829d927732ae2ac718158b109861243"
+      "size": 8300,
+      "sha256": "fad21da8e60907c212b6d216ffe591502941c8defa4ce212b521306e00332836"
     },
     {
       "path": "skills/render-pdf-doc/references/known_pitfalls.md",
@@ -3493,8 +3493,8 @@
     },
     {
       "path": "skills/render-pdf-doc/scripts/check_deps.sh",
-      "size": 984,
-      "sha256": "84d5b4d3455a66f21baaa2a3be1f01b9cba58c9e50331138c7132d23531f211d"
+      "size": 2183,
+      "sha256": "782efdda541c0a84a8d978bb076d43a1d3a026a00b878205dd6d922a197186f6"
     },
     {
       "path": "skills/render-pdf-doc/scripts/infer_colwidths.py",
@@ -3503,8 +3503,8 @@
     },
     {
       "path": "skills/render-pdf-doc/scripts/render_pdf.sh",
-      "size": 2874,
-      "sha256": "aad89324341121270be0093a05ff944927696180a27a97068f2faf906321e987"
+      "size": 3958,
+      "sha256": "b5a9ebcbb25b1ec85577c9864f60f4f363e90f88896903cff48f7626f5b6b95a"
     },
     {
       "path": "skills/render-pdf-doc/scripts/scan_glyph_coverage.py",

--- a/skills/render-pdf-doc/SKILL.md
+++ b/skills/render-pdf-doc/SKILL.md
@@ -45,18 +45,31 @@ Manual fixes work but the same pattern recurs across proposals, briefings, IRB c
 ## Dependencies
 
 ```bash
-# Required
-brew install pandoc                                                   # macOS
+# macOS
+brew install pandoc
 brew install --cask mactex-no-gui          # xelatex + xeCJK (~5 GB)
 
 # Linux
 sudo apt-get install pandoc texlive-xetex texlive-lang-cjk fonts-noto-cjk
+
+# Windows (PowerShell) — run in Git Bash afterwards
+winget install --id JohnMacFarlane.Pandoc
+winget install --id MiKTeX.MiKTeX          # xelatex; installs missing LaTeX packages on demand
+# No CJK font download needed: Malgun Gothic ships with Windows 7+ and is the default here.
 ```
 
 Detection:
 ```bash
 bash scripts/check_deps.sh
 ```
+
+**Windows / Git Bash note.** MiKTeX's binary directory
+(`%LOCALAPPDATA%\Programs\MiKTeX\miktex\bin\x64`) is often not on the Git Bash `PATH`,
+so `xelatex` can read as `[MISS]` even after install. Both `check_deps.sh` and
+`render_pdf.sh` now auto-probe that location; if `xelatex` still isn't found, add the
+directory to your `PATH` (or run from the *MiKTeX Console → Settings*-configured shell).
+The Windows CJK/main font default is **Malgun Gothic** (preinstalled); override per document
+via frontmatter, or with `--font` / `--cjk-font`.
 
 ## Workflow
 
@@ -76,7 +89,7 @@ colorlinks: true
 ---
 ```
 
-For Linux/CI, use `Noto Sans CJK KR` instead. The render script auto-detects.
+For Linux/CI, use `Noto Sans CJK KR`; on Windows, use `Malgun Gothic`. The render script auto-detects the default per OS.
 
 ### Step 2 — Infer column widths
 

--- a/skills/render-pdf-doc/scripts/check_deps.sh
+++ b/skills/render-pdf-doc/scripts/check_deps.sh
@@ -16,26 +16,57 @@ check() {
   fi
 }
 
+# Windows/Git Bash: MiKTeX's bin directory is frequently absent from the Git Bash
+# PATH, so xelatex reads as [MISS] even after `winget install MiKTeX.MiKTeX`.
+# Best-effort: prepend the known MiKTeX bin locations when xelatex is not resolvable.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if ! command -v xelatex >/dev/null 2>&1; then
+      _la="$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null || printf '%s' "${LOCALAPPDATA:-}")"
+      _pf="$(cygpath -u "${PROGRAMFILES:-}" 2>/dev/null || printf '%s' "${PROGRAMFILES:-}")"
+      for _d in \
+        "$_la/Programs/MiKTeX/miktex/bin/x64" \
+        "$_la/Programs/MiKTeX/miktex/bin" \
+        "$_pf/MiKTeX/miktex/bin/x64"; do
+        if [[ -x "$_d/xelatex.exe" ]]; then PATH="$_d:$PATH"; break; fi
+      done
+    fi
+    ;;
+esac
+
 check "pandoc" command -v pandoc
 check "xelatex" command -v xelatex
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  if /usr/bin/fc-list 2>/dev/null | grep -qi "Apple SD Gothic Neo" \
-     || system_profiler SPFontsDataType 2>/dev/null | grep -qi "Apple SD Gothic Neo"; then
-    echo "[OK] Apple SD Gothic Neo (macOS)"
-    ok=$((ok + 1))
-  else
-    echo "[WARN] Apple SD Gothic Neo not detected — falling back to default fontconfig"
-  fi
-else
-  if fc-list 2>/dev/null | grep -qi "Noto.*CJK.*KR"; then
-    echo "[OK] Noto Sans/Serif CJK KR"
-    ok=$((ok + 1))
-  else
-    echo "[MISS] Noto CJK KR — apt install fonts-noto-cjk"
-    fail=$((fail + 1))
-  fi
-fi
+case "$(uname -s)" in
+  Darwin)
+    if /usr/bin/fc-list 2>/dev/null | grep -qi "Apple SD Gothic Neo" \
+       || system_profiler SPFontsDataType 2>/dev/null | grep -qi "Apple SD Gothic Neo"; then
+      echo "[OK] Apple SD Gothic Neo (macOS)"
+      ok=$((ok + 1))
+    else
+      echo "[WARN] Apple SD Gothic Neo not detected — falling back to default fontconfig"
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    _win="$(cygpath -u "${WINDIR:-}" 2>/dev/null || printf '%s' "${WINDIR:-}")"
+    [[ -z "$_win" ]] && _win="/c/Windows"
+    if [[ -f "$_win/Fonts/malgun.ttf" ]]; then
+      echo "[OK] Malgun Gothic (Windows)"
+      ok=$((ok + 1))
+    else
+      echo "[WARN] Malgun Gothic not detected — it ships with Windows 7+; see C:\\Windows\\Fonts"
+    fi
+    ;;
+  *)
+    if fc-list 2>/dev/null | grep -qi "Noto.*CJK.*KR"; then
+      echo "[OK] Noto Sans/Serif CJK KR"
+      ok=$((ok + 1))
+    else
+      echo "[MISS] Noto CJK KR — apt install fonts-noto-cjk"
+      fail=$((fail + 1))
+    fi
+    ;;
+esac
 
 echo
 echo "Summary: $ok ok, $fail fail"

--- a/skills/render-pdf-doc/scripts/render_pdf.sh
+++ b/skills/render-pdf-doc/scripts/render_pdf.sh
@@ -61,17 +61,44 @@ done
 
 # OS-based font defaults
 if [[ -z "$MAINFONT" || -z "$CJKFONT" ]]; then
-  if [[ "$(uname)" == "Darwin" ]]; then
-    : "${MAINFONT:=Apple SD Gothic Neo}"
-    : "${CJKFONT:=Apple SD Gothic Neo}"
-  else
-    : "${MAINFONT:=Noto Serif CJK KR}"
-    : "${CJKFONT:=Noto Sans CJK KR}"
-  fi
+  case "$(uname -s)" in
+    Darwin)
+      : "${MAINFONT:=Apple SD Gothic Neo}"
+      : "${CJKFONT:=Apple SD Gothic Neo}"
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      # Windows: Malgun Gothic ships with Windows 7+ (the Korean UI font), so no
+      # font download is needed. Noto CJK is NOT preinstalled on Windows.
+      : "${MAINFONT:=Malgun Gothic}"
+      : "${CJKFONT:=Malgun Gothic}"
+      ;;
+    *)
+      : "${MAINFONT:=Noto Serif CJK KR}"
+      : "${CJKFONT:=Noto Sans CJK KR}"
+      ;;
+  esac
 fi
 
+# Windows/Git Bash: MiKTeX's bin directory is frequently absent from the Git Bash
+# PATH, so xelatex is not found even after `winget install MiKTeX.MiKTeX`. Prepend
+# the known MiKTeX bin locations (best-effort) when xelatex is not already resolvable.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    if ! command -v xelatex >/dev/null 2>&1; then
+      _la="$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null || printf '%s' "${LOCALAPPDATA:-}")"
+      _pf="$(cygpath -u "${PROGRAMFILES:-}" 2>/dev/null || printf '%s' "${PROGRAMFILES:-}")"
+      for _d in \
+        "$_la/Programs/MiKTeX/miktex/bin/x64" \
+        "$_la/Programs/MiKTeX/miktex/bin" \
+        "$_pf/MiKTeX/miktex/bin/x64"; do
+        if [[ -x "$_d/xelatex.exe" ]]; then PATH="$_d:$PATH"; break; fi
+      done
+    fi
+    ;;
+esac
+
 command -v pandoc >/dev/null || { echo "ERROR: pandoc not installed" >&2; exit 3; }
-command -v xelatex >/dev/null || { echo "ERROR: xelatex not installed (install mactex / texlive-xetex)" >&2; exit 3; }
+command -v xelatex >/dev/null || { echo "ERROR: xelatex not installed (install mactex / texlive-xetex / MiKTeX)" >&2; exit 3; }
 
 WORK="$INPUT"
 TMPDIR=""


### PR DESCRIPTION
Fixes #68.

## Problem (from the report)

On Windows/Git Bash, `render-pdf-doc` was non-functional out-of-the-box:

1. No Windows install instructions in `SKILL.md`.
2. `check_deps.sh` reported `[MISS] xelatex` even after MiKTeX install — Git Bash can't see MiKTeX's bin path (`%LOCALAPPDATA%\Programs\MiKTeX\miktex\bin\x64`).
3. `render_pdf.sh` had no Windows branch → fell through to the Linux default (`Noto Serif/Sans CJK KR`, not installed on Windows) → `fontspec Error: The font "Noto Serif CJK KR" cannot be found`.

## Fix

- **`render_pdf.sh` / `check_deps.sh`** — add a Windows (`MINGW*`/`MSYS*`/`CYGWIN*`) branch that defaults `mainfont`/`CJKmainfont` to **Malgun Gothic** (ships with Windows 7+, so no font download), and a best-effort **MiKTeX bin-path probe** (`cygpath`-resolved `%LOCALAPPDATA%\Programs\MiKTeX\miktex\bin\x64` and the Program Files location) so `xelatex` resolves in Git Bash. macOS and Linux paths are unchanged.
- **`SKILL.md`** — a Windows install block (`winget install` pandoc + MiKTeX; Malgun Gothic preinstalled, no CJK font download) and a Git-Bash `PATH` note; the font-default note now covers Windows.
- Regenerated `metadata/distribution_files.json`.

## Verification

**On macOS (done):** `bash -n` clean on both scripts; `check_deps.sh` unchanged (`3 ok / 0 fail`); a real render still produces a PDF with Apple SD Gothic Neo (no regression); the `MINGW64_NT-*` case resolves the font default to `Malgun Gothic`. Repo CI mirror green (`validate_skills.sh`, all `gen_*.py --check`, `validate_catalog_consistency.py`, the skill's glyph-coverage self-test).

**On Windows (needs a real machine — I can't test this from macOS):** whether `xelatex` now resolves in Git Bash after the probe, and whether Malgun Gothic renders Hangul + Latin cleanly.

@Rochelle1995 — thank you for the unusually precise report (exact MiKTeX path + the fontspec error made this straightforward). Would you be willing to check out this branch and run `bash scripts/check_deps.sh` and `bash scripts/render_pdf.sh -i <a small .md> -o out.pdf` on your Windows 11 / MiKTeX setup? If it works (or needs a tweak to the probe path), I'll credit you as the fix's verifier. Marked "Closes #68 (pending Windows verification)" until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
