### PR TITLE
docs(citations): record the first external citation

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -28,7 +28,7 @@ With your permission, it will be added below.
 
 | Date found | Work (authors, year) | Venue | How it uses MedSci Skills | Link |
 |---|---|---|---|---|
-| _none recorded yet_ | | | | |
+| 2026-07-13 | Chen, Wang & Qu (2026), *Recursive Self-Improvement in AI: From Bounded Self-Refinement to Autonomous Research Loops* | arXiv:2607.07663 (survey of 1,250 papers, 2024–2026) | Cites the project's methods paper (arXiv:2606.09500) **twice**, as the reference for what fails when an AI audits its own scientific output: in §5.3 (the self-confirming loop) — *"AI scientists whose self-critique 'inherits the blind spots that produce confident fabrication'"* — and in §6.3, *"In regulated domains, **deterministic integrity gates are interposed** because 'self-critique inherits the blind spots that produce confident fabrication'"*. The toolkit's approach is named as the remedy. | [arXiv](https://arxiv.org/abs/2607.07663) |
 
 ---
 


### PR DESCRIPTION
The "Peer-reviewed / preprint citations" table has said **_none recorded yet_** since it was created. This is the first entry.

**Chen, Wang & Qu (2026), *Recursive Self-Improvement in AI: From Bounded Self-Refinement to Autonomous Research Loops*** — [arXiv:2607.07663](https://arxiv.org/abs/2607.07663), a survey of **1,250 arXiv papers** (UC Riverside / AlphaAvatar / Illinois Institute of Technology).

It cites this project's methods paper ([arXiv:2606.09500](https://arxiv.org/abs/2606.09500)) **twice**, and not as a list-filler — it quotes the paper's own sentence and builds on it:

- **§5.3, Failure mode 1 (the self-confirming loop):** *"AI scientists whose self-critique **'inherits the blind spots that produce confident fabrication'**"*
- **§6.3:** *"In regulated domains, **deterministic integrity gates are interposed** because 'self-critique inherits the blind spots that produce confident fabrication'"*

So a survey of the self-improvement literature treats the paper as **the** citation for what goes wrong when an AI audits its own scientific output in a regulated domain — and names this toolkit's approach as the remedy.

Documentation only; no code, no counts.