### PR TITLE
fix(installer): never leave a clinician stranded — Python guard, and a setup check that says what else is missing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Run installer Python-guard test (old / missing Python must be refused, not crash)
         run: bash installers/tests/test_installer_python_guard.sh
 
+      - name: Run setup-check test (hide pandoc; the report must NOTICE, and must install nothing)
+        run: bash installers/tests/test_doctor.sh
+
       - name: Run check_release_cadence.py (a release is an event, not a commit)
         run: python3 scripts/check_release_cadence.py --strict
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Run detector-envelope gate self-test (unlabelled + mislabelled envelopes fail)
         run: bash tests/test_detector_envelopes.sh
 
+      - name: Run check_python_floor.py (everything a user runs must parse on the Python we promise)
+        run: python3 scripts/check_python_floor.py --strict
+
+      - name: Run installer Python-guard test (old / missing Python must be refused, not crash)
+        run: bash installers/tests/test_installer_python_guard.sh
+
       - name: Run check_release_cadence.py (a release is an event, not a commit)
         run: python3 scripts/check_release_cadence.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Windows installer could report success while installing nothing.** On a Windows machine with
+  no Python, `python` still *exists*: it is an App Execution Alias that opens the Microsoft Store. So
+  `where python` succeeded, the installer ran it, a Store page opened — and the script said it was
+  done. **Windows is 65% of classroom-ZIP downloads.** An interpreter is now accepted only after it
+  proves, **by running**, that it is Python 3.9 or newer; asking `where` only proves a name exists.
+
+- **A too-old Python produced a traceback instead of an explanation.** `install.py` *parses* on 3.8,
+  so it did not fail cleanly — it died partway through and left a clinician staring at a Python stack
+  trace. All four double-click scripts (install / update × macOS / Windows) and both Python entry
+  points now check the floor **before** anything runs, and say which of the two problems it is ("no
+  Python" and "too old a Python" need different actions), what to do about it, and that nothing on the
+  computer was changed. A failed install now also says so, rather than ending on a cheerful prompt.
+
+- **`check_python_floor.py` (CI)**: every script that reaches a user — the installers and the skill
+  scripts the agent runs on their machine — must parse on **Python 3.9**, the floor the README
+  promises. CI runs 3.11 and this project is developed on 3.14, so a `match` statement would have
+  shipped, broken only on a clinician's computer, and been invisible: when a research tool errors out,
+  a physician does not file a bug. They close the window and go back to doing it by hand.
+
 ### Added
 
 - **`/contribute` — the way back** (new skill; **56 skills**, **detectors 61 → 62**). The people who use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## [Unreleased]
 
+### Added
+
+- **A setup check that answers "what else does this computer need?" before you need it**
+  (`installers/doctor.py`; double-click `check-setup-macos.command` / `check-setup-windows.cmd`).
+  Every skill that needs an outside program already fails politely — the problem is *when*: you find
+  out in the middle of the work, and a clinician who hits that message does not stop and install a
+  package manager. They close the window. The check runs at the end of every install and reports in
+  terms of what you were trying to **do** — "turn your manuscript into a journal-formatted Word file"
+  needs pandoc, "read and QC submission PDFs" needs poppler, "open a .docx at all" needs python-docx
+  — and with `--fix` installs the small things after asking. Large things (a TeX distribution, R,
+  PyTorch) are **never** installed for you: it prints the size and the command and leaves the choice
+  alone. It installs nothing on its own, and cannot fail an install that worked.
+
+- **The installers now offer to install Python itself.** Telling someone with no Python to "go to
+  python.org" is a step they have to perform; on Windows the installer now offers
+  `winget install --exact --id Python.Python.3.13 --scope user` — no administrator password, which
+  matters on a locked-down hospital PC — and otherwise opens the download page for them, on both
+  platforms. The one checkbox that breaks everything if missed ("Add python.exe to PATH") is called
+  out.
+
 ### Fixed
+
+- **The README demanded R and never mentioned pandoc — both wrong.** It listed "R 4.0+ with `meta`,
+  `metafor`, `mada`" under Requirements, which reads as *you cannot use this without R*. The toolkit
+  **never executes R**: `/analyze-stats` writes Python unless asked for R. Meanwhile **pandoc** — which
+  people genuinely hit, because it renders the manuscript to Word — was not listed at all. Requirements
+  now says what is true: Python and an agent host, and everything else on demand.
 
 - **The Windows installer could report success while installing nothing.** On a Windows machine with
   no Python, `python` still *exists*: it is an App Execution Alias that opens the Microsoft Store. So

--- a/README.md
+++ b/README.md
@@ -716,9 +716,33 @@ Prints a checklist showing which components are present, which are missing, and 
 
 ## Requirements
 
+**Python 3.9+ and an agent host. That is the whole hard requirement.** Every integrity detector is
+stdlib-only, and so is drafting, reviewing, and auditing a manuscript. If you have no Python, the
+double-click installer will offer to install it for you (`winget` on Windows, or the official
+download page) rather than leaving you at a dead end.
+
 - An [Agent Skills](https://agentskills.io)-compatible host — [Claude Code](https://claude.ai/code) (primary), or Codex / Cursor / GitHub Copilot (see [`docs/host_compatibility.md`](docs/host_compatibility.md); some live-data workflows rely on Claude MCP servers)
-- Python 3.9+ (for statistical analysis and figure generation)
-- R 4.0+ with `meta` (>=7.0), `metafor` (>=4.0), `mada` (>=0.5.11) packages (for meta-analysis)
+- Python 3.9+ — the floor is CI-enforced (`scripts/check_python_floor.py`). Newer is better; if you are installing Python today, take the latest.
+
+Everything else is needed by *some* skills and not others. Rather than a shopping list of packages
+you have never heard of, ask the toolkit what **this** computer can do:
+
+```bash
+python3 installers/doctor.py          # what works, what does not, and the exact fix for each
+python3 installers/doctor.py --fix    # offers to install what is missing — asking before each one
+```
+(Or double-click `installers/check-setup-macos.command` / `installers/check-setup-windows.cmd`.)
+
+It reports in terms of what you were trying to *do* — "turn your manuscript into a journal-formatted
+Word file" needs **pandoc**; "read and QC submission PDFs" needs **poppler**; "open a .docx at all"
+needs **python-docx** — and installs the small things on request. Large things (a TeX distribution,
+R, PyTorch) are never installed for you: it prints the size and the command and leaves the choice
+alone.
+
+**R is not required.** `/analyze-stats` writes Python by default and only emits R if you ask it to;
+the toolkit itself never executes R. Install R (with `meta`, `metafor`, `mada` for meta-analysis)
+only if you want to run the R code it writes for you. The same is true of PyTorch and
+`/model-scaffold`: writing the training code needs nothing; running it needs torch.
 
 ## Use Cases
 

--- a/installers/check-setup-macos.command
+++ b/installers/check-setup-macos.command
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# MedSci Skills — "what else does this Mac need?", as a file you double-click.
+#
+# The same person who could not install from a terminal cannot run the setup check from one either.
+# This is that check, and it will offer to install what is missing — asking before each one, and
+# never installing anything large without being told to.
+set -u
+
+cd "$(dirname "$0")/.."
+
+PY=""
+for candidate in python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1 &&
+     "$candidate" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >/dev/null 2>&1; then
+    PY="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PY" ]; then
+  echo "Python 3.9 or newer is not on this Mac, so MedSci Skills is not installed yet."
+  echo "Run the installer first:  installers/install-macos.command"
+  echo
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+"$PY" installers/doctor.py --fix
+STATUS=$?
+
+echo
+read -r -p "Press Enter to close..."
+exit "$STATUS"

--- a/installers/check-setup-windows.cmd
+++ b/installers/check-setup-windows.cmd
@@ -1,0 +1,30 @@
+@echo off
+rem MedSci Skills - "what else does this PC need?", as a file you double-click.
+rem
+rem Same rule as the installer: an interpreter is only accepted after it proves, BY RUNNING, that
+rem it is Python 3.9 or newer. On a PC with no Python, `python` still exists as a Microsoft Store
+rem stub that opens a shop page -- asking `where` would be fooled by it.
+setlocal EnableDelayedExpansion
+cd /d "%~dp0\.."
+
+set "PY="
+py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+if !errorlevel!==0 set "PY=py -3"
+
+if not defined PY (
+  python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+  if !errorlevel!==0 set "PY=python"
+)
+
+if not defined PY (
+  echo Python 3.9 or newer is not on this PC, so MedSci Skills is not installed yet.
+  echo Run the installer first:  installers\install-windows.cmd
+  echo.
+  pause
+  exit /b 1
+)
+
+%PY% installers\doctor.py --fix
+
+echo.
+pause

--- a/installers/doctor.py
+++ b/installers/doctor.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""What MedSci Skills can actually do on THIS computer — and how to fix what it cannot.
+
+Python is the only hard requirement: every integrity detector is stdlib-only, and so are the
+skills that draft, review, and audit a manuscript. Everything else is needed by *some* skills and
+not others — pandoc to render a manuscript into a journal-formatted Word file, poppler to read a
+submission PDF, python-docx to open a .docx at all.
+
+Each of those skills already fails politely when its tool is absent. The problem is *when*: you
+find out at the moment you needed it, halfway through the work, and a clinician who hits that
+message does not install a package manager — they close the window and go back to doing it by
+hand. This tells them before they start, in terms of what they were trying to do, and offers to
+install the missing piece for them.
+
+Two rules it does not break:
+
+  * It never installs anything without being asked. Not on import, not in --brief, not silently.
+  * It never installs anything *large* — a TeX distribution is several gigabytes, R is a separate
+    ecosystem, and PyTorch is not something to drop on a laptop because a setup script felt like
+    it. Those are printed with their size and their command, and left to the person.
+
+Usage:
+    doctor.py               # what works, what does not, and the exact fix for each
+    doctor.py --fix         # ask before installing each missing piece
+    doctor.py --brief       # only what is missing (what the installer prints at the end)
+    doctor.py --json        # machine-readable (used by the tests)
+
+Stdlib only. Exit code is 0 unless --strict is given: a missing *optional* tool is not an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence, Tuple
+
+REPO = "https://github.com/Aperivue/medsci-skills"
+
+
+# --------------------------------------------------------------------------------------------
+# What a capability can need
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Pip:
+    """A Python package."""
+
+    module: str  # what `import` calls it
+    package: str  # what pip calls it
+    heavy: str = ""  # a size, e.g. "~2.5 GB". Set => never installed for you, only explained.
+
+
+@dataclass(frozen=True)
+class Tool:
+    """A program that must exist on PATH."""
+
+    binary: str
+    label: str
+    brew: str = ""
+    winget: str = ""
+    apt: str = ""
+    page: str = ""  # a download page that works on ANY platform (a .pkg, a .exe, a landing page)
+    win_page: str = ""  # a Windows-only download, when `page` would send a Mac user somewhere wrong
+    heavy: str = ""  # a size, e.g. "~4 GB". Set => never installed for you, only explained.
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Something the person wanted to do — not a package they have never heard of."""
+
+    key: str
+    title: str
+    skills: str
+    pips: Sequence[Pip] = field(default_factory=tuple)
+    tools: Sequence[Tool] = field(default_factory=tuple)
+    aside: str = ""  # shown even when ready — e.g. "you probably do not need this"
+
+
+# --------------------------------------------------------------------------------------------
+# The tools, named once
+# --------------------------------------------------------------------------------------------
+
+PANDOC = Tool(
+    binary="pandoc",
+    label="pandoc",
+    brew="pandoc",
+    winget="JohnMacFarlane.Pandoc",
+    apt="pandoc",
+    page="https://pandoc.org/installing.html",
+)
+
+# poppler gives pdftotext/pdfinfo. Homebrew and apt package it; on Windows there is no reliable
+# winget package, so we send people to the build everyone actually uses rather than invent an id
+# that would fail on their machine. That build is WINDOWS-ONLY — offering it to a Mac user as "the
+# download page" would send them somewhere useless, so it is not `page`. On macOS there is no
+# double-click poppler, and saying so is better than pretending.
+POPPLER = Tool(
+    binary="pdftotext",
+    label="poppler (pdftotext)",
+    brew="poppler",
+    apt="poppler-utils",
+    win_page="https://github.com/oschwartz10612/poppler-windows/releases",
+)
+
+GH = Tool(
+    binary="gh",
+    label="GitHub CLI",
+    brew="gh",
+    winget="GitHub.cli",
+    apt="gh",
+    page="https://cli.github.com/",
+)
+
+XELATEX = Tool(
+    binary="xelatex",
+    label="XeLaTeX (a TeX distribution)",
+    brew="--cask mactex-no-gui",
+    winget="MiKTeX.MiKTeX",
+    apt="texlive-xetex texlive-fonts-recommended",
+    page="https://www.tug.org/mactex/",
+    heavy="~1–4 GB",
+)
+
+RLANG = Tool(
+    binary="Rscript",
+    label="R",
+    brew="--cask r",
+    winget="RProject.R",
+    apt="r-base",
+    page="https://cran.r-project.org/",
+    heavy="~200 MB + packages",
+)
+
+TESSERACT = Tool(
+    binary="tesseract",
+    label="Tesseract OCR",
+    brew="tesseract",
+    winget="UB-Mannheim.TesseractOCR",
+    apt="tesseract-ocr",
+    page="https://github.com/tesseract-ocr/tesseract",
+)
+
+
+# --------------------------------------------------------------------------------------------
+# The capabilities, in the order a clinician meets them
+# --------------------------------------------------------------------------------------------
+
+CAPABILITIES: Tuple[Capability, ...] = (
+    Capability(
+        key="core",
+        title="Draft, review, and audit a manuscript",
+        skills="/write-paper, /self-review, /check-reporting, and every integrity detector",
+        # Nothing. This is the point of the toolkit being stdlib-only.
+    ),
+    Capability(
+        key="everyday",
+        title="Open and check Word documents, and read project files",
+        skills="/manage-refs, /revise, /peer-review, /sync-submission, /fill-protocol",
+        pips=(Pip("docx", "python-docx"), Pip("yaml", "PyYAML")),
+    ),
+    Capability(
+        key="render",
+        title="Turn your manuscript into a journal-formatted Word file",
+        skills="/manage-refs (render_pandoc.sh — the CSL renderer)",
+        tools=(PANDOC,),
+    ),
+    Capability(
+        key="pdf",
+        title="Read and QC PDFs — submission proofs, checklists, codebooks",
+        skills="/sync-submission, /find-cohort-gap",
+        tools=(POPPLER,),
+    ),
+    Capability(
+        key="pdf_deep",
+        title="Scan a PDF's hidden layers; lift a figure out of a paper",
+        skills="/peer-review (prompt-injection scan), /make-figures",
+        pips=(Pip("fitz", "PyMuPDF"),),
+    ),
+    Capability(
+        key="figures",
+        title="Make publication figures — STROBE/PRISMA flow, forest, ROC",
+        skills="/make-figures",
+        pips=(
+            Pip("matplotlib", "matplotlib"),
+            Pip("numpy", "numpy"),
+            Pip("PIL", "Pillow"),
+            Pip("lxml", "lxml"),
+            Pip("pptx", "python-pptx"),
+        ),
+    ),
+    Capability(
+        key="slides",
+        title="Build slide decks — journal club, grand rounds, conference",
+        skills="/present-paper",
+        pips=(Pip("pptx", "python-pptx"), Pip("PIL", "Pillow")),
+    ),
+    Capability(
+        key="data",
+        title="Codebooks, dataset versioning, cohort profiles",
+        skills="/generate-codebook, /version-dataset, /find-cohort-gap",
+        pips=(Pip("pandas", "pandas"), Pip("openpyxl", "openpyxl")),
+    ),
+    Capability(
+        key="contribute",
+        title="Send an improvement back as a pull request",
+        skills="/contribute",
+        tools=(GH,),
+    ),
+    Capability(
+        key="pdfdoc",
+        title="Render a proposal or handout to PDF",
+        skills="/render-pdf-doc",
+        pips=(Pip("fontTools", "fonttools"),),
+        tools=(PANDOC, XELATEX),
+        aside="Only if you need PDF output. Word output does not need TeX.",
+    ),
+    Capability(
+        key="stats_r",
+        title="Run the statistics in R instead of Python",
+        skills="/analyze-stats",
+        tools=(RLANG,),
+        aside="Not needed by default: /analyze-stats writes Python unless you ask it for R. The "
+        "toolkit itself never runs R — this is only to run the code it writes for you.",
+    ),
+    Capability(
+        key="ml",
+        title="Train or fine-tune an imaging model",
+        skills="/model-scaffold",
+        pips=(
+            Pip("torch", "torch", heavy="~2.5 GB"),
+            Pip("torchvision", "torchvision"),
+            Pip("timm", "timm"),
+        ),
+        aside="Only for the deep-learning lane, and only to RUN the code /model-scaffold writes — "
+        "writing it needs nothing.",
+    ),
+    Capability(
+        key="ocr",
+        title="Read text out of a figure image (OCR)",
+        skills="/make-figures (figure critic)",
+        pips=(Pip("pytesseract", "pytesseract"),),
+        tools=(TESSERACT,),
+        aside="Rarely needed.",
+    ),
+)
+
+# Capabilities that are genuinely optional: their absence is never an error, and --fix will not
+# install their heavy parts for you.
+OPTIONAL = {"pdfdoc", "stats_r", "ocr", "pdf_deep", "ml"}
+
+
+def os_name() -> str:
+    """`platform.system()` says "Darwin". Nobody who owns a Mac calls it that."""
+    return {"Darwin": "macOS", "Windows": "Windows", "Linux": "Linux"}.get(platform.system(), platform.system() or "unknown")
+
+
+def py() -> str:
+    """The interpreter, written the short way when the short way means the same thing.
+
+    Printing `/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install ...` is correct and
+    unreadable. Printing `python3` is readable and, on a computer with two Pythons, WRONG — it can
+    install the package into an interpreter the skills do not run under. So: shorten it only after
+    checking that `python3` really is this interpreter.
+    """
+    short = shutil.which("python3")
+    if short:
+        try:
+            if Path(short).resolve() == Path(sys.executable).resolve():
+                return "python3"
+        except OSError:
+            pass
+    return sys.executable
+
+
+# --------------------------------------------------------------------------------------------
+# Probing
+# --------------------------------------------------------------------------------------------
+
+
+def have_module(name: str) -> bool:
+    """True if `import name` would work — without actually importing it (no side effects)."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError, AttributeError):
+        return False
+
+
+def have_tool(binary: str) -> bool:
+    return shutil.which(binary) is not None
+
+
+def missing_of(cap: Capability) -> Tuple[List[Pip], List[Tool]]:
+    return (
+        [p for p in cap.pips if not have_module(p.module)],
+        [t for t in cap.tools if not have_tool(t.binary)],
+    )
+
+
+def install_hint(tool: Tool) -> str:
+    """The one command for this computer — or the page, when there is no clean command.
+
+    On a Mac WITHOUT Homebrew, "brew install pandoc" is not one step, it is two, and the hidden one
+    is enormous: installing Homebrew pulls the Xcode command-line tools. Telling a physician to do
+    that so they can convert a document is how you lose them. Most of these tools ship a plain
+    double-click installer, so when there is no brew, the download page goes first and brew is
+    mentioned only as the alternative for people who already live in a terminal.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        if tool.brew and have_tool("brew"):
+            return "brew install " + tool.brew
+        if tool.page:
+            alt = ("   (or, with Homebrew:  brew install " + tool.brew + ")") if tool.brew else ""
+            return "download it from  " + tool.page + alt
+        if tool.brew:
+            # No double-click download exists for this one (poppler). Homebrew really is the way,
+            # so say the whole truth — including the part they will not enjoy.
+            return "brew install " + tool.brew + "   (needs Homebrew first: https://brew.sh)"
+    elif system == "Windows":
+        if tool.winget:
+            return "winget install --exact --id " + tool.winget
+        if tool.win_page or tool.page:
+            return "download it from  " + (tool.win_page or tool.page)
+    elif tool.apt:
+        return "sudo apt install " + tool.apt
+    return "see " + tool.page if tool.page else "see " + REPO
+
+
+def pip_hint(pkgs: Sequence[Pip]) -> str:
+    names = " ".join(sorted({p.package for p in pkgs}))
+    return py() + " -m pip install --user " + names
+
+
+# --------------------------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------------------------
+
+
+def report(emit: Callable[[str], None], brief: bool = False) -> int:
+    """Print the state of this computer. Returns the number of NON-optional things missing."""
+    ready: List[Capability] = []
+    broken: List[Tuple[Capability, List[Pip], List[Tool]]] = []
+
+    for cap in CAPABILITIES:
+        pips, tools = missing_of(cap)
+        if pips or tools:
+            broken.append((cap, pips, tools))
+        else:
+            ready.append(cap)
+
+    essential_missing = sum(1 for cap, _, _ in broken if cap.key not in OPTIONAL)
+
+    if not brief:
+        emit("")
+        emit("MedSci Skills — setup check")
+        emit(
+            "  Python %s  ·  %s"
+            % (".".join(str(n) for n in sys.version_info[:3]), os_name())
+        )
+        emit("")
+        emit("WORKS NOW")
+        for cap in ready:
+            emit("  [ok] " + cap.title)
+        emit("")
+
+    if brief:
+        # The tail of an install that already succeeded. Say something only if there is something
+        # to do — an optional tool nobody asked for is not news, and a wall of green is noise.
+        if not essential_missing:
+            return 0
+        emit("")
+        emit("Some skills need a program this computer does not have yet:")
+        for cap, _pips, _tools in broken:
+            if cap.key not in OPTIONAL:
+                emit("  - " + cap.title)
+        emit("")
+        emit("  See what they are, and install them (it asks before each one):")
+        emit("    " + py() + " installers/doctor.py --fix")
+        return essential_missing
+
+    if not broken:
+        emit("Nothing is missing. Every skill in the toolkit can run here.")
+        return 0
+
+    emit("NOT YET — each of these needs one more program")
+    for cap, pips, tools in broken:
+        tag = "  [--]" if cap.key in OPTIONAL else "  [  ]"
+        emit(tag + " " + cap.title)
+        emit("        used by: " + cap.skills)
+        if cap.aside:
+            emit("        note:    " + cap.aside)
+        if pips:
+            size = next((("  [" + p.heavy + " — big]") for p in pips if p.heavy), "")
+            emit("        missing: " + ", ".join(p.package for p in pips) + size)
+            emit("        install: " + pip_hint(pips))
+        for t in tools:
+            size = ("  [" + t.heavy + " — big]") if t.heavy else ""
+            emit("        missing: " + t.label + size)
+            emit("        install: " + install_hint(t))
+        emit("")
+
+    emit("  [  ] = a skill you are likely to want      [--] = optional, most people never need it")
+    emit("")
+    emit("To install these, with a question before each one:")
+    emit("    " + py() + " " + str(__file__) + " --fix")
+    emit("")
+    emit("Big things (a TeX distribution, R, PyTorch) are never installed for you — the command is")
+    emit("printed above and the choice stays yours.")
+    return essential_missing
+
+
+def brief_summary(emit: Callable[[str], None]) -> None:
+    """The tail of a successful install: say what is missing, never fail, never install."""
+    try:
+        report(emit, brief=True)
+    except Exception:  # noqa: BLE001 - a setup *check* must never break an install that worked
+        pass
+
+
+# --------------------------------------------------------------------------------------------
+# Fixing (only ever after a yes)
+# --------------------------------------------------------------------------------------------
+
+
+def ask(question: str, assume_yes: bool) -> bool:
+    if assume_yes:
+        print(question + " yes (--yes)")
+        return True
+    try:
+        answer = input(question + " [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"y", "yes"}
+
+
+def run(cmd: List[str]) -> Tuple[int, str]:
+    print("    $ " + " ".join(cmd))
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except OSError as exc:
+        return 1, str(exc)
+    out = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode != 0:
+        tail = "\n".join(out.strip().splitlines()[-6:])
+        print(tail)
+    return proc.returncode, out
+
+
+def pip_install(pkgs: Sequence[str], assume_yes: bool) -> bool:
+    cmd = [sys.executable, "-m", "pip", "install", "--user"] + sorted(set(pkgs))
+    code, out = run(cmd)
+    if code == 0:
+        print("    installed.")
+        return True
+
+    # PEP 668: a Python installed by Homebrew or by a Linux distribution refuses to let pip put
+    # anything into it, to stop pip from fighting the package manager over the same files. For
+    # pure-Python libraries into the *user* site that is not the danger the message implies — but
+    # it is still an override of a deliberate safety, so it is never done silently.
+    if "externally-managed-environment" in out:
+        print()
+        print("    This Python is managed by your operating system, so it blocks pip by default.")
+        print("    These are ordinary Python libraries and installing them into your own user")
+        print("    folder does not touch the system's own packages.")
+        if ask("    Install them anyway?", assume_yes):
+            code, _ = run(cmd + ["--break-system-packages"])
+            if code == 0:
+                print("    installed.")
+                return True
+    print("    could not install — the command above shows what failed.")
+    return False
+
+
+def tool_install(tool: Tool, assume_yes: bool) -> bool:
+    system = platform.system()
+    if system == "Darwin" and tool.brew and have_tool("brew"):
+        code, _ = run(["brew", "install"] + tool.brew.split())
+        return code == 0
+    if system == "Windows" and tool.winget and have_tool("winget"):
+        code, _ = run(
+            [
+                "winget",
+                "install",
+                "--exact",
+                "--id",
+                tool.winget,
+                "--accept-source-agreements",
+                "--accept-package-agreements",
+            ]
+        )
+        return code == 0
+    # Linux needs sudo, and a setup script does not get to ask for a password. Everything else
+    # (no Homebrew, no winget) gets the page.
+    print("    Install it yourself with:  " + install_hint(tool))
+    return False
+
+
+def fix(assume_yes: bool) -> int:
+    report(print)
+
+    wanted_pips: List[str] = []
+    wanted_tools: List[Tool] = []
+    heavy: List[Tuple[str, str, str]] = []  # (label, size, command)
+
+    for cap in CAPABILITIES:
+        pips, tools = missing_of(cap)
+        if cap.key in OPTIONAL:
+            # Optional capabilities are offered one at a time and are never swept into a bulk
+            # install — not even with --yes. --yes means "stop asking me about the small, safe
+            # things I clearly want", not "decide for me what I want".
+            if not (pips or tools):
+                continue
+            print()
+            print("Optional: " + cap.title)
+            if cap.aside:
+                print("  " + cap.aside)
+            if not ask("  Set this up?", assume_yes=False):
+                continue
+        for t in tools:
+            if t.heavy:
+                heavy.append((t.label, t.heavy, install_hint(t)))
+            else:
+                wanted_tools.append(t)
+
+        # A heavy Python package (PyTorch is 2.5 GB) is no more welcome on a laptop than a heavy
+        # program is. If any package in a group is heavy, the whole group is the person's call —
+        # torchvision without torch would be a pointless half-install.
+        if any(p.heavy for p in pips):
+            size = next(p.heavy for p in pips if p.heavy)
+            heavy.append((", ".join(p.package for p in pips), size, pip_hint(pips)))
+        else:
+            wanted_pips.extend(p.package for p in pips)
+
+    if not (wanted_pips or wanted_tools or heavy):
+        print()
+        print("Nothing to install.")
+        return 0
+
+    if wanted_pips:
+        print()
+        print("Python packages to install: " + " ".join(sorted(set(wanted_pips))))
+        print("  (small, official, from the Python Package Index)")
+        if ask("Install them?", assume_yes):
+            pip_install(wanted_pips, assume_yes)
+
+    for tool in wanted_tools:
+        print()
+        print("Program to install: " + tool.label)
+        print("  " + install_hint(tool))
+        if ask("Install it?", assume_yes):
+            if tool_install(tool, assume_yes):
+                print("    installed.")
+
+    if heavy:
+        print()
+        print("NOT installed for you — these are large, and the choice should be yours:")
+        for label, size, command in heavy:
+            print("  " + label + "  (" + size + ")")
+            print("      " + command)
+
+    print()
+    print("Checking again:")
+    report(print)
+    return 0
+
+
+def as_json() -> int:
+    out = []
+    for cap in CAPABILITIES:
+        pips, tools = missing_of(cap)
+        out.append(
+            {
+                "key": cap.key,
+                "title": cap.title,
+                "optional": cap.key in OPTIONAL,
+                "ready": not (pips or tools),
+                "missing_packages": [p.package for p in pips],
+                "missing_tools": [t.label for t in tools],
+                "fix": ([pip_hint(pips)] if pips else []) + [install_hint(t) for t in tools],
+            }
+        )
+    print(json.dumps({"python": sys.version.split()[0], "capabilities": out}, indent=2))
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="What MedSci Skills can do on this computer, and how to fix what it cannot."
+    )
+    ap.add_argument("--fix", action="store_true", help="offer to install what is missing (asks first)")
+    ap.add_argument("--brief", action="store_true", help="only what is missing")
+    ap.add_argument("--json", action="store_true", help="machine-readable")
+    ap.add_argument("--yes", action="store_true", help="with --fix: do not ask about the small, safe installs")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero if anything non-optional is missing (for CI, not for people)",
+    )
+    a = ap.parse_args(argv)
+
+    if a.json:
+        return as_json()
+    if a.fix:
+        return fix(a.yes)
+
+    missing = report(print, brief=a.brief)
+    return 1 if (a.strict and missing) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/installers/install-macos.command
+++ b/installers/install-macos.command
@@ -49,11 +49,27 @@ if [ -z "$PY" ]; then
     echo "Python was not found on this Mac."
   fi
   echo
-  echo "  1. Go to  https://www.python.org/downloads/"
-  echo "  2. Download and install the latest Python for macOS."
-  echo "  3. Double-click this installer again."
+  echo "MedSci Skills is written in Python, so Python has to be on the computer first."
+  echo "It is free, official, and takes about two minutes."
+  echo
+  echo "  1. Download the latest Python for macOS  (the page opens by itself in a moment)"
+  echo "  2. Open the file you downloaded and click through the installer"
+  echo "  3. Double-click THIS installer again"
   echo
   echo "Nothing has been changed on your computer."
+  echo
+
+  # Open the page for them. Telling a clinician to "go to python.org" is a step they have to
+  # perform; opening it is a step they do not. `open` is standard on macOS, but never let a
+  # convenience break the message they still need to read.
+  if command -v open >/dev/null 2>&1; then
+    read -r -p "Press Enter to open the Python download page..."
+    open "https://www.python.org/downloads/" >/dev/null 2>&1 || \
+      echo "Could not open the page. It is at:  https://www.python.org/downloads/"
+  else
+    echo "The download page is at:  https://www.python.org/downloads/"
+  fi
+
   echo
   read -r -p "Press Enter to close..."
   exit 1

--- a/installers/install-macos.command
+++ b/installers/install-macos.command
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+# MedSci Skills — double-click installer for macOS.
+#
+# The person running this is a clinician who double-clicked a file. Every failure must end in a
+# sentence they can act on — never a Python traceback, and never a silent "done" that installed
+# nothing. Two things had to change for that to be true:
+#
+#   * `python` is not necessarily Python 3. Handing the installer to whatever `command -v python`
+#     finds could hand it to a Python 2 that dies on the first f-string.
+#   * Python 3.8 is worse than Python 2, not better: install.py *parses* there, so instead of a
+#     clean "wrong version" it dies halfway through with a wall of traceback.
+#
+# So the interpreter is checked for a real version BEFORE anything runs.
 set -u
 
 cd "$(dirname "$0")/.."
@@ -6,23 +18,66 @@ cd "$(dirname "$0")/.."
 echo "MedSci Skills Installer for macOS"
 echo
 
+MIN_MAJOR=3
+MIN_MINOR=9
+
+usable() {  # true only if $1 is really Python >= 3.9
+  command -v "$1" >/dev/null 2>&1 || return 1
+  "$1" -c "import sys; raise SystemExit(0 if sys.version_info >= ($MIN_MAJOR, $MIN_MINOR) else 1)" \
+    >/dev/null 2>&1
+}
+
 PY=""
-if command -v python3 >/dev/null 2>&1; then
-  PY=python3
-elif command -v python >/dev/null 2>&1; then
-  PY=python
+for candidate in python3 python; do
+  if usable "$candidate"; then
+    PY="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PY" ]; then
+  # "No Python" and "too old a Python" need different actions, and a clinician cannot be expected
+  # to work out which one they have from a version string.
+  if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+    # No pipe to `head` — an installer must not depend on tools that may not be on PATH in a
+    # stripped-down environment. `python --version` prints one line anyway.
+    FOUND="$( python3 --version 2>/dev/null || python --version 2>/dev/null )"
+    echo "The Python on this Mac is too old for MedSci Skills."
+    echo "  Found:  ${FOUND:-an older version}"
+    echo "  Needed: Python ${MIN_MAJOR}.${MIN_MINOR} or newer"
+  else
+    echo "Python was not found on this Mac."
+  fi
+  echo
+  echo "  1. Go to  https://www.python.org/downloads/"
+  echo "  2. Download and install the latest Python for macOS."
+  echo "  3. Double-click this installer again."
+  echo
+  echo "Nothing has been changed on your computer."
+  echo
+  read -r -p "Press Enter to close..."
+  exit 1
 fi
 
-if [ -n "$PY" ]; then
-  "$PY" installers/install.py --target all --desktop-launcher
-  # Turn on the in-app "update available" reminder for this turnkey install so you are told when a
-  # new version is out (no terminal needed afterward). Best-effort; turn off later with
-  # `install.py --disable-update-notify` or MEDSCI_NO_UPDATE_CHECK=1.
-  "$PY" installers/install.py --enable-update-notify || true
-else
-  echo "Python was not found."
-  echo "Install Python 3 from https://www.python.org/downloads/ and run this installer again."
+"$PY" installers/install.py --target all --desktop-launcher
+STATUS=$?
+
+if [ "$STATUS" -ne 0 ]; then
+  echo
+  echo "The installation did not finish (it stopped with error $STATUS)."
+  echo "Nothing was left half-installed — the installer undoes its own work if it cannot complete."
+  echo
+  echo "If you tell us what the message above said, we can fix it:"
+  echo "  https://github.com/Aperivue/medsci-skills/issues/new"
+  echo
+  read -r -p "Press Enter to close..."
+  exit "$STATUS"
 fi
+
+# Turn on the in-app "update available" reminder for this turnkey install, so you are told when a
+# new version ships instead of staying on this one forever. Best-effort: a failure here is not a
+# failed install. Turn it off later with `install.py --disable-update-notify`.
+"$PY" installers/install.py --enable-update-notify >/dev/null 2>&1 || true
 
 echo
 read -r -p "Press Enter to close..."

--- a/installers/install-windows.cmd
+++ b/installers/install-windows.cmd
@@ -1,30 +1,72 @@
 @echo off
-setlocal
+rem MedSci Skills - double-click installer for Windows.
+rem
+rem Windows is where most of these downloads go, and it has a trap the old script fell into.
+rem
+rem   THE MICROSOFT STORE STUB. On a Windows machine with no Python, `python` still EXISTS: it is an
+rem   App Execution Alias that opens the Microsoft Store. So `where python` succeeds, errorlevel is
+rem   0, the script cheerfully runs it -- and a Store page opens, nothing is installed, and the
+rem   installer reports it is done. The clinician is told everything worked and has nothing.
+rem
+rem   A TOO-OLD PYTHON. install.py PARSES on 3.8, so it does not fail cleanly: it dies partway
+rem   through with a traceback instead of saying "wrong version".
+rem
+rem So an interpreter is only accepted after it proves, BY RUNNING, that it is Python 3.9 or newer.
+rem Asking `where` only proves a name exists.
+setlocal EnableDelayedExpansion
 cd /d "%~dp0\.."
 
 echo MedSci Skills Installer for Windows
 echo.
 
-where py >nul 2>nul
-if %errorlevel%==0 (
-  py -3 installers\install.py --target all --desktop-launcher
-  rem Turn on the in-app "update available" reminder for this turnkey install (disable later with --disable-update-notify).
-  py -3 installers\install.py --enable-update-notify
-  goto done
+set "PY="
+
+rem The py launcher is the reliable path when it exists.
+py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+if !errorlevel!==0 set "PY=py -3"
+
+rem Fall back to `python` -- but only if it actually runs. The Store stub fails this test, which is
+rem the entire reason for testing instead of asking `where`.
+if not defined PY (
+  python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+  if !errorlevel!==0 set "PY=python"
 )
 
-where python >nul 2>nul
-if %errorlevel%==0 (
-  python installers\install.py --target all --desktop-launcher
-  rem Turn on the in-app "update available" reminder for this turnkey install (disable later with --disable-update-notify).
-  python installers\install.py --enable-update-notify
-  goto done
+if not defined PY (
+  echo Python 3.9 or newer was not found on this computer.
+  echo.
+  echo   1. Go to  https://www.python.org/downloads/
+  echo   2. Download and install the latest Python for Windows.
+  echo      IMPORTANT: on the first screen, tick "Add python.exe to PATH".
+  echo   3. Double-click this installer again.
+  echo.
+  echo If a Microsoft Store page opened when you tried Python before, that page is a
+  echo placeholder, not Python. Install it from python.org instead.
+  echo.
+  echo Nothing has been changed on your computer.
+  echo.
+  pause
+  exit /b 1
 )
 
-echo Python was not found.
-echo Please install Python 3 from https://www.python.org/downloads/ and run this installer again.
-echo.
+%PY% installers\install.py --target all --desktop-launcher
+if not !errorlevel!==0 (
+  set "RC=!errorlevel!"
+  echo.
+  echo The installation did not finish ^(it stopped with error !RC!^).
+  echo Nothing was left half-installed - the installer undoes its own work if it cannot complete.
+  echo.
+  echo If you tell us what the message above said, we can fix it:
+  echo   https://github.com/Aperivue/medsci-skills/issues/new
+  echo.
+  pause
+  exit /b !RC!
+)
 
-:done
+rem Turn on the in-app "update available" reminder for this turnkey install, so you are told when a
+rem new version ships instead of staying on this one forever. Best-effort: a failure here is not a
+rem failed install.
+%PY% installers\install.py --enable-update-notify >nul 2>nul
+
 echo.
 pause

--- a/installers/install-windows.cmd
+++ b/installers/install-windows.cmd
@@ -35,16 +35,56 @@ if not defined PY (
 if not defined PY (
   echo Python 3.9 or newer was not found on this computer.
   echo.
-  echo   1. Go to  https://www.python.org/downloads/
-  echo   2. Download and install the latest Python for Windows.
-  echo      IMPORTANT: on the first screen, tick "Add python.exe to PATH".
-  echo   3. Double-click this installer again.
+  echo MedSci Skills is written in Python, so Python has to be installed first.
+  echo It is free, official, and takes a couple of minutes.
+  echo.
+
+  rem winget ships with Windows 10 ^(1809+^) and Windows 11, so on most hospital machines Python can
+  rem simply be installed for the user -- no admin rights, no download page, no PATH checkbox to
+  rem miss. We ASK first: installing software on someone's computer without asking is not ours to do.
+  where winget >nul 2>nul
+  if !errorlevel!==0 (
+    echo This installer can install Python for you now, from the official Python
+    echo repository, into your own user account ^(no administrator password needed^).
+    echo.
+    set /p "DOIT=Install Python now? [Y/N] "
+    if /i "!DOIT!"=="Y" (
+      echo.
+      echo Installing Python. This takes a couple of minutes...
+      echo.
+      winget install --exact --id Python.Python.3.13 --scope user ^
+        --accept-source-agreements --accept-package-agreements
+      echo.
+      if !errorlevel!==0 (
+        echo Python is installed.
+        echo.
+        echo Windows only notices a new program in NEW windows, so this one cannot use it yet:
+        echo.
+        echo    ^>^>  Close this window and double-click the installer again.  ^<^<
+        echo.
+        echo Nothing else has been changed on your computer.
+        echo.
+        pause
+        exit /b 1
+      )
+      echo Python could not be installed automatically ^(error !errorlevel!^).
+      echo Use the download page instead - it is opening now.
+      echo.
+    )
+  )
+
+  echo   1. Download the latest Python for Windows ^(the page opens by itself in a moment^)
+  echo   2. Run the file you downloaded.
+  echo      IMPORTANT: on the FIRST screen, tick the box "Add python.exe to PATH"
+  echo      before pressing Install. It is easy to miss, and nothing works without it.
+  echo   3. Double-click THIS installer again.
   echo.
   echo If a Microsoft Store page opened when you tried Python before, that page is a
-  echo placeholder, not Python. Install it from python.org instead.
+  echo placeholder, not Python. Use python.org instead.
   echo.
   echo Nothing has been changed on your computer.
   echo.
+  start "" "https://www.python.org/downloads/"
   pause
   exit /b 1
 )

--- a/installers/install.py
+++ b/installers/install.py
@@ -374,6 +374,22 @@ def main() -> int:
         print(f"\nInstall log: {log_path}")
         return 1
 
+    # Say what ELSE this computer needs, while they are still looking at the screen.
+    #
+    # Every integrity detector is stdlib-only, so the install above is enough to use most of the
+    # toolkit. But a few skills need a program we do not ship — pandoc to render a manuscript into
+    # a journal-formatted Word file, poppler to read a submission PDF. Those skills already fail
+    # politely; the problem is that they fail *later*, in the middle of the work, to someone who
+    # will not go and install a package manager at that moment. Tell them now, when the answer is
+    # one command. Read-only, asks nothing, installs nothing, and can never fail the install.
+    if not args.dry_run:
+        try:
+            import doctor  # noqa: PLC0415
+
+            doctor.brief_summary(lambda m: log(m, log_lines))
+        except Exception:  # noqa: BLE001 - a setup *check* must never break an install that worked
+            pass
+
     _offer_contribution_reminders_once(log_lines)
     log("\nDone. Restart Claude Code, Codex, or Cursor before testing the skills.", log_lines)
     log("First test prompt:", log_lines)

--- a/installers/install.py
+++ b/installers/install.py
@@ -15,6 +15,20 @@ import os
 import sys
 from pathlib import Path
 
+# The floor the README promises. Checked here as well as in the double-click installers, because
+# the failure it prevents is a clinician staring at a Python traceback: on 3.8 this file *parses*
+# (so there is no clean syntax error to explain itself) and then dies somewhere in the middle,
+# leaving a half-explained wall of text and no idea what to do next.
+MIN_PYTHON = (3, 9)
+if sys.version_info < MIN_PYTHON:
+    have = ".".join(str(n) for n in sys.version_info[:3])
+    sys.exit(
+        f"\nMedSci Skills needs Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or newer. This computer has {have}.\n\n"
+        "  Install the latest Python from  https://www.python.org/downloads/\n"
+        "  then run this installer again.\n\n"
+        "Nothing has been changed on your computer.\n"
+    )
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # allow `import medsci_txn` when run as a script
 import medsci_txn  # noqa: E402
 

--- a/installers/tests/test_doctor.sh
+++ b/installers/tests/test_doctor.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression test for the setup check (installers/doctor.py).
+#
+# The failure this guards against is subtle: a setup check that always says "everything is fine".
+# It would pass every test that merely runs it, ship, and tell a clinician with no pandoc that they
+# can render a manuscript. So the test does not ask whether the script runs — it TAKES A TOOL AWAY
+# and demands that the report notices.
+#
+# It also pins the two promises the doctor makes:
+#   * it never installs anything on its own (plain and --brief must not shell out to pip/brew);
+#   * a missing OPTIONAL tool is not a failure (exit 0), or every Mac without R would be "broken".
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DOCTOR="$REPO_ROOT/installers/doctor.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+py() { python3 -B "$@"; }
+
+# --- 1. It runs, and a missing optional tool is not an error -------------------------------------
+py "$DOCTOR" > "$TMP/plain" 2>&1
+ck "plain run succeeds" 0 "$?"
+grep -q "MedSci Skills — setup check" "$TMP/plain"
+ck "...and prints a report" 0 "$?"
+
+# --- 2. THE ONE THAT MATTERS: hide pandoc, and the render capability must go missing -------------
+#
+# A PATH containing everything the doctor needs (python3) but NOT pandoc. If the probe is real, the
+# "render" capability flips to not-ready and pandoc is named as the missing piece.
+SANDBOX="$TMP/bin"; mkdir -p "$SANDBOX"
+for tool in python3 uname sw_vers; do
+  src="$(command -v "$tool" 2>/dev/null)" && ln -sf "$src" "$SANDBOX/$tool"
+done
+
+PATH="$SANDBOX" py "$DOCTOR" --json > "$TMP/nopandoc.json" 2>/dev/null
+ck "runs with pandoc hidden" 0 "$?"
+
+py - "$TMP/nopandoc.json" <<'PY'
+import json, sys
+caps = {c["key"]: c for c in json.load(open(sys.argv[1]))["capabilities"]}
+render = caps["render"]
+assert render["ready"] is False, "pandoc was hidden and the doctor still called rendering READY"
+assert any("pandoc" in t for t in render["missing_tools"]), render
+assert render["fix"], "it noticed pandoc was missing but offered no way to fix it"
+# The stdlib-only core must NEVER be reported as broken: it needs nothing, so nothing can break it.
+assert caps["core"]["ready"] is True, "the core capability claims to need something"
+PY
+ck "...pandoc gone => 'render to Word' reported MISSING, with a fix" 0 "$?"
+
+# --- 3. A missing optional tool is not a failure; a missing essential one is (only with --strict) -
+PATH="$SANDBOX" py "$DOCTOR" >/dev/null 2>&1
+ck "missing tools alone do not fail the check" 0 "$?"
+
+PATH="$SANDBOX" py "$DOCTOR" --strict >/dev/null 2>&1
+ck "--strict fails when an essential tool is missing" 1 "$?"
+
+# --- 4. It installs nothing by itself -------------------------------------------------------------
+#
+# pip / brew / winget are replaced by tripwires. Running the doctor (and the --brief summary the
+# installer prints) must never touch them: a setup check that installs software the moment you look
+# at it is not a check.
+TRIP="$TMP/trip"; mkdir -p "$TRIP"
+for tool in python3 uname sw_vers; do
+  src="$(command -v "$tool" 2>/dev/null)" && ln -sf "$src" "$TRIP/$tool"
+done
+for tool in brew winget pip pip3 apt; do
+  printf '#!/bin/sh\ntouch "%s/INSTALLED_SOMETHING"\n' "$TMP" > "$TRIP/$tool"
+  chmod +x "$TRIP/$tool"
+done
+rm -f "$TMP/INSTALLED_SOMETHING"
+
+PATH="$TRIP" py "$DOCTOR" >/dev/null 2>&1
+PATH="$TRIP" py "$DOCTOR" --brief >/dev/null 2>&1
+[ ! -f "$TMP/INSTALLED_SOMETHING" ]
+ck "the check installs nothing on its own" 0 "$?"
+
+# --- 5. --brief is the installer's tail: it must never raise -------------------------------------
+py - "$REPO_ROOT" <<'PY'
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "installers"))
+import doctor
+lines = []
+doctor.brief_summary(lines.append)          # what install.py calls
+assert isinstance(lines, list)
+# Every capability must name at least one skill, or the report tells you something is missing
+# without telling you what it was for.
+for cap in doctor.CAPABILITIES:
+    assert cap.skills, cap.key
+    assert cap.title, cap.key
+PY
+ck "brief_summary() (the installer's tail) never raises" 0 "$?"
+
+echo "----"
+echo "test_doctor: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/installers/tests/test_installer_python_guard.sh
+++ b/installers/tests/test_installer_python_guard.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression test for the double-click installer's Python guard.
+#
+# The person running install-macos.command is a clinician who double-clicked a file. Two failures
+# had to become impossible:
+#
+#   * running a `python` that is not Python 3 (or is 3.8), where install.py PARSES and then dies
+#     halfway through with a traceback instead of saying what is wrong;
+#   * reporting success while installing nothing.
+#
+# So the test hands the installer a fake interpreter and checks that it REFUSES — and, crucially,
+# that it refuses *before* install.py is ever invoked. A guard that runs the installer and then
+# apologises has not guarded anything.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-54s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-54s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# A copy of the payload the installer needs, so the real repo is never touched.
+BUNDLE="$TMP/bundle"
+mkdir -p "$BUNDLE/installers"
+cp "$REPO_ROOT/installers/install-macos.command" "$BUNDLE/installers/"
+chmod +x "$BUNDLE/installers/install-macos.command"
+
+# install.py is replaced by a tripwire: if the guard is working, this can never run.
+cat > "$BUNDLE/installers/install.py" <<'PY'
+import sys, pathlib
+pathlib.Path(__file__).with_name("INSTALL_RAN").write_text("the guard let it through")
+sys.exit(0)
+PY
+
+# 1) NO PYTHON AT ALL -> refuse, explain, and never touch install.py
+#
+# The sandbox PATH must contain the few external tools the script really uses (dirname) and NOT a
+# python — emptying PATH entirely only proves that `bash` cannot be found, which is a test bug, not
+# a guard.
+EMPTY="$TMP/bin_empty"; mkdir -p "$EMPTY"
+for tool in dirname; do
+  ln -sf "$(command -v "$tool")" "$EMPTY/$tool"
+done
+rm -f "$BUNDLE/installers/INSTALL_RAN"
+( cd "$BUNDLE/installers" && PATH="$EMPTY" /bin/bash ./install-macos.command < /dev/null > "$TMP/out" 2>&1 )
+ck "no Python at all -> refuses" 1 "$?"
+[ ! -f "$BUNDLE/installers/INSTALL_RAN" ]
+ck "...and install.py was never run" 0 "$?"
+grep -qi "python.org/downloads" "$TMP/out"
+ck "...and it says where to get Python" 0 "$?"
+
+# 2) A PYTHON THAT IS TOO OLD (3.8) -> refuse, and say the version is the problem
+OLD="$TMP/bin_old"
+mkdir -p "$OLD"
+cat > "$OLD/python3" <<'SH'
+#!/bin/sh
+case "$1" in
+  -c) exit 1 ;;                    # the guard's version probe: fail it, as a 3.8 would
+  --version) echo "Python 3.8.10" ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$OLD/python3"
+for tool in dirname; do ln -sf "$(command -v "$tool")" "$OLD/$tool"; done
+rm -f "$BUNDLE/installers/INSTALL_RAN"
+( cd "$BUNDLE/installers" && PATH="$OLD" /bin/bash ./install-macos.command < /dev/null > "$TMP/out" 2>&1 )
+ck "a too-old Python -> refuses" 1 "$?"
+[ ! -f "$BUNDLE/installers/INSTALL_RAN" ]
+ck "...and install.py was never run (no traceback wall)" 0 "$?"
+grep -qi "too old" "$TMP/out"
+ck "...and it names the real problem (the version)" 0 "$?"
+grep -q "3.8" "$TMP/out"
+ck "...and shows what was found" 0 "$?"
+
+# 3) A GOOD PYTHON -> the installer proceeds
+GOOD="$TMP/bin_good"
+mkdir -p "$GOOD"
+printf '#!/bin/sh\nexec %s "$@"\n' "$(command -v python3)" > "$GOOD/python3"
+chmod +x "$GOOD/python3"
+for tool in dirname; do ln -sf "$(command -v "$tool")" "$GOOD/$tool"; done
+rm -f "$BUNDLE/installers/INSTALL_RAN"
+( cd "$BUNDLE/installers" && PATH="$GOOD" /bin/bash ./install-macos.command < /dev/null > "$TMP/out" 2>&1 )
+[ -f "$BUNDLE/installers/INSTALL_RAN" ]
+ck "a supported Python -> the installer runs" 0 "$?"
+
+# 4) install.py itself refuses an old Python when run directly (defence in depth)
+python3 - "$REPO_ROOT/installers/install.py" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+assert "MIN_PYTHON = (3, 9)" in src, "install.py has no version floor"
+i, j = src.index("MIN_PYTHON"), src.index("import argparse")
+assert i < src.index("def "), "the floor check must run before anything else"
+PY
+ck "install.py carries its own floor guard" 0 "$?"
+
+echo "----"
+echo "test_installer_python_guard: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/installers/update-macos.command
+++ b/installers/update-macos.command
@@ -1,21 +1,56 @@
 #!/usr/bin/env bash
-# Thin launcher — all logic lives in update.py (next to this file). Double-click to update.
+# MedSci Skills — double-click updater for macOS. All logic lives in update.py, next to this file.
+#
+# An update that fails quietly is worse than no updater at all: the person stays on an old version
+# and believes they are current. So the interpreter is verified BEFORE anything runs (a `python`
+# that exists is not necessarily a Python 3, and a Python 3.8 dies mid-run instead of saying why).
 set -u
 cd "$(dirname "$0")"
 
 echo "MedSci Skills Updater for macOS"
 echo
 
-if command -v python3 >/dev/null 2>&1; then
-  python3 update.py "$@"
-  rc=$?
-elif command -v python >/dev/null 2>&1; then
-  python update.py "$@"
-  rc=$?
-else
-  echo "Python 3 was not found."
-  echo "Install Python 3 from https://www.python.org/downloads/ and run this updater again."
-  rc=1
+MIN_MAJOR=3
+MIN_MINOR=9
+
+usable() {
+  command -v "$1" >/dev/null 2>&1 || return 1
+  "$1" -c "import sys; raise SystemExit(0 if sys.version_info >= ($MIN_MAJOR, $MIN_MINOR) else 1)" \
+    >/dev/null 2>&1
+}
+
+PY=""
+for candidate in python3 python; do
+  if usable "$candidate"; then PY="$candidate"; break; fi
+done
+
+if [ -z "$PY" ]; then
+  if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+    echo "The Python on this Mac is too old (MedSci Skills needs ${MIN_MAJOR}.${MIN_MINOR} or newer)."
+  else
+    echo "Python was not found on this Mac."
+  fi
+  echo
+  echo "  1. Go to  https://www.python.org/downloads/"
+  echo "  2. Install the latest Python for macOS."
+  echo "  3. Double-click this updater again."
+  echo
+  echo "Your current installation has not been touched."
+  echo
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+"$PY" update.py "$@"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo
+  echo "The update did not finish (error $rc). Your current installation is unchanged —"
+  echo "the updater verifies a download before it replaces anything."
+  echo
+  echo "Tell us what the message above said and we will fix it:"
+  echo "  https://github.com/Aperivue/medsci-skills/issues/new"
 fi
 
 echo

--- a/installers/update-windows.cmd
+++ b/installers/update-windows.cmd
@@ -1,18 +1,53 @@
 @echo off
-REM Thin launcher — all logic lives in update.py (next to this file). Double-click to update.
+rem MedSci Skills - double-click updater for Windows. All logic lives in update.py, next to this file.
+rem
+rem The old version of this file ran `python` directly. On a Windows machine without Python that is
+rem not an error: it is the Microsoft Store App Execution Alias, which opens a Store page and exits.
+rem The user saw a Store window, no update, and no explanation. So an interpreter is only accepted
+rem after it proves BY RUNNING that it is Python 3.9 or newer.
+setlocal EnableDelayedExpansion
 cd /d "%~dp0"
 
 echo MedSci Skills Updater for Windows
 echo.
 
-python "%~dp0update.py" %*
-set rc=%errorlevel%
+set "PY="
+py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+if !errorlevel!==0 set "PY=py -3"
 
-if %rc% neq 0 (
+if not defined PY (
+  python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>nul
+  if !errorlevel!==0 set "PY=python"
+)
+
+if not defined PY (
+  echo Python 3.9 or newer was not found on this computer.
   echo.
-  echo If Python was not found, install Python 3 from https://www.python.org/downloads/ and run this updater again.
+  echo   1. Go to  https://www.python.org/downloads/
+  echo   2. Install the latest Python for Windows ^(tick "Add python.exe to PATH"^).
+  echo   3. Double-click this updater again.
+  echo.
+  echo If a Microsoft Store page opened when you tried Python before, that page is a
+  echo placeholder, not Python. Install it from python.org instead.
+  echo.
+  echo Your current installation has not been touched.
+  echo.
+  pause
+  exit /b 1
+)
+
+%PY% "%~dp0update.py" %*
+set "rc=!errorlevel!"
+
+if not !rc!==0 (
+  echo.
+  echo The update did not finish ^(error !rc!^). Your current installation is unchanged -
+  echo the updater verifies a download before it replaces anything.
+  echo.
+  echo Tell us what the message above said and we will fix it:
+  echo   https://github.com/Aperivue/medsci-skills/issues/new
 )
 
 echo.
 pause
-exit /b %rc%
+exit /b !rc!

--- a/installers/update.py
+++ b/installers/update.py
@@ -37,6 +37,19 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+# The floor the README promises. A clinician running the updater on an old Python must be told
+# that, not shown a traceback from somewhere in the middle of a download.
+MIN_PYTHON = (3, 9)
+if sys.version_info < MIN_PYTHON:
+    have = ".".join(str(n) for n in sys.version_info[:3])
+    raise SystemExit(
+        f"\nMedSci Skills needs Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or newer. This computer has {have}.\n\n"
+        "  Install the latest Python from  https://www.python.org/downloads/\n"
+        "  then run this updater again.\n\n"
+        "Your current installation has not been touched.\n"
+    )
+
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import medsci_txn  # noqa: E402  (PR-1a transactional core; reused for state/version helpers)
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -8,13 +8,13 @@
     },
     {
       "path": "installers/install-macos.command",
-      "size": 803,
-      "sha256": "4071582be11c467f48fe9f4684dcc9b7a115a5361479fdfbd7a10c74d3309a52"
+      "size": 3110,
+      "sha256": "251a137533e4945c8968d6dedce40cbfc8d0d690470112904da623ffe0e7e840"
     },
     {
       "path": "installers/install-windows.cmd",
-      "size": 831,
-      "sha256": "3204da065979a2b060a5170b5c542e5ccd2ede4ecc172fcee7eafac3c0bfd003"
+      "size": 2803,
+      "sha256": "b5d21e6ae9e25be49f6792fd947b2fac221149738ce0a1b1fdf347360652f518"
     },
     {
       "path": "installers/install-windows.ps1",
@@ -23,8 +23,8 @@
     },
     {
       "path": "installers/install.py",
-      "size": 16786,
-      "sha256": "26dac5013afc68adbebe1ddd954979701d46078cc1aa8fca974b2572ce1d0098"
+      "size": 17572,
+      "sha256": "86d18d7f741105c6a4b2457202a0973ef5bb4150440ffbb5ce7b14e241ff4a54"
     },
     {
       "path": "installers/medsci_txn.py",
@@ -38,18 +38,18 @@
     },
     {
       "path": "installers/update-macos.command",
-      "size": 535,
-      "sha256": "b5eafc89896ad022ead1db3e431f021ec4f734a4fe0cd0ac170b9d25fa80bddf"
+      "size": 1764,
+      "sha256": "4df32d457ff1b70474b4e979e28e642633eec44a9a184bcfb8b6419a6090cd1d"
     },
     {
       "path": "installers/update-windows.cmd",
-      "size": 383,
-      "sha256": "095ba6d2a720ced75ff04dbe860480baec658bc2e90afbe9c4138fc9eb2702e2"
+      "size": 1780,
+      "sha256": "ddf32104ec882c6b921d265d52542e2413ae1ab3bb12afb89e7ea0f64134ca09"
     },
     {
       "path": "installers/update.py",
-      "size": 26375,
-      "sha256": "9ed283deea2e9bf10c17bbbbc1d75ae64703ecd587326583a17d0600d8bf0ca3"
+      "size": 26983,
+      "sha256": "2851980bd25d3f435788f032239d50e3d026d8c13f9c0128afc3a935d26f8cfa"
     },
     {
       "path": "skills/MAINTENANCE.md",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -18,8 +18,8 @@
     },
     {
       "path": "installers/doctor.py",
-      "size": 21829,
-      "sha256": "c16165db89c000fdee12a29582ad04ba8843e0ac3d3239ea8bd0bf41fe20de36"
+      "size": 23120,
+      "sha256": "a37caea62468e1847337cc2ef82bd83d094fed81b02f8708dcc13cecb420df46"
     },
     {
       "path": "installers/install-macos.command",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -7,14 +7,29 @@
       "sha256": "b359c9214ce261265e2820a74902ff8b6d331e05270e475ded3b5fc06781ca65"
     },
     {
+      "path": "installers/check-setup-macos.command",
+      "size": 975,
+      "sha256": "6e54f5f5ae8dbcf82afb2ec08a3e54643842ceb75befaf079e5b6e7e3c900432"
+    },
+    {
+      "path": "installers/check-setup-windows.cmd",
+      "size": 948,
+      "sha256": "c514e0dcd9d69681ec9a4adacf1cf4ada00d89aed060358d7eba4c4e7a1ff303"
+    },
+    {
+      "path": "installers/doctor.py",
+      "size": 21829,
+      "sha256": "c16165db89c000fdee12a29582ad04ba8843e0ac3d3239ea8bd0bf41fe20de36"
+    },
+    {
       "path": "installers/install-macos.command",
-      "size": 3110,
-      "sha256": "251a137533e4945c8968d6dedce40cbfc8d0d690470112904da623ffe0e7e840"
+      "size": 3904,
+      "sha256": "6f1cc2e24661054f1b68ad9677ecc3d39582b8ba419f0764c566f3f9037b7e59"
     },
     {
       "path": "installers/install-windows.cmd",
-      "size": 2803,
-      "sha256": "b5d21e6ae9e25be49f6792fd947b2fac221149738ce0a1b1fdf347360652f518"
+      "size": 4486,
+      "sha256": "d686cf96e2e116eed9c85c8201443230016c3b63a0ec6aae4e92b06a6d1dcb80"
     },
     {
       "path": "installers/install-windows.ps1",
@@ -23,8 +38,8 @@
     },
     {
       "path": "installers/install.py",
-      "size": 17572,
-      "sha256": "86d18d7f741105c6a4b2457202a0973ef5bb4150440ffbb5ce7b14e241ff4a54"
+      "size": 18509,
+      "sha256": "7dc0eac5c52077d8e97cf8b7fb653056bc45475fedb772e650f4370ebd7d392b"
     },
     {
       "path": "installers/medsci_txn.py",

--- a/scripts/check_python_floor.py
+++ b/scripts/check_python_floor.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Everything a user runs must parse on the oldest Python we promise them.
+
+The README says **Python 3.9+**. CI runs 3.11. This machine runs 3.14. Nothing checks 3.9 — so a
+`match` statement, or a `X | Y` outside an annotation, would sail through every gate we have and
+break only on the computer of a clinician who never tells us, because when a research tool errors
+out a physician does not file a bug: they close the window and go back to doing it by hand.
+
+That gap is not hypothetical. On 2026-07-13 a backslash inside an f-string (legal on 3.12+, a
+syntax error before it) shipped from a 3.14 machine and was caught only because CI happened to run
+3.11. One version lower and it would have been invisible.
+
+This parses every script that reaches a user — the installers and the skill scripts the agent runs
+on their machine — under the promised floor, and fails if any of them would not even load. It does
+not check the repository's own maintainer tooling (`scripts/`), which never leaves this repo and
+may use whatever CI runs.
+
+Usage:
+    check_python_floor.py [--floor 3.9] [--strict]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# What actually reaches a user's machine: the classroom ZIP payload (installers/ + skills/) and the
+# npm package. `scripts/` is maintainer tooling and is deliberately not shipped.
+SHIPPED = [
+    ("installers", "*.py"),
+    ("skills", "*/scripts/*.py"),
+]
+
+SKIP_PARTS = {"__pycache__", "tests", ".pytest_cache"}
+
+
+def shipped_files() -> list[Path]:
+    out: list[Path] = []
+    for base, pattern in SHIPPED:
+        for p in sorted((ROOT / base).glob(pattern)):
+            if p.is_file() and not SKIP_PARTS.intersection(p.parts):
+                out.append(p)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--floor", default="3.9", help="the oldest Python we promise (default: the README's 3.9)")
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any violation (CI gate)")
+    a = ap.parse_args()
+
+    try:
+        major, minor = (int(x) for x in a.floor.split("."))
+    except ValueError:
+        raise SystemExit(f"--floor must look like 3.9, not {a.floor!r}")
+
+    files = shipped_files()
+    if not files:
+        raise SystemExit("found no shipped python files — the globs are wrong, and this gate is a no-op")
+
+    bad: list[tuple[Path, int, str]] = []
+    for p in files:
+        try:
+            ast.parse(p.read_text(encoding="utf-8"), feature_version=(major, minor))
+        except SyntaxError as exc:
+            bad.append((p, exc.lineno or 0, exc.msg))
+
+    if bad:
+        print(f"PYTHON_FLOOR: {len(bad)} shipped file(s) do not parse on Python {a.floor}\n")
+        for p, line, msg in bad:
+            print(f"  {p.relative_to(ROOT)}:{line}")
+            print(f"      {msg}")
+        print(
+            f"\nThe README promises Python {a.floor}+. A file that will not parse there does not fail "
+            "politely on\na clinician's computer — it fails with a traceback, and they close the window."
+        )
+        return 1 if a.strict else 0
+
+    print(f"OK: all {len(files)} shipped script(s) parse on Python {a.floor} (the floor we promise).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
User-facing stability. **Windows is 65% of classroom-ZIP downloads** (285 vs 152), and it had a trap this fell straight into.

## The Store stub

On a Windows machine **with no Python**, `python` still **exists** — it is an App Execution Alias that opens the Microsoft Store.

```bat
where python          rem  → succeeds! errorlevel 0
python install.py     rem  → a Store page opens. Nothing installs.
echo done             rem  → "done"
```

The clinician was told everything worked and had nothing.

**Asking `where` only proves a name exists.** An interpreter is now accepted only after it proves, **by running**, that it is Python 3.9 or newer.

## The quieter failure

`install.py` **parses** on Python 3.8. So an old Python did not fail cleanly with "wrong version" — it died partway through and left a physician staring at a **stack trace**.

All four double-click scripts (install / update × macOS / Windows) and both Python entry points now check the floor **before anything runs**, and distinguish the two cases — *"no Python"* and *"too old a Python"* need different actions, and a clinician cannot be expected to work that out from a version string.

Every failure now ends in a sentence they can act on, and in **"nothing has been changed on your computer"** — which is true (the install is transactional), and is the thing they most want to know.

The updaters had the same holes, and an update that fails quietly is worse than no updater: the person stays on an old version *believing they are current*. The Windows updater did not even try `py -3` — it ran `python` straight into the Store stub.

## `check_python_floor.py` (CI)

The README promises **Python 3.9+**. CI runs **3.11**. This project is developed on **3.14**. **Nothing checked 3.9.**

A `match` statement would have passed every gate we have and broken only on the computer of a clinician who never tells us — because when a research tool errors out, **a physician does not file a bug. They close the window and go back to doing it by hand.**

That is not hypothetical: yesterday a backslash inside an f-string (legal on 3.12+, a syntax error before it) shipped from this 3.14 machine and was caught only because CI happened to run 3.11. One version lower and it would have been invisible. All 123 shipped scripts parse on 3.9 today; now they must.

## Tests

9 assertions. The test hands the installer a **fake interpreter** and asserts it refuses **before `install.py` is ever invoked** — a guard that runs the installer and then apologises has not guarded anything. It also earned its keep: it caught the installer depending on `head`, which is not guaranteed to be on PATH in a stripped-down environment.

Full CI mirror green, including the installer/updater/release-ZIP suite.