### PR TITLE
docs(positioning): AI-agent-first framing + npm-downloads badge + AI-mediated-discovery metric

### DIFF
--- a/IMPACT.md
+++ b/IMPACT.md
@@ -45,6 +45,7 @@ confirmed use:
 - **Forks** may indicate experimentation or reuse — a somewhat stronger signal than a star.
 - **Clones / downloads** are inflated by CI and mirroring traffic; the *unique* columns are more meaningful.
 - **Confirmed use cases and academic citations** are the strongest evidence, and are scarcer than raw stars.
+- **AI-mediated discovery** is a distinct and growing channel: the referrer log ([`metrics/referrers_log.csv`](metrics/referrers_log.csv)) captures visits arriving from LLM assistants such as ChatGPT and Claude. Because agent-recommended installs are often cloned or run via `npx` without ever loading the GitHub page, this channel — and the real usage behind it — is systematically undercounted by the star count.
 - **Current status: early community interest for a niche biomedical-workflow repository — not widespread adoption.** This page never claims adoption that has not been observed; a thin section is a truthful section.
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/Aperivue/medsci-skills/validate.yml?branch=main&style=flat-square&label=CI)](https://github.com/Aperivue/medsci-skills/actions/workflows/validate.yml)
 ![Skills](https://img.shields.io/badge/Skills-55-brightgreen?style=flat-square)
 [![npm](https://img.shields.io/npm/v/medsci-skills?style=flat-square&label=npm&color=cb3837)](https://www.npmjs.com/package/medsci-skills)
+[![npm downloads](https://img.shields.io/npm/dw/medsci-skills?style=flat-square&label=npm%20downloads&color=cb3837)](https://www.npmjs.com/package/medsci-skills)
 [![Watch the 2-min intro](https://img.shields.io/badge/▶_Watch-2--min_intro-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://youtu.be/MclQ_RIofpE)
 [![good first issues](https://img.shields.io/github/issues/Aperivue/medsci-skills/good%20first%20issue?style=flat-square&label=good%20first%20issues&color=7057ff)](https://github.com/Aperivue/medsci-skills/contribute)
 
@@ -41,8 +42,9 @@
 
 ## What is MedSci Skills?
 
-MedSci Skills is an open-source Claude Code skill collection for **clinical
-research — the manuscript and the medical-AI model alike**. It helps
+MedSci Skills is an open-source **Agent Skills** collection for **clinical
+research — the manuscript and the medical-AI model alike** — designed to be driven
+directly by AI coding agents (Claude Code, Codex, Cursor, and GitHub Copilot). It helps
 physician-researchers and biomedical/medical-engineering investigators move from
 literature search, study design, statistics, and figures to reporting-guideline
 compliance, citation/reference auditing, numerical-consistency checks, and


### PR DESCRIPTION
A small positioning + adoption-evidence pass that acts on the "stars undercount adoption" insight **without** touching the repo's integrity brand.

- **README — AI-agent-first opening.** The opening prose now names all four host agents (Claude Code, Codex, Cursor, GitHub Copilot). An LLM assistant recommending tools parses README *prose* more reliably than badges, so stating the agent-first identity plainly raises the chance the repo is surfaced to the exact users who install it via an agent.
- **README — npm-downloads badge.** Adds `npm/dw/medsci-skills` next to the version badge, surfacing the strongest *usage* signal on the front page (stars measure interest; downloads measure use).
- **IMPACT.md — "AI-mediated discovery" interpretation bullet.** The referrer log (`metrics/referrers_log.csv`) already captures ChatGPT/Claude-referred visits. This channel — and the real usage behind it — is systematically undercounted by stars, because agent-recommended installs are usually cloned or `npx`-run without ever loading the GitHub page.

### Deliberately NOT included

A *"Used by physician-researchers, biomedical engineers, and clinical AI researchers…"* line was on the table, but that is an **unverified adoption claim** — it would repeat exactly the anti-pattern removed in #287 (the unbacked "indexed in awesome lists" line) and violate `IMPACT.md`'s own stated principle ("never claim adoption that has not been observed"). The repo's differentiator is deterministic integrity; positioning stays **"designed for"** (audience) rather than **"used by"** (observed) until `docs/citations.md` carries real entries.

### Verified

`validate_skills.sh`, `validate_catalog_consistency.py`, and `gen_distribution_manifest.py --check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
