### PR TITLE
docs(paper): reframe the JOSS paper around the deterministic verification layer

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -82,3 +82,13 @@
   url = {https://joss.readthedocs.io/en/latest/submitting.html},
   note = {Accessed 2026-05-23}
 }
+
+@misc{nam2026gates,
+  title        = {Deterministic Integrity Gates for {LLM}-Assisted Clinical Manuscript Preparation: An Auditable Biomedical Informatics Architecture},
+  author       = {Nam, Yoojin and Jeong, Jinhoon and Kim, Namkug},
+  year         = {2026},
+  eprint       = {2606.09500},
+  archivePrefix = {arXiv},
+  doi          = {10.48550/arXiv.2606.09500},
+  url          = {https://arxiv.org/abs/2606.09500}
+}

--- a/paper.md
+++ b/paper.md
@@ -1,10 +1,11 @@
 ---
-title: "MedSci Skills: Claude Code Skills for the Medical Research Lifecycle"
+title: "MedSci Skills: Deterministic Integrity Gates and an Agent-Skill Toolkit for the Medical Research Lifecycle"
 tags:
   - medical research
-  - systematic review
-  - meta-analysis
+  - research integrity
   - reporting guidelines
+  - systematic review
+  - reproducibility
   - research software
 authors:
   - name: Yoojin Nam
@@ -13,55 +14,52 @@ authors:
 affiliations:
   - name: "Department of Radiology and Research Institute of Radiology, University of Ulsan College of Medicine, Asan Medical Center, Seoul, Republic of Korea"
     index: 1
-date: 5 July 2026
+date: 12 July 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-MedSci Skills is a collection of Claude Code [@anthropic_claude_code] skills for medical researchers who need repeatable support across the manuscript lifecycle. The repository currently contains 55 skills covering topic discovery, literature search, full-text retrieval, study design, sample size planning, protocol drafting, de-identification, data cleaning, statistical analysis, publication figures, manuscript writing, reporting-guideline checks, reference verification, peer review, revision, presentation, and submission hygiene, together with a medical-AI model-engineering lane (architecture selection, reproducible training scaffolds, validation, evaluation, and model documentation).
+MedSci Skills is an open-source toolkit that pairs LLM-assisted medical research workflows with a **deterministic verification layer**. Its core is a suite of 57 stdlib-only detectors that *recompute* what a manuscript already asserts rather than asking a language model to judge it: reference records are checked against PubMed and CrossRef, printed percentages against their column denominators, reported *P* values against the cell counts they were computed from, sensitivity and specificity denominators against the reference-standard counts in the characteristics table, and reporting compliance against 46 vendored checklists (STROBE, PRISMA, STARD, CONSORT, TRIPOD+AI, and others). Each detector ships a synthetic challenge card — a positive case and a negative control — that runs in continuous integration, so a clean result is meaningful and a flagged defect is reproducible.
 
-The software is organized as auditable workflow modules rather than as single-use prompts. Each skill encodes task boundaries, anti-hallucination checks, deterministic script hooks where appropriate, and routing guidance for adjacent skills. Four public end-to-end demos illustrate diagnostic accuracy, meta-analysis, epidemiology, and medical-AI model-engineering workflows using public datasets.
+Around that verification core, the toolkit exposes 55 task-bounded skills spanning the manuscript lifecycle: literature search and reference management, study design and sample-size planning, de-identification and data cleaning, statistical analysis and publication figures, drafting, reporting-guideline audits, peer review, revision, and submission hygiene — together with a medical-AI model-engineering lane covering architecture selection, reproducible training scaffolds, validation, evaluation, explainability, and model documentation. The skills are agent-agnostic: a single transactional installer targets Claude Code [@anthropic_claude_code], Codex, Cursor, and GitHub Copilot, and skills interoperate with external tools such as reference managers through the Model Context Protocol [@model_context_protocol]. Four end-to-end demonstrations on public data — diagnostic accuracy, meta-analysis, epidemiology, and a medical-AI model — produce complete, inspectable outputs.
 
 # Statement of Need
 
-Medical manuscript work often fails at handoff points: references drift from PubMed records, reporting checklists are applied too late, figures and manuscript counts disagree, and submission packages accumulate stale files. These failures are not primarily model-capability problems. They are workflow and quality-control problems.
+LLM assistance in clinical manuscript preparation fails less often at generation than at **verification**. References drift from the records they claim to cite, printed percentages disagree with their denominators, reporting checklists are applied after the analysis is frozen, and submission bundles accumulate stale artifacts. These are quality-control failures rather than model-capability failures, and they are precisely the class of error a language model is least reliable at catching in its own output.
 
-MedSci Skills addresses this by packaging medical-research procedures as reusable agent skills with validators, checklists, and explicit downstream boundaries. The target audience is clinician-researchers, research assistants, medical AI teams, and manuscript-methods collaborators who already use local repositories for analysis and writing.
+A companion evaluation of this architecture, conducted on an earlier release of the toolkit [@nam2026gates], found that deterministic gates detected 27 of 27 seeded defects with zero false positives, while a single-prompt LLM reviewer detected 11 of 27. MedSci Skills operationalizes that result as a design rule: work that can be settled by recomputation is routed to a deterministic script, and the language model is used for synthesis, drafting, and procedural coordination — never as the final arbiter of a verifiable fact. The evaluation and the current catalog are deliberately reported as separate facts: detectors added since that benchmark are covered by their own continuous-integration challenge cards, not by a re-run of it.
+
+The intended users are clinician-researchers, research assistants, medical-AI teams, and methods collaborators who already keep analysis and writing in a local repository, and who need an auditable, re-executable trail rather than an opaque assistant.
 
 # State of the Field
 
-General LLM agent frameworks and prompt libraries provide broad orchestration patterns, but they rarely encode domain-specific medical manuscript constraints such as EQUATOR reporting guidelines [@equator_network] — for example PRISMA [@page2021prisma], STARD [@bossuyt2015stard], STROBE [@vonelm2007strobe], TRIPOD+AI [@collins2015tripod], and CLAIM [@mongan2020claim] — PubMed-backed reference checks, systematic-review screening stages, and submission-bundle hygiene. Existing medical AI resources emphasize models, datasets, or application libraries; MedSci Skills focuses on the research-production workflow that surrounds those analyses.
+General LLM agent frameworks and prompt libraries provide broad orchestration patterns, but they rarely encode the domain constraints that decide whether a medical manuscript survives peer review: EQUATOR reporting guidelines [@equator_network] — for example PRISMA [@page2021prisma], STARD [@bossuyt2015stard], STROBE [@vonelm2007strobe], TRIPOD+AI [@collins2015tripod], and CLAIM [@mongan2020claim] — PubMed-backed reference verification, staged systematic-review screening, and submission-bundle hygiene. Medical-AI software ecosystems, in turn, emphasize models, datasets, and training libraries.
 
-The repository complements rather than replaces statistical packages, reference managers, and reporting-guideline templates. It routes deterministic work to scripts or external tools where possible and uses agent behavior for synthesis, review, and procedural coordination.
+MedSci Skills targets the research-production workflow that surrounds those analyses, complementing rather than replacing statistical packages, reference managers, and reporting-guideline templates. It routes deterministic work to scripts or external tools wherever a check can be decided by recomputation, and uses agent behavior only for synthesis, review, and procedural coordination.
 
 # Software Design
 
-The system is a modular skill library. Each skill owns a bounded research task and declares when it should or should not be used. Higher-level skills such as `/orchestrate`, `/self-review`, and `/revise` coordinate downstream checks without hiding the underlying artifacts. Skills run within Claude Code and can interoperate with external tools, such as reference managers, through the Model Context Protocol [@model_context_protocol].
+The repository is organized as a modular skill library over a deterministic audit layer.
 
-Design trade-offs:
+- **Bounded skills.** Each skill owns one research task and declares when it should *and should not* be used, keeping procedural context next to the task instead of centralizing every rule in a single orchestrator. Higher-level skills such as `/orchestrate`, `/self-review`, and `/revise` coordinate downstream checks without hiding the underlying artifacts.
+- **Deterministic detectors.** Checks that must not depend on model judgment are implemented as stdlib-only Python scripts with explicit verdicts and non-zero exit codes, so they compose into halt-on-failure gates and can be re-executed independently by a reviewer.
+- **Challenge cards and continuous integration.** Every detector is paired with synthetic fixtures — a positive case and a negative control — that run on each push, alongside catalog-consistency, routing-reachability, and public-claim gates that keep the documentation and the code from drifting apart.
+- **Reproducible demonstrations.** The demos use openly available datasets and content-hash manifests, so complete outputs — manuscripts, figures, compliance audits, and model-evaluation tables — can be inspected without private data.
+- **Release hygiene.** Repository validators enforce public-release constraints, including project-identifier blocklists and metadata checks, before a release is cut.
 
-- Skills keep procedural context close to the task instead of centralizing all rules in one large orchestrator.
-- Validators enforce public-release hygiene, including project-identifier blocklists and metadata checks.
-- Deterministic scripts are used for checks that should not depend on language-model judgment.
-- Public demos use accessible datasets so users can inspect complete outputs without private data.
-
-# Research Applications
-
-MedSci Skills is archived with a citable Zenodo DOI and a public version history, and ships four reproducible end-to-end demonstrations — diagnostic accuracy, meta-analysis, epidemiology, and medical-AI model engineering — built on openly available datasets, so that complete outputs can be inspected without private data. It is most useful to groups that need a structured manuscript workflow with built-in checks for references, reporting-guideline compliance, meta-analysis artifacts, and submission-package consistency.
+The toolkit is archived with a citable Zenodo DOI and a public version history, and is distributed through npm and a plugin marketplace in addition to the source repository.
 
 # AI Usage Disclosure
 
-Generative AI tools including Claude Code and Codex were used to draft, revise, and audit skill documentation, scripts, validators, release notes, and this paper outline. Human authors made the core design decisions, reviewed AI-assisted outputs, ran repository validation checks, and remain responsible for accuracy, originality, licensing, and research-integrity compliance.
+Generative AI tools, including Claude Code and Codex, were used to draft, revise, and audit skill documentation, scripts, validators, release notes, and this paper. The author made the core design decisions, reviewed all AI-assisted output, ran the repository validation suite, and is responsible for the accuracy, originality, licensing, and research-integrity compliance of the work.
 
 # Competing Interests
 
-The author is the founder and CEO of Aperivue (Incheon, Republic of Korea), which hosts the MedSci Skills repository. The software is released under the MIT license and is freely available, and the author reports no other competing interests.
+The author is the founder of Aperivue (Incheon, Republic of Korea), which hosts the MedSci Skills repository. The software is released under the MIT license and is freely available. The author reports no other competing interests.
 
 # Acknowledgements
 
-This project builds on public reporting-guideline communities, open-source statistical and manuscript-production tooling, and the broader Claude Code skill ecosystem. No specific external funding supported the development of this software.
+The author thanks Jinhoon Jeong and Namkug Kim for their collaboration on the companion evaluation of this architecture [@nam2026gates], and the public reporting-guideline communities and open-source manuscript-production ecosystems on whose work this toolkit builds. No specific external funding supported the development of this software.
 
 # References
-
-References are managed in `paper.bib`.


### PR DESCRIPTION
Prepares `paper.md` for JOSS submission. The existing draft led with *"a collection of Claude Code skills"* — the weakest possible framing for JOSS's **substantial-scholarly-effort** bar (it invites "is this software, or a prompt collection?"), it buried the strongest contribution, and it is no longer accurate now that the toolkit installs into four hosts.

## Changes
- **Title + Summary now lead with the deterministic verification layer** — 57 stdlib-only detectors that *recompute* what a manuscript asserts (references vs PubMed/CrossRef, printed percentages vs column denominators, reported *P* vs the cell counts, sens/spec denominators vs the reference standard, 46 vendored checklists), each CI-gated by a synthetic challenge card (positive + negative control).
- **Agent-agnostic** (Claude Code · Codex · Cursor · GitHub Copilot) replaces the Claude-only wording.
- **Statement of Need cites the companion evaluation** (arXiv:2606.09500): **27/27 seeded defects detected, zero false positives**, vs **11/27** for a single-prompt LLM reviewer — while **explicitly noting it ran on an earlier release**, keeping evaluation evidence and current catalog as separate facts (the discipline `MEDSCI_AUDIT.md` already imposes).
- Numbers synced to the repo: **57 detectors / 55 skills / 46 guidelines / 4 demos**.
- `paper.bib` gains the arXiv companion entry (`nam2026gates`).

## Authorship
Stays **single-author**. JOSS authorship is contribution *to the software*, and reviewers check the contributor graph; the companion research paper (arXiv/JMIR) properly carries the co-authors. Collaborators are credited in **Acknowledgements** instead.

## Verification
957 words (JOSS range 250–1000); every `[@key]` resolves against `paper.bib` (0 undefined); local CI mirror green (validate_skills incl. PII, catalog consistency, orchestrate reachability, distribution manifest).

Not a submission — this only readies the paper. Submission can proceed with the arXiv preprint cited and the JMIR paper disclosed as in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)