### PR TITLE
docs(citations): log first external contribution — @Rochelle1995 Windows verification

### DIFF
--- a/IMPACT.md
+++ b/IMPACT.md
@@ -56,6 +56,9 @@ confirmed use:
   Claude Code, Codex, Cursor, GitHub Copilot — see
   [`docs/host_compatibility.md`](docs/host_compatibility.md)).
 - Published to the npm registry (`medsci-skills`) and the Claude Code plugin marketplace.
+- Listed in the [Evidence Synthesis Tools](https://evidencesynthesis-tools.github.io/) directory
+  (Workflow & Automation category; added via a maintainer-reviewed
+  [PR](https://github.com/evidencesynthesis-tools/awesome-evidence-synthesis/pull/4), 2026-06-03).
 - Archived for citation on Zenodo with a concept DOI (always resolves to latest).
 
 *(New listings are added here as they appear.)*

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -48,6 +48,17 @@ With your permission, it will be added below.
 
 ---
 
+## Community contributions & external verification
+
+Documented independent engagement — external bug reports, fix verifications, and code
+contributions — each verified against its public GitHub thread.
+
+| Date | Contributor | Contribution | Link |
+|---|---|---|---|
+| 2026-07-05 | @Rochelle1995 | Filed a precise bug report for `render-pdf-doc` on Windows (Git Bash could not resolve the MiKTeX PATH; no CJK font fallback), then independently verified the fix on Windows 11 + MiKTeX — all dependency checks pass and both an English and a Korean document (Hangul text + a mixed table) render cleanly with no missing-glyph warnings | [#68](https://github.com/Aperivue/medsci-skills/issues/68) · [#286](https://github.com/Aperivue/medsci-skills/pull/286) |
+
+---
+
 ## Media, talks, and listings
 
 | Date | Item | Type | Link |

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -63,7 +63,7 @@ contributions — each verified against its public GitHub thread.
 
 | Date | Item | Type | Link |
 |---|---|---|---|
-| _none recorded yet_ | | | |
+| 2026-06-03 | Listed in the **Evidence Synthesis Tools** directory (Workflow & Automation category), added via a maintainer-reviewed PR | Curated directory | [directory](https://evidencesynthesis-tools.github.io/) · [PR](https://github.com/evidencesynthesis-tools/awesome-evidence-synthesis/pull/4) |
 
 ---
 


### PR DESCRIPTION
Records the repo's **first documented external contribution** in the downstream-use ledger.

@Rochelle1995 filed a precise `render-pdf-doc` Windows bug report ([#68](https://github.com/Aperivue/medsci-skills/issues/68)) and then independently **verified the fix** ([#286](https://github.com/Aperivue/medsci-skills/pull/286)) on Windows 11 + MiKTeX — all dependency checks pass and both an English and a Korean (Hangul + mixed table) document render cleanly, confirming the part that could not be tested from macOS.

Adds a **Community contributions & external verification** section to `docs/citations.md` and this first entry. Verified against the public GitHub thread; this is documented independent engagement (the evidence layer this ledger exists to capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)