### PR TITLE
feat(release): a release is an event, not a commit

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # check_release_cadence.py compares CITATION.cff against the newest TAG. A shallow
+          # checkout has no tags, and the gate would pass by seeing nothing — the worst kind of
+          # green.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -81,6 +86,12 @@ jobs:
 
       - name: Run detector-envelope gate self-test (unlabelled + mislabelled envelopes fail)
         run: bash tests/test_detector_envelopes.sh
+
+      - name: Run check_release_cadence.py (a release is an event, not a commit)
+        run: python3 scripts/check_release_cadence.py --strict
+
+      - name: Run release-cadence gate self-test
+        run: bash tests/test_release_cadence.sh
 
       - name: Run check_locale_inventory.py (Korean-bearing files must be inventory-justified)
         run: python3 scripts/check_locale_inventory.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,44 @@ Maintainers may ask for:
 
 For JOSS readiness, contributions should strengthen open-source practice signals: public issues, pull requests, tests, CI, documentation, release notes, and clear contribution pathways.
 
+## Releasing (maintainers)
+
+**A release is an event, not a commit.** Merge to `main` continuously — that is what `main` is for —
+and let the work accumulate into something a person would actually want to read about.
+
+The rule is enforced by `scripts/check_release_cadence.py` (CI):
+
+- **At least 14 days since the last release.**
+- **The release must carry something a user would notice.** Docs, CI and internal changes are fine
+  to merge and a poor reason to make a hundred people update; they ride along with the next release
+  that has a reason of its own.
+- **Exception — a hotfix.** Something already shipped is broken: it will not install, it loses data,
+  it is a security problem, or it produced a wrong result that a user may have believed. Those go out
+  immediately. Say so, and the gate stands aside:
+
+  ```markdown
+  ## [5.20.1] - 2026-07-11
+
+  **Hotfix:** `/orchestrate --e2e` halted at step 3 requiring a DOCX only rendered at step 7,
+  so an end-to-end run could not complete.
+  ```
+
+### Why this is a gate and not a preference
+
+In the 37 days to 2026-07-13 this repository cut **42 releases** — a median gap of **zero days**,
+three of them on one afternoon. That was not merely untidy:
+
+1. **The release stopped meaning anything.** Someone who sees forty-nine releases does not read a
+   changelog; they wonder whether the project is stable. A version number that changes daily is a
+   commit log with extra ceremony, and it stops being usable as a coordinate — *"which version were
+   you on?"* has no answer when there were four that week.
+
+2. **It destroyed our own adoption signal.** Every release attracts a handful of automated asset
+   downloads (mirrors, scanners, crawlers), so `release_downloads` grows with the number of
+   **releases**, not the number of **users**. Across that window the cumulative total doubled while
+   per-release downloads collapsed from **32 to 5** — and the cumulative total was about to be cited
+   as evidence of adoption. **Cadence is a measurement decision, not only a shipping one.**
+
 ## Code of Conduct
 
 This project follows its [Code of Conduct](CODE_OF_CONDUCT.md), which adopts the Contributor Covenant. By participating, you agree to uphold it.

