### PR TITLE
fix(find-cohort-gap): a hard endpoint is a cluster, not "unclassified"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@
 
   Two structural facts *are* derivable from variable names, and both feed patterns the skill already
   scores: **serial / repeated-measure groups** (P1 Longitudinal Advantage) and **endpoint candidates**
-  (P2 Endpoint Upgrade). Each is reported with the variables that justify it, and a measurement is only
+  (P2 Endpoint Upgrade). Endpoints also get a cluster of their own (`outcome_endpoint`), assigned only
+  when no other cluster claims the variable — otherwise the profile contradicted itself, listing
+  `death_date` as "matched nothing, review it" in the cluster map while citing it as the P2 evidence
+  two sections below. Each is reported with the variables that justify it, and a measurement is only
   called serial when it genuinely repeats. Cluster assignment records the keyword that triggered it, and
   a variable matching nothing is left `unclassified` rather than forced into a bucket.
 
@@ -58,6 +61,11 @@
     regex `<w:t[^>]*>` also matches `<w:tbl>`, `<w:tc>` and `<w:tr>`, silently swallowing table markup as prose.
 
 ### Fixed
+
+- **The locale-inventory gate no longer trips over build artifacts.** It scanned `__pycache__`, so a
+  compiled `.pyc` of a Korean-bearing module — produced simply by running a test that imports it — was
+  reported as an un-inventoried Korean file: a CI failure on a git-ignored file that does not ship and
+  has nothing to fix.
 
 - **The JOSS paper's detector total is now gated.** `paper.md` states the size of the detector suite in its
   Summary but was absent from `DETECTOR_CLAIM_FILES`, so it would have silently disagreed with the software

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1238,8 +1238,8 @@
     },
     {
       "path": "skills/find-cohort-gap/scripts/build_cohort_profile.py",
-      "size": 23222,
-      "sha256": "dd6093e97822f79d49503880741ae92e6b7bcc384fc2327fc3cf1599e44a52a0"
+      "size": 23783,
+      "sha256": "9a08c1d1aef54d827bfc8d2a131ab2d3e9cfc36fe1f4e4c8918b05797220d669"
     },
     {
       "path": "skills/find-cohort-gap/skill.yml",

--- a/scripts/check_locale_inventory.py
+++ b/scripts/check_locale_inventory.py
@@ -36,6 +36,10 @@ HANGUL = re.compile(r"[가-힣ㄱ-ㆎ]")
 SKILLS_PATH = re.compile(r"skills/[A-Za-z0-9_./\-]+")
 # Files we never scan for content (binary-ish); kept small and explicit.
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".pdf", ".docx", ".xlsx", ".zip", ".pptx"}
+# Build artifacts are not source. A compiled .pyc of a Korean-bearing module still carries its
+# string literals, so a contributor whose test imports such a module would fail this gate on a
+# file that is git-ignored and does not ship — a confusing failure with nothing to fix.
+SKIP_DIRS = {"__pycache__", ".pytest_cache", ".ruff_cache", "node_modules"}
 
 
 def repo_root() -> Path:
@@ -47,6 +51,8 @@ def korean_files(skills_dir: Path, base: Path) -> set[str]:
     found: set[str] = set()
     for p in sorted(skills_dir.rglob("*")):
         if not p.is_file() or p.suffix.lower() in SKIP_SUFFIXES:
+            continue
+        if SKIP_DIRS.intersection(p.parts):
             continue
         try:
             text = p.read_text(encoding="utf-8", errors="ignore")

