### PR TITLE
fix(catalog): gate README plugin-count against marketplace SSOT (audit PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Public-claim plugin-count gate** (audit F/§6.1, PR-3) — the README plugin-marketplace claim was not
+  cross-checked against the SSOT, so it drifted: README said "eight `medsci-*` category plugins" while
+  `.claude-plugin/marketplace.json` has nine (all `medsci-*`). Fixed to "nine", and extended
+  `scripts/validate_catalog_consistency.py` to recompute the plugin count from the marketplace SSOT and
+  assert the README claim (word or digit) matches — the same drift-guard the skills / guideline / detector
+  counts already have. CI-enforced.
+
 - **`/orchestrate` coherence** (audit F1 + F2) — two P0 findings from a repo-improvement audit.
   **F1 (E2E state transition):** the `--e2e` post-skill validation required `manuscript_final.docx` for
   `/write-paper`, but the DOCX is only rendered by `/manage-refs` at step 7, so an `--e2e` run halted at

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ The E2E pipeline (`orchestrate --e2e`) produces everything up to `qc/`. The `sub
 
 **v4.1** ships distribution levers and a submission pre-flight gate — analysis-integrity detectors **24 → 25** (still 43 skills):
 
-- **Claude Code plugin marketplace** — `/plugin marketplace add Aperivue/medsci-skills`, then `/plugin` discovery of eight `medsci-*` category plugins generated from the catalog SSOT (`.claude-plugin/marketplace.json`).
+- **Claude Code plugin marketplace** — `/plugin marketplace add Aperivue/medsci-skills`, then `/plugin` discovery of nine `medsci-*` category plugins generated from the catalog SSOT (`.claude-plugin/marketplace.json`).
 - **MedSci-Audit detector registry** — the deterministic verification layer is now a named, enumerated, citable suite ([`MEDSCI_AUDIT.md`](MEDSCI_AUDIT.md) + generated `metadata/detectors_catalog.json`, six audit families).
 - **Hero-skill standalone mirrors** — `scripts/sync_hero_skill.py` mirrors a focused skill to its own star-funnel repo; first two live: [`Aperivue/verify-refs`](https://github.com/Aperivue/verify-refs) and [`Aperivue/check-reporting`](https://github.com/Aperivue/check-reporting).
 - **Placeholder/marker gate** — `check_placeholders.py` flags leftover `[@NEW:]` / `[version]` / `TODO` / template-URL markers before submission (the 25th detector).

--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -45,7 +45,11 @@ SSOT = ROOT / "metadata" / "catalog_counts.json"
 # cross-checks these counts, so disk is their sole source of truth. Maintainer-
 # scoped counts (skills, reporting_guidelines, integrity_detectors) stay hard-
 # asserted below and in catalog_counts.json.
-AUTO_DERIVED_KEYS = ("journal_profiles_find", "journal_profiles_write")
+# `plugins` is derived from the marketplace SSOT (.claude-plugin/marketplace.json),
+# not from catalog_counts.json, so it is not asserted against the JSON here — but
+# unlike the journal-profile keys it IS cross-checked against the README plugin
+# claim in Layer 3 (doc_claims).
+AUTO_DERIVED_KEYS = ("journal_profiles_find", "journal_profiles_write", "plugins")
 
 
 def disk_counts() -> dict[str, int]:
@@ -61,12 +65,23 @@ def disk_counts() -> dict[str, int]:
     detectors = len({
         str(p) for g in detector_globs for p in (ROOT / "skills").glob(f"*/scripts/{g}")
     })
+    # medsci-* category plugins in the plugin marketplace SSOT
+    mp = ROOT / ".claude-plugin" / "marketplace.json"
+    plugins = 0
+    if mp.exists():
+        try:
+            data = json.loads(mp.read_text(encoding="utf-8"))
+            plugins = sum(1 for p in data.get("plugins", [])
+                          if str(p.get("name", "")).startswith("medsci-"))
+        except (ValueError, OSError):
+            plugins = 0
     return {
         "skills": skills,
         "reporting_guidelines": checklists,
         "journal_profiles_find": find_prof,
         "journal_profiles_write": write_prof,
         "integrity_detectors": detectors,
+        "plugins": plugins,
     }
 
 
@@ -102,6 +117,17 @@ DETECTOR_CLAIM_PATTERNS = [
     r'"(\d{1,3})\s+detectors,\s*validated\b',
     r"\bcover all\s+(\d{1,3})\s+detectors\b",
 ]
+
+# Files carrying the plugin-marketplace count claim (the `medsci-*` category
+# plugins). Drifted once (README said "eight" while marketplace.json had nine)
+# because no gate watched it. The number is written as an English word, so a small
+# word->int map is needed; only a number token immediately preceding
+# "category plugins" is treated as a claim.
+PLUGIN_CLAIM_FILES = ["README.md"]
+NUM_WORDS = {w: i for i, w in enumerate(
+    ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+     "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+     "sixteen", "seventeen", "eighteen", "nineteen", "twenty"])}
 
 
 def doc_claims() -> list[tuple[str, int, int, str]]:
@@ -155,6 +181,24 @@ def doc_claims() -> list[tuple[str, int, int, str]]:
             for rx in det_res:
                 for m in rx.finditer(line):
                     out.append((rel, int(m.group(1)), d, f"L{i} detector total"))
+
+    # Plugin marketplace count: a number word or digit shortly before "category
+    # plugins". The capture group is constrained to number tokens so an ordinary
+    # word (e.g. "of", "medsci") that happens to sit before the phrase is not
+    # mistaken for the count.
+    pl = truth["plugins"]
+    _num_alt = "|".join(NUM_WORDS)
+    plugin_re = re.compile(rf"\b({_num_alt}|\d+)\b[^.\n]{{0,20}}?\bcategory plugins\b", re.IGNORECASE)
+    for rel in PLUGIN_CLAIM_FILES:
+        f = ROOT / rel
+        if not f.exists():
+            continue
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for m in plugin_re.finditer(line):
+                tok = m.group(1).lower()
+                n = NUM_WORDS.get(tok, int(tok) if tok.isdigit() else None)
+                if n is not None:
+                    out.append((rel, n, pl, f"L{i} plugin count"))
     return out
 
 


### PR DESCRIPTION
Acts on audit finding **§6.1 / PR-3** (public-claim drift). The README plugin-marketplace count was not cross-checked against the SSOT and had drifted: README said "**eight** `medsci-*` category plugins" while `.claude-plugin/marketplace.json` has **nine** (all `medsci-*`, incl. `medsci-modeling` for the model-engineering lane).

- **Fix**: README "eight" → "nine".
- **Gate**: `scripts/validate_catalog_consistency.py` now recomputes the plugin count from the marketplace SSOT and asserts the README claim (spelled word *or* digit) matches — the same drift-guard the skills / guideline / detector counts already have. `plugins` is `AUTO_DERIVED` (from marketplace.json, not `catalog_counts.json`) but doc-checked in Layer 3.
- **Verified both directions**: the gate flags the stale "eight" (`claims 8, expected 9`) and passes on "nine". The capture group is constrained to number tokens so a non-number word before "category plugins" is not mistaken for the count.

Full local CI mirror green (8 checks). No new skill/detector; catalog counts unchanged.

Bundles with the `/orchestrate` F1+F2 fix (#310) in `[Unreleased]` — both are audit-driven fixes, targeted for the next patch (v5.20.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)