### PR TITLE
docs(impact): record 4 verified third-party curated-list inclusions

### DIFF
--- a/IMPACT.md
+++ b/IMPACT.md
@@ -59,6 +59,12 @@ confirmed use:
 - Listed in the [Evidence Synthesis Tools](https://evidencesynthesis-tools.github.io/) directory
   (Workflow & Automation category; added via a maintainer-reviewed
   [PR](https://github.com/evidencesynthesis-tools/awesome-evidence-synthesis/pull/4), 2026-06-03).
+- Included by independent maintainers in four third-party curated "awesome" lists:
+  [awesome-medical-ai-skills](https://github.com/JuneYaooo/awesome-medical-ai-skills/blob/7e395fd600a64234dde74cb3be08710e300c8554/README.md#L424)
+  and its [Chinese edition](https://github.com/JuneYaooo/awesome-medical-ai-skills-cn/blob/239471ad76d2d2f88bf1674bd4f3d09e8e06bb03/README.md#L227) (juneyaooo),
+  [awesome-claude-skills](https://github.com/Chat2AnyLLM/awesome-claude-skills/blob/c2b12ff1a87c41045e28a7cc01863511f3654fcf/README.md#L127) (Chat2AnyLLM),
+  and [awesome-research-agents](https://github.com/chrisliu298/awesome-research-agents/blob/fb32bf2ed19ed37c2ebd944c9bfdcd68d83e1411/README.md#L90) (chrisliu298).
+  These are inclusion signals (a maintainer chose to list the toolkit), not independent reviews.
 - Archived for citation on Zenodo with a concept DOI (always resolves to latest).
 
 *(New listings are added here as they appear.)*

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -64,6 +64,10 @@ contributions — each verified against its public GitHub thread.
 | Date | Item | Type | Link |
 |---|---|---|---|
 | 2026-06-03 | Listed in the **Evidence Synthesis Tools** directory (Workflow & Automation category), added via a maintainer-reviewed PR | Curated directory | [directory](https://evidencesynthesis-tools.github.io/) · [PR](https://github.com/evidencesynthesis-tools/awesome-evidence-synthesis/pull/4) |
+| 2026-07-07 | Included by an independent maintainer in **awesome-medical-ai-skills** (juneyaooo), Biomedical Research section — a graded entry ("B-, Active") with an original one-line description | Curated list | [entry](https://github.com/JuneYaooo/awesome-medical-ai-skills/blob/7e395fd600a64234dde74cb3be08710e300c8554/README.md#L424) |
+| 2026-07-07 | Included in the Chinese edition, **awesome-medical-ai-skills-cn** (juneyaooo) — with a China-availability note (PubMed / Europe PMC search works domestically) | Curated list | [entry](https://github.com/JuneYaooo/awesome-medical-ai-skills-cn/blob/239471ad76d2d2f88bf1674bd4f3d09e8e06bb03/README.md#L227) |
+| 2026-07-07 | Included in **awesome-claude-skills** (Chat2AnyLLM) — an auto-validated table (install path + skill count checked, "ok") | Curated list | [entry](https://github.com/Chat2AnyLLM/awesome-claude-skills/blob/c2b12ff1a87c41045e28a7cc01863511f3654fcf/README.md#L127) |
+| 2026-07-07 | Included in **awesome-research-agents** (chrisliu298), CLI-native research-agent suites | Curated list | [entry](https://github.com/chrisliu298/awesome-research-agents/blob/fb32bf2ed19ed37c2ebd944c9bfdcd68d83e1411/README.md#L90) |
 
 ---
 


### PR DESCRIPTION
Records the third-party "awesome"-list inclusions of the toolkit in the adoption ledger. Until now only the Evidence Synthesis Tools directory was recorded, so `IMPACT.md`/`docs/citations.md` under-counted independent third-party inclusion.

## What
Four independent maintainers list `Aperivue/medsci-skills` in curated lists. Each was verified against the list's own README and cited with a **commit-pinned, line-anchored permalink** (so the entry is independently checkable and the link won't drift):

| List | Maintainer | Note |
|---|---|---|
| [awesome-medical-ai-skills](https://github.com/JuneYaooo/awesome-medical-ai-skills/blob/7e395fd600a64234dde74cb3be08710e300c8554/README.md#L424) | juneyaooo | Biomedical Research section, graded entry + original description |
| [awesome-medical-ai-skills-cn](https://github.com/JuneYaooo/awesome-medical-ai-skills-cn/blob/239471ad76d2d2f88bf1674bd4f3d09e8e06bb03/README.md#L227) | juneyaooo | Chinese edition, with a China-availability note |
| [awesome-claude-skills](https://github.com/Chat2AnyLLM/awesome-claude-skills/blob/c2b12ff1a87c41045e28a7cc01863511f3654fcf/README.md#L127) | Chat2AnyLLM | auto-validated table (install path + skill count) |
| [awesome-research-agents](https://github.com/chrisliu298/awesome-research-agents/blob/fb32bf2ed19ed37c2ebd944c9bfdcd68d83e1411/README.md#L90) | chrisliu298 | CLI-native research-agent suites |

Added to `docs/citations.md` (Media, talks, and listings) and `IMPACT.md` (Listings & ecosystem presence), explicitly framed as **inclusion signals — not independent reviews** (consistent with IMPACT.md's honest-snapshot principle). Self-submissions (the maintainer's own awesome-claude-code issues) are deliberately excluded.

## Scope
Docs-only. No skill, detector, catalog-count, or version change.

## Verified
Full local CI-mirror green (10 core structural/PII/catalog/generator gates + 102 suite steps, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)