### PR TITLE
fix(medsci-audit): three detectors were counted, tested, released — and never ran

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Run capabilities-validator self-test (drift fixtures fail, live repo clean)
         run: bash tests/test_capabilities_validator.sh
 
+      - name: "Run check_detector_reachability.py (a detector nothing calls never runs)"
+        run: python3 scripts/check_detector_reachability.py --strict
+
       - name: Run check_orchestrate_reachability.py (every skill routable from /orchestrate)
         run: python3 scripts/check_orchestrate_reachability.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,29 @@
 
 ### Fixed
 
+- **Three detectors were counted, tested, released — and never ran.** `check_table_percentages`,
+  `check_reported_p_from_counts` and `check_dta_denominators` shipped in v5.20.0 with challenge cards,
+  CI steps, JSON envelopes and a release note, and **`self-review/SKILL.md` never mentioned them**.
+  They passed every gate we had and had never once run on a manuscript, while being counted in the
+  number we publish. A challenge card proves a detector **works**; nothing proved the skill **calls**
+  it. They are now wired into Phase 2.5 — the arithmetic a reviewer redoes with a calculator: a
+  percentage that does not follow from its own denominator, and a P value that does not follow from
+  its own counts. `scripts/check_detector_reachability.py` (CI) now fails if any detector is not
+  invoked by a SKILL.md, directly or through a named bundle runner.
+
+- **`/present-paper` Phase 0 demanded ~14,000 tokens of references before a single slide.** Three of
+  the six mattered up front; `medical_presentation_templates.md` alone cost ~3,700 tokens to use a
+  fifth of, and the visual-style file was read before the style was chosen. Split into *read now*
+  (the AI-tells file, the archetypes, the enforceable rules) and *read when Q0/Q2 tells you which
+  one*. **~7,400 tokens saved per invocation, with nothing decision-shaping removed.**
+
+- **The archetypes file duplicated the medical templates.** Archetypes A–D (conference oral, critique,
+  case-anchored, didactic) are the same four venues the content templates already covered — two files
+  answering "how do I structure a journal club talk". The boundary is now explicit: the archetype
+  gives the **stance** (what the talk must do, what fails), the template gives the **sections**, and
+  the archetype wins where they conflict. A section list cannot tell you that a journal club which
+  merely summarises the paper has failed.
+
 - **A broken workflow file does not turn a pull request red — it makes the checks *disappear*.**
   A step named ``- name: Run deck-budget challenge (same deck: fits an oral, ...)`` put a `: ` inside
   an unquoted YAML scalar. `validate.yml` stopped being valid YAML, GitHub ran **zero jobs**, and

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3453,8 +3453,8 @@
     },
     {
       "path": "skills/present-paper/SKILL.md",
-      "size": 40128,
-      "sha256": "fbd3db6334755142d8b47c15779f2c8f5d36c1e35afca4067191d65614edd823"
+      "size": 41029,
+      "sha256": "9f9f7635053748e8174d23e78bd1e6661ab2acca87889a773282a01dde6edb55"
     },
     {
       "path": "skills/present-paper/references/ai_slide_tells.md",
@@ -3478,8 +3478,8 @@
     },
     {
       "path": "skills/present-paper/references/presentation_archetypes.md",
-      "size": 11968,
-      "sha256": "76428b7a2f84ca101db49bacc5159bf09954ef8679c5449a5f211abd2fc6204d"
+      "size": 12547,
+      "sha256": "02d45db18bd0c8cfd430b0f4683714988fdf8427653f30068140f3885ee008e7"
     },
     {
       "path": "skills/present-paper/references/presentation_design_guidelines.md",
@@ -3873,8 +3873,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 105088,
-      "sha256": "bc74e3138847edaf31d757d4fdab96667e740c4e0cb656ff2bd685a894bc2ed2"
+      "size": 106397,
+      "sha256": "09bf5f386c204b98fc10b2efdb19ad19761808539e6dab7db762622338ce3e2a"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",

--- a/scripts/check_detector_reachability.py
+++ b/scripts/check_detector_reachability.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""A detector nothing calls is a detector that never runs.
+
+We count 64 detectors. We test them in CI. We give each one a challenge card with a positive and a
+negative fixture, and a JSON envelope that names itself. All of that proves a detector **works**.
+
+None of it proves the skill **calls** it.
+
+On 2026-07-14 a sweep found five — `check_table_percentages`, `check_reported_p_from_counts`,
+`check_dta_denominators`, `check_nested_group_comparison`, `check_paired_difference_estimator` —
+that were shipped in v5.20.0 with challenge cards, CI steps, catalog entries and a release note, and
+that **`self-review/SKILL.md` never mentioned**. They passed every gate we had and had never once run
+on a real manuscript. They were counted in the number we publish.
+
+This is the same disease as a green test that would not catch the defect, one level up: the gate was
+verifying the tool instead of the *use* of the tool.
+
+A detector is REACHABLE if:
+  * some SKILL.md invokes it by filename, or
+  * a non-test script that is itself reachable invokes it (e.g. a preflight gate that runs a bundle).
+
+A challenge card, a test, or a CI step does NOT make it reachable. Those prove it works in a
+laboratory. They are exactly what these five had.
+
+Usage:
+    check_detector_reachability.py [--strict]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS = ROOT / "skills"
+
+# Same discovery globs as gen_detectors_catalog_json.py / validate_catalog_consistency.py: whatever
+# counts as a detector for the number we publish must count as one here, or the gate has a hole
+# exactly where the marketing is.
+DETECTOR_GLOBS = ("check_*.py", "detect_*.py", "derive_*.py")
+EXTRA_DETECTORS = ("verify-refs/scripts/verify_refs.py",)
+
+# Files that prove a detector WORKS but never cause it to RUN for a user.
+TEST_MARKERS = ("/tests/", "_challenge/", "/challenge/")
+
+# A detector may legitimately be reached only through another script — but that script has to be one
+# a skill actually runs. Named here so the exemption is a decision, not an accident.
+BUNDLE_RUNNERS = {
+    "preflight_gate.py",       # sync-submission: runs a bundle of checks before upload
+    "pre_submission_gate.sh",  # manage-refs: the 5-stage submission gate
+}
+
+
+def detectors() -> list[Path]:
+    out: list[Path] = []
+    for g in DETECTOR_GLOBS:
+        out += sorted(SKILLS.glob(f"*/scripts/{g}"))
+    for extra in EXTRA_DETECTORS:
+        p = SKILLS / extra
+        if p.is_file():
+            out.append(p)
+    return sorted(set(out))
+
+
+def invocation_sites() -> list[Path]:
+    """Everything that can cause a detector to run for a real user."""
+    sites = list(SKILLS.glob("*/SKILL.md"))
+    for name in BUNDLE_RUNNERS:
+        sites += list(SKILLS.glob(f"*/scripts/{name}"))
+    return sites
+
+
+def unreachable() -> list[tuple[str, str, list[str]]]:
+    sites = invocation_sites()
+    blobs = {p: p.read_text(encoding="utf-8", errors="ignore") for p in sites}
+
+    out: list[tuple[str, str, list[str]]] = []
+    for d in detectors():
+        name = d.name
+        skill = d.parts[d.parts.index("skills") + 1]
+
+        callers = [p for p, text in blobs.items() if name in text]
+        if callers:
+            continue
+
+        # Where IS it mentioned? That tells the maintainer whether it was forgotten or is new.
+        mentions = [
+            str(p.relative_to(ROOT))
+            for p in SKILLS.rglob("*")
+            if p.is_file() and p != d and not p.is_dir()
+            and p.suffix in {".md", ".sh", ".py", ".yml"}
+            and name in p.read_text(encoding="utf-8", errors="ignore")
+        ]
+        lab_only = [m for m in mentions if any(t in "/" + m for t in TEST_MARKERS)]
+        out.append((skill, name, lab_only or mentions))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any detector is unreachable")
+    a = ap.parse_args()
+
+    total = len(detectors())
+    bad = unreachable()
+
+    if not bad:
+        print(f"OK: all {total} detectors are invoked by a SKILL.md (directly or via a bundle runner).")
+        return 0
+
+    print(f"DETECTOR_UNREACHABLE: {len(bad)} of {total} detectors are never invoked by any skill.\n")
+    for skill, name, where in bad:
+        print(f"  {skill}/{name}")
+        if where:
+            shown = ", ".join(where[:3])
+            print(f"      mentioned only in: {shown}")
+            print("      — a challenge card and a CI step prove it WORKS. They do not make it RUN.")
+        else:
+            print("      — not mentioned anywhere. Dead code.")
+        print()
+    print("Fix: invoke it from its skill's SKILL.md (the phase where it belongs), or — if it is")
+    print("reached through a bundle runner — add that runner to BUNDLE_RUNNERS in this script.")
+    print("\nA detector that never runs is still counted in the number we publish. That makes the")
+    print("number a claim about our repository rather than about anyone's manuscript.")
+    return 1 if a.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/present-paper/SKILL.md
+++ b/skills/present-paper/SKILL.md
@@ -40,7 +40,43 @@ Use it when:
 
 ### Step 0a — Load design references (read before drafting outline)
 
-Before collecting inputs, the skill loads these reference files:
+Three of these are read **now**, in full — they change what you produce. The rest are read **when the
+answer to Q0 tells you which one you need**, because a talk has one venue and one style, and reading
+the others costs roughly seven thousand tokens to learn nothing you will use.
+
+**Read now (always):**
+
+**A. `references/ai_slide_tells.md`** — the marks a generated deck leaves. Read all of it, first.
+The complaint about AI decks is **not** that they are ugly — templates solved ugly. It is that they
+*stop communicating*, because they were built to make the maker comfortable rather than to serve the
+audience. This file is why the deck does not need catching later; `scripts/check_slide_tells.py`
+catches it after (Step 3.6). It **overrules older guidance where they conflict** — in particular the
+eyebrow-on-every-slide and brand-footer rules this project used to mandate, which are the single
+most-cited visual tell.
+
+**B. `references/presentation_archetypes.md`** — the **skeleton**, chosen by where the speaker is
+standing: conference oral, journal-club critique, case-anchored grand rounds, didactic lecture,
+defence, keynote (Duarte's sparkline, the Jobs STAR moment, Takahashi/Lessig), lay talk, decision
+brief (Minto's pyramid, action titles, Kawasaki's 10/20/30). A deck has **two independent choices**
+and conflating them is why talks fail: the *archetype* is what the talk has to **do**; the *visual
+style* is what it **looks like**. A conference oral in a keynote's skeleton dies (no data on the
+slides); a keynote in a conference oral's skeleton dies harder. **The skin is a preference; the
+skeleton is not.** Its mechanical half is `scripts/check_deck_budget.py`.
+
+**C. `references/presentation_design_guidelines.md`** — the enforceable rules (assertion headlines,
+24-pt floor, negative space, ≤3 colours, colourblind-safe palettes, redraw-don't-screenshot,
+animation discipline) plus the G1–G10 self-check the Phase 3.5 critic scores against.
+
+**Read on demand — after Q0/Q2 tell you which one:**
+
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/medical_presentation_templates.md` | the venue is one of the five medical ones — then read **that section only** | ~3,700 tokens, of which you use a fifth |
+| `references/slide_visual_styles/CATALOG.md` → one style file | Q2 has chosen a style | ~2,300 tokens per style |
+| `references/slide_design_principles.md` | you are stuck on *why* a slide is not landing — Reynolds / Duarte / Knaflic / Tufte, the theory under the rules in **C** | ~2,600 tokens of theory you mostly already applied |
+
+<details>
+<summary>The original list, for reference</summary>
 
 1. **`references/slide_design_principles.md`** — Reynolds (Presentation Zen) +
    Duarte (Slide:ology Glance Test™) + Knaflic (Storytelling with Data preattentive
@@ -66,25 +102,7 @@ Before collecting inputs, the skill loads these reference files:
    generic builder (`references/generate_pptx_templates.py`). PDF figures →
    `scripts/extract_pdf_figures.py`.
 
-5. **`references/presentation_archetypes.md`** — the **skeleton**, chosen by where the speaker is
-   standing: conference oral, journal-club critique, case-anchored grand rounds, didactic lecture,
-   defence, keynote (Duarte's sparkline, the Jobs STAR moment, Takahashi/Lessig), lay talk, and the
-   decision brief (Minto's pyramid, action titles, Kawasaki's 10/20/30). A deck has **two
-   independent choices** and conflating them is why talks fail: the *archetype* is what the talk has
-   to **do**; the *visual style* is what it **looks like**. A conference oral in a keynote's skeleton
-   dies (no data on the slides); a keynote in a conference oral's skeleton dies harder. **The skin is
-   a preference; the skeleton is not.** Its mechanical half is `scripts/check_deck_budget.py`.
-
-6. **`references/ai_slide_tells.md`** — **read this one first, and read all of it.** The marks a
-   generated deck leaves, and why reviewers now say they can spot one instantly: scaffolding
-   sentences that narrate the thought instead of stating it, chrome along every edge, the same box
-   eight times, unlabelled arrows, a vague brief producing a deck nobody can use. The complaint is
-   **not** that AI decks are ugly — templates solved ugly. It is that they *stop communicating*,
-   because they were built to make the maker comfortable rather than to serve the audience.
-   `scripts/check_slide_tells.py` catches these after the deck exists (Step 3.6); this file is so
-   the deck does not need catching. It also overrules older guidance where they conflict — the
-   eyebrow-on-every-slide and brand-footer rules in particular, which this project used to mandate
-   and which are the single most-cited visual tell.
+</details>
 
 These mirror the entry-point pattern used in
 `make-figures/references/design_principles.md` (Step 1 "Specify"). Both skills share

--- a/skills/present-paper/references/presentation_archetypes.md
+++ b/skills/present-paper/references/presentation_archetypes.md
@@ -6,6 +6,12 @@ A deck has two independent choices, and conflating them is why so many talks fai
 |---|---|---|
 | **Archetype** | *this file* | What the talk has to **do**, and therefore how it is built: what a slide is for, how many there are, how much can be on one, how the argument moves. |
 | **Visual style** | `slide_visual_styles/` | What it **looks like**. Palette, type, grid. A skin. |
+| **Content plan** | `medical_presentation_templates.md` | For the five *medical* venues only: the section-by-section plan, slide counts, design seed, pre-presentation checklist. |
+
+**Do not read the content plan until the venue is known** — you need one of its five, not all five.
+Archetypes A–D below are the same four medical venues; this file gives the **stance** (what the talk
+must do, what fails), the template gives the **sections**. Where they overlap, this file wins: a
+section list cannot tell you that a journal club which merely summarises the paper has failed.
 
 A conference oral in a keynote's skeleton dies (no data on the slides; the reviewer in row three
 came for the numbers). A keynote in a conference oral's skeleton dies harder (a 40-word slide read

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -396,6 +396,30 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/check_cohort_arithmetic.py" \
 
 `RATE_BACKCALC` / `CASCADE_SUM` / `PARTITION_OVERLAP` rows are Anticipated Major Comments (category: A. Study Design & Data Integrity); the partition check is the Phase 2.5b cohort branch below. Pass `--id-col` (or let it auto-detect a subject-ID column) on health-screening / EMR / registry data so the gate also runs the **analysis-unit** check: when `records > unique subjects` and the manuscript states neither the analysis unit nor a one-record-per-subject sensitivity, it emits `ANALYSIS_UNIT_UNDISCLOSED` (Major — non-independent observations give anti-conservative CIs; probe O8). Flag any remaining internal-consistency discrepancies as Anticipated Minor Comments (category: F. Reporting Completeness).
 
+**Then recompute the three things a reviewer recomputes by hand.** These are the arithmetic checks a
+careful reviewer does with a calculator on the train home, and the ones that end a submission when
+they fail:
+
+```bash
+# Every "n (%)" in a table, recomputed against its own denominator.
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_table_percentages.py" \
+  --manuscript manuscript.md --out qc/table_percentages.json --strict
+
+# Every reported P beside a 2×2 (or r×c) count, recomputed from the counts themselves.
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_reported_p_from_counts.py" \
+  --manuscript manuscript.md --out qc/reported_p.json --strict
+
+# Diagnostic-accuracy only: sensitivity/specificity against the reference-standard denominators.
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_dta_denominators.py" \
+  --manuscript manuscript.md --out qc/dta_denominators.json --strict
+```
+
+`PCT_MISMATCH`, `P_MISMATCH` / `P_IMPOSSIBLE`, and `DENOM_MISMATCH` are **P0 Major** — a percentage
+that does not follow from its own denominator, or a P value that does not follow from its own counts,
+is not a rounding disagreement. It means one of the two numbers is wrong, and the reviewer who checks
+will find it. Run the first two on **every** manuscript with a table; the third only on
+diagnostic-accuracy work.
+
 ### Phase 2.5a: Numerical Source-Fidelity Audit (External)
 
 Internal consistency (Phase 2.5) is necessary but not sufficient. Numbers can be fully self-


### PR DESCRIPTION
## The finding

`check_table_percentages`, `check_reported_p_from_counts`, `check_dta_denominators` shipped in **v5.20.0** with challenge cards, CI steps, JSON envelopes, catalog entries and a release note.

**`self-review/SKILL.md` never mentioned them.**

They passed every gate this repository has and had **never once run on anyone's manuscript** — while being counted in the 64 we publish.

> A challenge card proves a detector **works**. A CI step proves it works. A JSON envelope proves it names itself. **None of them proves the skill *calls* it.**

Same disease as a green test that would not catch the defect, one level up: verifying the tool instead of the *use* of the tool.

## Fixes

**1. Wired into `self-review` Phase 2.5** — the arithmetic a reviewer redoes with a calculator on the train home. A percentage that does not follow from its own denominator, and a P value that does not follow from its own counts, are not rounding disagreements: one of the two numbers is wrong, and the reviewer who checks will find it.

**2. `scripts/check_detector_reachability.py` (CI)** — fails if any counted detector is not invoked by a SKILL.md, directly or through a **named** bundle runner (`preflight_gate.py`, `pre_submission_gate.sh` — listed, so the exemption is a decision and not an accident). Verified by deleting the wiring and watching it go red.

## Two more, both mine, both from yesterday

**`/present-paper` Phase 0 demanded ~14,000 tokens of references before a single slide was drafted.** Three of the six mattered up front; `medical_presentation_templates.md` cost ~3,700 tokens to use a fifth of, and the style file was read *before the style was chosen*. Split into **read now** (AI tells, archetypes, enforceable rules) and **read once Q0/Q2 says which one** — **~7,400 tokens saved per invocation**, nothing decision-shaping removed.

**The archetypes file duplicated the medical templates.** A–D (conference oral, critique, case-anchored, didactic) are the same four venues the templates already covered — two files answering *"how do I structure a journal club talk"*. Boundary now explicit: the archetype gives the **stance** (what the talk must do, what fails), the template gives the **sections**, archetype wins on conflict. A section list cannot tell you that a journal club which merely summarises the paper has failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)