### PR TITLE
feat(model-evaluation): interactive/promptable segmentation metrics + gate (--task interactive)

### DIFF
--- a/docs/skills/model-evaluation.md
+++ b/docs/skills/model-evaluation.md
@@ -2,13 +2,13 @@
 
 # model-evaluation
 
-> Compute and report task-correct held-out metrics for a trained medical-imaging model — segmentation (Dice plus a boundary metric such as HD95 or NSD, per structure), classification (AUROC plus AUPRC and sensitivity/specificity with bootstrap CIs at the deployment prevalence), or detection (FROC or mAP with a stated IoU criterion) — plus calibration and subgroup slices. Emits a per-case results table that analyze-stats turns into publication tables, and gates the metric choice against Metrics Reloaded and CLAIM 2024 (no pixel accuracy for segmentation, no bare accuracy under imbalance). Numbers come only from executed code, never hand-typed.
+> Compute and report task-correct held-out metrics for a trained medical-imaging model — segmentation (Dice plus a boundary metric such as HD95 or NSD, per structure), classification (AUROC plus AUPRC and sensitivity/specificity with bootstrap CIs at the deployment prevalence), detection (FROC or mAP with a stated IoU criterion), or interactive/promptable segmentation (the interaction-count, convergence, and per-case-time axes a static Dice omits) — plus calibration and subgroup slices. Emits a per-case results table that analyze-stats turns into publication tables, and gates the metric choice against Metrics Reloaded and CLAIM 2024 (no pixel accuracy for segmentation, no bare accuracy under imbalance, no static Dice for an interactive method). Numbers come only from executed code, never hand-typed.
 
 **Invoke:** `/model-evaluation` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 
-`model-evaluation` activates on requests such as: model evaluation, held-out metrics, test set metrics, Dice, HD95, NSD, surface distance, Metrics Reloaded, AUROC, AUPRC, bootstrap CI, calibration, ECE, reliability diagram, subgroup analysis, slice metrics, mAP, FROC, segmentation metrics, detection metrics, evaluate predictions.
+`model-evaluation` activates on requests such as: model evaluation, held-out metrics, test set metrics, Dice, HD95, NSD, surface distance, Metrics Reloaded, AUROC, AUPRC, bootstrap CI, calibration, ECE, reliability diagram, subgroup analysis, slice metrics, mAP, FROC, segmentation metrics, detection metrics, evaluate predictions, interactive segmentation, promptable segmentation, SAM2, MedSAM2, nnInteractive, number of clicks, NoC, interactions-to-threshold, click budget.
 
 ## Quality Card
 
@@ -26,7 +26,7 @@
 
 **Validation**
 
-- `python3 scripts/check_metric_reporting.py --report <results.md> --task segmentation|classification|detection --strict`
+- `python3 scripts/check_metric_reporting.py --report <results.md> --task segmentation|classification|detection|interactive --strict`
 - `bash scripts/metric_reporting_challenge/verify.sh  # deterministic, network-free`
 
 **Evidence** — `ci_validator`
@@ -41,7 +41,7 @@
 **Scripts** (`skills/model-evaluation/scripts/`):
 
 - `check_metric_reporting.py`
