### PR TITLE
docs(academic-aio): AI-tool citation framing by use-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **AI-tool citation framing (`/academic-aio`)** — a use-class guide for citing an AI-assisted research
+  tool safely (`references/ai_tool_citation_framing.md` + a Section 2.4a pointer). Verification/QA and
+  analysis uses belong in a Software / Code-availability statement (citable, rigor-signalling); generative
+  drafting belongs in the journal's AI-disclosure field, not a proud citation. Self-citation by a tool's
+  author additionally requires a COI disclosure. States why a deterministic gate is deferred (use-class
+  classification is high-FP without context). Motivated by the recurring "how do I cite an AI-QA tool
+  under journal AI-hostility" question.
+
 ### Added
 
 - **Backbone full-text readiness gate for `/write-paper`** (`skills/write-paper/scripts/gate_backbone_fulltext.py`,

--- a/docs/skills/academic-aio.md
+++ b/docs/skills/academic-aio.md
@@ -36,6 +36,7 @@
 
 **References** (`skills/academic-aio/references/`):
 
+- `ai_tool_citation_framing.md`
 - `case_studies/` (1 file)
 - `checklists/` (1 file)
 - `journal_summarybox_templates.yaml`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -58,8 +58,13 @@
     },
     {
       "path": "skills/academic-aio/SKILL.md",
-      "size": 31396,
-      "sha256": "339f937d2218e11c8f6576df9bb6d5b2b827634092d8f4e6c1b6110e092076b5"
+      "size": 32276,
+      "sha256": "d893714e70af45b6f9d162d5220875685995e4a2c428331348689566e672989c"
+    },
+    {
+      "path": "skills/academic-aio/references/ai_tool_citation_framing.md",
+      "size": 4064,
+      "sha256": "e3c8403cc698a45bb5626b233c5cbf18eb283e6a606d6232471f0f0c657d0fec"
     },
     {
       "path": "skills/academic-aio/references/case_studies/kjr_mllm_2025.md",

--- a/skills/academic-aio/SKILL.md
+++ b/skills/academic-aio/SKILL.md
@@ -107,6 +107,9 @@ This pattern is the canonical shape LLM extractors parse first.
 ### 2.4 Reproducibility block
 Include a labeled block (typically end of Methods or a standalone Data/Code Availability section) listing: data availability and license, code availability with DOI, model weights and checkpoints, prompts and configuration files, random seeds, compute environment. This block is disproportionately scraped by AI agents when they cite a paper as reproducible.
 
+### 2.4a Citing an AI-assisted tool by use-class
+If the work used an AI-assisted tool (a verification/QA suite, analysis code, or a generative drafting assistant), frame the mention by *what it did*, not by hiding it — under current journal wariness, a proud in-text citation of a **generative** use invites suspicion, while the same placement for a **verification** use reads as rigor (like citing a reference manager or a linter). Split the mention: **verification/QA and analysis** → a **Software / Code-availability statement** (citable); **generative** drafting/humanizing → the journal's **AI-use disclosure field**, not a citation. A self-citation by the tool's author additionally requires a COI disclosure, and you should cite only the functions the work actually used. Full use-class table and rules: `${CLAUDE_SKILL_DIR}/references/ai_tool_citation_framing.md`.
+
 ### 2.5 Limitations enumeration
 List limitations explicitly and name each one (generalizability, spectrum bias, dataset shift, single-center training, label noise). Papers with enumerated limitations score higher for trustworthiness in LLM summarization benchmarks.
 

--- a/skills/academic-aio/references/ai_tool_citation_framing.md
+++ b/skills/academic-aio/references/ai_tool_citation_framing.md
@@ -1,0 +1,53 @@
+# Citing an AI-assisted research tool safely (framing by use-class)
+
+When a manuscript used an AI-assisted tool — a reference-verification / QA suite, a
+statistical-analysis helper, or a generative drafting assistant — *where and how you
+name it* changes how an editor or reviewer reads it. Under current journal wariness
+about AI, a proud in-text citation of a **generative** use can invite suspicion or a
+desk-reject, while the identical placement for a **verification** use reads as rigor
+(the same way citing R, SPSS, or a reference manager does). The safe move is to frame
+the mention by what the tool actually *did*, not to hide it.
+
+This applies to any AI-assisted tool; it also applies to **self-citation** by a tool's
+author (e.g. citing MedSci Skills in your own paper), which additionally requires a
+conflict-of-interest disclosure.
+
+## The three use-classes
+
+| Use-class | What it covers | Where it belongs | Citable like software? |
+|---|---|---|---|
+| **Verification / QA** (rigor-signalling) | Reference/citation verification (DOI/PMID against PubMed/CrossRef), reporting-guideline compliance checks, deterministic integrity gates, numerical-consistency checks | **Software / Code-availability statement** (or Methods, as a named tool with version) | **Yes** — cite it plainly, like a reference manager or a linter. It signals rigor. |
+| **Analysis** (neutral) | Statistical-analysis code, figure generation, data-transformation scripts | Methods (named, with version) and/or Code-availability | **Yes** — neutral and citable, like citing R/Python packages. |
+| **Generative** (disclosure, not citation) | Drafting or rewriting prose, "humanizing", summarizing, idea generation | The journal's **AI-use disclosure field / statement** (per its policy), *not* a proud in-text citation | **No** — declare it in the disclosure field; do not farm it into the running text. |
+
+## Rules of thumb
+
+- **Prefer the deterministic, verifiable functions for the cleanest cite.** A tool's
+  reproducible/verifiable capabilities (reference verification, compliance gates,
+  analysis code) are the ones that read as rigor and are safest to name in a Software
+  statement. Its generative capabilities belong in the disclosure field.
+- **Match the placement to the use-class**, not to the tool. The *same* tool can be
+  citable (its QA gate ran your references) *and* disclosure-only (its drafting helper
+  touched your prose) in the *same* paper — split the mention accordingly.
+- **Do not self-cite generatively.** If the paper did not materially use the generative
+  parts, do not add a self-citation for them to inflate a citation count; cite only the
+  functions the work actually used.
+- **Pair a self-citation with a COI disclosure.** If you authored the tool, state the
+  relationship (e.g. "Author X develops the cited toolkit") in the COI/competing-interests
+  section — the same standard as any other intellectual/financial interest.
+- **Honor the target journal's AI policy first.** Where a journal specifies *where* AI
+  use must be declared (Methods vs Acknowledgements vs a dedicated field), that placement
+  wins for the generative use-class; the Software-statement guidance above is for the
+  verification/analysis classes, which are tool-use, not AI-authorship.
+
+## Why this is guidance, not a deterministic gate (yet)
+
+A deterministic check ("flag an AI-tool citation placed in running-text Methods for a
+*generative* use") would need both a maintained tool-name allowlist and a reliable
+classifier of *which use-class* a given sentence describes — the latter is high false-
+positive without context the grep cannot see. The reliable, low-FP part (a tool named in
+a Software/Code-availability statement) is already the recommended state, so there is
+nothing to flag. If a bounded, allowlist-driven placement check proves worthwhile on real
+manuscripts, it can be added later; until then this stays advisory. (See
+`~/.claude/rules/manuscript-style-classical.md` §7/§15 for AI-disclosure placement and the
+self-applicability rule.)


### PR DESCRIPTION
Adds guidance for a recurring question: **how do I cite an AI-assisted research tool (including this toolkit) without triggering editor/reviewer AI-suspicion?**

## What
`skills/academic-aio/references/ai_tool_citation_framing.md` + a Section 2.4a pointer. Frames the mention by **use-class**, not by hiding it:

| Use-class | Where it belongs | Citable like software? |
|---|---|---|
| Verification / QA (reference checks, compliance gates, integrity gates) | Software / Code-availability statement | **Yes** — reads as rigor, like a reference manager / linter |
| Analysis (stats code, figures) | Methods + Code-availability | **Yes** — neutral |
| Generative (drafting, humanizing) | the journal's **AI-disclosure field** | **No** — declare, don't cite proudly |

Plus: a self-citation by a tool's author needs a COI disclosure; cite only functions actually used; the target journal's AI policy wins for the generative class.

## Deterministic-gate note
Per the repo's "no prose-only probe without a reason" discipline, the doc states explicitly why a gate is deferred: flagging a generative-use tool citation needs a use-class classifier that is high-FP without context, while the reliable state (a tool in a Software statement) is already the recommendation, so there is nothing to flag.

## Doc-only
No skill logic, detector, or count change. Rebased on main after #299.

## Verified
Full local CI-mirror green (116 steps, 0 fail); the `${CLAUDE_SKILL_DIR}/references/...` pointer resolves under `validate_routing_assets --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)