--- a/scripts/check_release_cadence.py
+++ b/scripts/check_release_cadence.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""A release is an event, not a commit. This stops us from pretending otherwise.
+
+In the 37 days to 2026-07-13 this repository cut **42 releases** — a median gap of **zero
+days**, three of them on one afternoon. Three things follow, and all three are worse than they
+look:
+
+  1. THE RELEASE STOPS MEANING ANYTHING. A user who sees forty-nine releases does not read a
+     changelog; they wonder whether the thing is stable. A version number that changes daily is
+     a commit log with extra ceremony.
+
+  2. IT DESTROYS OUR OWN ADOPTION SIGNAL. Every release attracts a handful of automated asset
+     downloads (mirrors, scanners, crawlers), so `release_downloads` grows with the *number of
+     releases* rather than the number of users. Per-release downloads collapsed from 32 to 5
+     across that window while the cumulative total doubled — and the cumulative total is the
+     number we were about to cite as evidence of adoption. Cadence is a **measurement**
+     decision, not only a shipping one.
+
+  3. IT MAKES THE VERSION USELESS AS A COORDINATE. "Which version were you on?" stops being
+     answerable when there were four that week.
+
+So: **a release needs a reason to exist, and a gap since the last one.** Ship the work to `main`
+continuously — that is what `main` is for — and let releases accumulate into something a person
+would want to read about.
+
+Exemption, and only this one: a **hotfix**. Something shipped is broken (it will not install, it
+loses data, it is a security problem, or it produced a wrong result that a user might have
+believed). Those go out immediately, and say so in the changelog:
+
+    ## [5.20.1] - 2026-07-11
+
+    **Hotfix:** `/orchestrate --e2e` halted at step 3 requiring a DOCX only rendered at step 7,
+    so an end-to-end run could not complete.
+
+Usage:
+    check_release_cadence.py [--min-days 14] [--strict]
+
+It is a no-op unless a release is actually being prepared: if `CITATION.cff` still declares the
+version of the newest tag, there is nothing to check and it exits 0. Stdlib only (shells to git).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MIN_DAYS = 14
+
+# A release that fixes something already broken in the wild does not wait.
+HOTFIX = re.compile(r"^\s*\*\*Hotfix:?\*\*\s*(.+)$", re.MULTILINE | re.IGNORECASE)
+
+# A release must carry something a user would notice. These headings do not qualify on their own.
+COSMETIC_ONLY = {"changed", "docs", "documentation", "internal", "chore", "ci"}
+
+
+def git(*args: str) -> str:
+    p = subprocess.run(["git", *args], cwd=ROOT, capture_output=True, text=True)
+    return p.stdout.strip() if p.returncode == 0 else ""
+
+
+def declared_version() -> str:
+    m = re.search(r'^version:\s*"?([0-9]+\.[0-9]+\.[0-9]+)"?\s*$',
+                  (ROOT / "CITATION.cff").read_text(encoding="utf-8"), re.MULTILINE)
+    if not m:
+        raise SystemExit("CITATION.cff: no semver version")
+    return m.group(1)
+
+
+def latest_tag() -> tuple[str, date] | None:
+    line = git("for-each-ref", "--sort=-creatordate", "--count=1",
+               "--format=%(refname:short)|%(creatordate:short)", "refs/tags")
+    if not line or "|" not in line:
+        return None
+    tag, when = line.split("|", 1)
+    try:
+        return tag, datetime.strptime(when.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def changelog_section(version: str) -> str:
+    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    m = re.search(rf"^## \[{re.escape(version)}\].*?$(.*?)(?=^## \[|\Z)", text,
+                  re.MULTILINE | re.DOTALL)
+    return m.group(1) if m else ""
+
+
+def substantive(section: str) -> bool:
+    """Does this release contain anything a user would notice?
+
+    A docs-only or CI-only change is a fine thing to merge and a poor reason to make a hundred
+    people update. It rides along with the next release that has a reason of its own.
+    """
+    headings = [h.strip().lower() for h in re.findall(r"^###\s+(.+)$", section, re.MULTILINE)]
+    if not headings:
+        return False
+    return any(h not in COSMETIC_ONLY for h in headings)
+
+
+def audit(min_days: int) -> tuple[list[str], dict]:
+    problems: list[str] = []
+    version = declared_version()
+    tag = latest_tag()
+
+    if tag and tag[0].lstrip("v") == version:
+        return [], {"release_pending": False, "version": version, "last_tag": tag[0]}
+
+    info = {
+        "release_pending": True,
+        "version": version,
+        "last_tag": tag[0] if tag else None,
+        "last_tag_date": tag[1].isoformat() if tag else None,
+        "days_since": (date.today() - tag[1]).days if tag else None,
+    }
+
+    section = changelog_section(version)
+    if not section.strip():
+        problems.append(
+            f"CHANGELOG.md has no `## [{version}]` section. A release that cannot be described "
+            "is a release nobody asked for."
+        )
+        return problems, info
+
+    hotfix = HOTFIX.search(section)
+    info["hotfix"] = bool(hotfix)
+    if hotfix:
+        info["hotfix_reason"] = hotfix.group(1).strip()
+
+    if tag and info["days_since"] is not None and info["days_since"] < min_days and not hotfix:
+        problems.append(
+            f"{info['days_since']} day(s) since {tag[0]} — a release needs {min_days}.\n"
+            f"      A release is an event, not a commit. Merge the work to main and let it "
+            f"accumulate into\n      something a person would want to read about; the version "
+            f"number is a coordinate, and it stops\n      being one when there were four of them "
+            f"that week.\n"
+            f"      If something shipped is genuinely broken — it will not install, it loses "
+            f"data, it is a\n      security problem, or it produced a wrong result someone may "
+            f"have believed — say so in the\n      changelog section and this passes:\n\n"
+            f"          ## [{version}] - <date>\n\n"
+            f"          **Hotfix:** <what is broken for users right now>"
+        )
+
+    if not substantive(section) and not hotfix:
+        problems.append(
+            f"the `[{version}]` section carries nothing a user would notice "
+            f"(only: {', '.join(re.findall(r'^###\\s+(.+)$', section, re.MULTILINE)) or 'no headings'}).\n"
+            "      Docs, CI and internal changes are fine to merge and a poor reason to make a "
+            "hundred people\n      update. Let them ride along with the next release that has a "
+            "reason of its own."
+        )
+
+    return problems, info
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--min-days", type=int, default=MIN_DAYS)
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any problem (CI gate)")
+    a = ap.parse_args()
+
+    problems, info = audit(a.min_days)
+
+    if not info["release_pending"]:
+        print(f"OK: no release pending (CITATION.cff and {info['last_tag']} both say {info['version']}).")
+        return 0
+
+    print(f"Release pending: {info['version']} (last: {info['last_tag']}, "
+          f"{info['days_since']} day(s) ago)")
+    if info.get("hotfix"):
+        print(f"  HOTFIX declared: {info['hotfix_reason']}")
+
+    if problems:
+        print(f"\nRELEASE_CADENCE: {len(problems)} problem(s)\n")
+        for p in problems:
+            print(f"  - {p}\n")
+        return 1 if a.strict else 0
+
+    print("OK: enough has changed, and enough time has passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_cadence.py
+++ b/scripts/check_release_cadence.py
@@ -146,9 +146,11 @@ def audit(min_days: int) -> tuple[list[str], dict]:
         )
 
     if not substantive(section) and not hotfix:
+        # Computed outside the f-string: a backslash inside an f-string expression is a syntax
+        # error before Python 3.12, and CI runs 3.11 while this machine runs 3.14.
+        found = ", ".join(re.findall(r"^###\s+(.+)$", section, re.MULTILINE)) or "no headings"
         problems.append(
-            f"the `[{version}]` section carries nothing a user would notice "
-            f"(only: {', '.join(re.findall(r'^###\\s+(.+)$', section, re.MULTILINE)) or 'no headings'}).\n"
+            f"the `[{version}]` section carries nothing a user would notice (only: {found}).\n"
             "      Docs, CI and internal changes are fine to merge and a poor reason to make a "
             "hundred people\n      update. Let them ride along with the next release that has a "
             "reason of its own."

--- a/tests/test_release_cadence.sh
+++ b/tests/test_release_cadence.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check_release_cadence.py.
+#
+# The gate exists because this repository cut 42 releases in 37 days — a median gap of zero days,
+# three of them on one afternoon. That did not merely look untidy: it destroyed the project's own
+# adoption signal, because every release attracts a handful of automated asset downloads, so
+# `release_downloads` grew with the number of RELEASES rather than the number of users. The
+# cumulative total doubled while per-release downloads collapsed from 32 to 5 — and the cumulative
+# total was about to be cited as evidence of adoption.
+#
+# So the gate must (a) block a too-soon release, (b) let a genuine hotfix straight through, and
+# (c) stay silent when no release is being prepared, which is almost every commit.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+G="$REPO_ROOT/scripts/check_release_cadence.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-54s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-54s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# A throwaway repo, so the test never depends on this project's own tag history.
+REPO="$TMP/repo"
+mkdir -p "$REPO/scripts"
+cp "$G" "$REPO/scripts/"
+cd "$REPO"
+git init -q .
+git config user.email t@t.t
+git config user.name t
+
+write_release() {   # $1 version   $2 changelog body
+  printf 'cff-version: 1.2.0\nversion: "%s"\n' "$1" > CITATION.cff
+  printf '# Changelog\n\n## [Unreleased]\n\n## [%s] - 2026-07-13\n%s\n' "$1" "$2" > CHANGELOG.md
+}
+
+# --- a released state: the tag and CITATION.cff agree -----------------------------------------
+write_release "1.0.0" "
+### Added
+
+- The first thing.
+"
+git add -A > /dev/null && git commit -qm v1
+GIT_COMMITTER_DATE="2026-07-13T12:00:00" git tag -a v1.0.0 -m v1.0.0
+
+# 1) no release pending -> silent, and this is the case on almost every commit
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "no release pending -> passes (the common case)" 0 "$?"
+
+# 2) a release cut the same day as the last one -> blocked
+write_release "1.1.0" "
+### Added
+
+- Something new.
+"
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a release 0 days after the last one is blocked" 1 "$?"
+
+OUT="$(python3 scripts/check_release_cadence.py 2>&1)"
+echo "$OUT" | grep -q "Hotfix"
+ck "...and the message shows the way out (a hotfix)" 0 "$?"
+
+# 3) a genuine hotfix goes out immediately — something is broken in the wild
+write_release "1.0.1" "
+**Hotfix:** the installer crashes on Windows and nobody can install.
+
+### Fixed
+
+- The crash.
+"
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a declared hotfix ships immediately" 0 "$?"
+
+# 4) a docs-only release is not a release
+write_release "1.1.0" "
+### Docs
+
+- Fixed a typo.
+"
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a docs-only release is refused" 1 "$?"
+
+# 5) ...and it is still refused even when enough time HAS passed: the objection is that nobody
+#    would notice, not that it is too soon.
+GIT_COMMITTER_DATE="2026-06-01T12:00:00" git tag -a v0.9.0 -m old > /dev/null 2>&1 || true
+python3 scripts/check_release_cadence.py 2>&1 | grep -q "nothing a user would notice"
+ck "the docs-only objection is substance, not timing" 0 "$?"
+
+# 6) a version with no changelog section at all
+printf 'cff-version: 1.2.0\nversion: "2.0.0"\n' > CITATION.cff
+printf '# Changelog\n\n## [Unreleased]\n' > CHANGELOG.md
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a release with no changelog section is refused" 1 "$?"
+
+# 7) after enough time, a substantive release passes
+write_release "1.1.0" "
+### Added
+
+- Something a user would notice.
+"
+python3 scripts/check_release_cadence.py --strict --min-days 0 > /dev/null 2>&1
+ck "enough time + real content -> passes" 0 "$?"
+
+echo "----"
+echo "test_release_cadence: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## The number I was about to put in a grant

In the 37 days to today this repository cut **42 releases** — a **median gap of zero days**, three of them on one afternoon.

I read `release_downloads` (220 → 438, **+99%**) against stars (134 → 198, **+48%**) and concluded that *usage is growing twice as fast as stars* — which is exactly the evidence an adoption case wants. Then I looked at the releases:

| | releases | downloads | **per release** |
|---|--:|--:|--:|
| before 2026-06-06 | 7 | 226 | **32.3** |
| since | **42** | 213 | **5.1** |

The doubling was not adoption. **It was us tagging a lot.** Every release attracts a handful of automated asset downloads — mirrors, scanners, crawlers — so `release_downloads` grows with the number of **releases**, not the number of **users**. Per-release downloads *collapsed*, from 32 to 5.

**Cadence is a measurement decision, not only a shipping one**, and we had been silently corrupting the one adoption number we were most likely to cite.

## And the version stopped being a coordinate

*"Which version were you on?"* has no answer when there were four that week. Someone who lands on a repository with forty-nine releases does not read a changelog — they wonder whether the thing is stable.

## The gate

`scripts/check_release_cadence.py`, in CI:

- **≥ 14 days** since the last release.
- **The release must carry something a user would notice.** Docs, CI and internal changes are fine to merge and a poor reason to make a hundred people update; they ride along with the next release that has a reason of its own. (Refused *on substance*, even when the timing is fine.)
- **A hotfix ships immediately** — something already shipped will not install, loses data, is a security problem, or produced a wrong result a user may have believed. Declare it and the gate stands aside:

  ```markdown
  ## [5.20.1] - 2026-07-11

  **Hotfix:** `/orchestrate --e2e` halted at step 3 requiring a DOCX only rendered at step 7.
  ```

It is a **no-op on almost every commit** — if `CITATION.cff` still declares the newest tag's version, no release is pending and there is nothing to check.

## One thing that would have made it useless

`validate.yml`'s checkout was shallow, so **it had no tags**. The gate compares `CITATION.cff` against the newest tag; with no tags it would have found nothing to complain about and passed. Green, and meaningless. `fetch-depth: 0` now.

8 assertions, CI-wired. The policy and the evidence are in `CONTRIBUTING.md`, so the next maintainer does not have to rediscover why.