### PR TITLE
docs(contributing): add a "Running the tests" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,48 @@ invariants — run it after adding or moving a skill:
 A single-skill domain that needs no adjudication is *not* declared in
 `capabilities.yml` — that is intentional, not drift.
 
+## Running the tests
+
+MedSci Skills is guarded by a deterministic test suite that runs in CI on every
+push and pull request. The authoritative list of every check is
+[`.github/workflows/validate.yml`](.github/workflows/validate.yml); the whole
+suite uses synthetic fixtures and needs no private data or network access.
+
+To run it locally, install the test dependencies and execute the checks:
+
+```bash
+pip install pyyaml pandas numpy python-pptx python-docx
+
+# Structure, PII, and skill-contract validation
+bash scripts/validate_skills.sh
+
+# Version + distribution manifest + installer round-trip
+python3 scripts/check_version_consistency.py
+python3 scripts/gen_distribution_manifest.py --check
+python3 installers/install.py --self-test
+bash installers/tests/test_release_zip.sh
+
+# Skill-registry, /orchestrate routing, and catalog consistency
+python3 scripts/validate_capabilities.py --strict
+python3 scripts/check_orchestrate_reachability.py --strict
+python3 scripts/validate_catalog_consistency.py
+
+# Deterministic-detector self-tests (drift fixtures must fail, live repo clean)
+for t in skills/self-review/tests/*.sh; do bash "$t"; done
+```
+
+Each deterministic detector additionally ships a self-contained
+`<detector>_challenge/` directory — a positive case, a negative control, and a
+`verify.sh` — so any single detector can be exercised offline in isolation, for
+example:
+
+```bash
+bash skills/self-review/scripts/check_reported_p_from_counts_challenge/verify.sh
+```
+
+A green run of `.github/workflows/validate.yml` is required before any release is
+cut.
+
 ## Pull Request Checklist
 
 - [ ] `bash scripts/validate_skills.sh`


### PR DESCRIPTION
Closes the last JOSS submission-readiness gap: JOSS review verifies that automated tests exist **and are documented** so a reviewer can run them. `CONTRIBUTING.md` listed a handful of validation commands inside the PR checklist but had no single "how to run the test suite" entry point.

## Change
Adds a **Running the tests** section (before the PR Checklist) that:
- points to `.github/workflows/validate.yml` as the authoritative list of every CI check,
- notes the suite is synthetic-fixture-only (no private data, no network),
- gives a copy-pasteable local recipe grouped by purpose (structure/PII · version+manifest+installer round-trip · registry/routing/catalog consistency · detector self-tests),
- shows how to run a single detector's `<detector>_challenge/verify.sh` offline.

## Verification
Every command in the new section was executed on this branch and passes (9/9 + the challenge `verify.sh`). Local CI mirror green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)