### PR TITLE
docs: add CONTRIBUTORS.md crediting community contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,43 @@
+# Contributors
+
+MedSci Skills is maintained by a physician-researcher with help from the community.
+Thank you to everyone who has reported issues, verified fixes on new platforms, or
+shaped the design.
+
+Commit-level contributions also appear on the
+[GitHub contributors graph](https://github.com/Aperivue/medsci-skills/graphs/contributors);
+this page additionally credits community members whose contributions — bug reports,
+cross-platform verification, feature and design feedback — do not show up there.
+
+## Maintainer
+
+- **Yoojin Nam** ([@Yoojin-nam](https://github.com/Yoojin-nam)) — creator and maintainer.
+
+## Community contributions
+
+### Cross-platform verification
+
+- **[@Rochelle1995](https://github.com/Rochelle1995)** — reported the Windows / Git Bash bug in
+  `render-pdf-doc` ([#68](https://github.com/Aperivue/medsci-skills/issues/68)) with a precise
+  diagnosis, then independently **verified the fix**
+  ([#286](https://github.com/Aperivue/medsci-skills/pull/286)) on Windows 11 + MiKTeX — all
+  dependency checks pass and both an English and a Korean document render cleanly — confirming
+  behaviour that could not be tested from macOS.
+
+### Feature and design feedback
+
+- **[@Rochelle1995](https://github.com/Rochelle1995)** — proposed extending `find-cohort-gap` to
+  accept local codebooks / data dictionaries and URLs as gap-analysis inputs
+  ([#69](https://github.com/Aperivue/medsci-skills/issues/69)).
+- **[@ibadmursalov-crypto](https://github.com/ibadmursalov-crypto)** — proposed a full-text
+  backbone-article extraction gate and proactive backbone selection for `write-paper`
+  ([#8](https://github.com/Aperivue/medsci-skills/issues/8),
+  [#4](https://github.com/Aperivue/medsci-skills/issues/4)).
+
+## How to contribute
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) — most contributions are a single, self-contained file, and
+there is a [5-minute first-PR quickstart](CONTRIBUTING.md#quickstart-your-first-pr-5-minutes). Open
+good first issues are [listed here](https://github.com/Aperivue/medsci-skills/contribute). Merged
+external contributions and cross-platform verifications are added to this page and to the
+[downstream-use ledger](docs/citations.md).

--- a/README.md
+++ b/README.md
@@ -810,6 +810,8 @@ or a [detector request](https://github.com/Aperivue/medsci-skills/issues/new?tem
 [`docs/maintainer_workflow.md`](docs/maintainer_workflow.md) (review + release process),
 and [`SECURITY.md`](SECURITY.md) (vulnerability reporting + the medical-scope boundary).
 A change that touches a medical/research claim needs Clinical-Lead review.
+Community members who have reported, verified, or shaped the project are credited in
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md).
 
 ## In the Wild
 


### PR DESCRIPTION
Adds a visible `CONTRIBUTORS.md` (linked from the README governance block) so community members are credited where the GitHub commit graph can't show them.

- **@Rochelle1995** — Windows bug report + independent cross-platform **verification** of the `render-pdf-doc` fix ([#68](https://github.com/Aperivue/medsci-skills/issues/68)/[#286](https://github.com/Aperivue/medsci-skills/pull/286)); `find-cohort-gap` enhancement ([#69](https://github.com/Aperivue/medsci-skills/issues/69)).
- **@ibadmursalov-crypto** — full-text backbone-article feedback for `write-paper` ([#4](https://github.com/Aperivue/medsci-skills/issues/4)/[#8](https://github.com/Aperivue/medsci-skills/issues/8)).

Complements the downstream-use ledger in `docs/citations.md`. Full local CI-mirror (validate_skills, validate_catalog_consistency, check_frontmatter_schema, check_locale_inventory, all gen_*.py --check) green; changeset is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)