### PR TITLE
feat(find-cohort-gap): accept a local codebook or document as input (closes #69)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Run sync-submission marked-manuscript round-trip gate test (move-aware)
         run: bash skills/sync-submission/tests/test_marked_manuscript.sh
 
+      - name: Run find-cohort-gap local-codebook input adapter test
+        run: bash skills/find-cohort-gap/tests/test_cohort_profile.sh
+
       - name: Run self-review parenthesis-span corruption gate test (A9)
         run: bash skills/self-review/tests/test_paren_spans.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Added
 
+- **`/find-cohort-gap` accepts your own cohort** (issue #69, requested by an external user).
+  The skill used to start from a *named* database — NHIS, UK Biobank, and the handful of registries it
+  knows about. Most researchers do not have one of those: they have an institutional registry, a
+  single-centre EMR export, or a specialty cohort, described by a data dictionary nobody else has ever
+  seen. Those users could not use the skill at all.
+
+  **`scripts/build_cohort_profile.py`** is the input layer that lets them in. It reads a local codebook
+  (`.csv` / `.tsv` / `.json` / `.md` / `.txt`, plus `.xlsx` via openpyxl and `.pdf` via `pdftotext`) and
+  emits the same cohort profile the skill already consumes, so the intersection matrix, saturation scan
+  and 6-pattern scoring are unchanged. A review, guideline, or preprint can be attached as domain
+  context (`--context`), as a file or a URL. A `.csv` is auto-detected as a codebook (rows are
+  variables) or a data export (the header row is the variable list).
+
+  It is a script and not "the model reads the file" for a reason: asked to *summarise* a codebook, a
+  language model will paraphrase a variable name, merge two that look alike, or invent one the cohort
+  does not have — and the intersection matrix, the feasibility gate, and eventually the manuscript's
+  Methods all inherit it. So variables are **enumerated, never generated**: copied verbatim, each
+  carrying its provenance (`file:row`). What the codebook cannot state — sample size, follow-up
+  duration, IRB status, prior publications — is emitted as `[UNKNOWN - ask the user]` rather than
+  guessed, because a fabricated N does not merely sit there; it flows into the Phase 5 feasibility gate,
+  which then passes for a reason unrelated to the cohort.
+
+  Two structural facts *are* derivable from variable names, and both feed patterns the skill already
+  scores: **serial / repeated-measure groups** (P1 Longitudinal Advantage) and **endpoint candidates**
+  (P2 Endpoint Upgrade). Each is reported with the variables that justify it, and a measurement is only
+  called serial when it genuinely repeats. Cluster assignment records the keyword that triggered it, and
+  a variable matching nothing is left `unclassified` rather than forced into a bucket.
+
 - **Marked (tracked-changes) manuscript: a build step and a round-trip gate** (`/sync-submission` Phase 10,
   used by `/revise`). Every revision round must ship the revised paper with tracked changes against the
   version the reviewers saw. This was the last hand-done, unverified step of a submission: produced by

--- a/docs/locale_inventory.md
+++ b/docs/locale_inventory.md
@@ -44,6 +44,7 @@ Buckets:
 | `skills/deidentify/tests/README.md` | A | Documents the Korean placeholder test names (김철수 etc., synthetic). |
 | `skills/deidentify/deidentify.py` | A | Korean date parsing (년/월/일) + bilingual `Select country / 국가 선택` prompt. |
 | `skills/deidentify/SKILL.md` | A/D | Locale-pack description (kr: 주민번호 …) + bilingual trigger. |
+| `skills/find-cohort-gap/scripts/build_cohort_profile.py` | A | Codebook column-header aliases: a Korean hospital registry's data dictionary labels its description column `설명` / `한글`, and the adapter must recognise it to read the codebook at all. Language-specific parsing, not prose. |
 | `skills/publish-skill/SKILL.md` | A | Language-hardcoding **detection** patterns (`한국어로`, `<한글이름> 교수님`) — the feature. |
 | `skills/publish-skill/scripts/audit_skill.sh` | A | Korean PII/name detection regex. |
 | `skills/publish-skill/references/pii-patterns.md` | A | Korean PII pattern examples for the auditor. |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -21,7 +21,7 @@ One reference page per skill, generated from each skill's `SKILL.md` and `skill.
 - [explainability](explainability.md) — Produce or audit the interpretability/explainability analysis of a medical-imaging model — Grad-CAM / Grad-CAM++ / attention-rollout / saliency / integrated-gradients — so it clears the rigor bar a re… _(evidence: ci_validator)_
 - [fill-icmje-coi](fill-icmje-coi.md) — Batch-generate per-author ICMJE Conflict of Interest Disclosure Forms (`coi_disclosure.docx`) for manuscript submission. _(evidence: bundled_script)_
 - [fill-protocol](fill-protocol.md) — Fill institutional Word form templates (.doc/.docx) for IRB protocols, ethics applications, grant proposals, and other structured research documents while preserving the original styles, table layouts… _(evidence: bundled_script)_
-- [find-cohort-gap](find-cohort-gap.md) — Research gap finder for longitudinal cohort databases. _(evidence: manual_workflow)_
+- [find-cohort-gap](find-cohort-gap.md) — Research gap finder for longitudinal cohort databases. _(evidence: bundled_script)_
 - [find-journal](find-journal.md) — Journal recommendation engine for medical manuscripts. _(evidence: manual_workflow)_
 - [fulltext-retrieval](fulltext-retrieval.md) — Batch download open-access PDFs by DOI using legitimate OA APIs (Unpaywall, PMC, OpenAlex, Crossref). _(evidence: bundled_script)_
 - [generate-codebook](generate-codebook.md) — Generate a citable data dictionary / codebook from a tabular dataset (CSV/TSV/Excel/Parquet/Stata/SAS). _(evidence: bundled_script)_

--- a/docs/skills/find-cohort-gap.md
+++ b/docs/skills/find-cohort-gap.md
@@ -23,12 +23,15 @@
 
 - Literature scans are point-in-time; a gap can close between scan and submission.
 - No standalone demo; proposals require domain judgement.
+- The codebook adapter clusters variables by a keyword lexicon that is not exhaustive; unmatched variables are surfaced as 'unclassified' for the user to review rather than force-assigned.
+- A codebook cannot state sample size, follow-up, or IRB status; those are emitted as [UNKNOWN] and must be collected from the user.
 
 **Validation**
 
+- `bash tests/test_cohort_profile.sh`
 - `re-run the saturation search before committing to a topic`
 
-**Evidence** — `manual_workflow`
+**Evidence** — `bundled_script`
 
 ## Bundled resources
 
@@ -38,6 +41,10 @@
 - `onepager_template.md`
 - `pattern_scoring_rubric.md`
 - `saturation_query_templates.md`
+
+**Scripts** (`skills/find-cohort-gap/scripts/`):
+
+- `build_cohort_profile.py`
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1213,13 +1213,13 @@
     },
     {
       "path": "skills/find-cohort-gap/SKILL.md",
-      "size": 14253,
-      "sha256": "22a560e69e5309d28d293a23aad7a23b3d475f4cb51fa1b73688230d54cfcb74"
+      "size": 16508,
+      "sha256": "5a8f96af2b3f44853231fb677efb9ab92395fcfab1d58283ebe24fba0656a8c1"
     },
     {
       "path": "skills/find-cohort-gap/references/cohort_profile_template.md",
-      "size": 3395,
-      "sha256": "dfaf0cbe27236334bdeea2efdba73a7cbad3564ec3c95787b349b0d759cda3fd"
+      "size": 4219,
+      "sha256": "a370ea69d1c71a7f2546de396c189aab63f4b566b3950a8bc37951f05128711b"
     },
     {
       "path": "skills/find-cohort-gap/references/onepager_template.md",
@@ -1237,9 +1237,14 @@
       "sha256": "ee21c6fd0b10c22f2f9a9f120005b7e6ee0e1404dbf00aede8bbbe59f2eba1ef"
     },
     {
+      "path": "skills/find-cohort-gap/scripts/build_cohort_profile.py",
+      "size": 23222,
+      "sha256": "dd6093e97822f79d49503880741ae92e6b7bcc384fc2327fc3cf1599e44a52a0"
+    },
+    {
       "path": "skills/find-cohort-gap/skill.yml",
-      "size": 1365,
-      "sha256": "f7ed59f9ad3655cb88439b90bc0bcf32cc2bf0c7b4172decdae574e7916015b4"
+      "size": 2147,
+      "sha256": "ba9d514645ce4f3036b8b8ccdfa09cc7fdc3fafea761685e61f427fed3fdfa5c"
     },
     {
       "path": "skills/find-journal/POLICY.md",

--- a/skills/find-cohort-gap/SKILL.md
+++ b/skills/find-cohort-gap/SKILL.md
@@ -36,22 +36,63 @@ literature to gaps. This skill works from the data outward.
 
 ## Phase 0: Cohort Intake
 
-Collect cohort metadata. Use the template at `${CLAUDE_SKILL_DIR}/references/cohort_profile_template.md`.
+The cohort does not have to be one this skill has heard of. Route on what the user
+actually has.
 
-Required information:
-1. **Cohort name and setting** (institution, country, population type)
-2. **Sample size** (N at baseline, N with follow-up)
-3. **Time span** (enrollment period, follow-up duration, measurement intervals)
-4. **Variable categories** (demographics, labs, imaging, questionnaires, medications, procedures)
-5. **Endpoints available** (mortality, cancer incidence, cardiovascular events, hospitalization)
-6. **Special strengths** (serial measurements, linkage to national registries, unique population)
-7. **Known limitations** (healthy volunteer bias, attrition, missing data patterns)
-8. **Existing publications** from this cohort (if known — to avoid duplication)
+| The user has… | Do this |
+|---------------|---------|
+| A **named public cohort** (NHIS, UK Biobank, KNHANES, …) | Fill the profile from published documentation. Cite the source for every field. |
+| A **codebook / data dictionary / CSV export** of their own registry or EMR extract | Run the input adapter below. This is the common case — an institutional registry or single-centre export that no public documentation describes. |
+| A **review, guideline, or preprint** defining the clinical domain | Attach it as domain context (`--context`), as a file or a URL. |
 
-If the user provides a data dictionary file (Excel/CSV), read it to extract variable
-categories and construct the variable cluster map automatically.
+### Input adapter (local codebook / documents)
 
-**Gate:** Present the cohort profile summary. Confirm before proceeding.
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/build_cohort_profile.py" \
+  --codebook data_dictionary.csv \
+  --context narrative_review.pdf --context https://example.org/guideline \
+  --cohort-name "Institutional CT registry" --out-dir .
+```
+
+Formats: `.csv` / `.tsv` / `.json` / `.md` / `.txt` (stdlib), `.xlsx` (needs `openpyxl`),
+`.pdf` (needs `pdftotext`). A `.csv` is auto-detected as a **codebook** (rows are
+variables) or a **data export** (the header row is the variable list). Writes
+`cohort_profile.md` + `cohort_profile.json` (+ `context_extract.md`).
+
+**Do not read the codebook yourself and summarise it.** Paraphrasing a variable name,
+merging two that look alike, or inventing one the cohort does not have poisons every
+downstream claim — the intersection matrix, the feasibility gate, and eventually the
+manuscript's Methods. The adapter *enumerates* variables verbatim with provenance
+(`file:row`) instead, which is the dictionary-first discipline a reviewer expects of a
+DB-backed study. Read `cohort_profile.md`; do not re-derive it.
+
+What the adapter infers (and shows its work for): the **variable cluster map**, **serial
+/ repeated-measure groups** (evidence for P1 Longitudinal Advantage), and **endpoint
+candidates** (evidence for P2 Endpoint Upgrade). Every cluster assignment records the
+keyword that triggered it, and a variable matching nothing is left `unclassified` rather
+than forced into a bucket — review those, since the lexicon is not exhaustive.
+
+### What the adapter cannot know — ASK, never guess
+
+A codebook lists variables. It does not state any of the following, and each is emitted
+as `[UNKNOWN - ask the user]`:
+
+1. **Sample size** (N at baseline, N with follow-up)
+2. **Time span** (enrollment period, follow-up duration, measurement intervals)
+3. **Known limitations** (healthy volunteer bias, attrition, missing-data patterns)
+4. **Existing publications** from this cohort (to avoid duplicating them)
+5. **IRB status and data-access route**
+
+Collect these from the user before Phase 2. A guessed N does not merely sit there — it
+flows into the Phase 5 feasibility gate, which then passes (or fails) for a reason that
+has nothing to do with the cohort.
+
+Also confirm the **setting** (institution type, country, population type) and any
+**special strengths** the variable names cannot reveal — registry linkage, biobank
+availability, a distinctive population.
+
+**Gate:** Present the cohort profile summary, including the `[UNKNOWN]` list and the
+unclassified variables. Confirm before proceeding.
 
 ---
 

--- a/skills/find-cohort-gap/references/cohort_profile_template.md
+++ b/skills/find-cohort-gap/references/cohort_profile_template.md
@@ -86,8 +86,22 @@ List known papers already published from this cohort (to avoid topic duplication
 
 ## Variable Cluster Map (Auto-generated)
 
-If a data dictionary is provided, the skill will auto-generate clusters below:
+If a codebook / data dictionary / CSV export is available, do not fill this in by hand
+and do not summarise the file yourself — run the input adapter:
 
-| Cluster | Variables | Serial? | Endpoint Link? |
-|---------|-----------|---------|----------------|
-| (auto-filled) | | | |
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/build_cohort_profile.py" --codebook <file> --out-dir .
+```
+
+It writes `cohort_profile.md` + `cohort_profile.json` with:
+
+| Section | Content |
+|---------|---------|
+| Variable cluster map | every variable copied **verbatim**, with its source (`file:row`) and the keyword that placed it in its cluster |
+| Serial / repeated measures | measurement groups that genuinely repeat (evidence for **P1**) |
+| Endpoint candidates | mortality / cancer / CVD / hospitalisation variables (evidence for **P2**) |
+| `[UNKNOWN]` list | sample size, follow-up, IRB, prior publications — **ask the user; never guess** |
+
+Variables that match no cluster keyword are reported as `unclassified` rather than forced
+into a bucket. Review them: the lexicon is not exhaustive, and a mis-clustered exposure
+variable will distort the intersection matrix.

--- a/skills/find-cohort-gap/scripts/build_cohort_profile.py
+++ b/skills/find-cohort-gap/scripts/build_cohort_profile.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Build a cohort profile from a local codebook (and optional domain context).
+
+`/find-cohort-gap` used to start from a *named* database — NHIS, UK Biobank, and the
+handful of registries the skill knows about. Most researchers do not have one of those.
+They have an institutional registry, a single-centre EMR export, or a specialty cohort,
+described by a data dictionary nobody else has ever seen (issue #69).
+
+This is the input layer that lets them in. It reads their codebook and emits the same
+cohort profile the skill already consumes, so everything downstream — the intersection
+matrix, saturation scan, 6-pattern scoring — is unchanged.
+
+WHY A SCRIPT AND NOT JUST READING THE FILE. A language model asked to "summarise this
+codebook" will paraphrase a variable name, merge two variables that look alike, or
+quietly invent one that the cohort does not have — and every downstream claim inherits
+it. So the variable inventory is *enumerated*, never generated: each variable is copied
+verbatim from the file and carries its provenance (`file:row`), which is exactly the
+dictionary-first discipline that a reviewer expects of a DB-backed study.
+
+WHAT IT REFUSES TO DO. A codebook lists variables; it does not state the sample size,
+the enrollment window, the follow-up duration, or the IRB status. Those are emitted as
+`[UNKNOWN - ask the user]`, never guessed — a fabricated N is worse than a missing one,
+because it survives all the way to a feasibility gate that then passes for the wrong
+reason.
+
+WHAT IT INFERS (and shows its work). Two structural facts *are* derivable from variable
+names alone, and both feed patterns the skill already scores:
+
+  * serial / repeated measures (`bp_v1`, `bp_v2`, `visit2_hba1c`, ...) -> P1 Longitudinal
+    Advantage. Reported as the actual variable groups, so the claim is auditable.
+  * endpoint-like variables (`death_date`, `cvd_event`, `cancer_incidence`) -> P2
+    Endpoint Upgrade.
+
+Every cluster assignment records the keyword that triggered it, and anything that matches
+nothing is left `unclassified` rather than forced into a bucket.
+
+Usage:
+    build_cohort_profile.py --codebook dict.csv [--codebook more.xlsx ...] \\
+        [--context review.pdf --context https://example.org/guideline] \\
+        [--cohort-name "Institutional CT registry"] [--out-dir .]
+
+Formats: .csv / .tsv / .json / .md / .txt (stdlib), .xlsx (needs openpyxl),
+.pdf (needs `pdftotext` from poppler). Context URLs are fetched with stdlib urllib;
+a paywalled or JavaScript-rendered page will not extract, and that is reported rather
+than papered over.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html.parser
+import json
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+UNKNOWN = "[UNKNOWN - ask the user]"
+
+# Variable-name lexicons. Each cluster maps to the template's category names, and the
+# matched keyword is recorded so a wrong assignment is visible instead of silent.
+#
+# Short keys are matched as WHOLE TOKENS, not substrings (see `classify`). Substring
+# matching on a two-letter abbreviation is a false-positive machine: `us` (ultrasound)
+# fires on `statin_use`, and `age` fires on `storage_temp`. Long keys keep substring
+# matching so that `smok` still catches `smoking_status`.
+CLUSTERS: dict[str, tuple[str, ...]] = {
+    "demographics": (
+        "age", "sex", "gender", "birth", "race", "ethnic", "income", "educat",
+        "marital", "occupation", "smok", "alcohol", "drink", "exercise", "activity",
+    ),
+    "anthropometry": ("height", "weight", "bmi", "waist", "hip", "circumf", "body_fat", "muscle"),
+    "vital_signs": ("sbp", "dbp", "bp", "blood_pressure", "pulse", "heart_rate", "hr", "resp_rate", "temp"),
+    "laboratory": (
+        "glucose", "glu", "hba1c", "chol", "lipid", "ldl", "hdl", "triglyc", "tg", "ast", "alt",
+        "ggt", "bilirubin", "albumin", "creatinin", "egfr", "bun", "uric", "crp", "esr",
+        "hb", "hgb", "hct", "wbc", "rbc", "platelet", "psa", "cea", "afp", "ca19", "tsh",
+        "insulin", "lab",
+    ),
+    "imaging": (
+        "ct", "mri", "xray", "x_ray", "cxr", "ultrasound", "us", "sono", "dexa",
+        "dxa", "mammo", "echo", "angio", "pet", "cac", "calcium_score", "imaging", "radiol",
+    ),
+    "questionnaire": (
+        "phq", "gad", "psqi", "ipaq", "sf36", "sf_36", "eq5d", "eq_5d", "qol", "questionn",
+        "survey", "scale", "sleep", "diet", "food_freq", "ffq", "stress", "depress",
+    ),
+    "medication": ("med", "drug", "rx", "prescri", "statin", "antihyp", "therapy", "treat"),
+    "procedure": ("surg", "operat", "procedur", "biopsy", "resect", "ablat", "stent", "pci", "cabg", "intervention"),
+    "diagnosis": ("icd", "diag", "dx", "disease", "hypertension", "diabetes", "history_of", "hx", "comorbid"),
+    "identifier_admin": ("id", "key", "index", "seq", "code", "visit_date", "site", "center"),
+}
+
+# Below this length a keyword is matched as a whole token, never as a substring.
+TOKEN_ONLY = 4
+
+# Endpoint-like variables. A cohort's value proposition is usually its hard endpoints, and
+# the skill scores that (P2), so surface them explicitly.
+ENDPOINT_HINTS = (
+    "death", "mortal", "expire", "died", "survival", "cancer", "malign", "incid",
+    "cvd", "chd", "mace", "stroke", "myocard", "mi", "infarct", "event", "outcome",
+    "hospital", "admission", "readmit", "recurrence", "progression", "relapse",
+)
+
+# Serial / repeated measures: <stem><separator><index>, or an explicit visit/wave marker.
+SERIAL_SUFFIX = re.compile(r"^(?P<stem>.+?)[ _\-.]?(?:v|t|w|wave|visit|yr|y|round|r|time)?(?P<idx>\d{1,2})$", re.I)
+SERIAL_PREFIX = re.compile(r"^(?:v|t|w|wave|visit|yr|y|round|time)(?P<idx>\d{1,2})[ _\-.](?P<stem>.+)$", re.I)
+
+# A column in a codebook that holds the variable NAME (as opposed to its description).
+NAME_COL = re.compile(r"^\s*(variable|var|var_?name|name|field|field_?name|column|col|item|code)\s*$", re.I)
+DESC_COL = re.compile(r"^\s*(desc|description|label|definition|meaning|explanation|comment|note|한글|설명)", re.I)
+
+
+class _Strip(html.parser.HTMLParser):
+    """Minimal HTML -> text. Not a browser: a JS-rendered page yields nothing, and the
+    caller is told so rather than being handed an empty 'context'."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.chunks: list[str] = []
+        self._skip = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style", "nav", "footer"):
+            self._skip += 1
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style", "nav", "footer") and self._skip:
+            self._skip -= 1
+
+    def handle_data(self, data):
+        if not self._skip and data.strip():
+            self.chunks.append(data.strip())
+
+
+# --------------------------------------------------------------------------------------
+# Variable extraction — one function per format, all returning (name, description, where)
+# --------------------------------------------------------------------------------------
+
+Var = tuple[str, str, str]
+
+
+def _from_delimited(path: Path, delim: str) -> list[Var]:
+    """A .csv/.tsv is either a CODEBOOK (rows are variables) or a DATA export (columns are
+    variables). Decide by whether a header column names a variable column."""
+    with path.open(newline="", encoding="utf-8-sig", errors="replace") as fh:
+        rows = list(csv.reader(fh, delimiter=delim))
+    if not rows:
+        return []
+    header = rows[0]
+    name_idx = next((i for i, h in enumerate(header) if NAME_COL.match(h or "")), None)
+
+    if name_idx is None:  # data export: the header row IS the variable list
+        return [
+            (h.strip(), "", f"{path.name}:1 (column {i + 1})")
+            for i, h in enumerate(header)
+            if h and h.strip()
+        ]
+
+    desc_idx = next((i for i, h in enumerate(header) if DESC_COL.match(h or "")), None)
+    out: list[Var] = []
+    for r, row in enumerate(rows[1:], start=2):
+        if name_idx >= len(row) or not (row[name_idx] or "").strip():
+            continue
+        desc = row[desc_idx].strip() if desc_idx is not None and desc_idx < len(row) else ""
+        out.append((row[name_idx].strip(), desc, f"{path.name}:{r}"))
+    return out
+
+
+def _from_json(path: Path) -> list[Var]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[Var] = []
+    if isinstance(data, dict):
+        for i, (k, v) in enumerate(data.items(), start=1):
+            desc = v if isinstance(v, str) else (v.get("description", "") if isinstance(v, dict) else "")
+            out.append((str(k), str(desc), f"{path.name}:key {i}"))
+    elif isinstance(data, list):
+        for i, item in enumerate(data, start=1):
+            if isinstance(item, str):
+                out.append((item, "", f"{path.name}:item {i}"))
+            elif isinstance(item, dict):
+                name = next((item[k] for k in ("variable", "var", "name", "field", "column") if k in item), None)
+                if name:
+                    desc = next((item[k] for k in ("description", "desc", "label", "definition") if k in item), "")
+                    out.append((str(name), str(desc), f"{path.name}:item {i}"))
+    return out
+
+
+def _from_markdown(text: str, origin: str) -> list[Var]:
+    """A markdown/plain codebook: a pipe table, or `var` — description lines."""
+    out: list[Var] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        s = line.strip()
+        if not s or set(s) <= set("|-: "):  # separator row
+            continue
+        if s.startswith("|"):
+            cells = [c.strip().strip("`*") for c in s.strip("|").split("|")]
+            if len(cells) >= 1 and cells[0] and not NAME_COL.match(cells[0]):
+                out.append((cells[0], cells[1] if len(cells) > 1 else "", f"{origin}:{i}"))
+            continue
+        m = re.match(r"^[-*+]?\s*`([^`]+)`\s*[-–—:]?\s*(.*)$", s)
+        if m:
+            out.append((m.group(1).strip(), m.group(2).strip(), f"{origin}:{i}"))
+    return out
+
+
+def _from_xlsx(path: Path) -> list[Var]:
+    try:
+        from openpyxl import load_workbook  # type: ignore
+    except ImportError:
+        raise SystemExit(
+            f"reading {path.name} needs openpyxl (`pip install openpyxl`). "
+            "Or export the sheet to .csv and pass that — the CSV path is stdlib-only."
+        )
+    ws = load_workbook(path, read_only=True, data_only=True).active
+    rows = [[("" if c is None else str(c)) for c in row] for row in ws.iter_rows(values_only=True)]
+    if not rows:
+        return []
+    header = rows[0]
+    name_idx = next((i for i, h in enumerate(header) if NAME_COL.match(h or "")), None)
+    if name_idx is None:
+        return [(h.strip(), "", f"{path.name}:1 (column {i + 1})") for i, h in enumerate(header) if h.strip()]
+    desc_idx = next((i for i, h in enumerate(header) if DESC_COL.match(h or "")), None)
+    out: list[Var] = []
+    for r, row in enumerate(rows[1:], start=2):
+        if name_idx >= len(row) or not row[name_idx].strip():
+            continue
+        desc = row[desc_idx].strip() if desc_idx is not None and desc_idx < len(row) else ""
+        out.append((row[name_idx].strip(), desc, f"{path.name}:{r}"))
+    return out
+
+
+def _pdf_text(path: Path) -> str:
+    if not shutil.which("pdftotext"):
+        raise SystemExit(
+            f"reading {path.name} needs `pdftotext` (poppler: `brew install poppler` / "
+            "`apt install poppler-utils`). Or convert the PDF to .md / .txt and pass that."
+        )
+    p = subprocess.run(["pdftotext", "-layout", str(path), "-"], capture_output=True, text=True)
+    if p.returncode != 0:
+        raise SystemExit(f"pdftotext failed on {path.name}: {p.stderr.strip()}")
+    return p.stdout
+
+
+def read_codebook(path: Path) -> list[Var]:
+    if not path.is_file():
+        raise SystemExit(f"not found: {path}")
+    suf = path.suffix.lower()
+    if suf == ".csv":
+        return _from_delimited(path, ",")
+    if suf in (".tsv", ".tab"):
+        return _from_delimited(path, "\t")
+    if suf == ".json":
+        return _from_json(path)
+    if suf == ".xlsx":
+        return _from_xlsx(path)
+    if suf == ".pdf":
+        return _from_markdown(_pdf_text(path), path.name)
+    if suf in (".md", ".markdown", ".txt"):
+        return _from_markdown(path.read_text(encoding="utf-8", errors="replace"), path.name)
+    raise SystemExit(f"unsupported codebook format: {path.suffix} ({path.name})")
+
+
+# --------------------------------------------------------------------------------------
+# Structure inference — clusters, serial groups, endpoints
+# --------------------------------------------------------------------------------------
+
+
+def _tokens(s: str) -> set[str]:
+    return set(re.split(r"[^a-z0-9]+", s.lower())) - {""}
+
+
+def _hits(key: str, hay: str, toks: set[str]) -> bool:
+    """A short key must BE a token; a long key may appear anywhere.
+
+    This is the whole defence against the abbreviation false positive: `us` matching
+    `statin_use`, `age` matching `storage_temp`, `id` matching `lipid`.
+    """
+    if len(key) >= TOKEN_ONLY or "_" in key:
+        return key in hay
+    return key in toks
+
+
+def classify(name: str, desc: str) -> tuple[str, str]:
+    """Return (cluster, matched_keyword). Unmatched stays 'unclassified' — a variable is
+    never forced into a bucket to make the map look complete."""
+    hay = f"{name} {desc}".lower()
+    toks = _tokens(hay)
+    for cluster, keys in CLUSTERS.items():
+        for k in keys:
+            if _hits(k, hay, toks):
+                return cluster, k
+    return "unclassified", ""
+
+
+def is_endpoint(name: str, desc: str) -> str:
+    hay = f"{name} {desc}".lower()
+    toks = _tokens(hay)
+    return next((k for k in ENDPOINT_HINTS if _hits(k, hay, toks)), "")
+
+
+def serial_groups(names: list[str]) -> dict[str, list[str]]:
+    """Group variables that look like the same measurement repeated over time.
+
+    Only a stem seen with >= 2 distinct indices counts: a lone `visit1_bp` is not evidence
+    of serial data, and claiming otherwise would hand P1 a free point it has not earned.
+    """
+    stems: dict[str, dict[str, str]] = {}
+    for n in names:
+        for rx in (SERIAL_PREFIX, SERIAL_SUFFIX):
+            m = rx.match(n)
+            if m:
+                stem = m.group("stem").strip("_- .").lower()
+                if stem:
+                    stems.setdefault(stem, {})[m.group("idx")] = n
+                break
+    return {
+        stem: [v for _, v in sorted(idx.items(), key=lambda kv: int(kv[0]))]
+        for stem, idx in stems.items()
+        if len(idx) >= 2
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Domain context (a review, a guideline page) — extracted, never summarised here
+# --------------------------------------------------------------------------------------
+
+
+def read_context(src: str) -> tuple[str, str]:
+    """Return (text, provenance). The LLM reads this; the script only fetches it."""
+    if src.startswith(("http://", "https://")):
+        try:
+            req = urllib.request.Request(src, headers={"User-Agent": "medsci-skills/find-cohort-gap"})
+            with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310 - user-supplied context URL
+                raw = r.read().decode("utf-8", errors="replace")
+        except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+            raise SystemExit(
+                f"could not fetch {src}: {exc}\n"
+                "If the page is paywalled or JavaScript-rendered (UpToDate and many guideline "
+                "portals are), save it as PDF/markdown and pass the file instead."
+            )
+        p = _Strip()
+        p.feed(raw)
+        text = "\n".join(p.chunks)
+        if len(text.split()) < 50:
+            raise SystemExit(
+                f"{src} yielded almost no text ({len(text.split())} words) — it is probably "
+                "JavaScript-rendered or paywalled. Save it as PDF/markdown and pass the file."
+            )
+        return text, src
+    path = Path(src)
+    if not path.is_file():
+        raise SystemExit(f"not found: {src}")
+    if path.suffix.lower() == ".pdf":
+        return _pdf_text(path), path.name
+    return path.read_text(encoding="utf-8", errors="replace"), path.name
+
+
+# --------------------------------------------------------------------------------------
+
+
+def build(codebooks: list[Path], contexts: list[str], cohort_name: str | None) -> tuple[dict, str]:
+    variables: list[dict] = []
+    seen: set[str] = set()
+    for cb in codebooks:
+        for name, desc, where in read_codebook(cb):
+            if name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            cluster, kw = classify(name, desc)
+            variables.append(
+                {
+                    "name": name,
+                    "description": desc,
+                    "source": where,
+                    "cluster": cluster,
+                    "matched_keyword": kw,
+                    "endpoint_hint": is_endpoint(name, desc),
+                }
+            )
+
+    names = [v["name"] for v in variables]
+    serial = serial_groups(names)
+    endpoints = [v for v in variables if v["endpoint_hint"]]
+
+    by_cluster: dict[str, list[str]] = {}
+    for v in variables:
+        by_cluster.setdefault(v["cluster"], []).append(v["name"])
+
+    ctx: list[dict] = []
+    for c in contexts:
+        text, prov = read_context(c)
+        ctx.append({"source": prov, "words": len(text.split()), "text": text})
+
+    profile = {
+        "cohort_name": cohort_name or UNKNOWN,
+        "codebooks": [str(c) for c in codebooks],
+        "n_variables": len(variables),
+        "variables": variables,
+        "clusters": {k: sorted(v) for k, v in sorted(by_cluster.items())},
+        "serial_groups": serial,
+        "endpoint_candidates": [v["name"] for v in endpoints],
+        "context_documents": [{"source": c["source"], "words": c["words"]} for c in ctx],
+        # Not derivable from a codebook. Guessing any of these corrupts the feasibility gate.
+        "must_ask_user": {
+            "n_baseline": UNKNOWN,
+            "n_with_followup": UNKNOWN,
+            "enrollment_period": UNKNOWN,
+            "followup_duration": UNKNOWN,
+            "measurement_intervals": UNKNOWN,
+            "irb_status": UNKNOWN,
+            "existing_publications": UNKNOWN,
+            "known_limitations": UNKNOWN,
+        },
+    }
+    return profile, "\n\n".join(f"# Context: {c['source']}\n\n{c['text']}" for c in ctx)
+
+
+def render_markdown(p: dict) -> str:
+    L = [
+        "# Cohort Profile (auto-generated)",
+        "",
+        f"**Cohort name:** {p['cohort_name']}",
+        f"**Codebook(s):** {', '.join(p['codebooks']) or UNKNOWN}",
+        f"**Variables enumerated:** {p['n_variables']}",
+        "",
+        "> Every variable below is copied verbatim from the codebook and carries its source",
+        "> location. Nothing here is inferred except the cluster assignment and the serial /",
+        "> endpoint flags, each of which shows the keyword that triggered it.",
+        "",
+        "## Variable Cluster Map",
+        "",
+        "| Cluster | N | Variables |",
+        "|---------|--:|-----------|",
+    ]
+    for cluster, vs in p["clusters"].items():
+        shown = ", ".join(f"`{v}`" for v in vs[:12])
+        if len(vs) > 12:
+            shown += f", … (+{len(vs) - 12})"
+        L.append(f"| {cluster} | {len(vs)} | {shown} |")
+
+    L += ["", "## Serial / repeated measures (evidence for P1 Longitudinal Advantage)", ""]
+    if p["serial_groups"]:
+        L += ["| Measurement | Timepoints | Variables |", "|-------------|-----------:|-----------|"]
+        for stem, vs in sorted(p["serial_groups"].items()):
+            L.append(f"| {stem} | {len(vs)} | {', '.join(f'`{v}`' for v in vs)} |")
+    else:
+        L.append("None detected from variable names. If the cohort *does* have repeated measures,")
+        L.append("say so — the naming convention may simply not encode the timepoint.")
+
+    L += ["", "## Endpoint candidates (evidence for P2 Endpoint Upgrade)", ""]
+    if p["endpoint_candidates"]:
+        L += [", ".join(f"`{v}`" for v in p["endpoint_candidates"])]
+    else:
+        L.append("None detected. Without a hard endpoint, P2 cannot score and the cohort is")
+        L.append("limited to cross-sectional questions — confirm before proceeding.")
+
+    if p["context_documents"]:
+        L += ["", "## Domain context supplied", ""]
+        for c in p["context_documents"]:
+            L.append(f"- {c['source']} ({c['words']:,} words) — see `context_extract.md`")
+
+    L += [
+        "",
+        "## Not derivable from a codebook — ASK THE USER before Phase 2",
+        "",
+        "A data dictionary lists variables. It does not state any of the following, and a",
+        "guessed value here would silently pass the Phase 5 feasibility gate for the wrong reason.",
+        "",
+    ]
+    L += [f"- **{k.replace('_', ' ')}:** {v}" for k, v in p["must_ask_user"].items()]
+    return "\n".join(L) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--codebook", action="append", type=Path, required=True,
+                    help="data dictionary / codebook / CSV header (repeatable)")
+    ap.add_argument("--context", action="append", default=[],
+                    help="domain context: a review/guideline file (.md/.txt/.pdf) or a URL (repeatable)")
+    ap.add_argument("--cohort-name", help="what the cohort is called")
+    ap.add_argument("--out-dir", type=Path, default=Path("."))
+    a = ap.parse_args()
+
+    profile, context_text = build(a.codebook, a.context, a.cohort_name)
+    if not profile["n_variables"]:
+        raise SystemExit(
+            "no variables found. If this is a data export, the first row must be the header; "
+            "if it is a codebook, one column must be named variable / var / name / field / column."
+        )
+
+    a.out_dir.mkdir(parents=True, exist_ok=True)
+    (a.out_dir / "cohort_profile.json").write_text(json.dumps(profile, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    (a.out_dir / "cohort_profile.md").write_text(render_markdown(profile), encoding="utf-8")
+    if context_text:
+        (a.out_dir / "context_extract.md").write_text(context_text + "\n", encoding="utf-8")
+
+    print(f"{profile['n_variables']} variables enumerated from {len(a.codebook)} codebook(s)")
+    for cluster, vs in profile["clusters"].items():
+        print(f"  {cluster:<18} {len(vs)}")
+    print(f"  serial groups      {len(profile['serial_groups'])}")
+    print(f"  endpoint candidates {len(profile['endpoint_candidates'])}")
+    unclassified = len(profile["clusters"].get("unclassified", []))
+    if unclassified:
+        print(f"\n{unclassified} variable(s) matched no cluster — review them; the lexicon is not exhaustive.")
+    print(f"\nwrote {a.out_dir / 'cohort_profile.md'} + cohort_profile.json")
+    print("ASK THE USER for: " + ", ".join(k.replace("_", " ") for k in profile["must_ask_user"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/find-cohort-gap/skill.yml
+++ b/skills/find-cohort-gap/skill.yml
@@ -8,11 +8,15 @@ when_to_use: "Find research gaps in a longitudinal cohort DB by profiling its st
 when_NOT_to_use: "Finding meta-analysis topics (use ma-scout); designing a chosen study (use design-study)."
 
 inputs:
-  - "cohort profile / data dictionary"
+  - "named cohort, OR a local codebook / data dictionary / CSV export (.csv/.tsv/.json/.md/.xlsx/.pdf)"
+  - "optional domain context: a review / guideline / preprint (file or URL)"
   - "PI expertise"
   - "literature landscape"
 outputs:
+  - "cohort_profile.md + cohort_profile.json (variables enumerated verbatim, with provenance)"
   - "ranked topic proposals with gap evidence"
+deterministic_scripts:
+  - scripts/build_cohort_profile.py
 side_effects:
   - writes_report_artifacts
   - network_access_literature
@@ -22,6 +26,8 @@ downstream_consumers:
 forbidden_actions:
   - claim_a_gap_without_literature_evidence
   - fabricate_saturation_counts
+  - invent_a_variable_the_codebook_does_not_contain
+  - guess_a_sample_size_or_follow_up_the_codebook_does_not_state
 
 # v2.1 quality card
 purpose: "Rank under-studied topics for a specific cohort, each backed by literature-saturation evidence and feasibility."
@@ -31,6 +37,9 @@ safety_boundaries:
 known_limitations:
   - "Literature scans are point-in-time; a gap can close between scan and submission."
   - "No standalone demo; proposals require domain judgement."
+  - "The codebook adapter clusters variables by a keyword lexicon that is not exhaustive; unmatched variables are surfaced as 'unclassified' for the user to review rather than force-assigned."
+  - "A codebook cannot state sample size, follow-up, or IRB status; those are emitted as [UNKNOWN] and must be collected from the user."
 validation_commands:
+  - "bash tests/test_cohort_profile.sh"
   - "re-run the saturation search before committing to a topic"
-evidence_surface: manual_workflow
+evidence_surface: bundled_script

--- a/skills/find-cohort-gap/tests/test_cohort_profile.sh
+++ b/skills/find-cohort-gap/tests/test_cohort_profile.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Regression test for skills/find-cohort-gap/scripts/build_cohort_profile.py — the
+# local-codebook / document input layer (issue #69).
+#
+# The contract under test is as much about what the adapter REFUSES to do as what it
+# extracts: variables are enumerated verbatim with provenance (never paraphrased or
+# invented), a sample size that the codebook does not state stays [UNKNOWN], and a serial
+# structure is only claimed when a measurement really does repeat.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+B="$REPO_ROOT/skills/find-cohort-gap/scripts/build_cohort_profile.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-54s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-54s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- a CODEBOOK (rows are variables, one column names them) ---
+cat > "$TMP/codebook.csv" <<'CSV'
+variable,description,type
+subject_id,Study identifier,char
+age,Age at baseline in years,num
+sex,Biological sex,char
+sbp_v1,Systolic blood pressure at visit 1,num
+sbp_v2,Systolic blood pressure at visit 2,num
+sbp_v3,Systolic blood pressure at visit 3,num
+hba1c,Glycated haemoglobin,num
+ct_lung_nodule,Lung nodule seen on chest CT,char
+phq9_total,PHQ-9 depression score,num
+statin_use,Statin prescription at baseline,char
+death_date,Date of death from national registry,date
+cvd_event,Incident cardiovascular event,char
+weird_unmatchable_token,,char
+CSV
+
+# --- a DATA EXPORT (columns are the variables; no codebook column) ---
+printf 'age,sex,ldl_chol,mri_brain,death_date\n45,M,130,normal,\n' > "$TMP/export.csv"
+
+# --- a markdown codebook (pipe table AND bullet/backtick lines) ---
+cat > "$TMP/codebook.md" <<'MD'
+| variable | description |
+|----------|-------------|
+| waist_circumference | Waist circumference (cm) |
+
+Additional variables:
+
+- `alt` — Alanine aminotransferase
+MD
+
+# --- a JSON codebook ---
+cat > "$TMP/codebook.json" <<'JSON'
+{"egfr": "Estimated glomerular filtration rate", "cancer_incidence": "Incident cancer from registry"}
+JSON
+
+# 1) a codebook is read and every variable is enumerated
+python3 "$B" --codebook "$TMP/codebook.csv" --cohort-name "Test registry" --out-dir "$TMP/o1" > /dev/null 2>&1
+ck "codebook (rows = variables) is read" 0 "$?"
+
+python3 - "$TMP/o1/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+names = [v["name"] for v in p["variables"]]
+assert len(names) == 13, f"expected 13 variables, got {len(names)}: {names}"
+# verbatim, not paraphrased
+for must in ("sbp_v1", "ct_lung_nodule", "phq9_total", "weird_unmatchable_token"):
+    assert must in names, f"{must} missing — variables must be copied verbatim"
+# provenance points at the real row
+src = {v["name"]: v["source"] for v in p["variables"]}
+assert src["age"].endswith(":3"), f"bad provenance for age: {src['age']}"
+PY
+ck "variables verbatim + provenance (file:row)" 0 "$?"
+
+# 2) clusters are assigned, and an unmatchable variable is NOT forced into a bucket
+python3 - "$TMP/o1/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+c = {v["name"]: v["cluster"] for v in p["variables"]}
+assert c["age"] == "demographics", c["age"]
+assert c["hba1c"] == "laboratory", c["hba1c"]
+assert c["ct_lung_nodule"] == "imaging", c["ct_lung_nodule"]
+assert c["phq9_total"] == "questionnaire", c["phq9_total"]
+assert c["statin_use"] == "medication", c["statin_use"]
+assert c["weird_unmatchable_token"] == "unclassified", c["weird_unmatchable_token"]
+# every assignment shows the keyword that caused it
+assert all(v["matched_keyword"] for v in p["variables"] if v["cluster"] != "unclassified")
+PY
+ck "clusters assigned; unmatched stays 'unclassified'" 0 "$?"
+
+# 2b) the abbreviation false positive: a short keyword must match a whole TOKEN, never a
+# substring. `us` (ultrasound) inside `statin_use` once made a statin an imaging variable.
+python3 - "$B" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("bcp", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+cases = [
+    ("statin_use", "Statin prescription", "medication"),   # not imaging via "us"
+    ("lipid_panel", "Lipid panel", "laboratory"),          # not identifier_admin via "id"
+    ("ct_lung_nodule", "Chest CT nodule", "imaging"),      # token "ct" still works
+    ("sbp_v1", "Systolic BP visit 1", "vital_signs"),
+]
+for name, desc, want in cases:
+    got, kw = m.classify(name, desc)
+    assert got == want, f"{name!r} -> {got} (via {kw!r}), expected {want}"
+PY
+ck "short keywords match whole tokens, not substrings" 0 "$?"
+
+# 3) serial structure detected — the P1 evidence — and only when it really repeats
+python3 - "$TMP/o1/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+sg = p["serial_groups"]
+assert "sbp" in sg, f"sbp_v1/v2/v3 not detected as serial: {sg}"
+assert sg["sbp"] == ["sbp_v1", "sbp_v2", "sbp_v3"], sg["sbp"]
+# phq9_total ends in a digit but never repeats -> must NOT be claimed as serial
+assert "phq" not in sg and "phq9_total" not in sg, f"false serial group: {sg}"
+PY
+ck "serial group found; a lone digit-suffixed var is not one" 0 "$?"
+
+# 4) endpoints surfaced (P2 evidence)
+python3 - "$TMP/o1/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+e = set(p["endpoint_candidates"])
+assert {"death_date", "cvd_event"} <= e, e
+assert "age" not in e
+PY
+ck "endpoint candidates surfaced (death, cvd event)" 0 "$?"
+
+# 5) THE ANTI-HALLUCINATION CONTRACT: what a codebook cannot state stays UNKNOWN
+python3 - "$TMP/o1/cohort_profile.json" "$TMP/o1/cohort_profile.md" <<'PY'
+import json, re, sys
+p = json.load(open(sys.argv[1]))
+must = p["must_ask_user"]
+for k in ("n_baseline", "enrollment_period", "followup_duration", "irb_status"):
+    assert must[k] == "[UNKNOWN - ask the user]", f"{k} was invented: {must[k]!r}"
+md = open(sys.argv[2]).read()
+assert "ASK THE USER" in md.upper()
+# no fabricated sample size anywhere in the rendered profile
+assert not re.search(r"\bN\s*=\s*[\d,]+", md), "a sample size appeared from nowhere"
+PY
+ck "un-stated facts stay [UNKNOWN], never guessed" 0 "$?"
+
+# 6) a DATA EXPORT (header row = variables) is routed correctly
+python3 "$B" --codebook "$TMP/export.csv" --out-dir "$TMP/o2" > /dev/null 2>&1
+python3 - "$TMP/o2/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+names = [v["name"] for v in p["variables"]]
+assert names == ["age", "sex", "ldl_chol", "mri_brain", "death_date"], names
+assert not any(v["name"] == "45" for v in p["variables"]), "read a data row as a variable"
+PY
+ck "data export (header = variables) routed correctly" 0 "$?"
+
+# 7) markdown + json codebooks, and multiple codebooks merge without duplicates
+python3 "$B" --codebook "$TMP/codebook.md" --codebook "$TMP/codebook.json" \
+  --codebook "$TMP/codebook.csv" --out-dir "$TMP/o3" > /dev/null 2>&1
+python3 - "$TMP/o3/cohort_profile.json" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))
+names = [v["name"] for v in p["variables"]]
+for must in ("waist_circumference", "alt", "egfr", "cancer_incidence", "sbp_v1"):
+    assert must in names, f"{must} missing from merged profile"
+assert len(names) == len(set(n.lower() for n in names)), "duplicate variables across codebooks"
+PY
+ck "markdown + json + csv codebooks merge, de-duplicated" 0 "$?"
+
+# 8) a local document is attached as domain context (no URL needed)
+cat > "$TMP/review.md" <<'MD'
+# Narrative review: coronary calcium and mortality
+Coronary artery calcium scoring predicts cardiovascular events across populations.
+Repeated scanning and its incremental value remain debated.
+MD
+python3 "$B" --codebook "$TMP/codebook.csv" --context "$TMP/review.md" --out-dir "$TMP/o4" > /dev/null 2>&1
+ck "local document accepted as domain context" 0 "$?"
+grep -q "coronary calcium" "$TMP/o4/context_extract.md"
+ck "context text extracted to context_extract.md" 0 "$?"
+
+# 9) a missing file fails loudly rather than proceeding with an empty profile
+python3 "$B" --codebook "$TMP/does_not_exist.csv" --out-dir "$TMP/o5" > /dev/null 2>&1
+ck "missing codebook fails loudly" 1 "$?"
+
+# 10) an unparseable codebook fails rather than emitting an empty profile
+printf 'just some prose with no table and no variables at all\n' > "$TMP/prose.txt"
+python3 "$B" --codebook "$TMP/prose.txt" --out-dir "$TMP/o6" > /dev/null 2>&1
+ck "codebook with no variables fails (no empty profile)" 1 "$?"
+
+echo "----"
+echo "test_cohort_profile: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #69 (requested by @Rochelle1995).

## The problem

`/find-cohort-gap` only ever started from a **named** database — NHIS, UK Biobank, and the handful of registries it knows about. Most researchers do not have one of those. They have an institutional registry, a single-centre EMR export, or a specialty cohort described by a data dictionary nobody else has ever seen. For them the skill did not work at all.

## The input layer

`scripts/build_cohort_profile.py` reads their codebook and emits the same cohort profile the skill already consumes, so **everything downstream is unchanged** — the intersection matrix, the saturation scan, the 6-pattern scoring.

```bash
python3 scripts/build_cohort_profile.py \
  --codebook data_dictionary.csv \
  --context narrative_review.pdf --context https://example.org/guideline \
  --cohort-name "Institutional CT registry"
```

- **Codebooks**: `.csv` / `.tsv` / `.json` / `.md` / `.txt` (stdlib), `.xlsx` (openpyxl), `.pdf` (`pdftotext`). A `.csv` is auto-detected as a *codebook* (rows are variables) or a *data export* (the header row is the variable list).
- **Domain context**: a review / guideline / preprint, as a file or a URL. A paywalled or JS-rendered page is reported as such rather than silently yielding an empty "context".

## Why a script, and not just letting the model read the file

Asked to *summarise* a codebook, a language model will paraphrase a variable name, merge two that look alike, or quietly invent one the cohort does not have — and the intersection matrix, the feasibility gate, and eventually the manuscript's Methods all inherit it.

So variables are **enumerated, never generated**: copied verbatim, each carrying its provenance (`file:row`). That is the dictionary-first discipline a reviewer expects of a DB-backed study.

And what a codebook **cannot** state — sample size, follow-up duration, IRB status, prior publications — is emitted as `[UNKNOWN - ask the user]` rather than guessed. A fabricated N does not merely sit in a profile; it flows into the Phase 5 feasibility gate, which then passes (or fails) for a reason that has nothing to do with the cohort.

## What it does infer, and shows its work for

Two structural facts *are* derivable from variable names, and both feed patterns the skill already scores:

- **Serial / repeated-measure groups** → P1 Longitudinal Advantage. `sbp_v1, sbp_v2, sbp_v3` is reported as a group; a lone `phq9_total` that merely ends in a digit is **not** claimed as serial, so P1 cannot collect a free point.
- **Endpoint candidates** → P2 Endpoint Upgrade.

Every cluster assignment records the keyword that triggered it, and a variable matching nothing is left `unclassified` rather than forced into a bucket — the lexicon is not exhaustive and says so.

## Tests

`skills/find-cohort-gap/tests/test_cohort_profile.sh` — 13 assertions, CI-wired: codebook vs data-export routing, verbatim extraction with provenance, cluster assignment, the `[UNKNOWN]` contract (asserts no sample size materialises anywhere in the rendered profile), serial detection, endpoint detection, multi-codebook merge, context attachment, and loud failure on a missing or unparseable file.

The test earned its keep immediately: it caught the ultrasound abbreviation `us` matching **`statin_use`** and filing a statin under *imaging*. Short lexicon keys now match whole tokens, never substrings (`id` no longer matches `lipid`, `age` no longer matches `storage`), with a dedicated regression case.

Full CI mirror green locally, including `validate_skills.sh`, the catalog generators, and the release-ZIP round trip. No detector count change (`build_*` is a producer, not a detector). The skill's evidence surface moves from `manual_workflow` to `bundled_script`.