### PR TITLE
feat(present-paper): the clock stops at the backup section

### DIFF
--- a/docs/locale_inventory.md
+++ b/docs/locale_inventory.md
@@ -146,6 +146,8 @@ English defaults, each with a `_ko` sibling below).
 | `skills/lit-sync/SKILL.md` | D | English-default vault/headings; `triggers:` line + honor-existing Korean-folder examples documenting the detect-and-honor behavior. |
 | `skills/present-paper/references/generate_pptx_templates.py` | A | Legacy Korean slide-marker parser regex (backward compatibility). |
 | `skills/present-paper/references/slide_visual_styles/nature_lancet.md` | A | Korean-glyph rendering verification grep. |
+| `skills/present-paper/scripts/check_deck_budget.py` | A | Backup-section markers a divider may carry in Korean (백업 / 부록 / 예비), so a Korean deck's Q&A section stops the clock like an English one. Recognition data, not prose. |
+| `skills/present-paper/tests/test_backup_off_the_clock.py` | A | Fixture for the Korean backup markers above. |
 
 ### AI-slide-tell detection (Korean is the evidence, not a translation)
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3463,8 +3463,8 @@
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget.py",
-      "size": 10932,
-      "sha256": "146de4082103b12781a630882ca33bd88447b1ee55d90a766934903f8b2c249a"
+      "size": 11412,
+      "sha256": "d8f031df3fae3bf21b86729bd416fd4be9e8f45ea7ff78997e7e09d4a7f210b6"
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py",
@@ -3478,8 +3478,8 @@
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells.py",
-      "size": 24148,
-      "sha256": "e703164783cea7a14886f657b47ae672f5a5e8f8f526015a456ad19bae5f1d0c"
+      "size": 24730,
+      "sha256": "3b91a0f6850b2badaf1657208a779b892931f50ae4962a7c7ccdfc50836a5396"
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells_challenge/make_fixtures.py",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3463,8 +3463,8 @@
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget.py",
-      "size": 8995,
-      "sha256": "a4fbee1ec4e0c00d7558f92aa7780eab725e51b71699d10aa3d0553afb2c00d3"
+      "size": 10932,
+      "sha256": "146de4082103b12781a630882ca33bd88447b1ee55d90a766934903f8b2c249a"
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py",

--- a/skills/present-paper/scripts/check_deck_budget.py
+++ b/skills/present-paper/scripts/check_deck_budget.py
@@ -14,6 +14,16 @@ It checks the three things about a deck that are mechanical, and therefore check
                       also listening to you. A keynote audience is not reading.
   TYPE_TOO_SMALL      the back row exists. Below the floor, the slide is decoration.
 
+The clock stops at the backup section. Nearly every conference deck carries one — the slides you
+do not present, and open only if someone asks. Counting them against the clock told people to
+delete their Q&A preparation, so the check was wrong in the one place a speaker most needs to be
+prepared. A slide whose headline is "Backup", "Appendix", "Q&A", "Reserve" or "Supplementary" ends
+the talk: everything from there on is off the clock.
+
+Density and type size still apply to those slides. Anything you might put on a screen has to be
+readable when it gets there; a backup slide is shown under questioning, which is the worst possible
+moment to discover it is a wall of 11-point text.
+
 Everything else about an archetype — whether the argument opens with its answer, whether the case is
 a pretext, whether the limitation is the one that matters — is judgment, and is in
 `references/presentation_archetypes.md` where a person can act on it.
@@ -29,6 +39,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import zipfile
 from dataclasses import dataclass
@@ -99,6 +110,27 @@ def words_on(shapes) -> int:
     return n
 
 
+_BACKUP_RE = re.compile(
+    r"^\W*(back[\s-]?up|appendix|q\s*&\s*a|q\s*and\s*a|reserve|supplement(?:ary)?"
+    r"|백업|부록|예비)(?![A-Za-z])", re.I)
+
+
+def find_backup_boundary(slides) -> Optional[int]:
+    """Index of the first backup slide, or None. Everything from there on is off the clock.
+
+    A backup section opens with a marker slide -- a divider or a heading that says "Backup",
+    "Appendix", "Q&A". We look for that headline, and we require it to be *short*: a slide whose
+    body happens to discuss "the appendix of the guideline" is not a boundary, and a nine-word
+    sentence containing the word "reserve" is a sentence, not a signpost.
+    """
+    for i, shapes in enumerate(slides):
+        for s in shapes:
+            t = (s.text or "").strip()
+            if t and len(t.split()) <= 6 and _BACKUP_RE.match(t):
+                return i
+    return None
+
+
 def audit(deck: Path, archetype: str, minutes: float) -> List[Finding]:
     from check_slide_tells import mark_chrome  # noqa: PLC0415
 
