### PR TITLE
fix(model-evaluation): interaction_time gate missed 'N seconds'/'N ms' timing (real-prose dogfood)

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2823,8 +2823,8 @@
     },
     {
       "path": "skills/model-evaluation/scripts/check_metric_reporting.py",
-      "size": 17474,
-      "sha256": "cb64587503b783fb4e2c373af8bc4dbd8a3c54cbb05030dc746c54c264a29deb"
+      "size": 17964,
+      "sha256": "f1315745ceba694cb2437a412618d86cd7f0a7f4e652f5ced2cc207b67eaa731"
     },
     {
       "path": "skills/model-evaluation/scripts/metric_reporting_challenge/fixture/clf_bad.md",

--- a/skills/model-evaluation/scripts/check_metric_reporting.py
+++ b/skills/model-evaluation/scripts/check_metric_reporting.py
@@ -98,11 +98,16 @@ P = {
                    r"first[- ]?(?:click|prompt) dice|converged? dice|convergence|peak dice|"
                    r"plateau|saturat\w+|dice after \d+|"
                    r"after (?:the )?(?:first|final|last|\d+) (?:click|prompt|interaction))\b",
-    # per-case interaction / inference efficiency
+    # per-case interaction / inference efficiency. Matches named time terms AND a bare
+    # number-plus-time-unit ("179±114 seconds", "120-200 ms"), since real interactive papers
+    # report timing that way rather than always writing "inference time" (dogfood: nnInteractive).
     "interaction_time": r"\b(interaction time|time per (?:case|click|interaction|prompt)|"
-                        r"per[- ]?case (?:time|latency)|inference time|inference latency|"
-                        r"seconds per (?:case|click|interaction)|wall[- ]?clock|"
-                        r"time[- ]?to[- ]?(?:threshold|target))\b",
+                        r"per[- ]?case (?:time|latency)|(?:inference|annotation|completion|"
+                        r"segmentation|processing|response) (?:time|latency|speed)|"
+                        r"seconds per (?:case|click|interaction)|runtime|wall[- ]?clock|"
+                        r"time[- ]?to[- ]?(?:threshold|target)|"
+                        r"\d+(?:\.\d+)?\s*(?:±|\+/-|–|-|to)?\s*\d*(?:\.\d+)?\s*"
+                        r"(?:ms|msec|milliseconds?|seconds?|minutes?|hours?)\b)\b",
     # generative / synthesis image evaluation (Park et al., Radiol Med 2024): full-reference
     # pixel/intensity similarity, no-reference quality, and the downstream-task efficacy that
     # image similarity alone does not establish.

--- a/skills/model-evaluation/tests/test_metric_reporting.sh
+++ b/skills/model-evaluation/tests/test_metric_reporting.sh
@@ -59,6 +59,11 @@ check "interactive_good no NO_BOUNDARY_METRIC" no NO_BOUNDARY_METRIC
 # and a full interactive report must not spuriously fire the interaction verdicts.
 printf 'Interactive tumor segmentation: Dice rose from an initial-click Dice 0.55 to a peak Dice 0.90 (95%% CI 0.88-0.92); HD95 5.1 mm; median 3 clicks to threshold; interaction time 30 s/case.\n' > "$W/int_ok.md"
 check "FP: full interactive one-liner passes --strict" ok0 "$W/int_ok.md" interactive
+# dogfood regression (nnInteractive, arXiv 2503.08373): timing written as "N seconds" / "N ms"
+# — not the literal phrase "inference time" — must still satisfy the interaction-time check.
+printf 'Interactive segmentation: number of clicks to threshold, converged Dice, HD95 6 mm; per case 179±114 seconds and 120-200 ms per structure.\n' > "$W/int_time.md"
+python3 "$DET" --report "$W/int_time.md" --task interactive --out "$OUT" --quiet >/dev/null 2>&1
+check "dogfood: 'N seconds' / 'N ms' timing -> no INTERACTIVE_NO_TIME" no INTERACTIVE_NO_TIME
 
 # --- generative / synthesis ---
 python3 "$DET" --report "$F/generative_bad.md" --task generative --out "$OUT" --strict --quiet >/dev/null 2>&1


### PR DESCRIPTION
## Why — non-circular validation caught a real false positive

The `--task interactive` / `--task generative` gates (PRs #290/#291) were validated only on **self-authored synthetic fixtures** — circular. Running them against **real published results sections** (a "dogfood", like the JMIR paper's in-the-wild citation test) surfaced one real bug.

**Interactive** — running `--task interactive` on nnInteractive's published results (arXiv:2503.08373) fired `INTERACTIVE_NO_TIME` even though the paper reports **"179±114 seconds"** per case and **"120–200 ms"** inference. The `interaction_time` pattern only matched the literal phrase `inference time` / `time per case`, not the bare number+time-unit phrasing real papers use → **false positive**.

**Generative** — the same dogfood on real values quoted in **Park et al. 2024** passed cleanly:
- Shiri et al. (RMSE/PSNR/SSIM only, no downstream) → correctly flagged `GENERATIVE_NO_DOWNSTREAM` (Major).
- Hwang et al. (downstream segmentation Dice) → correctly **cleared** `NO_DOWNSTREAM`.

## Fix
- Broaden `interaction_time` to match a numeric value + explicit time unit (ms/msec/milliseconds/seconds/minutes/hours, with optional ± SD or range) and named time terms (inference/annotation/completion/segmentation/processing/response time·latency·speed, runtime). **No other verdict changed.**
- Add a **dogfood regression guard**: nnInteractive-style "N seconds"/"N ms" timing must not fire `INTERACTIVE_NO_TIME`.

Confirmed on the real nnInteractive text: `INTERACTIVE_NO_TIME` no longer fires. (The remaining `NO_BOUNDARY_METRIC` + `INTERACTIVE_NO_CONVERGENCE` on that excerpt are defensible — it reports Dice-only with no boundary metric or initial-vs-converged split — not FPs.)

## Verified
All `gen_*.py --check`, `validate_catalog_consistency.py`, `check_frontmatter_schema.py`, `validate_skills.sh`, and the model-evaluation regression test + challenge pass locally. No new detector, no catalog-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)