### PR TITLE
fix(contributing): a stranger's first PR went red for doing exactly what we asked

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Run setup-check test (hide pandoc; the report must NOTICE, and must install nothing)
         run: bash installers/tests/test_doctor.sh
 
+      - name: Run manifest-drift message test (a contributor's red X must be actionable)
+        run: bash tests/test_manifest_drift_message.sh
+
       - name: Run check_release_cadence.py (a release is an event, not a commit)
         run: python3 scripts/check_release_cadence.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@
 
 ### Fixed
 
+- **We invited contributors through the browser, then failed them with a Python script.** A
+  stranger's first pull request — five nephrology journal profiles, exactly what our "good first
+  issue" asked for — went red with `DISTRIBUTION_MANIFEST_DRIFT: … out of date — run python3
+  scripts/gen_distribution_manifest.py`. He had added ten shipped files, so the hashed inventory the
+  self-updater verifies against no longer matched. Nothing was wrong with his work. But CONTRIBUTING
+  promises a browser-only path with **no git and no terminal**, and someone who accepts that
+  invitation cannot run a Python script: we told them to do the one thing we had just promised they
+  would never have to do. The gate stays strict — it protects the updater — but it now **names the
+  files that moved**, gives the command, and says plainly that a contributor who cannot run it should
+  leave it red, because **a maintainer will refresh the manifest before merging and this is not a
+  rejection**. CONTRIBUTING says the same. A regression test adds a shipped file and asserts the
+  message, because the message was the defect.
+
 - **The README demanded R and never mentioned pandoc — both wrong.** It listed "R 4.0+ with `meta`,
   `metafor`, `mada`" under Requirements, which reads as *you cannot use this without R*. The toolkit
   **never executes R**: `/analyze-stats` writes Python unless asked for R. Meanwhile **pandoc** — which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ the file → push → open a PR. Either way, you do **not** need the worktree di
 process, or any catalog-count bump. The catalog-consistency check auto-derives journal-profile counts
 from disk, so adding a profile will not flag you; a maintainer handles the bookkeeping in review.
 
+**One check may go red, and it is not your fault.** If your change *adds* a file that ships to users
+(a journal profile, a reference doc), the `Distribution manifests in sync` check fails: we keep a
+hashed list of every shipped file so the self-updater can verify a download, and your new file is not
+in it yet. If you are working locally, refresh it with `python3 scripts/gen_distribution_manifest.py`
+and commit the `metadata/` files it writes. **If you contributed through the browser, you cannot run
+that — and you are not expected to.** Leave it red, say so in the PR, and a maintainer will refresh
+the manifest before merging. A red mark on that one check is bookkeeping, not a rejection.
+
 ### Already changed something on your own machine?
 
 If you have adapted an installed skill — added your journal, fixed something that was wrong for your

--- a/scripts/gen_distribution_manifest.py
+++ b/scripts/gen_distribution_manifest.py
@@ -140,6 +140,32 @@ def dumps(obj: dict) -> str:
     return json.dumps(obj, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
 
 
+def _explain_drift(fresh_files_json: str, limit: int = 8) -> None:
+    """Name the files that moved, so the failure is a fact and not an accusation.
+
+    "The manifest is out of date" tells someone nothing. "You added these ten files" tells them
+    they did exactly what the issue asked, and that this check is bookkeeping.
+    """
+    try:
+        old = {e["path"]: e["sha256"] for e in json.loads(FILES.read_text(encoding="utf-8"))["files"]}
+    except (OSError, ValueError, KeyError):
+        return  # no readable previous manifest: the prose below is all we can honestly say
+    new = {e["path"]: e["sha256"] for e in json.loads(fresh_files_json)["files"]}
+
+    added = sorted(set(new) - set(old))
+    removed = sorted(set(old) - set(new))
+    changed = sorted(p for p in set(old) & set(new) if old[p] != new[p])
+
+    for label, paths in (("added", added), ("removed", removed), ("changed", changed)):
+        if not paths:
+            continue
+        print(f"  {len(paths)} file(s) {label}:", file=sys.stderr)
+        for p in paths[:limit]:
+            print(f"    {p}", file=sys.stderr)
+        if len(paths) > limit:
+            print(f"    ... and {len(paths) - limit} more", file=sys.stderr)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Generate/verify the distribution manifests.")
     ap.add_argument("--check", action="store_true", help="verify on-disk files match; exit 1 on drift")
@@ -157,8 +183,34 @@ def main() -> int:
             if have != want:
                 drift.append(path.relative_to(ROOT).as_posix())
         if drift:
-            print(f"DISTRIBUTION_MANIFEST_DRIFT: {', '.join(drift)} out of date — run "
-                  f"python3 scripts/gen_distribution_manifest.py", file=sys.stderr)
+            # This gate protects the self-updater, which verifies a downloaded release against
+            # these hashes. A stale manifest is a broken update, so the gate is strict and stays
+            # strict.
+            #
+            # But the people who trip it are mostly FIRST-TIME contributors adding a shipped file —
+            # a journal profile, a reference doc — because adding a file *is* the whole of a good
+            # first issue. And our own CONTRIBUTING invites them through a browser-only path with
+            # no git and no terminal: someone who accepted that invitation **cannot run this
+            # generator at all**. "Run python3 scripts/…" is not an instruction to them, it is a
+            # dead end, and a red X on a stranger's first contribution is how you lose them.
+            #
+            # So: name what moved, say what to do, and say plainly that if they cannot do it, their
+            # PR is not wrong and a maintainer will finish it.
+            print(f"DISTRIBUTION_MANIFEST_DRIFT: {', '.join(drift)} out of date.\n", file=sys.stderr)
+            _explain_drift(files)
+            print(
+                "\nWhat this is: these files list every file we ship, with its hash, so the\n"
+                "self-updater can verify a download. Adding or editing a shipped file changes that\n"
+                "list. Nothing is wrong with your change — the list just has to be refreshed.\n"
+                "\n"
+                "  To refresh it:  python3 scripts/gen_distribution_manifest.py\n"
+                "                  then commit the changed file(s) under metadata/\n"
+                "\n"
+                "If you contributed through the GitHub website and cannot run Python: that is fine,\n"
+                "and expected. Leave it — say so in the pull request and a maintainer will refresh\n"
+                "the manifest before merging. This check being red is not a rejection.",
+                file=sys.stderr,
+            )
             return 1
         print(f"OK: distribution manifests in sync (version {build_manifest()['version']}, "
               f"{len(build_files()['files'])} payload files, {len(build_owned_skills())} owned skills).")

--- a/tests/test_manifest_drift_message.sh
+++ b/tests/test_manifest_drift_message.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# The manifest gate must fail a first-time contributor USEFULLY.
+#
+# On 2026-07-13 a stranger's first pull request — five nephrology journal profiles, the exact thing
+# our "good first issue" asked for — went red with:
+#
+#     DISTRIBUTION_MANIFEST_DRIFT: metadata/distribution_files.json out of date — run
+#     python3 scripts/gen_distribution_manifest.py
+#
+# He had added ten shipped files, so the hashed inventory no longer matched. Nothing was wrong with
+# his work. But CONTRIBUTING invites people to contribute **through the browser, with no git and no
+# terminal** — and someone who accepts that invitation cannot run a Python script. We told them to do
+# the one thing we had just promised they would never have to do.
+#
+# This test reproduces that exact situation: add a shipped file, do not touch metadata/, and demand
+# that the failure (a) still fails — the gate protects the updater and must stay strict — and (b)
+# names the file, and (c) tells a browser contributor that a maintainer will handle it.
+#
+# It asserts on the MESSAGE, because the message was the defect.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"; rm -f "$ROOT/skills/find-journal/references/journal_profiles/__ci_probe__.md"' EXIT
+
+pass=0
+fail=0
+ck() {
+  if [ "$2" = "$3" ]; then
+    printf '  PASS  %s\n' "$1"; pass=$((pass + 1))
+  else
+    printf '  FAIL  %s (expected=%s actual=%s)\n' "$1" "$2" "$3"; fail=$((fail + 1))
+  fi
+}
+has() {  # has <label> <pattern>
+  if grep -qi -- "$2" "$TMP/out"; then
+    printf '  PASS  %s\n' "$1"; pass=$((pass + 1))
+  else
+    printf '  FAIL  %s (missing: %s)\n' "$1" "$2"; fail=$((fail + 1))
+  fi
+}
+
+# Sanity: the tree is in sync before we disturb it, or this test proves nothing.
+python3 "$ROOT/scripts/gen_distribution_manifest.py" --check >/dev/null 2>&1
+ck "the repo starts in sync (otherwise this test is meaningless)" 0 "$?"
+
+# Reproduce the trap: a new shipped file, exactly as a good-first-issue contributor would add it.
+PROBE="$ROOT/skills/find-journal/references/journal_profiles/__ci_probe__.md"
+printf '# CI probe\n\nA synthetic profile, added and removed by this test.\n' > "$PROBE"
+
+python3 "$ROOT/scripts/gen_distribution_manifest.py" --check > "$TMP/out" 2>&1
+ck "adding a shipped file still FAILS the gate (it guards the updater)" 1 "$?"
+
+has "...names the file that moved"                 "__ci_probe__.md"
+has "...says how many files were added"            "1 file(s) added"
+has "...gives the command to refresh it"           "gen_distribution_manifest.py"
+has "...tells browser contributors it is not on them" "maintainer will refresh"
+has "...says this is not a rejection"              "not a rejection"
+
+# And the gate must go green again once the manifest is refreshed — otherwise the advice we just
+# printed would be a lie.
+rm -f "$PROBE"
+python3 "$ROOT/scripts/gen_distribution_manifest.py" --check >/dev/null 2>&1
+ck "removing the file restores sync (the advice is true)" 0 "$?"
+
+echo "----"
+echo "test_manifest_drift_message: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What happened

**@insanehahaha** opened his first PR on this repo yesterday (#330): five nephrology journal profiles — exactly what good-first-issue #115 asks for. CI failed:

```
DISTRIBUTION_MANIFEST_DRIFT: metadata/distribution_files.json out of date — run
python3 scripts/gen_distribution_manifest.py
```

He added ten shipped files, so the hashed inventory the self-updater verifies against no longer matched. **The gate is right to fail.** It protects the updater and stays strict.

The problem is what it said next. `CONTRIBUTING.md` invites people to contribute **in the browser — no git, no clone, no terminal** — and it explicitly promised *"adding a profile will not flag you."* Both halves failed him: he *was* flagged, and the fix was a Python script he had no way to run.

A dead end, in maintainer shorthand, on a stranger's first contribution. That is how you lose contributors.

## What changed

The failure now names what moved, gives the command, and tells someone who cannot run it that they are not the problem:

```
DISTRIBUTION_MANIFEST_DRIFT: metadata/distribution_files.json out of date.

  10 file(s) added:
    skills/find-journal/references/journal_profiles/AJKD.md
    ...

What this is: these files list every file we ship, with its hash, so the
self-updater can verify a download. Nothing is wrong with your change — the
list just has to be refreshed.

  To refresh it:  python3 scripts/gen_distribution_manifest.py

If you contributed through the GitHub website and cannot run Python: that is fine,
and expected. Leave it — say so in the pull request and a maintainer will refresh
the manifest before merging. This check being red is not a rejection.
```

`CONTRIBUTING.md` now says the same, right where it makes the no-git promise.

## Test

`tests/test_manifest_drift_message.sh` reproduces the trap — adds a shipped file, leaves `metadata/` alone — and asserts **on the message**, because the message was the defect. A test that only checked "the gate fails" would have passed on the day this happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)