-- `metric_reporting_challenge/` (8 files)
+- `metric_reporting_challenge/` (10 files)
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1033,8 +1033,8 @@
     },
     {
       "path": "skills/design-study/SKILL.md",
-      "size": 19220,
-      "sha256": "d4a05f6dd2530620bd1ec3e1c64ba0625aae25def12892247e61a77724132cd6"
+      "size": 20296,
+      "sha256": "98644b7750b65ff9bb38af7cb6e0b3300169f498332a3f143394cc35f5ba7ff7"
     },
     {
       "path": "skills/design-study/references/dag_adjustment.md",
@@ -2808,13 +2808,13 @@
     },
     {
       "path": "skills/model-evaluation/SKILL.md",
-      "size": 5780,
-      "sha256": "334b4ca87a2f672446563f3fb6d78c0585386fac12aee29e10dc09465e892193"
+      "size": 6494,
+      "sha256": "f06d36d734527c39c296be529946e216a5eb2454289539e51b178ee67f748e63"
     },
     {
       "path": "skills/model-evaluation/references/metric_guide.md",
-      "size": 2454,
-      "sha256": "8d09ca7ce9fb9f66ee4942689294d9b12ae1d892ac67769cd68fdc38a4e220ee"
+      "size": 4323,
+      "sha256": "aea0ecac9824feb75f7f984ce9465861b73949f2441320594677cfbfc1035820"
     },
     {
       "path": "skills/model-evaluation/references/metric_selection_grounding.md",
@@ -2823,8 +2823,8 @@
     },
     {
       "path": "skills/model-evaluation/scripts/check_metric_reporting.py",
-      "size": 9562,
-      "sha256": "fd6c0205f652651a5a43910cb415ed8442100fc553ce04aa5d5905d97743a0bf"
+      "size": 13166,
+      "sha256": "96b2cd038c825799e74a29937817cad7a065b14b93c810b5dc83ca111a39c99d"
     },
     {
       "path": "skills/model-evaluation/scripts/metric_reporting_challenge/fixture/clf_bad.md",
@@ -2847,6 +2847,16 @@
       "sha256": "08227fbe46829b8eecdfe15680e1bb32087f1e6c5a353b3df6055c67d8300fc0"
     },
     {
+      "path": "skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_bad.md",
+      "size": 128,
+      "sha256": "be714934c18566a89c6c7b06951a420d8e2cbfca814e1daf26df87866252a185"
+    },
+    {
+      "path": "skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_good.md",
+      "size": 500,
+      "sha256": "a45e14485fb02f0ee790350235c652ea2b871aa16cfd89e12a32e49cd6e1b9ca"
+    },
+    {
       "path": "skills/model-evaluation/scripts/metric_reporting_challenge/fixture/seg_bad.md",
       "size": 119,
       "sha256": "50c138840976b8fa010cb0ca9fd24fffc7181e275eb6c71e76500da7d2a0420d"
@@ -2863,13 +2873,13 @@
     },
     {
       "path": "skills/model-evaluation/scripts/metric_reporting_challenge/verify.sh",
-      "size": 1663,
-      "sha256": "4aa6db49d3552f01a54ddb70484df5d214806d805b836b24beda81d9aca32bd6"
+      "size": 2186,
+      "sha256": "1968d80c13423b4aa09d6e226f8990aa3dd9e8754efe80400b74c52e0f8832db"
     },
     {
       "path": "skills/model-evaluation/skill.yml",
-      "size": 2921,
-      "sha256": "9713dbab40c54ca88324e7dcd74d3142890f9625ad68d708ba40b0cf57a7b9ee"
+      "size": 2933,
+      "sha256": "f767583346095135f50cc83a24b8b8928a20b03883a068b5a31758cc51bbe24c"
     },
     {
       "path": "skills/model-scaffold/SKILL.md",
@@ -2928,8 +2938,8 @@
     },
     {
       "path": "skills/model-validation/SKILL.md",
-      "size": 10836,
-      "sha256": "5cfd4ac6d75b3a474408b10d8eead3fdf7be8a44e1578dcac332cc2203ae75fe"
+      "size": 11524,
+      "sha256": "ac326c03451282a5adeeb3592f511dac47720bba9338dba761bf6ea4679d7c0b"
     },
     {
       "path": "skills/model-validation/references/validation_design.md",

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -191,6 +191,19 @@ scale validity; a low overall ICC is interpretable only if raters at least conve
 - Require each item to be judged standalone; discourage cross-item references in free-text, which
   signal non-independent rating.
 
+**Human-as-operator arm (interactive / promptable AI).** The reader-study patterns above assume the
+human is a *rater / reference* judging outputs. Interactive / promptable segmentation (SAM2, MedSAM2,
+nnInteractive) inverts this: the human is the *operator* who places the prompts, so the measured object
+is the human-operated system's **accuracy + interaction count + time + learning curve**, not a rating.
+Design for it explicitly:
+- Define the operator population and their onboarding; a **learning curve** (performance vs case index)
+  is a first-class outcome, not noise to average away.
+- Fix the prompting protocol (allowed prompt types, stopping rule, target Dice) identically to any
+  simulated-prompting arm so the two are comparable — **protocol fidelity**, checked in `/model-validation`.
+- Pre-specify the interaction and timing metrics; their deterministic reporting gate is
+  `/model-evaluation --task interactive`. (A design document is free-form prose, so the deterministic
+  anchor for these items sits at the reporting stage, not on the protocol text.)
+
 For an AI-system-versus-human-expert benchmark specifically, route to `/design-ai-benchmarking`, which
 extends this subsection with arm definition, LLM-as-judge versus human-as-judge adjudication, and a
 structured export schema.

--- a/skills/model-evaluation/SKILL.md
+++ b/skills/model-evaluation/SKILL.md
@@ -3,12 +3,13 @@ name: model-evaluation
 description: >
   Compute and report task-correct held-out metrics for a trained medical-imaging model — segmentation
   (Dice plus a boundary metric such as HD95 or NSD, per structure), classification (AUROC plus AUPRC and
-  sensitivity/specificity with bootstrap CIs at the deployment prevalence), or detection (FROC or mAP with
-  a stated IoU criterion) — plus calibration and subgroup slices. Emits a per-case results table that
-  analyze-stats turns into publication tables, and gates the metric choice against Metrics Reloaded and
-  CLAIM 2024 (no pixel accuracy for segmentation, no bare accuracy under imbalance). Numbers come only
-  from executed code, never hand-typed.
-triggers: model evaluation, held-out metrics, test set metrics, Dice, HD95, NSD, surface distance, Metrics Reloaded, AUROC, AUPRC, bootstrap CI, calibration, ECE, reliability diagram, subgroup analysis, slice metrics, mAP, FROC, segmentation metrics, detection metrics, evaluate predictions
+  sensitivity/specificity with bootstrap CIs at the deployment prevalence), detection (FROC or mAP with
+  a stated IoU criterion), or interactive/promptable segmentation (the interaction-count, convergence,
+  and per-case-time axes a static Dice omits) — plus calibration and subgroup slices. Emits a per-case
+  results table that analyze-stats turns into publication tables, and gates the metric choice against
+  Metrics Reloaded and CLAIM 2024 (no pixel accuracy for segmentation, no bare accuracy under imbalance,
+  no static Dice for an interactive method). Numbers come only from executed code, never hand-typed.
+triggers: model evaluation, held-out metrics, test set metrics, Dice, HD95, NSD, surface distance, Metrics Reloaded, AUROC, AUPRC, bootstrap CI, calibration, ECE, reliability diagram, subgroup analysis, slice metrics, mAP, FROC, segmentation metrics, detection metrics, evaluate predictions, interactive segmentation, promptable segmentation, SAM2, MedSAM2, nnInteractive, number of clicks, NoC, interactions-to-threshold, click budget
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
@@ -40,7 +41,7 @@ ECE of a softmax head); `/analyze-stats` owns DeLong / NRI / IDI / decision curv
 ## Workflow
 
 ### Phase 1 — Fix the analysis unit and the task
