### PR TITLE
fix(present-paper): the markdown parser was deleting the asterisk inside HLA alleles

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3468,8 +3468,8 @@
     },
     {
       "path": "skills/present-paper/scripts/inject_speaker_notes.py",
-      "size": 6758,
-      "sha256": "6eeaf94c396d0f4ff365eaea0408f2fc00f8e2dc75b53a9514214194cb9329f9"
+      "size": 7592,
+      "sha256": "c81c7d7b67eb216644f91c59ba7221b0f0bed4b38669cf0fbdc76f511394ee83"
     },
     {
       "path": "skills/present-paper/scripts/inspect_pptx_template.py",
@@ -3493,8 +3493,8 @@
     },
     {
       "path": "skills/present-paper/templates/build_pptx_nature_lancet.py",
-      "size": 29739,
-      "sha256": "55d8369897acbba8afe5d0196b78c87f3ede1980fa90eb901ccd0c87af67804d"
+      "size": 30309,
+      "sha256": "e2ed9c3757cf1f8b8e059d04964c4a64e6ac916287a3081f97a3a1bd1977fb8d"
     },
     {
       "path": "skills/publish-skill/SKILL.md",

--- a/skills/present-paper/scripts/inject_speaker_notes.py
+++ b/skills/present-paper/scripts/inject_speaker_notes.py
@@ -51,15 +51,27 @@ notes: dict[int, str] = {
 # asterisks show literally in Presenter View. Parse ``**bold**`` / ``*italic*``
 # (non-nested) into run-level styling instead. (Opt out with --no-markdown.)
 # ---------------------------------------------------------------------------
-_MD_INLINE = re.compile(r"(\*\*[^*\n]+\*\*|\*[^*\n]+\*)")
+# The italic rule needs word boundaries, or it eats the asterisk that belongs to the
+# *content*: HLA alleles (DRB1*07:01), SNP ids, footnote markers. Losing it silently
+# rewrites a genotype. The bold rule tolerates an inner single "*" for the same reason.
+# Mandated by SKILL.md ("Word-boundary aware markdown parser"); tests/test_md_parity.py
+# asserts both call sites keep using this exact pattern.
+_MD_RE = (
+    r"(\*\*(?:(?!\*\*).)+?\*\*"                       # **bold** — inner single * allowed
+    r"|(?<![A-Za-z0-9])\*[^*\n]+?\*(?![A-Za-z0-9]))"       # *italic* — word-boundary
+)
+_MD_INLINE = re.compile(_MD_RE)
 
 
 def _add_markdown_line(paragraph, line: str) -> None:
     """Emit one note line as styled runs, parsing **bold** / *italic*.
 
     Non-nested by design (matches the ``add_styled_note_line`` convention in
-    ``pptx-speaker-notes.md``): malformed/mixed markers such as ``***x***`` render
-    partially rather than nesting — text is never dropped and never raises.
+    ``pptx-speaker-notes.md``). A single ``*`` **inside** a bold span is kept verbatim,
+    because in this domain it is far more likely to be content (``**DRB1*07:01**``) than a
+    nested-italic marker. So ``**a *b* c**`` renders bold with the asterisks visible —
+    ugly, and a signal to the author to stop nesting — rather than silently deleting the
+    asterisk of an allele. Never raises; never drops a character.
     """
     if not line:
         paragraph.add_run().text = ""

--- a/skills/present-paper/templates/build_pptx_nature_lancet.py
+++ b/skills/present-paper/templates/build_pptx_nature_lancet.py
@@ -131,7 +131,16 @@ def set_run(run, *, size: float = 20, bold: bool = False, italic: bool = False,
         rPr.set("spc", str(letter_space))
 
 
-_MD_PATTERN = re.compile(r"(\*\*[^*\n]+\*\*|\*[^*\n]+\*)")
+# The italic rule needs word boundaries, or it eats the asterisk that belongs to the
+# *content*: HLA alleles (DRB1*07:01), SNP ids, footnote markers. Losing it silently
+# rewrites a genotype. The bold rule tolerates an inner single "*" for the same reason.
+# Mandated by SKILL.md ("Word-boundary aware markdown parser"); tests/test_md_parity.py
+# asserts both call sites keep using this exact pattern.
+_MD_RE = (
+    r"(\*\*(?:(?!\*\*).)+?\*\*"                       # **bold** — inner single * allowed
+    r"|(?<![A-Za-z0-9])\*[^*\n]+?\*(?![A-Za-z0-9]))"       # *italic* — word-boundary
+)
+_MD_PATTERN = re.compile(_MD_RE)
 
 
 def add_styled(p, text: str, *, size: float = 20, color: RGBColor = COLOR_TEXT,

--- a/skills/present-paper/tests/test_md_parity.py
+++ b/skills/present-paper/tests/test_md_parity.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""The inline-markdown parser must not eat an asterisk that belongs to the content.
+
+Two call sites parse ``**bold**`` / ``*italic*`` — ``scripts/inject_speaker_notes.py``
+(speaker notes) and ``templates/build_pptx_nature_lancet.py`` (slide body). SKILL.md
+mandates a word-boundary pattern for both. They had drifted to a naive
+``\\*[^*\\n]+\\*``, which silently deleted the asterisk in ``DRB1*07:01`` — rewriting a
+genotype in a medical deck and losing the bold with it.
+
+This test pins two things:
+
+  1. **Parity** — both modules compile the same pattern, so they cannot drift apart again.
+  2. **Behaviour** — an allele survives; nothing is ever dropped.
+
+Skips cleanly (exit 0) without python-pptx. Network-free.
+
+    python3 skills/present-paper/tests/test_md_parity.py
+"""
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+try:
+    from pptx import Presentation  # noqa: F401
+except ImportError:
+    print("python-pptx not installed — SKIP (compile-only)")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+notes_mod = load(ROOT / "scripts" / "inject_speaker_notes.py", "isn")
+build_mod = load(ROOT / "templates" / "build_pptx_nature_lancet.py", "bnl")
+
+fails: list[str] = []
+
+
+# --- 1. parity ---------------------------------------------------------------------
+if notes_mod._MD_INLINE.pattern != build_mod._MD_PATTERN.pattern:
+    fails.append(
+        "the two call sites use DIFFERENT inline-markdown patterns — they will drift:\n"
+        f"    inject_speaker_notes : {notes_mod._MD_INLINE.pattern!r}\n"
+        f"    build_pptx_nature_l. : {build_mod._MD_PATTERN.pattern!r}"
+    )
+
+# The naive pattern is the bug. Refuse it by name, in either site.
+NAIVE = r"(\*\*[^*\n]+\*\*|\*[^*\n]+\*)"
+for label, pat in (("inject_speaker_notes", notes_mod._MD_INLINE.pattern),
+                   ("build_pptx_nature_lancet", build_mod._MD_PATTERN.pattern)):
+    if pat == NAIVE:
+        fails.append(f"{label} regressed to the naive pattern — it eats DRB1*07:01")
+    if "(?![A-Za-z0-9])" not in pat or "(?<![A-Za-z0-9])" not in pat:
+        fails.append(f"{label} italic rule has no word boundary — an allele asterisk will be eaten")
+
+
+# --- 2. behaviour ------------------------------------------------------------------
+# (source, visible text after rendering, spans that must be bold)
+CASES = [
+    ("Carriers of **DRB1*07:01** had higher risk",
+     "Carriers of DRB1*07:01 had higher risk", ["DRB1*07:01"]),
+    ("The allele DRB1*04:02 and HLA-A*02:01 were typed",
+     "The allele DRB1*04:02 and HLA-A*02:01 were typed", []),
+    ("rs1801133*T carriers",
+     "rs1801133*T carriers", []),
+    ("**bold** and *ital* both",
+     "bold and ital both", ["bold"]),
+    # nested emphasis: markers stay visible (author's error, made loud) — but the
+    # bold span still applies and NOT ONE CHARACTER is lost. The old parser dropped
+    # the final "e" of "core" here.
+    ("**The sign is *itself* fluid** — a core",
+     "The sign is *itself* fluid — a core", ["The sign is *itself* fluid"]),
+]
+
+
+def render(mod_pattern, text):
+    """Reproduce the split/emit contract both modules share."""
+    out, bolds = [], []
+    for part in mod_pattern.split(text):
+        if not part:
+            continue
+        if part.startswith("**") and part.endswith("**") and len(part) > 4:
+            out.append(part[2:-2]); bolds.append(part[2:-2])
+        elif (part.startswith("*") and part.endswith("*")
+              and not part.startswith("**") and len(part) > 2):
+            out.append(part[1:-1])
+        else:
+            out.append(part)
+    return "".join(out), bolds
+
+
+for src, want_text, want_bold in CASES:
+    got_text, got_bold = render(notes_mod._MD_INLINE, src)
+    if got_text != want_text:
+        fails.append(f"rendered text differs\n    in   {src!r}\n    want {want_text!r}\n    got  {got_text!r}")
+    if got_bold != want_bold:
+        fails.append(f"bold spans differ for {src!r}\n    want {want_bold!r}\n    got  {got_bold!r}")
+    # nothing may vanish: every non-marker character survives
+    if len(got_text) < len(re.sub(r"\*\*", "", src)) - src.count("*"):
+        fails.append(f"characters were dropped rendering {src!r} -> {got_text!r}")
+
+
+# --- 3. the real notes injector, end to end ----------------------------------------
+prs = Presentation()
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+tf = slide.notes_slide.notes_text_frame
+tf.clear()
+notes_mod._add_markdown_line(tf.paragraphs[0], "Carriers of **DRB1*07:01** had higher risk")
+runs = tf.paragraphs[0].runs
+visible = "".join(r.text for r in runs)
+if "DRB1*07:01" not in visible:
+    fails.append(f"inject_speaker_notes corrupted the allele in a real note: {visible!r}")
+if not any(r.font.bold and "DRB1*07:01" in r.text for r in runs):
+    fails.append(f"the allele lost its bold styling: {[(r.text, r.font.bold) for r in runs]!r}")
+
+
+if fails:
+    print("FAIL — inline-markdown parser")
+    for f in fails:
+        print("  ·", f)
+    sys.exit(1)
+print(f"PASS — parity + {len(CASES)} rendering cases; alleles survive, nothing dropped")


### PR DESCRIPTION
## The bug

`SKILL.md` calls a word-boundary italic rule **mandatory**:

> Without these, a naive `\*[^*]+\*` italic pattern silently corrupts every HLA allele in the deck.

Both call sites shipped the naive pattern anyway — `scripts/inject_speaker_notes.py:54` and `templates/build_pptx_nature_lancet.py:134`. So the skill did to real decks exactly what its own documentation warned about:

| in | out (shipped code) |
|---|---|
| `The allele DRB1*04:02 and HLA-A*02:01 were typed` | `The allele DRB104:02 and HLA-A02:01 were typed` — **genotype rewritten** |
| `Carriers of **DRB1*07:01** had higher risk` | `Carriers of *DRB107:01** had higher risk` — allele eaten, bold lost, markers leak |
| `**The sign is *itself* fluid** — a core` | `*The sign is itself fluid* — a cor` — **final character dropped** |

The asterisk in an allele is *content*, not markup. It was being deleted silently, in speaker notes and slide bodies of medical decks. The docstring's claim that "text is never dropped" was false.

## The fix

Both sites now compile the mandated pattern — bold tolerates an inner single `*`, italic requires word boundaries.

A lone `*` inside a bold span is **kept verbatim**: in this domain it is far likelier to be an allele than a nested-italic marker. So `**a *b* c**` renders bold with the markers visible — ugly, loud, and the author's cue to stop nesting — rather than corrupting `DRB1*07:01`. Choosing allele integrity over nesting convenience is the whole point.

## The regression guard

`tests/test_md_parity.py` pins both halves:

1. **Parity** — the two call sites must compile the *same* pattern, so they cannot drift apart again (which is how this happened).
2. **Behaviour** — alleles (`DRB1*07:01`, `HLA-A*02:01`, `rs1801133*T`) survive, bold still applies, and not one character is dropped.

Reverting either site to the naive pattern fails the test. Verified by doing exactly that.

## Verification

```
python3 skills/present-paper/tests/test_md_parity.py             PASS (parity + 5 cases)
python3 skills/present-paper/tests/test_speaker_notes_markdown.py PASS (existing)
python3 skills/present-paper/tests/test_builder_no_chrome.py      PASS (existing)
gen_distribution_manifest / gen_skill_docs / gen_detectors_catalog_json --check   OK
validate_catalog_consistency / validate_skills.sh                                 OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)