### PR TITLE
test(make-figures): regression test for validate_pptx_mac_compat.py

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run make-figures legend-reconcile test
         run: bash skills/make-figures/tests/test_legend_reconcile.sh
 
+      - name: Run make-figures pptx Mac-compatibility validator test
+        run: python3 skills/make-figures/tests/test_pptx_mac_compat.py
+
       - name: Run clean-data structural-zero test
         run: bash skills/clean-data/tests/test_structural_zero.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 
 ### Added
 
+- **`make-figures` PPTX Mac-compatibility validator test** (`skills/make-figures/tests/test_pptx_mac_compat.py`).
+  `validate_pptx_mac_compat.py` (TIFF media / `<a:sp3d>` bevel / `docProps/app.xml` slide-count mismatch /
+  `srcRect` over-crop) previously shipped without a regression test. The test builds a clean deck
+  (python-pptx, with a corrected app.xml slide count so the known `<Slides>0` bug does not false-fail),
+  asserts it passes, then injects each of the four defect classes and asserts a `--strict` failure, plus a
+  missing-input exit code and the WARN-tolerated (no app.xml) path. CI-wired. No skill-logic change.
+
 - **Backbone full-text readiness gate for `/write-paper`** (`skills/write-paper/scripts/gate_backbone_fulltext.py`,
   issues #4 + #8). Phase 0 records a backbone article (`project.yaml::backbone_article`), but nothing forced
   its **full text** to be extracted before drafting — so the draft could follow an abstract. The gate resolves

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -28,6 +28,7 @@
 
 - `Rscript scripts/generate_flow_diagram.R`
 - `python3 scripts/validate_pptx_mac_compat.py <file>`
+- `python3 tests/test_pptx_mac_compat.py`
 - `bash scripts/render_core_figures_challenge/verify.sh`
 
 **Evidence** — `demo`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2273,8 +2273,8 @@
     },
     {
       "path": "skills/make-figures/skill.yml",
-      "size": 2205,
-      "sha256": "b973c376998b15cefe9bffdf580889f905b60ddc2dead00cc5cbc900a6fd50f5"
+      "size": 2249,
+      "sha256": "6a8ebbe077c2073bb546a044bbecb5d483dbe2d2a50b31adabba6cf5e3a87990"
     },
     {
       "path": "skills/make-figures/templates/official/NOTES.md",

--- a/skills/make-figures/skill.yml
+++ b/skills/make-figures/skill.yml
@@ -50,5 +50,6 @@ known_limitations:
 validation_commands:
   - "Rscript scripts/generate_flow_diagram.R"
   - "python3 scripts/validate_pptx_mac_compat.py <file>"
+  - "python3 tests/test_pptx_mac_compat.py"
   - "bash scripts/render_core_figures_challenge/verify.sh"
 evidence_surface: demo

--- a/skills/make-figures/tests/test_pptx_mac_compat.py
+++ b/skills/make-figures/tests/test_pptx_mac_compat.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Regression test for scripts/validate_pptx_mac_compat.py.
+
+Builds a clean .pptx (python-pptx, with a corrected docProps/app.xml slide
+count) that must PASS, then injects each of the four Mac-incompatibility defect
+classes into a copy and asserts the validator FAILs under --strict:
+
+    TIFF media, <a:sp3d> 3-D bevel, app.xml slide-count mismatch, srcRect
+    over-crop (> 100000).
+
+Also asserts a missing input exits 2. Requires python-pptx (a CI dependency).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VALIDATOR = HERE.parent / "scripts" / "validate_pptx_mac_compat.py"
+
+_pass = 0
+_fail = 0
+
+
+def ck(label: str, expected: int, actual: int) -> None:
+    global _pass, _fail
+    if expected == actual:
+        print(f"  PASS  {label:<48} exit={actual}")
+        _pass += 1
+    else:
+        print(f"  FAIL  {label:<48} expected={expected} actual={actual}")
+        _fail += 1
+
+
+def run(pptx: Path, strict: bool = True) -> int:
+    cmd = [sys.executable, str(VALIDATOR), str(pptx)]
+    if strict:
+        cmd.append("--strict")
+    return subprocess.run(cmd, capture_output=True, text=True).returncode
+
+
+def build_clean(path: Path, n_slides: int = 2) -> None:
+    """A python-pptx deck with app.xml <Slides> corrected to match — should PASS."""
+    from pptx import Presentation
+
+    prs = Presentation()
+    for _ in range(n_slides):
+        prs.slides.add_slide(prs.slide_layouts[6])  # blank
+    prs.save(str(path))
+    # python-pptx writes <Slides>0</Slides>; fix it so the clean baseline passes.
+    _rewrite_member(path, "docProps/app.xml",
+                     lambda b: re.sub(rb"<Slides>\d+</Slides>",
+                                      f"<Slides>{n_slides}</Slides>".encode(), b))
+
+
+def _read_member(path: Path, member: str) -> bytes:
+    with zipfile.ZipFile(path) as z:
+        return z.read(member)
+
+
+def _rewrite_member(path: Path, member: str, transform, extra: dict | None = None) -> None:
+    """Rewrite the zip, replacing `member` (via transform) and adding `extra` files."""
+    with zipfile.ZipFile(path) as z:
+        items = {n: z.read(n) for n in z.namelist()}
+    if member in items:
+        items[member] = transform(items[member])
+    if extra:
+        items.update(extra)
+    tmp = path.with_suffix(".tmp.pptx")
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as z:
+        for n, data in items.items():
+            z.writestr(n, data)
+    tmp.replace(path)
+
+
+def first_slide(path: Path) -> str:
+    with zipfile.ZipFile(path) as z:
+        for n in sorted(z.namelist()):
+            if n.startswith("ppt/slides/slide") and n.endswith(".xml"):
+                return n
+    raise AssertionError("no slide XML in fixture")
+
+
+def main() -> int:
+    if VALIDATOR.exists() is False:
+        print(f"validator missing: {VALIDATOR}")
+        return 1
+    tmp = Path(tempfile.mkdtemp())
+
+    clean = tmp / "clean.pptx"
+    build_clean(clean)
+    ck("clean deck (app.xml fixed) passes", 0, run(clean))
+
+    # 1) TIFF embedded in ppt/media/
+    tiff = tmp / "tiff.pptx"
+    build_clean(tiff)
+    _rewrite_member(tiff, "docProps/app.xml", lambda b: b,
+                    extra={"ppt/media/image1.tiff": b"II*\x00 fake tiff"})
+    ck("TIFF media -> FAIL", 1, run(tiff))
+
+    # 2) <a:sp3d> 3-D bevel inside a slide
+    sp3d = tmp / "sp3d.pptx"
+    build_clean(sp3d)
+    sl = first_slide(sp3d)
+    _rewrite_member(sp3d, sl, lambda b: b.replace(b"</p:sld>", b"<a:sp3d/></p:sld>"))
+    ck("sp3d bevel -> FAIL", 1, run(sp3d))
+
+    # 3) app.xml slide-count mismatch (declare a wrong count)
+    appx = tmp / "appx.pptx"
+    build_clean(appx)
+    _rewrite_member(appx, "docProps/app.xml",
+                    lambda b: re.sub(rb"<Slides>\d+</Slides>", b"<Slides>99</Slides>", b))
+    ck("app.xml slide-count mismatch -> FAIL", 1, run(appx))
+
+    # 4) srcRect over-crop (> 100000)
+    src = tmp / "srcrect.pptx"
+    build_clean(src)
+    sl2 = first_slide(src)
+    _rewrite_member(src, sl2, lambda b: b.replace(b"</p:sld>", b'<a:srcRect l="997171"/></p:sld>'))
+    ck("srcRect over-crop (>100000) -> FAIL", 1, run(src))
+
+    # 5) missing input -> exit 2
+    ck("missing input -> exit 2", 2, run(tmp / "does_not_exist.pptx"))
+
+    # 6) non-strict tolerates a WARN-only deck (no app.xml -> WARN, exit 0)
+    nowarn = tmp / "noappxml.pptx"
+    build_clean(nowarn)
+    _rewrite_member(nowarn, "docProps/app.xml", lambda b: b, extra=None)
+    # remove app.xml entirely
+    with zipfile.ZipFile(nowarn) as z:
+        items = {n: z.read(n) for n in z.namelist() if n != "docProps/app.xml"}
+    with zipfile.ZipFile(nowarn, "w", zipfile.ZIP_DEFLATED) as z:
+        for n, data in items.items():
+            z.writestr(n, data)
+    ck("missing app.xml is WARN, tolerated without --strict", 0, run(nowarn, strict=False))
+
+    print("----")
+    print(f"test_pptx_mac_compat: {_pass} passed, {_fail} failed")
+    return 0 if _fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes a test-coverage gap: `make-figures`' `validate_pptx_mac_compat.py` (TIFF media / `<a:sp3d>` bevel / `docProps/app.xml` slide-count mismatch / `srcRect` over-crop) shipped with **13 scripts but only 1 test** — this logic validator had none.

## What
`skills/make-figures/tests/test_pptx_mac_compat.py` builds a **clean** deck with python-pptx and corrects its `app.xml` `<Slides>` count (python-pptx writes `<Slides>0`, the exact bug the validator flags — so the clean baseline is genuinely clean), asserts it passes, then injects each of the four defect classes into a copy and asserts a `--strict` failure:
- TIFF in `ppt/media/`, `<a:sp3d/>` in a slide, `app.xml` slide-count mismatch, `srcRect` value > 100000.

Plus the missing-input exit code (2) and the WARN-tolerated (no `app.xml`) path without `--strict`. CI-wired next to the make-figures legend test.

## No skill-logic change
Test-only; detector count unchanged (51). Rebased on main after #301.

## Verified
Full local CI-mirror green (117 steps, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)