-State the task (segmentation / classification / detection) and the **analysis unit** the metric must
+State the task (segmentation / classification / detection / interactive) and the **analysis unit** the metric must
 respect (per-patient vs per-lesion vs per-image). A per-lesion metric must not be reported as
 per-patient.
 
@@ -51,13 +52,17 @@ Generate evaluation code that computes, on the held-out predictions:
 - **classification**: **AUROC and AUPRC** with bootstrap CIs, sensitivity/specificity, and PPV/NPV **at
   the deployment prevalence** (not a balanced set).
 - **detection**: **FROC / mAP** with the **IoU match criterion stated**.
+- **interactive / promptable segmentation** (SAM2 / MedSAM2 / nnInteractive): the segmentation
+  metrics above **plus** the interaction axis — Dice-vs-interactions / number-of-clicks (NoC) to a
+  target threshold, initial-vs-converged (or peak) Dice, and per-case interaction/inference time
+  (see the metric guide; the study design is in `/design-study` + `/model-validation`).
 Add **calibration** (reliability diagram / ECE) and **subgroup** slices (the Model Card Factors).
 See `${CLAUDE_SKILL_DIR}/references/metric_guide.md`. Emit a **per-case CSV** for `/analyze-stats`.
 
 ### Phase 3 — Gate the metric choice (deterministic)
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/check_metric_reporting.py \
-  --report results.md --task segmentation|classification|detection --strict
+  --report results.md --task segmentation|classification|detection|interactive --strict
 ```
 `PIXEL_ACCURACY_SEG` / `NO_BOUNDARY_METRIC` / `ACCURACY_ONLY` / `DETECTION_METRIC_MISSING` must be zero.
 

--- a/skills/model-evaluation/references/metric_guide.md
+++ b/skills/model-evaluation/references/metric_guide.md
@@ -15,6 +15,30 @@ the comparative inference is `/analyze-stats`.
   (a Dice of 0/0 is undefined) — Metrics Reloaded discusses this explicitly.
 - **CIs**: bootstrap over cases (resample patients, not pixels).
 
+## Interactive / promptable segmentation
+For promptable / interactive methods (SAM2, MedSAM2, nnInteractive), a single static Dice omits the
+axis that makes the method interactive, and **Metrics Reloaded does not cover this regime**. Report,
+in addition to the overlap + boundary metrics above:
+- **Accuracy-vs-interaction trajectory**: Dice as a function of the number of corrective interactions
+  (the click / interaction budget), not one operating point.
+- **Interactions-to-threshold**: the number of clicks / interactions to reach a target Dice — the
+  **NoC** (Number of Clicks) convention from the interactive-segmentation literature (e.g. RITM,
+  SimpleClick); state the target threshold explicitly (e.g. NoC@0.80).
+- **Initial vs converged / peak Dice**: the first-prompt Dice and the converged (or peak) Dice, so the
+  interactive gain is visible rather than folded into one number.
+- **Per-case interaction / inference time**: efficiency is a primary claim — a high-Dice method that
+  needs many slow interactions may be clinically unusable.
+- **Threshold-reached fraction**: the proportion of cases that reach the target Dice within the budget.
+- **Subgroup robustness**: the trajectory and NoC sliced by tumor size / type / modality.
+
+**Deterministic gate** — `check_metric_reporting.py --task interactive` still applies the
+segmentation overlap + boundary checks and additionally flags an interactive claim whose report omits
+the interaction axis (`INTERACTIVE_NO_INTERACTION_COUNT`, Major), the initial-vs-converged split
+(`INTERACTIVE_NO_CONVERGENCE`, Minor), or per-case time (`INTERACTIVE_NO_TIME`, Minor). The **study
+design** for an interactive evaluation — the human-as-operator reader arm and the two-arm
+(simulated-prompting + human-operator validation) protocol-fidelity check — is covered in
+`/design-study` and `/model-validation`.
+
 ## Classification
 - **Discrimination with CIs**: **AUROC and AUPRC** (AUPRC tracks the minority class under
   imbalance), with bootstrap 95% CIs.

--- a/skills/model-evaluation/scripts/check_metric_reporting.py
+++ b/skills/model-evaluation/scripts/check_metric_reporting.py
@@ -22,13 +22,19 @@ CHECKS (verdicts; which apply depends on --task):
   detection:
     DETECTION_METRIC_MISSING (Major)  no FROC / mAP / sensitivity-per-false-positive,
                                       or no IoU match criterion stated.
+  interactive (promptable segmentation — SAM2 / MedSAM2 / nnInteractive; also runs the
+  segmentation checks above, since interactive segmentation is still segmentation):
+    INTERACTIVE_NO_INTERACTION_COUNT (Major)  no interaction axis (number of clicks /
+                                      interactions-to-threshold / Dice-vs-interactions).
+    INTERACTIVE_NO_CONVERGENCE (Minor)  no initial-prompt vs converged/peak Dice split.
+    INTERACTIVE_NO_TIME        (Minor)  no per-case interaction / inference time.
   all tasks:
     CI_MISSING           (Minor)  no confidence interval / uncertainty mentioned for
                                   the headline metric.
 
 INPUTS
   --report  metrics report / results markdown (required).
-  --task    segmentation | classification | detection (required).
+  --task    segmentation | classification | detection | interactive (required).
 
 OUTPUT
   A table (stdout) and, with --out, a JSON artifact:
@@ -69,6 +75,26 @@ P = {
                 r"|hit (?:rule|criterion)|within (?:the )?lesion",
     "ci": r"confidence interval|credible interval|\b95\s*%?\s*ci|\bcis?\b|±|\+/-|\bsd\b|"
           r"standard deviation|bootstrap|interquartile|\biqr\b",
+    # interactive / promptable segmentation (SAM2 / MedSAM2 / nnInteractive). The
+    # interaction axis: number of clicks (NoC), interactions/clicks-to-threshold, or a
+    # Dice-vs-interactions trajectory — the metric a static Dice cannot express.
+    "interactions": r"\b(number of clicks|#\s?clicks|clicks?[- ]?to[- ]?(?:threshold|target)|"
+                    r"\bnoc\b|noc@\d+|interaction[- ]?(?:count|budget)|"
+                    r"interactions?[- ]?to[- ]?(?:threshold|target)|"
+                    r"number of (?:interactions|prompts|corrections|edits)|"
+                    r"corrective (?:click|interaction)|"
+                    r"dice[- ]?(?:vs|versus|per|over|against)[- ]?(?:click|interaction|prompt)|"
+                    r"clicks required)\b",
+    # separation of the initial prompt from the converged / peak operating point
+    "convergence": r"\b(initial[- ]?(?:dice|prompt|click|mask|prediction)|"
+                   r"first[- ]?(?:click|prompt) dice|converged? dice|convergence|peak dice|"
+                   r"plateau|saturat\w+|dice after \d+|"
+                   r"after (?:the )?(?:first|final|last|\d+) (?:click|prompt|interaction))\b",
+    # per-case interaction / inference efficiency
+    "interaction_time": r"\b(interaction time|time per (?:case|click|interaction|prompt)|"
+                        r"per[- ]?case (?:time|latency)|inference time|inference latency|"
+                        r"seconds per (?:case|click|interaction)|wall[- ]?clock|"
+                        r"time[- ]?to[- ]?(?:threshold|target))\b",
 }
 
 # Negation BEFORE the token ('we do NOT report pixel accuracy ...').
@@ -105,7 +131,9 @@ def analyze(report: str, task: str) -> dict:
     def add(v, s, d):
         claims.append({"verdict": v, "severity": s, "detail": d, "where": Path(report).name})
 
-    if task == "segmentation":
+    if task in ("segmentation", "interactive"):
+        # interactive/promptable segmentation is still segmentation: the overlap-plus-boundary
+        # requirement applies to its per-structure quality regardless of the interaction axis.
         if has_affirmative(text, "pixel_acc"):
             add("PIXEL_ACCURACY_SEG", "Major",
                 "pixel/voxel accuracy is reported for segmentation — misleading on imbalanced masks; "
@@ -115,6 +143,23 @@ def analyze(report: str, task: str) -> dict:
                 "Dice/IoU is reported without a boundary metric (HD95 / NSD / surface distance) — "
                 "overlap alone is shape- and size-insensitive; pair it with a boundary metric, "
                 "per structure")
+    if task == "interactive":
+        # A promptable / interactive method's contribution is the accuracy-vs-interaction
+        # trajectory and its efficiency, not a single operating point; a static Dice omits
+        # exactly what makes it interactive (Metrics Reloaded does not cover this regime).
+        if not has(text, "interactions"):
+            add("INTERACTIVE_NO_INTERACTION_COUNT", "Major",
+                "an interactive/promptable segmentation report does not quantify the interaction "
+                "axis (number of clicks / interactions-to-threshold / Dice-vs-interactions) — a "
+                "single Dice evaluates a promptable method as if it were one-shot")
+        if not has(text, "convergence"):
+            add("INTERACTIVE_NO_CONVERGENCE", "Minor",
+                "no separation of the initial prompt from the converged/peak Dice — the interactive "
+                "contribution is the improvement across interactions, not one operating point")
+        if not has(text, "interaction_time"):
+            add("INTERACTIVE_NO_TIME", "Minor",
+                "no per-case interaction/inference time — efficiency is a primary interactive claim "
+                "(a high-Dice method needing many slow interactions may not be clinically usable)")
     elif task == "classification":
         # the accuracy METRIC, excluding the study-type phrase 'diagnostic accuracy'; a
         # sensitivity+specificity pair is a threshold-pair report, not accuracy-only
@@ -162,7 +207,8 @@ def render(result: dict) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Task-correct metric-reporting gate (model-evaluation).")
     ap.add_argument("--report", required=True, help="metrics report / results markdown")
-    ap.add_argument("--task", required=True, choices=["segmentation", "classification", "detection"])
+    ap.add_argument("--task", required=True,
+                    choices=["segmentation", "classification", "detection", "interactive"])
     ap.add_argument("--out", help="write JSON artifact to this path")
     ap.add_argument("--strict", action="store_true", help="exit 1 if any Major claim exists")
     ap.add_argument("--quiet", action="store_true", help="suppress stdout table")

--- a/skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_bad.md
+++ b/skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_bad.md
@@ -1,0 +1,2 @@
+# Results (interactive segmentation)
+The interactive segmentation model achieved a mean Dice of 0.86 on the held-out tumor set.

--- a/skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_good.md
+++ b/skills/model-evaluation/scripts/metric_reporting_challenge/fixture/interactive_good.md
@@ -1,0 +1,6 @@
+# Results (interactive / promptable segmentation)
+For the promptable model, Dice improved from an initial-click Dice of 0.62 to a converged Dice of
+0.87 (95% CI 0.85-0.89), with HD95 of 6.4 mm reported per structure. We report the number of clicks
+to reach the 0.80 Dice threshold (median 4 clicks), the full Dice-vs-interactions trajectory, and the
+interaction time per case (median 41 s). 78% of cases reached the target threshold; robustness by
+tumor size and modality is given in the supplement.

--- a/skills/model-evaluation/scripts/metric_reporting_challenge/verify.sh
+++ b/skills/model-evaluation/scripts/metric_reporting_challenge/verify.sh
@@ -30,5 +30,11 @@ clean clf_good.md classification
 # locks the iou_crit proximity window against newline-induced false fires.
 want det_no_iou.md detection DETECTION_METRIC_MISSING
 clean det_good_wrapped.md detection
+# Interactive / promptable segmentation: a static-Dice-only report must be flagged for the
+# missing interaction axis (and, being segmentation, for the missing boundary metric); a report
+# with the interaction axis, convergence split, per-case time, and a boundary metric must clear.
+want interactive_bad.md interactive INTERACTIVE_NO_INTERACTION_COUNT
+want interactive_bad.md interactive NO_BOUNDARY_METRIC
+clean interactive_good.md interactive
 
-echo "PASS: metric-reporting gate flags Dice-only/pixel-accuracy, accuracy-only, and detection without an IoU criterion; clears task-correct reports (including a line-wrapped IoU criterion)."
+echo "PASS: metric-reporting gate flags Dice-only/pixel-accuracy, accuracy-only, detection without an IoU criterion, and interactive segmentation reported as one-shot; clears task-correct reports (including a line-wrapped IoU criterion and a full interactive report)."

--- a/skills/model-evaluation/skill.yml
+++ b/skills/model-evaluation/skill.yml
@@ -38,6 +38,6 @@ known_limitations:
   - "It produces the per-case metrics; the comparative inference (DeLong / NRI / IDI / decision curves / MRMC) is analyze-stats."
   - "Metric correctness depends on a correctly defined analysis unit and a clean held-out split (use model-validation first)."
 validation_commands:
-  - "python3 scripts/check_metric_reporting.py --report <results.md> --task segmentation|classification|detection --strict"
+  - "python3 scripts/check_metric_reporting.py --report <results.md> --task segmentation|classification|detection|interactive --strict"
   - "bash scripts/metric_reporting_challenge/verify.sh  # deterministic, network-free"
 evidence_surface: ci_validator

--- a/skills/model-evaluation/tests/test_metric_reporting.sh
+++ b/skills/model-evaluation/tests/test_metric_reporting.sh
@@ -44,4 +44,20 @@ python3 "$DET" --report "$W/aur.md" --task classification --out "$OUT" --quiet >
 check "negation: 'AUROC was not computed' -> ACCURACY_ONLY" has ACCURACY_ONLY
 check "negation: no spurious AUPRC_MISSING" no AUPRC_MISSING
 
+# --- interactive / promptable segmentation ---
+python3 "$DET" --report "$F/interactive_bad.md" --task interactive --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "interactive_bad exits 1" test "$?" -eq 1
+check "INTERACTIVE_NO_INTERACTION_COUNT" has INTERACTIVE_NO_INTERACTION_COUNT
+check "interactive_bad also flags NO_BOUNDARY_METRIC (still segmentation)" has NO_BOUNDARY_METRIC
+check "interactive_bad flags INTERACTIVE_NO_TIME" has INTERACTIVE_NO_TIME
+python3 "$DET" --report "$F/interactive_good.md" --task interactive --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "interactive_good exits 0" test "$?" -eq 0
+check "interactive_good no INTERACTIVE_NO_INTERACTION_COUNT" no INTERACTIVE_NO_INTERACTION_COUNT
+check "interactive_good no INTERACTIVE_NO_CONVERGENCE" no INTERACTIVE_NO_CONVERGENCE
+check "interactive_good no NO_BOUNDARY_METRIC" no NO_BOUNDARY_METRIC
+# FP guard: a static (non-interactive) segmentation report is NOT run under --task interactive,
+# and a full interactive report must not spuriously fire the interaction verdicts.
+printf 'Interactive tumor segmentation: Dice rose from an initial-click Dice 0.55 to a peak Dice 0.90 (95%% CI 0.88-0.92); HD95 5.1 mm; median 3 clicks to threshold; interaction time 30 s/case.\n' > "$W/int_ok.md"
+check "FP: full interactive one-liner passes --strict" ok0 "$W/int_ok.md" interactive
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"; exit "$fail"

--- a/skills/model-validation/SKILL.md
+++ b/skills/model-validation/SKILL.md
@@ -98,7 +98,14 @@ reports **AUROC and AUPRC with CIs** plus sensitivity / specificity and prevalen
 never bare accuracy on a balanced set; **detection** reports FROC / mAP with the IoU match criterion
 stated. Require the headline metric as **mean ± SD across ≥ 3 seeds / runs**, or a fixed reported seed
 with the determinism caveat. The per-case metric computation + the deterministic metric-reporting gate
-live in `/model-evaluation` (which emits the per-case table for `/analyze-stats`).
+live in `/model-evaluation` (which emits the per-case table for `/analyze-stats`). For **interactive /
+promptable segmentation** (SAM2 / MedSAM2 / nnInteractive) the metric set adds the interaction axis —
+number of clicks / interactions-to-threshold (NoC), initial-vs-converged Dice, and per-case
+interaction / inference time (`/model-evaluation --task interactive`). When the evaluation runs two arms
+(simulated prompting + human-operator validation), record **protocol fidelity** across arms — identical
+prompt types, stopping rule, target threshold, and seeds — as an explicit validity item: arm-to-arm
+comparability is the precondition for reading the human-operator arm as validating the simulated one,
+and the human-operator arm design is in `/design-study`.
 
 ### Phase 6 — Test-set sizing
 Check the **events per class** in the test set, not the cohort total — a metric on a sparse positive set


### PR DESCRIPTION
**Direction 1** of the evaluation-metric coverage extension (interactive/promptable segmentation). Demand-gated by an active multi-institution interactive-segmentation benchmark + human validation — not roadmap symmetry.

## Problem
`model-evaluation`'s segmentation path covered only static one-shot metrics (Dice + HD95/NSD per structure). Promptable/interactive methods (SAM2, MedSAM2, nnInteractive) have a defining axis — **accuracy as a function of the number of interactions, and efficiency** — that a single Dice cannot express and that **Metrics Reloaded does not cover**.

## What

- **`check_metric_reporting.py` — new `--task interactive`.** Extends the existing detector (**no new detector; `integrity_detectors` stays 50**, so no catalog-count churn — matching the additive-verdict pattern). It runs the segmentation overlap+boundary checks **and** adds:
  - `INTERACTIVE_NO_INTERACTION_COUNT` (Major) — no interaction axis (number of clicks / interactions-to-threshold / Dice-vs-interactions); a single Dice evaluates a promptable method as one-shot.
  - `INTERACTIVE_NO_CONVERGENCE` (Minor) — no initial-prompt vs converged/peak Dice split.
  - `INTERACTIVE_NO_TIME` (Minor) — no per-case interaction/inference time.
  - Ships `interactive_good` / `interactive_bad` fixtures, the challenge `verify.sh`, and a regression test **with a false-positive guard** (a full interactive report must pass `--strict`).
- **`metric_guide.md` + `SKILL.md`** — the interactive metric block: Dice-vs-interactions trajectory, **NoC@threshold** (Number-of-Clicks convention), initial-vs-converged/peak Dice, per-case time, threshold-reached fraction, subgroup robustness (tumor size/type/modality); grounded in the interactive-segmentation literature and the Metrics-Reloaded non-coverage.
- **`design-study`** — a **human-as-operator reader-arm** pattern: when the human is the AI *operator* (places prompts), the measured object is accuracy + interaction count + time + **learning curve**, not a rating.
- **`model-validation`** — a **two-arm (simulated-prompting + human-operator) protocol-fidelity** validity item (arm-to-arm comparability is the precondition for the human arm to validate the simulated one).

**Prose-only note (per the engineering convention):** the deterministic detector + fixtures cover the model-evaluation reporting items. The design-side items (`design-study`, `model-validation`) are prose guidance because a design document is free-form; their deterministic anchor is the reporting-stage gate above.

## Confidentiality
Grounded only in public literature (SAM2, MedSAM2, nnInteractive/Isensee, the NoC convention, Metrics Reloaded). No cohort/institution/numeric specifics from the motivating (unpublished) study are embedded in any skill body or fixture.

## Verified
`gen_*.py --check` (all 5), `validate_catalog_consistency.py`, `validate_skills.sh`, `check_locale_inventory.py`, the model-evaluation regression test, and the challenge `verify.sh` all pass locally.

**Direction 2** (generative/synthesis image metrics + metric-selection grounding from Park 2024) is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