@@ -108,14 +140,19 @@ def audit(deck: Path, archetype: str, minutes: float) -> List[Finding]:
     out: List[Finding] = []
 
     # --- the clock -------------------------------------------------------------------------
+    # Backup slides are not part of the talk, so they are not part of its clock.
+    backup_at = find_backup_boundary(slides)
+    n = backup_at if backup_at is not None else len(slides)
     allowed = max(1, round(minutes * b.slides_per_minute))
-    n = len(slides)
     if n > allowed * 1.25:  # 25% of slack: some slides are a divider, some are a single number
+        held = "" if backup_at is None else (
+            f" ({len(slides) - backup_at} more are held in backup from slide {backup_at + 1}, "
+            "off the clock.)")
         out.append(Finding(
             DETECTOR, "DECK_OVER_BUDGET", None,
-            f"{n} slides for a {minutes:g}-minute {b.label.lower()}. At this archetype's pace "
-            f"(~{b.slides_per_minute:g} slide/min) that is a deck for about "
-            f"{n / b.slides_per_minute:.0f} minutes.",
+            f"{n} presented slides for a {minutes:g}-minute {b.label.lower()}. At this archetype's "
+            f"pace (~{b.slides_per_minute:g} slide/min) that is a talk of about "
+            f"{n / b.slides_per_minute:.0f} minutes.{held}",
             [f"Budget: ~{allowed} slides.",
              "Cutting is the work. A talk that runs over is not a talk with more content in it — "
              "it is a talk whose ending was taken away at the microphone."],

--- a/skills/present-paper/scripts/check_deck_budget.py
+++ b/skills/present-paper/scripts/check_deck_budget.py
@@ -119,14 +119,22 @@ def find_backup_boundary(slides) -> Optional[int]:
     """Index of the first backup slide, or None. Everything from there on is off the clock.
 
     A backup section opens with a marker slide -- a divider or a heading that says "Backup",
-    "Appendix", "Q&A". We look for that headline, and we require it to be *short*: a slide whose
+    "Appendix", "Q&A". We look for that *headline*, and we require it to be short: a slide whose
     body happens to discuss "the appendix of the guideline" is not a boundary, and a nine-word
     sentence containing the word "reserve" is a sentence, not a signpost.
+
+    Headline means the shape's FIRST LINE, not its whole text. A section divider normally carries
+    its title and its subtitle in one text frame, so the shape reads
+
+        "Backup\\nQ&A -- the four questions this design invites"
+
+    and a guard that measured the whole text threw the boundary away for being ten words long.
+    That is not hypothetical: it is how this check failed the first real deck it met.
     """
     for i, shapes in enumerate(slides):
         for s in shapes:
-            t = (s.text or "").strip()
-            if t and len(t.split()) <= 6 and _BACKUP_RE.match(t):
+            head = next((ln.strip() for ln in (s.text or "").splitlines() if ln.strip()), "")
+            if head and len(head.split()) <= 6 and _BACKUP_RE.match(head):
                 return i
     return None
 

--- a/skills/present-paper/scripts/check_slide_tells.py
+++ b/skills/present-paper/scripts/check_slide_tells.py
@@ -171,8 +171,16 @@ def parse_shape(el: ET.Element, kind: str) -> Optional[Shape]:
     except (TypeError, ValueError):
         return None
 
-    texts = [t.text or "" for t in el.iter(f"{A}t")]
-    text = "".join(texts).strip()
+    # Runs inside one paragraph concatenate — a run boundary can fall mid-word, so "" is right
+    # there. Paragraphs do NOT: they are separate lines. Joining the whole shape with "" fused
+    # them, so a title slide's meta rows came out as the single token "PresenterAugust 2026" —
+    # one word where there were three, and no line for a headline to be the first of.
+    paras = []
+    for p_el in el.iter(f"{A}p"):
+        paras.append("".join(t.text or "" for t in p_el.iter(f"{A}t")))
+    if not paras:  # a shape with runs but no <a:p> ancestor we walked
+        paras = ["".join(t.text or "" for t in el.iter(f"{A}t"))]
+    text = "\n".join(paras).strip()
 
     sizes = [int(rpr.get("sz")) / 100 for rpr in el.iter(f"{A}rPr") if rpr.get("sz")]
     max_pt = max(sizes) if sizes else 0.0

--- a/skills/present-paper/tests/test_backup_off_the_clock.py
+++ b/skills/present-paper/tests/test_backup_off_the_clock.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Backup slides are not part of the talk, so they are not part of its clock.
+
+Nearly every conference deck carries a backup section — the Q&A slides you do not present
+and open only if someone asks. The budget check counted them against the clock, so a
+10-minute talk with four backup slides was told to cut, and the honest way to satisfy the
+tool was to delete the Q&A preparation. That is the tool being wrong in the one place a
+speaker most needs to be prepared.
+
+The clock now stops at the first slide marked "Backup" / "Appendix" / "Q&A" / "백업".
+Density and type size still apply past that line — a backup slide is shown *under
+questioning*, which is the worst possible moment to find out it is a wall of 11-pt text.
+
+Skips cleanly (exit 0) without python-pptx. Network-free.
+
+    python3 skills/present-paper/tests/test_backup_off_the_clock.py
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from pptx import Presentation
+    from pptx.util import Inches, Pt
+except ImportError:
+    print("python-pptx not installed — SKIP (compile-only)")
+    sys.exit(0)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import check_deck_budget as budget  # noqa: E402
+
+fails: list[str] = []
+
+
+def deck(headlines, body_words=8, pt=24):
+    """One slide per headline: the headline, plus a little body so it counts as content."""
+    prs = Presentation()
+    prs.slide_width, prs.slide_height = Inches(13.333), Inches(7.5)
+    for h in headlines:
+        s = prs.slides.add_slide(prs.slide_layouts[6])
+        for txt, y in ((h, 0.5), (" ".join(["word"] * body_words), 2.5)):
+            if not txt:
+                continue
+            tb = s.shapes.add_textbox(Inches(0.7), Inches(y), Inches(11), Inches(1.2))
+            tb.text_frame.text = txt
+            tb.text_frame.paragraphs[0].runs[0].font.size = Pt(pt)
+    p = Path(tempfile.mkdtemp()) / "d.pptx"
+    prs.save(str(p))
+    return p
+
+
+def verdicts(path, minutes=10, archetype="conference_oral"):
+    return [f.verdict for f in budget.audit(path, archetype, minutes)]
+
+
+# --- the boundary itself ------------------------------------------------------------
+CASES = [
+    (["Backup"], 0),
+    (["Backup — Q&A"], 0),
+    (["Appendix"], 0),
+    (["Q & A"], 0),
+    (["백업"], 0),
+    # a sentence that merely contains the word is a sentence, not a signpost
+    (["Reserved for the appendix of the guideline"], None),
+    (["Supplemental oxygen was given to every patient"], None),
+    (["58 tells us nothing — four numbers do"], None),
+]
+for heads, want in CASES:
+    prs = Presentation()
+    prs.slide_width, prs.slide_height = Inches(13.333), Inches(7.5)
+    for h in heads:
+        s = prs.slides.add_slide(prs.slide_layouts[6])
+        tb = s.shapes.add_textbox(Inches(0.7), Inches(0.5), Inches(11), Inches(1))
+        tb.text_frame.text = h
+    p = Path(tempfile.mkdtemp()) / "b.pptx"
+    prs.save(str(p))
+    slides, _n, _w, _h = budget.read_deck(p)
+    got = budget.find_backup_boundary(slides)
+    if got != want:
+        fails.append(f"boundary for {heads[0]!r}: want {want}, got {got}")
+
+
+# --- the clock stops there ----------------------------------------------------------
+TALK = [f"Finding {i} changed what we do" for i in range(11)]      # 11 presented slides
+BACKUP = ["Backup"] + [f"Answer to question {i}" for i in range(6)]  # 7 more, off the clock
+
+# 11 presented slides for a 10-min conference oral: allowed 10, slack to 12.5 -> fits.
+if "DECK_OVER_BUDGET" in verdicts(deck(TALK)):
+    fails.append("11 presented slides for a 10-min oral should fit (budget 10, +25% slack)")
+
+# The same talk with a backup section must STILL fit -- that is the whole fix.
+if "DECK_OVER_BUDGET" in verdicts(deck(TALK + BACKUP)):
+    fails.append("backup slides were counted against the clock — the bug this test exists for")
+
+# ...but a genuinely over-long talk must still be caught, backup section or not.
+if "DECK_OVER_BUDGET" not in verdicts(deck([f"Point {i} matters here" for i in range(20)] + BACKUP)):
+    fails.append("20 presented slides for a 10-min oral must still be caught")
+
+
+# --- legibility does NOT stop there -------------------------------------------------
+# A dense, tiny backup slide is shown under questioning. It still has to be readable.
+dense = deck(TALK + ["Backup"] + ["Answer"], body_words=0)
+prs = Presentation(str(dense))
+s = prs.slides[-1]
+tb = s.shapes.add_textbox(Inches(0.7), Inches(2.5), Inches(11), Inches(4))
+tb.text_frame.word_wrap = True
+tb.text_frame.text = " ".join(["word"] * 90)              # over the 60-word ceiling
+tb.text_frame.paragraphs[0].runs[0].font.size = Pt(9)     # under the 20 pt floor
+prs.save(str(dense))
+v = verdicts(dense)
+if "SLIDE_TOO_DENSE" not in v:
+    fails.append("a 90-word backup slide escaped the density check — backups get shown too")
+if "TYPE_TOO_SMALL" not in v:
+    fails.append("a 9-pt backup slide escaped the type floor — backups get shown too")
+if "DECK_OVER_BUDGET" in v:
+    fails.append("the backup section was still on the clock")
+
+
+if fails:
+    print("FAIL — backup section")
+    for f in fails:
+        print("  ·", f)
+    sys.exit(1)
+print(f"PASS — boundary ({len(CASES)} cases), clock stops at backup, legibility does not")

--- a/skills/present-paper/tests/test_backup_off_the_clock.py
+++ b/skills/present-paper/tests/test_backup_off_the_clock.py
@@ -79,6 +79,23 @@ for heads, want in CASES:
     if got != want:
         fails.append(f"boundary for {heads[0]!r}: want {want}, got {got}")
 
+# A section divider puts its title AND its subtitle in one text frame. So the shape reads
+# "Backup\nQ&A — the four questions this design invites", and a guard that measured the whole
+# text threw the boundary away for being ten words long. This is the deck that caught it.
+prs = Presentation()
+prs.slide_width, prs.slide_height = Inches(13.333), Inches(7.5)
+s = prs.slides.add_slide(prs.slide_layouts[6])
+tb = s.shapes.add_textbox(Inches(1.5), Inches(3.1), Inches(10), Inches(2.5))
+tf = tb.text_frame
+tf.text = "Backup"
+tf.add_paragraph().text = "Q&A — the four questions this design invites"
+p = Path(tempfile.mkdtemp()) / "divider.pptx"
+prs.save(str(p))
+slides, _n, _w, _h = budget.read_deck(p)
+if budget.find_backup_boundary(slides) != 0:
+    fails.append("a real section divider (title + subtitle in one frame) was not recognised — "
+                 "the boundary must be read from the shape's FIRST LINE, not its whole text")
+
 
 # --- the clock stops there ----------------------------------------------------------
 TALK = [f"Finding {i} changed what we do" for i in range(11)]      # 11 presented slides


### PR DESCRIPTION
## The gap

Nearly every conference deck carries a backup section — the Q&A slides you don't present, and open only if someone asks.

`check_deck_budget` counted them against the clock. A 10-minute talk with four backup slides was reported as a 14-minute talk, and **the only way to satisfy the tool was to delete the Q&A preparation.** That's the check being wrong in the one place a speaker most needs to be prepared — and it had no way to be right, because the tool had no vocabulary for *"this part is not presented."*

Found while rebuilding a real 10-minute deck: adding section dividers, a closing slide, a references slide and a Q&A section pushed it to 17 slides, and the gate demanded the Q&A section be cut.

## The fix

`DECK_OVER_BUDGET` now measures **only the presented slides**. The clock stops at the first slide whose headline is `Backup` / `Appendix` / `Q&A` / `Reserve` / `Supplementary` / `백업` — the marker slide such a section already opens with, so nothing new has to be declared anywhere.

The match requires a *short* headline, so a body sentence that happens to read "reserved for the appendix of the guideline" is not mistaken for a signpost.

## What deliberately does NOT stop there

`SLIDE_TOO_DENSE` and `TYPE_TOO_SMALL` still apply past the boundary.

A backup slide is put on a screen **under questioning** — the worst possible moment to discover it is a wall of 11-point text. The clock measures *the talk*; legibility measures *anything that can be projected*, and a backup slide can be.

## Tests

`tests/test_backup_off_the_clock.py` pins all three:

- the boundary — 8 cases, including the sentences that must **not** match
- the clock stops at it (and a genuinely 20-slide talk is still caught)
- legibility does **not** stop at it — a 90-word, 9-pt backup slide is still flagged

Reverting the clock to `len(slides)` fails the test. Verified by doing exactly that.

```
test_backup_off_the_clock.py     PASS
test_speaker_notes_markdown.py   PASS
test_builder_no_chrome.py        PASS
gen_* --check / validate_catalog_consistency / validate_skills.sh   OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)