### PR TITLE
fix(orchestrate): E2E state-transition + skill reachability (audit F1 + F2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Run capabilities-validator self-test (drift fixtures fail, live repo clean)
         run: bash tests/test_capabilities_validator.sh
 
+      - name: Run check_orchestrate_reachability.py (every skill routable from /orchestrate)
+        run: python3 scripts/check_orchestrate_reachability.py --strict
+
+      - name: Run orchestrate-reachability self-test (missing-row + ghost-route fail)
+        run: bash tests/test_orchestrate_reachability.sh
+
       - name: Run check_locale_inventory.py (Korean-bearing files must be inventory-justified)
         run: python3 scripts/check_locale_inventory.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/orchestrate` coherence** (audit F1 + F2) — two P0 findings from a repo-improvement audit.
+  **F1 (E2E state transition):** the `--e2e` post-skill validation required `manuscript_final.docx` for
+  `/write-paper`, but the DOCX is only rendered by `/manage-refs` at step 7, so an `--e2e` run halted at
+  step 3 ("STOP, do not proceed"). `/write-paper` now validates only `manuscript.md`; the DOCX requirement
+  stays on the `/manage-refs` row where it is produced. **F2 (reachability):** the hand-maintained
+  "Available Skills" routing table listed 34 of 55 skills, so the single entry point could not route to the
+  other 20 (most of the model-engineering lane: `architecture-zoo`, `preprocess-imaging`, `model-scaffold`,
+  `radiomics-ml`, `model-validation`, `model-evaluation`, `mllm-eval`, `explainability`,
+  `uncertainty-imaging`, `model-card`, plus `author-strategy`, `batch-cohort`, `cross-national`,
+  `replicate-study`, `ma-scout`, `find-cohort-gap`, `design-ai-benchmarking`, `review-paper`,
+  `polish-language`, `setup-medsci`). All 20 are added to the table, and a new
+  `scripts/check_orchestrate_reachability.py` CI gate (with self-test) asserts every skill directory is
+  routable from `/orchestrate` (or explicitly direct-only), so the drift cannot recur. No new skill or
+  detector; catalog counts unchanged.
+
 ## [5.20.0] - 2026-07-11
 
 Reviewer-arithmetic gates — five deterministic `self-review` detectors that recompute what a manuscript

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3023,8 +3023,8 @@
     },
     {
       "path": "skills/orchestrate/SKILL.md",
-      "size": 35203,
-      "sha256": "ef8b919606efbf794d7ebe67b011bd676c129cd1d9d51bac16d85dcaaae5e12e"
+      "size": 40144,
+      "sha256": "6535b55a55791f1339c32d4b8ee8e7ebdaf749a6c3dc1677ef8f3a653ef424ca"
     },
     {
       "path": "skills/orchestrate/references/dialogue_nodes.md",

--- a/scripts/check_orchestrate_reachability.py
+++ b/scripts/check_orchestrate_reachability.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Orchestrate reachability gate (audit finding F2).
+
+`/orchestrate` is documented as the single entry point for the whole bundle, but it
+routes from a hand-maintained "Available Skills" table in
+`skills/orchestrate/SKILL.md`. When a new skill ships without a table row, the
+single entry point cannot route to it — a silent discoverability regression that no
+existing check caught (20 skills, most of the model-engineering lane, drifted out of
+reach before this gate existed).
+
+This validator asserts every skill directory is reachable from the router: its name
+appears as a bolded first-column entry in the Available Skills table. The router
+itself (`orchestrate`) is exempt, and a skill may be intentionally direct-only by
+listing it in DIRECT_ONLY below with a one-line reason.
+
+Top-level `scripts/` validator (not a `skills/*/scripts/` detector) — it audits the
+routing surface, not a manuscript, so it is not part of the MedSci-Audit detector
+count.
+
+Usage:
+  python3 scripts/check_orchestrate_reachability.py --strict
+  python3 scripts/check_orchestrate_reachability.py --skill-md <f> --skills-dir <d> --strict
+Exit: 0 when every skill is reachable (or exempt); with --strict, 1 on any gap; 2 on read error.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# The router itself is never a route target. A skill that is genuinely not meant to
+# be reached through /orchestrate goes here with a reason (keep this near-empty).
+DIRECT_ONLY: dict[str, str] = {
+    "orchestrate": "the router itself",
+}
+
+ROW_RE = re.compile(r"^\|\s*\*\*([a-z0-9-]+)\*\*\s*\|", re.M)
+
+
+def table_skills(skill_md: Path) -> set[str]:
+    text = skill_md.read_text(encoding="utf-8")
+    if "## Available Skills" not in text:
+        raise ValueError(f"{skill_md}: no '## Available Skills' section")
+    section = text.split("## Available Skills", 1)[1].split("## Classification Logic", 1)[0]
+    return set(ROW_RE.findall(section))
+
+
+def skill_dirs(skills_dir: Path) -> set[str]:
+    return {p.name for p in skills_dir.iterdir() if p.is_dir() and (p / "SKILL.md").exists()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--skill-md", default=str(ROOT / "skills/orchestrate/SKILL.md"))
+    ap.add_argument("--skills-dir", default=str(ROOT / "skills"))
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any unreachable skill")
+    args = ap.parse_args(argv)
+
+    try:
+        routed = table_skills(Path(args.skill_md))
+        dirs = skill_dirs(Path(args.skills_dir))
+    except (OSError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    required = dirs - set(DIRECT_ONLY)
+    unreachable = sorted(required - routed)
+    # a table row naming a skill that no longer exists is also drift
+    ghost = sorted(routed - dirs - set(DIRECT_ONLY))
+
+    print(f"orchestrate reachability: {len(routed)} routed / {len(dirs)} skills "
+          f"({len(DIRECT_ONLY) - 1} direct-only exempt)")
+    if unreachable:
+        print(f"  UNREACHABLE ({len(unreachable)}) — not in the Available Skills table:")
+        for s in unreachable:
+            print(f"    - {s}")
+    if ghost:
+        print(f"  GHOST ({len(ghost)}) — routed to a skill directory that does not exist:")
+        for s in ghost:
+            print(f"    - {s}")
+    if not unreachable and not ghost:
+        print("  OK: every skill is reachable from /orchestrate.")
+
+    return 1 if (args.strict and (unreachable or ghost)) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -73,6 +73,26 @@ You do NOT do the work yourself. You classify, plan, and delegate.
 | **fill-icmje-coi** | Form filling | Batch ICMJE COI Disclosure Form generation per author from a synthetic seed |
 | **sync-submission** | Submission | SSOT-to-submission drift audit; journal-specific submission manifest creation from canonical manuscript artifacts |
 | **peer-review** | Review | External manuscript peer review draft generation (journal-specific formatting). Use ONLY for reviewing other authors' work, never for self-review |
+| **review-paper** | Writing | Scaffold/draft a literature review (narrative / scoping PRISMA-ScR / systematic); reuses the self-review narrative-review probes for QC. Distinct from `write-paper` (original research) and `meta-analysis` (pooling) |
+| **polish-language** | Quality | Academic-English consistency lint + non-native clarity polish (abbreviation define-once, US/UK spelling drift, hyphen/en-dash ranges, P/p case, value/unit spacing). Style-only; distinct from `humanize` (AI-tell removal) and `check-reporting` (guideline items) |
+| **author-strategy** | Analysis | PubMed author-profile analysis: study-type classification, trajectory-archetype, publication-strategy report from a name |
+| **batch-cohort** | Analysis | Generate N analysis scripts from one validated methodology template × many exposure/outcome combinations (same method, swap variables) + summary matrix |
+| **replicate-study** | Analysis | Replicate an existing cohort study's methodology on a different database: design extraction, variable-harmonization table, replication-difference report |
+| **cross-national** | Analysis | Cross-national comparison study (KNHANES + NHANES + CHNS or parallel surveys): variable harmonization + parallel weighted analysis |
+| **ma-scout** | Systematic review | Meta-analysis topic discovery + feasibility (professor-first profile→gap, or topic-first question→gap→co-author) before a protocol exists |
+| **find-cohort-gap** | Methodology | Research-gap discovery from a longitudinal cohort DB: profile strengths, match PI expertise, literature-saturation scan, ranked topic proposals |
+| **design-ai-benchmarking** | Methodology | Design/validity review for benchmarking one or more AI systems against a human-expert reference panel (decoupled rubrics, planted calibration probes, reviewer-panel construction, IRR targets, rating-export schema) — before data collection |
+| **architecture-zoo** | Modeling | Choose a medical-imaging model architecture (classification / segmentation / detection / transfer) before scaffolding — maps task + modality + labelled-data scale + imbalance to a paper-grounded shortlist |
+| **preprocess-imaging** | Modeling | Design/audit DICOM/NIfTI intake, resampling, normalisation, and augmentation so the pipeline is leakage-safe before `model-scaffold`; emits a preprocessing manifest + data-stage leakage gate |
+| **model-scaffold** | Modeling | Generate a reproducible runnable PyTorch training repo (patient-level seed-locked split, task model, train/eval scripts, repro record) — the link between choosing an architecture and validating a trained model |
+| **radiomics-ml** | Modeling | Produce/audit a radiomics / tabular-ML study (imaging or clinical features → penalised logistic / SVM / RF / gradient-boosting / MLP → outcome) with a learner-agnostic nested-CV / feature-stability / calibration / external-validation gate (no GPU) |
+| **model-validation** | Validation | Design/audit the clinical-validation study for an engineer-built imaging model (segmentation / classification / detection): patient-level split disjointness, internal-vs-external validation, comparator, metric fit — with a deterministic split-leakage gate |
+| **model-evaluation** | Evaluation | Compute task-correct held-out metrics for a trained imaging model (segmentation Dice + boundary; classification AUROC + AUPRC + Se/Sp with bootstrap CIs; detection FROC/mAP; calibration; subgroup slices) → per-case results table |
+| **mllm-eval** | Evaluation | Design/audit a model-agnostic evaluation harness for an LLM/MLLM clinical task (report generation, VQA, extraction/classification): adjudicated reference, clinical-efficacy metrics beyond BLEU/ROUGE, hallucination, contamination, prompt-sensitivity, reader study |
+| **explainability** | Modeling | Produce/audit a medical-imaging model's interpretability analysis (Grad-CAM / saliency / integrated-gradients) held to the reviewer bar — Adebayo sanity checks, quantitative localisation vs ground truth, cohort-level results, attribution-not-validation framing |
+| **uncertainty-imaging** | Modeling | Design/audit the uncertainty-quantification / OOD-detection / selective-prediction layer of a deployment-framed imaging model (MC-dropout / ensemble / conformal, held-out OOD set, abstention at a pre-specified point) + deployment-claim gate |
+| **model-card** | Documentation | Generate a Model Card + Datasheet + METRIC-informed data-quality pass for an engineer-built imaging model, filled from user-supplied facts, with a completeness gate (never fabricates numbers/provenance/licence) |
+| **setup-medsci** | Setup | Diagnostic checklist for the runtime (Python, R, Node, Claude Code, Git, Zotero, MCP servers) — read-only pass/fail table pointing to the right setup doc for any missing component |
 
 ---
 
@@ -287,7 +307,7 @@ After each skill completes, verify that expected output files exist. If validati
 |-------|-----------------|------------|
 | `/analyze-stats` | At least one file in `analysis/tables/*.csv` OR `analysis/_analysis_outputs.md` | Check file existence and non-empty |
 | `/make-figures` | `analysis/figures/_figure_manifest.md` with at least 1 entry | Parse manifest, verify listed files exist |
-| `/write-paper` | `manuscript/manuscript.md` (required), `manuscript/manuscript_final.docx` (required in --e2e) | Check file existence and non-empty |
+| `/write-paper` | `manuscript/manuscript.md` (required) | Check file existence and non-empty. Do NOT require the DOCX here — `manuscript_final.docx` is rendered later by `/manage-refs` (step 7); requiring it at this step would halt an `--e2e` run before the DOCX exists |
 | `/check-reporting` | `qc/reporting_checklist.md` or inline report | Check file existence |
 | `/verify-refs` | `qc/reference_audit.json` (sole output) | Parse JSON; halt if `submission_safe == false` (i.e., `FABRICATED` / `MISMATCH` count > 0 OR `duplicate_findings[]` nonempty) |
 | `/self-review` | Review report with JSON block (when --json) | Check JSON block is parseable. In `--panel` mode each issue may carry an additional optional `consensus` array plus R1/R2/R3 attribution annotations on the `M`/`m` comments — these are additive and backwards-compatible; accept them |

--- a/tests/test_orchestrate_reachability.sh
+++ b/tests/test_orchestrate_reachability.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_orchestrate_reachability.py:
+#  - the live repo must pass (every skill reachable from /orchestrate)
+#  - a synthetic fixture that omits one skill's table row must fail (exit 1)
+#  - a synthetic fixture routing to a non-existent skill (ghost) must fail
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DET="$ROOT/scripts/check_orchestrate_reachability.py"
+
+# 1) live repo passes
+python3 "$DET" --strict >/dev/null || { echo "FAIL: live repo should be fully reachable" >&2; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/skills/alpha" "$tmp/skills/beta" "$tmp/skills/orchestrate"
+: > "$tmp/skills/alpha/SKILL.md"; : > "$tmp/skills/beta/SKILL.md"; : > "$tmp/skills/orchestrate/SKILL.md"
+
+# 2) omit 'beta' from the table -> must fail
+cat > "$tmp/md_missing.md" <<'MD'
+## Available Skills
+| Skill | Domain | When to Route |
+|---|---|---|
+| **alpha** | X | route alpha |
+## Classification Logic
+MD
+if python3 "$DET" --skill-md "$tmp/md_missing.md" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1; then
+  echo "FAIL: a missing skill row should exit 1" >&2; exit 1
+fi
+
+# 3) full table -> passes
+cat > "$tmp/md_full.md" <<'MD'
+## Available Skills
+| Skill | Domain | When to Route |
+|---|---|---|
+| **alpha** | X | route alpha |
+| **beta** | X | route beta |
+## Classification Logic
+MD
+python3 "$DET" --skill-md "$tmp/md_full.md" --skills-dir "$tmp/skills" --strict >/dev/null \
+  || { echo "FAIL: a complete table should exit 0" >&2; exit 1; }
+
+# 4) ghost route (table names a non-existent skill) -> must fail
+cat > "$tmp/md_ghost.md" <<'MD'
+## Available Skills
+| Skill | Domain | When to Route |
+|---|---|---|
+| **alpha** | X | route alpha |
+| **beta** | X | route beta |
+| **gamma** | X | route a skill that does not exist |
+## Classification Logic
+MD
+if python3 "$DET" --skill-md "$tmp/md_ghost.md" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1; then
+  echo "FAIL: a ghost route should exit 1" >&2; exit 1
+fi
+
+echo "PASS: orchestrate reachability gate — live repo reachable, missing-row and ghost-route both fail."


### PR DESCRIPTION
Acts on the two **P0** findings of the 2026-07-11 repo-improvement audit (`docs/audits/2026-07-11_repo_improvement_audit.md`), both independently verified against the live repo before fixing.

## F1 — `/orchestrate --e2e` state-transition conflict
The `--e2e` post-skill validation required `manuscript_final.docx` for `/write-paper`, and "On validation failure → STOP, do not proceed." But the DOCX is only rendered by `/manage-refs` at **step 7**, so an `--e2e` run halted at **step 3** — contradicting the same file's "DOCX rendering delegated to step 7." Fix: `/write-paper` now validates only `manuscript.md`; the DOCX check stays on the `/manage-refs` row where it is produced.

## F2 — 20 skills unreachable from the single entry point
The hand-maintained "Available Skills" routing table listed **34 of 55** skills. The other **20** — most of the model-engineering lane (`architecture-zoo`, `preprocess-imaging`, `model-scaffold`, `radiomics-ml`, `model-validation`, `model-evaluation`, `mllm-eval`, `explainability`, `uncertainty-imaging`, `model-card`) plus `author-strategy`, `batch-cohort`, `cross-national`, `replicate-study`, `ma-scout`, `find-cohort-gap`, `design-ai-benchmarking`, `review-paper`, `polish-language`, `setup-medsci` — had no table row, so `/orchestrate` could not route to them. All 20 added with concise route descriptions.

## Prevention
New `scripts/check_orchestrate_reachability.py` (top-level validator, **not** a counted detector) + self-test, CI-wired: asserts every skill directory is either in the routing table or explicitly `DIRECT_ONLY`, and flags a ghost route (table row for a non-existent skill). The drift cannot silently recur.

**Verification** — full local CI mirror green (13 checks) incl. the new gate + self-test, `gen_*_catalog --check`, `validate_catalog_consistency`, `validate_routing_assets`, release-ZIP provenance. No new skill/detector; catalog counts unchanged.

Remaining audit items (README/public-claim validator, capabilities layer semantics, public-site + YouTube SSOT sync) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)