### PR TITLE
feat(write-paper): backbone full-text readiness gate before drafting (#4, #8)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Run write-paper title-page affiliation-order test
         run: bash skills/write-paper/tests/test_title_page_affiliations.sh
 
+      - name: Run write-paper backbone full-text readiness gate test
+        run: bash skills/write-paper/tests/test_backbone_fulltext.sh
+
       - name: Run sync-submission cross-artifact staleness gate test (A3)
         run: bash skills/sync-submission/tests/test_cross_artifact_stale.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- **Backbone full-text readiness gate for `/write-paper`** (`skills/write-paper/scripts/gate_backbone_fulltext.py`,
+  issues #4 + #8). Phase 0 records a backbone article (`project.yaml::backbone_article`), but nothing forced
+  its **full text** to be extracted before drafting — so the draft could follow an abstract. The gate resolves
+  the backbone (via `project.yaml`, or `--backbone`, mapping citekey→DOI from `refs.bib`) and confirms an
+  extracted Markdown full text exists and is substantial: `BACKBONE_FULLTEXT_MISSING` (nothing extracted),
+  `BACKBONE_FULLTEXT_THIN` (below the full-text size floor — an abstract/landing page), or `BACKBONE_UNDECLARED`
+  (warn). Wired into Phase 0 as a mandatory pre-drafting gate that routes to `/lit-sync` Phase 2.7 +
+  `/fulltext-retrieval` `pdf_to_md.py`. A pre-draft **workflow prerequisite**, not a manuscript-integrity
+  detector (named `gate_*`, not `check_*`) — **detector count unchanged (51)**. Ships
+  `skills/write-paper/tests/test_backbone_fulltext.sh`.
+
 - **Reframe / headline-change survivor scan** — `check_cross_artifact_stale.py` (sync-submission) gains
   opt-in `--retired-term` / `--old-value`. After a revision reframes a claim class or changes a headline
   number, stale copies survive in un-touched body paragraphs, figure/table legends, the supplement, and

--- a/docs/skills/write-paper.md
+++ b/docs/skills/write-paper.md
@@ -29,7 +29,9 @@
 
 - `/verify-refs --strict`
 - `/self-review`
+- `python3 scripts/gate_backbone_fulltext.py --project project.yaml --refs manuscript/_src/refs.bib --fulltext-dir pdfs/ --strict`
 - `python3 scripts/build_title_page_affiliations.py --check manuscript/title_page.md --strict`
+- `bash tests/test_backbone_fulltext.sh`
 - `bash tests/test_title_page_affiliations.sh`
 
 **Evidence** — `demo`
@@ -55,6 +57,7 @@
 
 - `build_title_page_affiliations.py`
 - `check_placeholders.py`
+- `gate_backbone_fulltext.py`
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4168,8 +4168,8 @@
     },
     {
       "path": "skills/write-paper/SKILL.md",
-      "size": 67054,
-      "sha256": "62b3cbff56a139ed20a783c462fb6dde6b7a932bb057762a2d1c6382c8d044c1"
+      "size": 68059,
+      "sha256": "d05e1bbde228a87abf459ec19484e560dc08b7e88213e36655b680ebecf7dd8f"
     },
     {
       "path": "skills/write-paper/references/exemplar_abstract.md",
@@ -4662,9 +4662,14 @@
       "sha256": "6bc4032302265ba2c834212e77fbe78b8ddeddba716c833ecf8c65e85e586320"
     },
     {
+      "path": "skills/write-paper/scripts/gate_backbone_fulltext.py",
+      "size": 8358,
+      "sha256": "fa06f0d38c59b319a6cb892f4fb0beeccbf147ec4377a87d0f4b35a49d607050"
+    },
+    {
       "path": "skills/write-paper/skill.yml",
-      "size": 2191,
-      "sha256": "06bd12d85f94702b6e23f74ea8e7009a746d31d247e437f4ba08ea6bd26f7d18"
+      "size": 2466,
+      "sha256": "185eb0948913e0fd0c0f6ddcf4bea30ff7d6b50185b5c6c401b51600039b745c"
     },
     {
       "path": "skills/write-protocol/SKILL.md",

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -117,6 +117,13 @@ When paper type is "case series" (n≥2 patients reported together):
       - **Multiple candidates** — present the top 3 ranked list with rationale and ask the user to choose.
       - **No refs.bib, or no candidates** — ask the user to provide a published study (legacy behavior).
    d. Record the chosen citekey in `project.yaml::backbone_article` so Methods, Tables, and Figures phases reuse it without re-asking.
+   e. **Full-text readiness gate (MANDATORY before any drafting).** A backbone whose full text is not extracted is a backbone in name only — the draft would follow an abstract. After recording the citekey, confirm its full text is retrieved and converted to Markdown, then gate on it:
+      ```bash
+      python3 ${CLAUDE_SKILL_DIR}/scripts/gate_backbone_fulltext.py \
+        --project project.yaml --refs manuscript/_src/refs.bib \
+        --fulltext-dir pdfs/ --strict
+      ```
+      `BACKBONE_FULLTEXT_MISSING` / `BACKBONE_FULLTEXT_THIN` means stop and retrieve it first — `/lit-sync` Phase 2.7 (open-access + Zotero "Find Available PDF") then `/fulltext-retrieval` `pdf_to_md.py` to convert the PDF to Markdown. Do **not** begin Methods drafting until this gate passes (addresses issues #4 and #8: the backbone is *used*, not merely *detected*). If the article is genuinely unavailable in full text, record that limitation explicitly and get user confirmation before proceeding on the abstract.
 8. Summarize the setup to the user and confirm before proceeding.
 
 **Output:** Setup summary with journal constraints, paper type, reporting guideline, backbone article, directory path, and LLM disclosure status (ON/OFF).

--- a/skills/write-paper/scripts/gate_backbone_fulltext.py
+++ b/skills/write-paper/scripts/gate_backbone_fulltext.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Backbone-article full-text readiness gate for /write-paper (issues #4, #8).
+
+`/write-paper` Phase 0 records a *backbone article* (`project.yaml::backbone_article`)
+whose structure the draft follows. Retrieval and PDF->Markdown conversion exist
+(`/lit-sync` Phase 2.7, `/fulltext-retrieval` `pdf_to_md.py`), but nothing forces
+the backbone's **full text** to be extracted *before* drafting — so the model can
+scaffold Methods/Results from an abstract alone, which is exactly what the
+backbone is supposed to prevent.
+
+This is a pre-draft **workflow prerequisite**, not a manuscript-integrity
+detector (it inspects the source material, not the manuscript), so it is
+deliberately named `gate_*` and is not part of the MedSci-Audit detector count.
+
+It answers one question: is the backbone article's extracted full text present
+and substantial (more than an abstract)?
+
+  * BACKBONE_FULLTEXT_MISSING (major) — no extracted Markdown found for the
+    backbone article; drafting would proceed from the abstract only.
+  * BACKBONE_FULLTEXT_THIN (major) — an extracted file exists but is below the
+    full-text size floor (likely an abstract/landing page, not the article).
+  * BACKBONE_UNDECLARED (warn) — no backbone article is declared; Phase 0 should
+    record one before drafting (cannot gate what is not declared).
+
+Resolution order for the backbone's extracted text:
+  1. an explicit `--fulltext PATH` (authoritative);
+  2. a `<citekey>.md` in any `--fulltext-dir`;
+  3. any `*.md` in a `--fulltext-dir` whose text contains the backbone DOI
+     (resolved from `--refs`) or the citekey.
+
+Usage:
+    gate_backbone_fulltext.py --project project.yaml --refs manuscript/_src/refs.bib \
+        --fulltext-dir pdfs/ [--fulltext pdfs/backbone.md] [--min-bytes 3000] [--strict]
+
+Exit 0 = ready (or only a warning), 1 = a major verdict under --strict, 2 = usage.
+Requires PyYAML for --project (a CI dependency); refs.bib parsed with stdlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_MIN_BYTES = 3000  # a real article body is well above this; an abstract is below
+
+
+def load_backbone_from_project(project: Path) -> str | None:
+    try:
+        import yaml
+    except Exception:  # pragma: no cover
+        # stdlib fallback: grep the key
+        for line in project.read_text(encoding="utf-8", errors="replace").splitlines():
+            m = re.match(r"\s*backbone_article\s*:\s*(.+?)\s*$", line)
+            if m:
+                return m.group(1).strip().strip("'\"") or None
+        return None
+    data = yaml.safe_load(project.read_text(encoding="utf-8", errors="replace")) or {}
+    val = data.get("backbone_article")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    return None
+
+
+def doi_for_citekey(refs: Path, citekey: str) -> str | None:
+    """Minimal .bib scan: find the entry for citekey and return its doi field."""
+    if not refs or not refs.is_file():
+        return None
+    text = refs.read_text(encoding="utf-8", errors="replace")
+    # locate "@type{citekey," then read until the next "@" at line start
+    m = re.search(r"@\w+\s*\{\s*" + re.escape(citekey) + r"\s*,", text)
+    if not m:
+        return None
+    tail = text[m.end():]
+    nxt = re.search(r"\n@\w+\s*\{", tail)
+    entry = tail[: nxt.start()] if nxt else tail
+    d = re.search(r"doi\s*=\s*[{\"]\s*([^}\"]+?)\s*[}\"]", entry, re.IGNORECASE)
+    return d.group(1).strip() if d else None
+
+
+def find_fulltext(citekey: str, doi: str | None, dirs: list[Path]) -> Path | None:
+    """Locate an extracted-markdown file for the backbone article."""
+    doi_l = doi.lower() if doi else None
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        direct = d / f"{citekey}.md"
+        if direct.is_file():
+            return direct
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        for md in sorted(d.rglob("*.md")):
+            try:
+                head = md.read_text(encoding="utf-8", errors="replace")[:20000].lower()
+            except OSError:
+                continue
+            if citekey.lower() in head or (doi_l and doi_l in head):
+                return md
+    return None
+
+
+def build_report(project: Path | None, backbone_cli: list[str], refs: Path | None,
+                 fulltext: Path | None, fulltext_dirs: list[Path], min_bytes: int) -> dict:
+    findings: list[dict] = []
+    backbones = list(backbone_cli)
+    if not backbones and project and project.is_file():
+        b = load_backbone_from_project(project)
+        if b:
+            backbones = [b]
+
+    if not backbones:
+        findings.append({
+            "verdict": "BACKBONE_UNDECLARED", "severity": "warn",
+            "message": "No backbone article declared (project.yaml::backbone_article). "
+                       "Phase 0 should record one before drafting.",
+        })
+        return {"backbones": [], "findings": findings, "ready": False}
+
+    for citekey in backbones:
+        doi = doi_for_citekey(refs, citekey) if refs else None
+        path = fulltext if (fulltext and fulltext.is_file() and len(backbones) == 1) else None
+        if path is None:
+            path = find_fulltext(citekey, doi, fulltext_dirs)
+        if path is None:
+            findings.append({
+                "verdict": "BACKBONE_FULLTEXT_MISSING", "severity": "major", "backbone": citekey,
+                "doi": doi,
+                "message": f"No extracted full-text Markdown found for backbone '{citekey}'. "
+                           "Retrieve + convert it (/lit-sync Phase 2.7 or /fulltext-retrieval "
+                           "pdf_to_md.py) before drafting.",
+            })
+            continue
+        size = path.stat().st_size
+        if size < min_bytes:
+            findings.append({
+                "verdict": "BACKBONE_FULLTEXT_THIN", "severity": "major", "backbone": citekey,
+                "path": str(path), "bytes": size,
+                "message": f"Backbone full text '{path}' is {size} bytes (< {min_bytes}); "
+                           "looks like an abstract/landing page, not the article body.",
+            })
+    ready = not any(f["severity"] == "major" for f in findings)
+    return {"backbones": backbones, "findings": findings, "ready": ready}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--project", type=Path, help="project.yaml (read backbone_article)")
+    ap.add_argument("--backbone", action="append", default=[], help="backbone citekey (overrides project). Repeatable.")
+    ap.add_argument("--refs", type=Path, help="refs.bib to resolve citekey -> DOI")
+    ap.add_argument("--fulltext", type=Path, help="explicit path to the backbone's extracted markdown")
+    ap.add_argument("--fulltext-dir", action="append", default=[], type=Path, help="dir(s) of extracted .md. Repeatable.")
+    ap.add_argument("--min-bytes", type=int, default=DEFAULT_MIN_BYTES, help=f"full-text size floor (default {DEFAULT_MIN_BYTES})")
+    ap.add_argument("--out", type=Path, help="write JSON report here")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any major verdict fires")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not args.project and not args.backbone:
+        print("error: pass --project or at least one --backbone", file=sys.stderr)
+        return 2
+
+    report = build_report(args.project, args.backbone, args.refs, args.fulltext,
+                          args.fulltext_dir, args.min_bytes)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    if not args.quiet:
+        if report["ready"] and not report["findings"]:
+            print(f"OK: backbone full text present for {report['backbones']}.")
+        else:
+            for f in report["findings"]:
+                print(f"  [{f['severity'].upper()}] {f['verdict']}: {f['message']}")
+
+    if args.strict and any(f["severity"] == "major" for f in report["findings"]):
+        print("\nBACKBONE_FULLTEXT_NOT_READY: extract the backbone article's full text before drafting.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/write-paper/skill.yml
+++ b/skills/write-paper/skill.yml
@@ -23,7 +23,9 @@ outputs:
   - manuscript/title_page.md
   - qc/_pipeline_log.md
 deterministic_scripts:
-  - none_required
+  - scripts/gate_backbone_fulltext.py
+  - scripts/build_title_page_affiliations.py
+  - scripts/check_placeholders.py
 side_effects:
   - writes_project_artifacts
 downstream_consumers:
@@ -46,6 +48,8 @@ known_limitations:
 validation_commands:
   - "/verify-refs --strict"
   - "/self-review"
+  - "python3 scripts/gate_backbone_fulltext.py --project project.yaml --refs manuscript/_src/refs.bib --fulltext-dir pdfs/ --strict"
   - "python3 scripts/build_title_page_affiliations.py --check manuscript/title_page.md --strict"
+  - "bash tests/test_backbone_fulltext.sh"
   - "bash tests/test_title_page_affiliations.sh"
 evidence_surface: demo

--- a/skills/write-paper/tests/test_backbone_fulltext.sh
+++ b/skills/write-paper/tests/test_backbone_fulltext.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression test for skills/write-paper/scripts/gate_backbone_fulltext.py — the
+# pre-draft backbone full-text readiness gate (issues #4, #8). Synthetic fixtures.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+V="$REPO_ROOT/skills/write-paper/scripts/gate_backbone_fulltext.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s exit=%s\n' "$label" "$actual"; pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"; fail=$((fail + 1))
+  fi
+}
+
+# project.yaml with a declared backbone
+cat > "$TMP/project.yaml" <<'YAML'
+paper_type: diagnostic_accuracy
+backbone_article: smith2023ctai
+YAML
+
+# refs.bib mapping the citekey to a DOI
+cat > "$TMP/refs.bib" <<'BIB'
+@article{smith2023ctai,
+  title = {A CT AI validation study},
+  author = {Smith, Jane},
+  doi = {10.1000/ctai.2023.42},
+  year = {2023}
+}
+BIB
+
+mkdir -p "$TMP/pdfs"
+
+# a SUBSTANTIAL extracted full text (well above the 3000-byte floor)
+{ echo "# A CT AI validation study (10.1000/ctai.2023.42)"; \
+  for i in $(seq 1 200); do echo "Full-text paragraph line $i describing methods, cohort, and results in detail."; done; } \
+  > "$TMP/pdfs/smith2023ctai.md"
+
+# 1) backbone full text present + substantial -> ready, exit 0
+python3 "$V" --project "$TMP/project.yaml" --refs "$TMP/refs.bib" --fulltext-dir "$TMP/pdfs" --strict > /dev/null 2>&1
+ck "present + substantial backbone -> ready" 0 "$?"
+
+# 2) no extracted file at all -> MISSING, exit 1
+rm -f "$TMP/pdfs/smith2023ctai.md"
+python3 "$V" --project "$TMP/project.yaml" --refs "$TMP/refs.bib" --fulltext-dir "$TMP/pdfs" --strict > /dev/null 2>&1
+ck "missing backbone full text -> exit 1" 1 "$?"
+
+# 3) an abstract-sized stub (thin) -> THIN, exit 1
+printf '# A CT AI validation study\nAbstract only: a short summary.\n' > "$TMP/pdfs/smith2023ctai.md"
+python3 "$V" --project "$TMP/project.yaml" --refs "$TMP/refs.bib" --fulltext-dir "$TMP/pdfs" --strict > /dev/null 2>&1
+ck "thin (abstract-only) backbone -> exit 1" 1 "$?"
+
+# 4) match by DOI when the file is not named after the citekey
+rm -f "$TMP/pdfs/smith2023ctai.md"
+{ echo "# Paper (doi 10.1000/ctai.2023.42)"; for i in $(seq 1 200); do echo "Body line $i with detailed methods and results."; done; } \
+  > "$TMP/pdfs/downloaded_42.md"
+python3 "$V" --project "$TMP/project.yaml" --refs "$TMP/refs.bib" --fulltext-dir "$TMP/pdfs" --strict > /dev/null 2>&1
+ck "resolves backbone by DOI in file content" 0 "$?"
+
+# 5) no backbone declared -> UNDECLARED warn, exit 0 (not a hard block)
+cat > "$TMP/project_nobb.yaml" <<'YAML'
+paper_type: diagnostic_accuracy
+YAML
+python3 "$V" --project "$TMP/project_nobb.yaml" --fulltext-dir "$TMP/pdfs" --strict > /dev/null 2>&1
+ck "undeclared backbone warns but does not fail" 0 "$?"
+
+# 6) explicit --fulltext path (authoritative)
+python3 "$V" --backbone smith2023ctai --fulltext "$TMP/pdfs/downloaded_42.md" --strict > /dev/null 2>&1
+ck "explicit --fulltext path passes" 0 "$?"
+
+# 7) the MISSING verdict is emitted in the report
+rm -f "$TMP"/pdfs/*.md
+OUT="$(python3 "$V" --project "$TMP/project.yaml" --refs "$TMP/refs.bib" --fulltext-dir "$TMP/pdfs" 2>&1)"
+echo "$OUT" | grep -q BACKBONE_FULLTEXT_MISSING
+ck "MISSING verdict reported" 0 "$?"
+
+echo "----"
+echo "test_backbone_fulltext: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #4 and #8. `/write-paper` Phase 0 records a *backbone article* (`project.yaml::backbone_article`), and retrieval + PDF→Markdown conversion exist (`/lit-sync` Phase 2.7, `/fulltext-retrieval` `pdf_to_md.py`) — but nothing forced the backbone's **full text** to be extracted before drafting. So the draft could scaffold Methods/Results from an abstract, exactly what the backbone is meant to prevent.

## What
`skills/write-paper/scripts/gate_backbone_fulltext.py` resolves the backbone (from `project.yaml`, or `--backbone`; citekey→DOI via `refs.bib`) and confirms an extracted full-text Markdown exists and is substantial:
- `BACKBONE_FULLTEXT_MISSING` (major) — no extracted Markdown for the backbone;
- `BACKBONE_FULLTEXT_THIN` (major) — a file exists but is below the full-text size floor (abstract/landing page);
- `BACKBONE_UNDECLARED` (warn) — no backbone declared; Phase 0 should record one.

Resolution order: explicit `--fulltext PATH` → `<citekey>.md` in a `--fulltext-dir` → any `*.md` whose text contains the DOI/citekey. Wired into **Phase 0 as a mandatory pre-drafting gate** that routes to `/lit-sync` Phase 2.7 + `/fulltext-retrieval` `pdf_to_md.py` when it fires.

## Not a detector
A pre-draft **workflow prerequisite** (it inspects the source material, not the manuscript), so it is named `gate_*`, not `check_*` — **detector count unchanged (51)**. Ships `test_backbone_fulltext.sh` (present/missing/thin/DOI-match/undeclared/explicit-path/verdict-reported).

## Verified
Full local CI-mirror green (116 steps, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)