### PR TITLE
feat(registry): capabilities.yml ⇄ skill.yml consistency validator (#15) + canonical manage-refs (#16)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 
-      - name: Run validate_capabilities.py (skill registry: capabilities.yml <-> skills/*/skill.yml)
+      - name: Run validate_capabilities.py (skill-registry consistency, capabilities.yml vs skill.yml)
         run: python3 scripts/validate_capabilities.py --strict
 
       - name: Run capabilities-validator self-test (drift fixtures fail, live repo clean)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 
+      - name: Run validate_capabilities.py (skill registry: capabilities.yml <-> skills/*/skill.yml)
+        run: python3 scripts/validate_capabilities.py --strict
+
+      - name: Run capabilities-validator self-test (drift fixtures fail, live repo clean)
+        run: bash tests/test_capabilities_validator.sh
+
       - name: Run check_locale_inventory.py (Korean-bearing files must be inventory-justified)
         run: python3 scripts/check_locale_inventory.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Developer tooling
+
+- **Skill-registry consistency validator** (`scripts/validate_capabilities.py`, CI-enforced, issue #15).
+  Asserts that `capabilities.yml` (which adjudicates the overlapping domains) and every
+  `skills/*/skill.yml` (`owner_domain`) agree: valid-YAML contracts, owner⇄skill agreement, no silent
+  claimant of a declared domain, and resolvable `overlaps`/umbrella members. It found and fixed two
+  latent drifts it now guards against — a malformed `render-pdf-doc/skill.yml` (an unquoted embedded
+  colon that no prior check caught, because `validate_skill_contracts.py` parses skill.yml by regex and
+  was never wired into CI) and `fulltext-retrieval` claiming the `literature_discovery` domain without
+  appearing in its `overlaps`. Ships `tests/test_capabilities_validator.sh` (each drift class fails
+  under `--strict`; the live repo is clean). Not an integrity detector — a repo validator, so the
+  detector count is unchanged.
+- **manage-refs designated canonical** (issue #16) — `skills/manage-refs/SKILL.md` now carries a
+  canonical-source banner for the reference *workflow* (`verify-refs` remains canonical for bib
+  *audit*), so external/user-scope notes point here rather than restating the "how" and drifting.
+
 ### Documentation
 
 - **Demo 4 — PneumoniaMNIST CNN** (`demo/04_pneumoniamnist_cnn/`). A fourth live demo that runs the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,30 @@ Per-skill documentation under `docs/skills/` is **generated** from each `skills/
 5. Add focused tests or validation scripts for deterministic behavior.
 6. Run the repository validators before opening a pull request.
 
+### Registry consistency (`capabilities.yml` ⇄ `skill.yml`)
+
+`capabilities.yml` adjudicates the *overlapping* domains (each with an `owner`
+and `overlaps` list); every skill's `skill.yml` declares its `owner_domain`.
+`scripts/validate_capabilities.py --strict` (CI-enforced) asserts four
+invariants — run it after adding or moving a skill:
+
+1. **Valid contract** — every `skills/*/skill.yml` is valid YAML with `name`
+   equal to its directory and a non-empty `owner_domain`.
+2. **Owner agreement** — each declared domain's `owner` is a real skill whose
+   `owner_domain` is that domain.
+3. **No silent claimant** — a skill whose `owner_domain` is a *declared* domain
+   must be that domain's owner or listed in its `overlaps`.
+4. **Resolvable references** — every `overlaps` entry and every umbrella member
+   resolves to an existing skill / declared domain.
+
+A single-skill domain that needs no adjudication is *not* declared in
+`capabilities.yml` — that is intentional, not drift.
+
 ## Pull Request Checklist
 
 - [ ] `bash scripts/validate_skills.sh`
 - [ ] `python3 scripts/validate_skill_contracts.py`
+- [ ] `python3 scripts/validate_capabilities.py --strict` (skill-registry consistency)
 - [ ] `python3 scripts/check_locale_inventory.py` (any new non-English text is justified in `docs/locale_inventory.md`).
 - [ ] No private project identifiers, manuscript IDs, collaborator names, patient-level examples, or institution-specific hidden context.
 - [ ] No personal absolute paths.

--- a/capabilities.yml
+++ b/capabilities.yml
@@ -37,6 +37,7 @@ domains:
     overlaps:
       - verify-refs
       - ma-scout
+      - fulltext-retrieval
     rule: Finds literature and generates verified candidate citations.
   zotero_sync:
     owner: lit-sync

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2373,8 +2373,8 @@
     },
     {
       "path": "skills/manage-refs/SKILL.md",
-      "size": 18165,
-      "sha256": "49adc82dea2b5d7eb93946b2cd8143d66d50b53169d3ed18f4bd738bfe3af39f"
+      "size": 18627,
+      "sha256": "abb0f38acbff93ffdff68be6a29b68757027fd7ffec545abd90df2df4113c08c"
     },
     {
       "path": "skills/manage-refs/citation_styles/README.md",
@@ -3538,8 +3538,8 @@
     },
     {
       "path": "skills/render-pdf-doc/skill.yml",
-      "size": 3131,
-      "sha256": "af400eb4f819fd982dc0df71ed6ad8b003987a164fbff1cf467c9d1d3c0c0a6c"
+      "size": 3133,
+      "sha256": "77fe112e5a013d3169290132f9882fbb05b3ebe9317729960582895509c21568"
     },
     {
       "path": "skills/render-pdf-doc/templates/anchor-doc.md",

--- a/scripts/validate_capabilities.py
+++ b/scripts/validate_capabilities.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Skill-registry consistency check (issue #15).
+
+`capabilities.yml` declares the *contested* domains — the ones where more than
+one skill overlaps and ownership must be adjudicated (owner + overlaps). Each
+`skills/<name>/skill.yml` in turn declares its `owner_domain`. Nothing currently
+asserts that these two views agree, so drift accumulates silently: a malformed
+`skill.yml` (an unquoted colon) parses nowhere and is never caught; a skill can
+claim a declared domain it neither owns nor overlaps; a domain can name an owner
+that does not exist.
+
+This validator enforces the invariants that must hold for the registry to be
+trustworthy. It deliberately encodes the *actual* design — capabilities.yml
+declares only the overlapping domains; the ~30 single-skill domains are
+self-owned and intentionally absent — rather than the naive "every skill in
+exactly one declared domain", which would false-positive on every self-owned
+skill.
+
+Invariants
+----------
+  1. Every skills/*/skill.yml is valid YAML and declares `name` (== its
+     directory) and a non-empty string `owner_domain`.  [catches malformation]
+  2. Every declared domain's `owner` resolves to an existing skill whose own
+     `owner_domain` equals that domain (owner ⇄ skill agreement).
+  3. Every skill whose `owner_domain` is a *declared* domain is either that
+     domain's owner or listed in its `overlaps` (no silent claimant).
+  4. Every `overlaps` entry resolves to an existing skill with a skill.yml.
+  5. Every umbrella's member list resolves to declared domains.
+
+Exit 0 when the registry is consistent. With --strict, exit 1 on any drift
+(CI gate). Requires PyYAML (already a CI dependency).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _load_yaml(path: Path):
+    """Return (data, error). error is a one-line string on parse failure."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh), None
+    except yaml.YAMLError as exc:
+        first = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
+        return None, first
+    except OSError as exc:
+        return None, str(exc)
+
+
+def _umbrella_members(value) -> list[str]:
+    """Umbrella values are [[domain, ...], "description"]; return the domain list."""
+    if isinstance(value, list) and value and isinstance(value[0], list):
+        return [m for m in value[0] if isinstance(m, str)]
+    if isinstance(value, dict):
+        got = value.get("includes") or value.get("domains") or []
+        return [m for m in got if isinstance(m, str)]
+    if isinstance(value, list):
+        return [m for m in value if isinstance(m, str)]
+    return []
+
+
+def validate(root: Path) -> list[str]:
+    """Return a list of violation strings (empty == consistent)."""
+    violations: list[str] = []
+
+    cap_path = root / "capabilities.yml"
+    if not cap_path.is_file():
+        return [f"capabilities.yml not found at {cap_path}"]
+    cap, err = _load_yaml(cap_path)
+    if err:
+        return [f"capabilities.yml is not valid YAML: {err}"]
+    cap = cap or {}
+    domains = cap.get("domains", {}) or {}
+    umbrellas = cap.get("umbrellas", {}) or {}
+    declared = set(domains.keys())
+
+    # --- Invariant 1: every skill.yml valid + name + owner_domain ---
+    skills_dir = root / "skills"
+    skill_owner_domain: dict[str, str] = {}
+    skill_dirs = sorted(p for p in skills_dir.glob("*") if p.is_dir()) if skills_dir.is_dir() else []
+    for sd in skill_dirs:
+        name = sd.name
+        yml = sd / "skill.yml"
+        if not yml.is_file():
+            violations.append(f"[{name}] skill.yml missing")
+            continue
+        data, err = _load_yaml(yml)
+        if err:
+            violations.append(f"[{name}] skill.yml is not valid YAML: {err}")
+            continue
+        data = data or {}
+        declared_name = data.get("name")
+        if declared_name != name:
+            violations.append(
+                f"[{name}] skill.yml name={declared_name!r} does not match directory"
+            )
+        od = data.get("owner_domain")
+        if not isinstance(od, str) or not od.strip():
+            violations.append(f"[{name}] skill.yml has no non-empty owner_domain")
+        else:
+            skill_owner_domain[name] = od
+
+    existing_skills = {sd.name for sd in skill_dirs}
+
+    # --- Invariant 2: declared domain owner resolves + agrees ---
+    for dname, dbody in domains.items():
+        dbody = dbody or {}
+        owner = dbody.get("owner")
+        if not owner:
+            violations.append(f"domain '{dname}' has no owner")
+            continue
+        if owner not in existing_skills:
+            violations.append(f"domain '{dname}' owner '{owner}' has no skills/{owner}/")
+            continue
+        owner_od = skill_owner_domain.get(owner)
+        if owner_od != dname:
+            violations.append(
+                f"domain '{dname}' owner '{owner}' declares owner_domain={owner_od!r} "
+                f"(expected '{dname}')"
+            )
+        # --- Invariant 4: overlaps resolve ---
+        for ov in dbody.get("overlaps", []) or []:
+            if ov not in existing_skills:
+                violations.append(
+                    f"domain '{dname}' overlaps '{ov}' which has no skills/{ov}/"
+                )
+
+    # --- Invariant 3: a skill claiming a *declared* domain must own or overlap it ---
+    for skill, od in skill_owner_domain.items():
+        if od not in declared:
+            continue  # self-owned domain, intentionally absent from capabilities.yml
+        dbody = domains.get(od, {}) or {}
+        allowed = {dbody.get("owner")} | set(dbody.get("overlaps", []) or [])
+        if skill not in allowed:
+            violations.append(
+                f"[{skill}] claims declared domain '{od}' but is neither its owner "
+                f"nor in its overlaps (add it to capabilities.yml domains.{od}.overlaps)"
+            )
+
+    # --- Invariant 5: umbrella members resolve to declared domains ---
+    for uname, ubody in umbrellas.items():
+        for member in _umbrella_members(ubody):
+            if member not in declared:
+                violations.append(
+                    f"umbrella '{uname}' references undeclared domain '{member}'"
+                )
+
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="repo root containing capabilities.yml and skills/ (default: inferred)",
+    )
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any drift (CI gate)")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    violations = validate(root)
+
+    if not violations:
+        print("OK: skill registry is consistent (capabilities.yml ⇄ skills/*/skill.yml).")
+        return 0
+
+    print(f"REGISTRY DRIFT ({len(violations)}):")
+    for v in violations:
+        print(f"  {v}")
+
+    if args.strict:
+        print("\nSKILL_REGISTRY_DRIFT: capabilities.yml and skills/*/skill.yml disagree.", file=sys.stderr)
+        return 1
+    print("\n(non-strict: reported only; rerun with --strict to fail.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/manage-refs/SKILL.md
+++ b/skills/manage-refs/SKILL.md
@@ -17,6 +17,13 @@ model: inherit
 
 # Manage-Refs Skill
 
+> **Canonical source (issue #16).** This SKILL.md is the single canonical
+> reference for the reference-*workflow* (validate keys → render CSL → convert
+> markers → QC cross-references → inject Zotero CWYW). Audit-only bib
+> verification is owned by `skills/verify-refs/SKILL.md`. Any user-scope rule or
+> external note about reference handling should point here (workflow) or to
+> verify-refs (audit) rather than restating the "how", to prevent drift.
+
 You are routing reference-handling work for a medical manuscript. The user is
 somewhere in the lifecycle — drafting, building a circulation DOCX, swapping
 CSL after a journal rejection, fixing a cross-reference defect surfaced by

--- a/skills/render-pdf-doc/skill.yml
+++ b/skills/render-pdf-doc/skill.yml
@@ -42,7 +42,7 @@ provenance:
 quality_gates:
   - check_deps.sh: hard exit if pandoc + xelatex + CJK-font dependencies are not installed
   - infer_colwidths.py: enforce content-proportional dashes unless the equal-split (--equal) option is specified
-  - circulation_redaction: for circulation PDFs, enforce frontmatter `redact_internal: true` or keep change history / version numbers / PI attribution out of the body
+  - circulation_redaction: "for circulation PDFs, enforce frontmatter `redact_internal: true` or keep change history / version numbers / PI attribution out of the body"
 
 # v2.1 quality card
 purpose: "Render a Markdown manuscript to a styled DOCX/PDF (tables, column widths, dependencies checked)."

--- a/tests/test_capabilities_validator.sh
+++ b/tests/test_capabilities_validator.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression test for scripts/validate_capabilities.py — the registry-consistency
+# gate (issue #15). Confirms a clean fixture passes and each drift class fails
+# under --strict, and that the live repo is clean.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+V="$REPO_ROOT/scripts/validate_capabilities.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- helper: build a minimal fixture root at $1 with a clean registry ---
+make_clean() {
+  local r="$1"
+  mkdir -p "$r/skills/alpha" "$r/skills/beta"
+  cat > "$r/capabilities.yml" <<'YAML'
+schema_version: 2
+domains:
+  shared_domain:
+    owner: alpha
+    overlaps:
+      - beta
+    rule: Alpha owns it; beta overlaps.
+umbrellas:
+  bundle:
+    - - shared_domain
+    - "A one-domain umbrella."
+YAML
+  printf 'schema_version: 2\nname: alpha\nowner_domain: shared_domain\n' > "$r/skills/alpha/skill.yml"
+  printf 'schema_version: 2\nname: beta\nowner_domain: shared_domain\n' > "$r/skills/beta/skill.yml"
+}
+
+# 1) clean fixture -> exit 0 (--strict)
+CLEAN="$TMP/clean"; make_clean "$CLEAN"
+python3 "$V" --root "$CLEAN" --strict > /dev/null 2>&1
+ck "clean registry passes (--strict)" 0 "$?"
+
+# 2) malformed skill.yml (unquoted embedded colon) -> exit 1
+BADYAML="$TMP/badyaml"; make_clean "$BADYAML"
+printf 'schema_version: 2\nname: beta\nowner_domain: shared_domain\nnote: enforce redact_internal: true here\n' \
+  > "$BADYAML/skills/beta/skill.yml"
+python3 "$V" --root "$BADYAML" --strict > /dev/null 2>&1
+ck "malformed skill.yml fails (--strict)" 1 "$?"
+
+# 3) owner ⇄ skill disagreement (owner's owner_domain != domain) -> exit 1
+BADOWNER="$TMP/badowner"; make_clean "$BADOWNER"
+printf 'schema_version: 2\nname: alpha\nowner_domain: something_else\n' > "$BADOWNER/skills/alpha/skill.yml"
+python3 "$V" --root "$BADOWNER" --strict > /dev/null 2>&1
+ck "owner/owner_domain mismatch fails (--strict)" 1 "$?"
+
+# 4) a skill claims a declared domain but is not owner/overlap -> exit 1
+BADCLAIM="$TMP/badclaim"; make_clean "$BADCLAIM"
+mkdir -p "$BADCLAIM/skills/gamma"
+printf 'schema_version: 2\nname: gamma\nowner_domain: shared_domain\n' > "$BADCLAIM/skills/gamma/skill.yml"
+python3 "$V" --root "$BADCLAIM" --strict > /dev/null 2>&1
+ck "unlisted claimant of declared domain fails (--strict)" 1 "$?"
+
+# 5) umbrella references an undeclared domain -> exit 1
+BADUMB="$TMP/badumb"; make_clean "$BADUMB"
+cat > "$BADUMB/capabilities.yml" <<'YAML'
+schema_version: 2
+domains:
+  shared_domain:
+    owner: alpha
+    overlaps:
+      - beta
+    rule: Alpha owns it.
+umbrellas:
+  bundle:
+    - - shared_domain
+      - ghost_domain
+    - "References a domain that does not exist."
+YAML
+python3 "$V" --root "$BADUMB" --strict > /dev/null 2>&1
+ck "umbrella -> undeclared domain fails (--strict)" 1 "$?"
+
+# 6) drift tolerated without --strict -> exit 0
+python3 "$V" --root "$BADCLAIM" > /dev/null 2>&1
+ck "drift tolerated without --strict" 0 "$?"
+
+# 7) the live repo registry must be clean (the CI invariant)
+python3 "$V" --strict > /dev/null 2>&1
+ck "live repo registry clean (--strict)" 0 "$?"
+
+echo "----"
+echo "test_capabilities_validator: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #15. Addresses #16 (repo side).

## Problem
`capabilities.yml` adjudicates the overlapping domains (owner + overlaps); every `skills/*/skill.yml` declares its `owner_domain`. Nothing asserted the two agree, so drift accumulated silently. Two real latent drifts existed:
- **`render-pdf-doc/skill.yml` was invalid YAML** — an unquoted embedded colon (`redact_internal: true` inside a value). Uncaught because `validate_skill_contracts.py` parses skill.yml by regex **and was never wired into CI**.
- **`fulltext-retrieval` claimed `owner_domain: literature_discovery`** without being listed in that domain's `overlaps` (added in #226, never registered).

## What
- **`scripts/validate_capabilities.py`** (CI-enforced, stdlib + PyYAML) — four invariants:
  1. every `skills/*/skill.yml` is valid YAML with `name`==dir and a non-empty `owner_domain`;
  2. each declared domain's `owner` is a real skill whose `owner_domain` is that domain;
  3. a skill whose `owner_domain` is a *declared* domain must be its owner or in its `overlaps`;
  4. every `overlaps` entry and umbrella member resolves.

  It deliberately encodes the real design — `capabilities.yml` declares only the *overlapping* domains; the ~30 single-skill domains are self-owned and intentionally absent — so it doesn't false-positive on every self-owned skill.
- **`tests/test_capabilities_validator.sh`** — clean fixture passes; each drift class (malformed YAML, owner mismatch, unlisted claimant, umbrella→undeclared) fails under `--strict`; live repo clean.
- **Fixes** both drifts above.
- **#16**: `skills/manage-refs/SKILL.md` gains a canonical-source banner (workflow here; bib audit in `verify-refs`).
- CONTRIBUTING.md documents the four invariants + adds the validator to the PR checklist.

## Not a detector
Repo validator, not an integrity detector — **detector count unchanged (50)**, skills unchanged (55).

## Verified
Full local CI-mirror green (core gates + 114 suite steps, 0 fail), including the new validator + self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)