--- a/skills/find-cohort-gap/scripts/build_cohort_profile.py
+++ b/skills/find-cohort-gap/scripts/build_cohort_profile.py
@@ -99,7 +99,8 @@ CLUSTERS: dict[str, tuple[str, ...]] = {
 TOKEN_ONLY = 4
 
 # Endpoint-like variables. A cohort's value proposition is usually its hard endpoints, and
-# the skill scores that (P2), so surface them explicitly.
+# the skill scores that (P2), so they get both a cluster of their own (`outcome_endpoint`,
+# assigned only when no other cluster claims the variable) and an explicit candidate list.
 ENDPOINT_HINTS = (
     "death", "mortal", "expire", "died", "survival", "cancer", "malign", "incid",
     "cvd", "chd", "mace", "stroke", "myocard", "mi", "infarct", "event", "outcome",
@@ -287,13 +288,22 @@ def _hits(key: str, hay: str, toks: set[str]) -> bool:
 
 def classify(name: str, desc: str) -> tuple[str, str]:
     """Return (cluster, matched_keyword). Unmatched stays 'unclassified' — a variable is
-    never forced into a bucket to make the map look complete."""
+    never forced into a bucket to make the map look complete.
+
+    Endpoints are resolved LAST, and only against variables no other cluster claimed, so a
+    cohort's hard endpoint lands in `outcome_endpoint` instead of `unclassified`. Otherwise
+    the profile contradicts itself: `death_date` would be listed as "matched nothing —
+    review it" in the cluster map and as the P2 evidence two sections below.
+    """
     hay = f"{name} {desc}".lower()
     toks = _tokens(hay)
     for cluster, keys in CLUSTERS.items():
         for k in keys:
             if _hits(k, hay, toks):
                 return cluster, k
+    kw = is_endpoint(name, desc)
+    if kw:
+        return "outcome_endpoint", kw
     return "unclassified", ""
 
 

--- a/skills/find-cohort-gap/tests/test_cohort_profile.sh
+++ b/skills/find-cohort-gap/tests/test_cohort_profile.sh
@@ -92,14 +92,20 @@ assert c["ct_lung_nodule"] == "imaging", c["ct_lung_nodule"]
 assert c["phq9_total"] == "questionnaire", c["phq9_total"]
 assert c["statin_use"] == "medication", c["statin_use"]
 assert c["weird_unmatchable_token"] == "unclassified", c["weird_unmatchable_token"]
+# a hard endpoint gets its own cluster — it must never read as "matched nothing, review it"
+# in the cluster map while being cited as P2 evidence two sections below.
+assert c["death_date"] == "outcome_endpoint", c["death_date"]
+assert c["cvd_event"] == "outcome_endpoint", c["cvd_event"]
+assert "death_date" not in p["clusters"].get("unclassified", []), "endpoint landed in unclassified"
 # every assignment shows the keyword that caused it
 assert all(v["matched_keyword"] for v in p["variables"] if v["cluster"] != "unclassified")
 PY
-ck "clusters assigned; unmatched stays 'unclassified'" 0 "$?"
+ck "clusters assigned; endpoints get outcome_endpoint" 0 "$?"
 
 # 2b) the abbreviation false positive: a short keyword must match a whole TOKEN, never a
 # substring. `us` (ultrasound) inside `statin_use` once made a statin an imaging variable.
-python3 - "$B" <<'PY'
+# -B: importing the module must not leave a __pycache__ artifact in the skill directory.
+python3 -B - "$B" <<'PY'
 import importlib.util, sys
 spec = importlib.util.spec_from_file_location("bcp", sys.argv[1])
 m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)


### PR DESCRIPTION
Follow-up to #318, caught by smoke-testing the installed adapter on a real-shaped codebook.

## The self-contradiction

`death_date` matches no cluster keyword, so the cluster map listed it under **`unclassified`** with *"review these — the lexicon is not exhaustive"* — while two sections below, the same variable was cited as the cohort's **P2 Endpoint Upgrade evidence**.

The most valuable variable a cohort has (its hard endpoint) read as a defect, and the profile invited the user to go fix something that was already right.

```
  demographics       1
  identifier_admin   1
  imaging            1
  medication         1
  unclassified       1     <- death_date
  vital_signs        2
  endpoint candidates 1    <- death_date
```

## The fix

Endpoints resolve into their own `outcome_endpoint` cluster — and only when no other cluster claims the variable, so a lab or imaging variable that happens to mention an outcome keeps its real cluster, and `unclassified` keeps meaning *genuinely unrecognised*.

```
  outcome_endpoint   1
```

## Also: the locale gate no longer trips over a build artifact

`check_locale_inventory.py` scanned `__pycache__`. The compiled `.pyc` of a Korean-bearing module still carries its string literals, so **merely running a test that imports such a module** produced a CI failure naming a git-ignored file that does not ship and has nothing to fix. The scanner now skips build directories, and the test imports with `-B` so it leaves none behind.

That was going to bite any contributor who ran the test suite locally.

## Tests

Existing suite tightened: an endpoint must be in `outcome_endpoint` and must **not** appear in `unclassified`. 13/13 pass. Full CI mirror green, including the release-ZIP round trip.