### PR TITLE
test(verify-refs): extract author_cross_check + network-free fabricated-author regression

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Run verify-refs OpenAlex tertiary-index test (A8b)
         run: bash skills/verify-refs/tests/test_openalex_tier.sh
 
+      - name: Run verify-refs fabricated-author cross-check test
+        run: bash skills/verify-refs/tests/test_fabricated_author.sh
+
       - name: Run self-review parenthesis-span corruption gate test (A9)
         run: bash skills/self-review/tests/test_paren_spans.sh
 

--- a/docs/skills/verify-refs.md
+++ b/docs/skills/verify-refs.md
@@ -30,6 +30,7 @@
 - `bash scripts/verify_cli.sh <refs.bib>`
 - `confirm qc/reference_audit.json submission_safe: true`
 - `bash tests/test_openalex_tier.sh`
+- `bash tests/test_fabricated_author.sh`
 
 **Evidence** — `bundled_script`
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4108,13 +4108,13 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 41415,
-      "sha256": "4377e25e6b125ace31fd35df9ffdd21a413f0f70ba1e429e5bfcf50c0a29510e"
+      "size": 43072,
+      "sha256": "ce0db6183942afdb2dfd55733c8b1330dee1b10ce091ce99c31497f83d9c4e0b"
     },
     {
       "path": "skills/verify-refs/skill.yml",
-      "size": 2248,
-      "sha256": "3933c313777557ad8ac82b9ed6389fba12675880588af85193791f3facc636e9"
+      "size": 2291,
+      "sha256": "608e80234418a3560c9662e83a786b20ad16a340b934bfea59e2421712595fc5"
     },
     {
       "path": "skills/version-dataset/SKILL.md",

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -626,6 +626,71 @@ def verify_openalex(doi: str, title: str, timeout: int) -> tuple[str, str, list]
     return "OK", ev, families
 
 
+def author_cross_check(
+    cited_authors: list,
+    actual_authors: list,
+    cited_author_count: int,
+    actual_author_count: int,
+    *,
+    corporate: bool = False,
+    soft: bool = False,
+    audit_truncated: bool = False,
+    first_author_guess: str = "",
+) -> tuple[list, list]:
+    """Pure family-by-family + author-count cross-check (no network, no RefRecord).
+
+    Compares every cited author family against the authoritative list positionally,
+    flags any cited author beyond the source list, and compares total counts (a count
+    mismatch is downgraded to a note when ``audit_truncated`` and cited < actual — an
+    intentional CSL et-al truncation). When no cited list was parsed (TSV / plain
+    text) it degrades to a first-author surname check. Corporate/collective authors
+    and OpenAlex-``soft`` lists are exempt (they must never fire MISMATCH).
+
+    Returns ``(mismatches, notes)``: ``mismatches`` — human-readable mismatch strings
+    (empty = clean); ``notes`` — non-mismatch evidence strings (the truncation note).
+    This is the sole decision surface behind an AUTHOR MISMATCH status, extracted so
+    the fabricated-co-author path (a real AI-assembled bib once registered 7 of 10
+    fabricated co-author names) has a network-free regression test
+    (``tests/test_fabricated_author.sh``). Behaviour is identical to the inline logic
+    it replaced in ``verify_record``.
+    """
+    mismatches: list = []
+    notes: list = []
+    if not corporate and cited_authors and actual_authors and not soft:
+        compare_n = min(len(cited_authors), len(actual_authors))
+        for i in range(compare_n):
+            cited = cited_authors[i]
+            if not author_surnames_match(cited, actual_authors[i]):
+                mismatches.append(
+                    f"#{i+1} family: cited='{cited}' vs source='{actual_authors[i]}'"
+                )
+        # cited has more authors than source — always flag (cannot be intentional)
+        for i in range(compare_n, len(cited_authors)):
+            mismatches.append(
+                f"#{i+1} extra cited='{cited_authors[i]}' (source has only {len(actual_authors)} authors)"
+            )
+        # source has more authors than cited — count mismatch, suppressed under
+        # `_audit_truncated` marker (intentional CSL et-al truncation).
+        if cited_author_count != actual_author_count:
+            if audit_truncated and cited_author_count < actual_author_count:
+                notes.append(
+                    f"NOTE: intentional truncate ({cited_author_count} of {actual_author_count}; "
+                    f"`_audit_truncated` marker set)"
+                )
+            else:
+                mismatches.append(
+                    f"AUTHOR COUNT: cited={cited_author_count} vs source={actual_author_count}"
+                )
+    elif not corporate and first_author_guess and actual_authors:
+        # No parsed cited author list (TSV / plain-text input) — degrade to the
+        # first-author surname cross-check (Gate 4 behaviour).
+        if not any(author_surnames_match(first_author_guess, a) for a in actual_authors):
+            mismatches.append(
+                f"#1 family: cited='{first_author_guess}' vs source='{actual_authors[0]}'"
+            )
+    return mismatches, notes
+
+
 def verify_record(record: RefRecord, offline: bool, timeout: int,
                   use_openalex: bool = True) -> RefRecord:
     """v1.3.0: full-author cross-check.
@@ -738,40 +803,17 @@ def verify_record(record: RefRecord, offline: bool, timeout: int,
             record.note = "corporate/collective author — personal-name cross-check skipped"
         evidence_parts.append("CORPORATE AUTHOR (collective/organization; family cross-check skipped)")
 
-    mismatches: list[str] = []
-    if (not (record.corporate_author or source_corporate)
-            and record.cited_authors and actual_authors and not actual_authors_soft):
-        compare_n = min(len(record.cited_authors), len(actual_authors))
-        for i in range(compare_n):
-            cited = record.cited_authors[i]
-            if not author_surnames_match(cited, actual_authors[i]):
-                mismatches.append(
-                    f"#{i+1} family: cited='{cited}' vs source='{actual_authors[i]}'"
-                )
-        # cited has more authors than source — always flag (cannot be intentional)
-        for i in range(compare_n, len(record.cited_authors)):
-            mismatches.append(
-                f"#{i+1} extra cited='{record.cited_authors[i]}' (source has only {len(actual_authors)} authors)"
-            )
-        # source has more authors than cited — count mismatch, suppressed under
-        # `_audit_truncated` marker (intentional CSL et-al truncation).
-        if record.cited_author_count != record.actual_author_count:
-            if record.audit_truncated and record.cited_author_count < record.actual_author_count:
-                evidence_parts.append(
-                    f"NOTE: intentional truncate ({record.cited_author_count} of {record.actual_author_count}; "
-                    f"`_audit_truncated` marker set)"
-                )
-            else:
-                mismatches.append(
-                    f"AUTHOR COUNT: cited={record.cited_author_count} vs source={record.actual_author_count}"
-                )
-    elif not (record.corporate_author or source_corporate) and record.first_author_guess and actual_authors:
-        # No parsed cited author list (TSV / plain-text input) — degrade to the
-        # first-author surname cross-check (Gate 4 behaviour).
-        if not any(author_surnames_match(record.first_author_guess, a) for a in actual_authors):
-            mismatches.append(
-                f"#1 family: cited='{record.first_author_guess}' vs source='{actual_authors[0]}'"
-            )
+    mismatches, xcheck_notes = author_cross_check(
+        record.cited_authors,
+        actual_authors,
+        record.cited_author_count,
+        record.actual_author_count,
+        corporate=(record.corporate_author or source_corporate),
+        soft=actual_authors_soft,
+        audit_truncated=record.audit_truncated,
+        first_author_guess=record.first_author_guess,
+    )
+    evidence_parts.extend(xcheck_notes)
 
     author_mismatch = bool(mismatches)
     if author_mismatch:

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -44,4 +44,5 @@ validation_commands:
   - "bash scripts/verify_cli.sh <refs.bib>"
   - "confirm qc/reference_audit.json submission_safe: true"
   - "bash tests/test_openalex_tier.sh"
+  - "bash tests/test_fabricated_author.sh"
 evidence_surface: bundled_script

--- a/skills/verify-refs/tests/test_fabricated_author.sh
+++ b/skills/verify-refs/tests/test_fabricated_author.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression test for verify-refs fabricated-author detection (network-free).
+#
+# author_cross_check() is the sole decision surface behind an AUTHOR MISMATCH status
+# (family-by-family + author-count). It is the repo's most trust-critical citation
+# check: a real AI-assembled bib once registered 7 of 10 fabricated co-author names
+# with a correct first author + DOI, and only the family/count cross-check catches
+# that. This test locks the logic so a refactor cannot silently drop the MISMATCH
+# path. Stdlib-only, no network (the pure function is tested in isolation, so no
+# PubMed/CrossRef/OpenAlex call is made).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$HERE/../scripts"
+[[ -f "$SCRIPTS/verify_refs.py" ]] || { echo "ENV-ERR: verify_refs.py missing" >&2; exit 2; }
+
+python3 - "$SCRIPTS" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+from verify_refs import author_cross_check
+
+fails = 0
+def check(label, cond):
+    global fails
+    print(("  PASS  " if cond else "  FAIL  ") + label)
+    if not cond:
+        fails += 1
+
+# 1. Clean list — cited == actual — no mismatch.
+m, n = author_cross_check(["Liu", "Chen", "Wang"], ["Liu", "Chen", "Wang"], 3, 3)
+check("clean list -> no mismatch", m == [])
+
+# 2. Fabricated co-authors — correct first author + count, wrong #2..#N families.
+m, n = author_cross_check(["Liu", "Ingram", "Xue"], ["Liu", "Chen", "Wang"], 3, 3)
+check("fabricated co-authors -> 2 family mismatches",
+      len(m) == 2 and "#2 family" in m[0] and "#3 family" in m[1])
+
+# 3. Extra cited author beyond the source list.
+m, n = author_cross_check(["Liu", "Chen", "Ghost"], ["Liu", "Chen"], 3, 2)
+check("extra cited author -> flagged", any("extra cited='Ghost'" in x for x in m))
+
+# 4. Author-count mismatch (not truncated) -> AUTHOR COUNT flag.
+m, n = author_cross_check(["Liu"], ["Liu", "Chen", "Wang"], 1, 3)
+check("count mismatch -> AUTHOR COUNT flag", any("AUTHOR COUNT" in x for x in m))
+
+# 5. Intentional CSL et-al truncation (cited < actual, marker set) -> note, NOT mismatch.
+m, n = author_cross_check(["Liu"], ["Liu", "Chen", "Wang"], 1, 3, audit_truncated=True)
+check("audit_truncated -> note not mismatch",
+      m == [] and any("intentional truncate" in x for x in n))
+
+# 6. Corporate/collective author -> exempt (must never fire MISMATCH).
+m, n = author_cross_check(["Ghost"], ["KDIGO Working Group"], 1, 1, corporate=True)
+check("corporate author -> exempt", m == [])
+
+# 7. OpenAlex-soft list -> exempt from strict positional check.
+m, n = author_cross_check(["Liu", "Ingram"], ["Liu", "Chen"], 2, 2, soft=True)
+check("soft (OpenAlex) list -> exempt", m == [])
+
+# 8. First-author degrade (no cited list; first_author_guess mismatches source).
+m, n = author_cross_check([], ["Chen", "Wang"], 0, 2, first_author_guess="Liu")
+check("first-author degrade -> #1 mismatch", any("#1 family" in x for x in m))
+
+# 9. First-author degrade clean (first_author_guess matches source).
+m, n = author_cross_check([], ["Liu", "Wang"], 0, 2, first_author_guess="Liu")
+check("first-author degrade clean -> no mismatch", m == [])
+
+print(f"\nfails={fails}")
+sys.exit(1 if fails else 0)
+PY
+rc=$?
+echo
+[[ $rc -eq 0 ]] && echo "ALL PASS" || echo "FAILURES"
+exit $rc


### PR DESCRIPTION
Follow-up to closing #17 — adds the missing regression fixture for the repo's most trust-critical citation check.

## Why

`verify-refs`' family-by-family + author-count cross-check is the **sole decision surface** behind an `AUTHOR MISMATCH` status — it's what catches an AI-assembled bib that pairs a correct first author + DOI with fabricated co-author names (a real case once registered multiple fabricated co-authors). It lived inline in `verify_record` with **zero regression coverage** — it runs only on the online path, so no offline test touched it. A future refactor could silently drop the MISMATCH branch and CI would stay green.

## What

- **`verify_refs.py`** — extract the inline block into a pure, module-level `author_cross_check(cited_authors, actual_authors, cited_author_count, actual_author_count, *, corporate, soft, audit_truncated, first_author_guess) -> (mismatches, notes)`. **Byte-for-byte identical logic**; `verify_record` now calls it and `extend`s `evidence_parts` with the returned notes. The diff is two surgical hunks (function added; inline block → call).
- **`tests/test_fabricated_author.sh`** — a 9-case **network-free** unit test (the pure function is tested in isolation, so no PubMed / CrossRef / OpenAlex call is made): clean list, fabricated #2..#N families, extra cited author, author-count mismatch, intentional CSL et-al truncation (note, not mismatch), corporate + OpenAlex-`soft` exemptions, and first-author degrade (both directions). Wired into `skill.yml` `validation_commands` **and** `validate.yml` CI.
- Regenerated `docs/skills/verify-refs.md` + the distribution manifest.

## Behaviour-preserving — verified

All three existing verify-refs tests pass, including the **online** `test_openalex_tier` case *"catches first-author hallucination via openalex"*, which exercises `verify_record → author_cross_check` end to end. `validate_skills.sh`, `validate_catalog_consistency.py`, and all `gen_*.py --check` pass locally. **No new detector, no count change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
