### PR TITLE
fix(present-paper): the shipped builder tripped the shipped detector — a rule was drawn as a rectangle

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3529,7 +3529,7 @@
     {
       "path": "skills/present-paper/templates/build_pptx_nature_lancet.py",
       "size": 30327,
-      "sha256": "0944cf8bae0a8b2043758e8511c06f0dd7ac884f1cb3369b29ddc239464b5e30"
+      "sha256": "8a08bb4e981c76aa8b3d262037c7456dc4eab2ef12c809a26297c85be9508f6e"
     },
     {
       "path": "skills/publish-skill/SKILL.md",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3528,8 +3528,8 @@
     },
     {
       "path": "skills/present-paper/templates/build_pptx_nature_lancet.py",
-      "size": 30309,
-      "sha256": "e2ed9c3757cf1f8b8e059d04964c4a64e6ac916287a3081f97a3a1bd1977fb8d"
+      "size": 30327,
+      "sha256": "0944cf8bae0a8b2043758e8511c06f0dd7ac884f1cb3369b29ddc239464b5e30"
     },
     {
       "path": "skills/publish-skill/SKILL.md",

--- a/skills/present-paper/templates/build_pptx_nature_lancet.py
+++ b/skills/present-paper/templates/build_pptx_nature_lancet.py
@@ -80,7 +80,7 @@ from pptx import Presentation
 from pptx.util import Inches, Pt, Emu
 from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
 from pptx.dml.color import RGBColor
-from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.shapes import MSO_CONNECTOR, MSO_SHAPE
 from lxml import etree
 
 
@@ -197,6 +197,22 @@ def _blank(prs: Presentation):
 # Slide builders
 # ============================================================================
 
+def _rule(s, *, x: float, y: float, w: float, color: RGBColor, pt: float = 2.0):
+    """A typographic rule — drawn as a LINE, because that is what it is.
+
+    It used to be a rectangle 20,000 EMU tall (~0.02"), which looks identical and is not the
+    same thing. check_slide_tells counts drawn shapes and exempts ``prst == "line"``, because a
+    rule is typography, not an idea. Faking one with a rectangle put a 13th identical box in a
+    15-slide deck and tripped this project's own SHAPE_MONOTONY detector — with the shipped
+    builder, following the house style. Use the right primitive and the rule costs nothing.
+    """
+    c = s.shapes.add_connector(MSO_CONNECTOR.STRAIGHT,
+                               Inches(x), Inches(y), Inches(x + w), Inches(y))
+    c.line.color.rgb = color
+    c.line.width = Pt(pt)
+    return c
+
+
 def add_title_slide(prs: Presentation, *,
                     eyebrow: str = "",
                     title: str,
@@ -230,10 +246,7 @@ def add_title_slide(prs: Presentation, *,
         set_run(r2, size=18, italic=True, color=COLOR_TEXT_SUB)
 
     if meta_top or meta_bottom:
-        line = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                                  Inches(1.1), Inches(5.95), Inches(2.0), Emu(8000))
-        line.fill.solid(); line.fill.fore_color.rgb = COLOR_NAVY
-        line.line.fill.background()
+        _rule(s, x=1.1, y=5.95, w=2.0, color=COLOR_NAVY, pt=1.0)
 
         sub = s.shapes.add_textbox(Inches(1.1), Inches(6.0), Inches(11.5), Inches(1.0))
         stf = sub.text_frame; stf.word_wrap = True
@@ -354,10 +367,7 @@ def add_content_slide(prs: Presentation, *,
         r2 = p2.add_run(); r2.text = subtitle
         set_run(r2, size=15, italic=True, color=COLOR_TEXT_SUB)
 
-    line = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                              Inches(0.7), Inches(2.05), Inches(0.6), Emu(20000))
-    line.fill.solid(); line.fill.fore_color.rgb = COLOR_HIGHLIGHT
-    line.line.fill.background()
+    _rule(s, x=0.7, y=2.06, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
     has_fig = figure_path is not None and Path(figure_path).exists()
     if has_fig:
@@ -465,10 +475,7 @@ def add_toc_slide(prs: Presentation, *,
         r2 = p2.add_run(); r2.text = subtitle
         set_run(r2, size=16, italic=True, color=COLOR_TEXT_SUB)
 
-    line = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                              Inches(0.7), Inches(2.1), Inches(0.6), Emu(20000))
-    line.fill.solid(); line.fill.fore_color.rgb = COLOR_HIGHLIGHT
-    line.line.fill.background()
+    _rule(s, x=0.7, y=2.1, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
     y_start = 2.5
     row_h = 0.85
@@ -543,10 +550,7 @@ def add_glossary_slide(prs: Presentation, *,
     r = p.add_run(); r.text = title
     set_run(r, size=30, bold=True, color=COLOR_NAVY)
 
-    line = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                              Inches(0.7), Inches(1.65), Inches(0.6), Emu(20000))
-    line.fill.solid(); line.fill.fore_color.rgb = COLOR_HIGHLIGHT
-    line.line.fill.background()
+    _rule(s, x=0.7, y=1.65, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
     # Tier 1 — full width
     if tier1:
@@ -606,10 +610,7 @@ def add_closing_slide(prs: Presentation, *,
     r = p.add_run(); r.text = title
     set_run(r, size=32, bold=True, color=COLOR_NAVY)
 
-    line = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                              Inches(0.7), Inches(1.75), Inches(0.6), Emu(20000))
-    line.fill.solid(); line.fill.fore_color.rgb = COLOR_HIGHLIGHT
-    line.line.fill.background()
+    _rule(s, x=0.7, y=1.75, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
     if bullets:
         box = s.shapes.add_textbox(Inches(0.7), Inches(2.2), Inches(12.0), Inches(4.0))

--- a/skills/present-paper/templates/build_pptx_nature_lancet.py
+++ b/skills/present-paper/templates/build_pptx_nature_lancet.py
@@ -232,7 +232,7 @@ def add_title_slide(prs: Presentation, *,
         eye = s.shapes.add_textbox(Inches(1.1), Inches(2.2), Inches(10), Inches(0.5))
         p = eye.text_frame.paragraphs[0]
         r = p.add_run(); r.text = eyebrow
-        set_run(r, size=14, bold=True, color=COLOR_HIGHLIGHT, letter_space="300")
+        set_run(r, size=20, bold=True, color=COLOR_HIGHLIGHT, letter_space="300")
 
     box = s.shapes.add_textbox(Inches(1.1), Inches(2.7), Inches(11.5), Inches(2.5))
     tf = box.text_frame; tf.word_wrap = True
@@ -251,8 +251,8 @@ def add_title_slide(prs: Presentation, *,
         sub = s.shapes.add_textbox(Inches(1.1), Inches(6.0), Inches(11.5), Inches(1.0))
         stf = sub.text_frame; stf.word_wrap = True
         rows = [
-            (meta_top,    16, True,  COLOR_NAVY),
-            (meta_bottom, 13, False, COLOR_TEXT_SUB),
+            (meta_top,    20, True,  COLOR_NAVY),
+            (meta_bottom, 20, False, COLOR_TEXT_SUB),
         ]
         first = True
         for text, sz, bld, col in rows:
@@ -289,7 +289,7 @@ def add_section_divider(prs: Presentation, *,
     num_box = s.shapes.add_textbox(Inches(1.5), Inches(2.5), Inches(3), Inches(1.5))
     p = num_box.text_frame.paragraphs[0]; p.alignment = PP_ALIGN.LEFT
     r = p.add_run(); r.text = f"SECTION  {num}"
-    set_run(r, size=18, bold=True, color=COLOR_HIGHLIGHT, letter_space="400")
+    set_run(r, size=20, bold=True, color=COLOR_HIGHLIGHT, letter_space="400")
 
     title_box = s.shapes.add_textbox(Inches(1.5), Inches(3.1), Inches(10), Inches(2.5))
     tf = title_box.text_frame; tf.word_wrap = True
@@ -306,7 +306,7 @@ def add_section_divider(prs: Presentation, *,
         time_box = s.shapes.add_textbox(Inches(11.0), Inches(6.5), Inches(2.0), Inches(0.5))
         p = time_box.text_frame.paragraphs[0]; p.alignment = PP_ALIGN.RIGHT
         r = p.add_run(); r.text = f"{time_min}  MIN"
-        set_run(r, size=13, bold=True, color=COLOR_MUTED, letter_space="500")
+        set_run(r, size=20, bold=True, color=COLOR_MUTED, letter_space="500")
 
     add_notes(s, notes)
     return s
@@ -354,7 +354,7 @@ def add_content_slide(prs: Presentation, *,
         eye = s.shapes.add_textbox(Inches(0.7), Inches(0.32), Inches(8), Inches(0.4))
         p = eye.text_frame.paragraphs[0]
         r = p.add_run(); r.text = eyebrow
-        set_run(r, size=10, bold=True, color=COLOR_MUTED, letter_space="300")
+        set_run(r, size=20, bold=True, color=COLOR_MUTED, letter_space="300")
 
     title_box = s.shapes.add_textbox(Inches(0.7), Inches(0.75), Inches(12.0), Inches(1.1))
     ttf = title_box.text_frame; ttf.word_wrap = True
@@ -430,9 +430,9 @@ def add_content_slide(prs: Presentation, *,
             ctf = cap.text_frame; ctf.word_wrap = True
             cp = ctf.paragraphs[0]; cp.alignment = PP_ALIGN.CENTER
             cr = cp.add_run(); cr.text = "Figure  ·  "
-            set_run(cr, size=10, bold=True, color=COLOR_HIGHLIGHT, letter_space="200")
+            set_run(cr, size=20, bold=True, color=COLOR_HIGHLIGHT, letter_space="200")
             cr2 = cp.add_run(); cr2.text = fig_caption
-            set_run(cr2, size=11, italic=True, color=COLOR_MUTED)
+            set_run(cr2, size=20, italic=True, color=COLOR_MUTED)
 
     if footnote:
         fn = s.shapes.add_textbox(Inches(0.7), Inches(7.05), Inches(12.0), Inches(0.35))
@@ -543,7 +543,7 @@ def add_glossary_slide(prs: Presentation, *,
         eye = s.shapes.add_textbox(Inches(0.7), Inches(0.32), Inches(8), Inches(0.4))
         p = eye.text_frame.paragraphs[0]
         r = p.add_run(); r.text = eyebrow
-        set_run(r, size=10, bold=True, color=COLOR_MUTED, letter_space="300")
+        set_run(r, size=20, bold=True, color=COLOR_MUTED, letter_space="300")
 
     tb = s.shapes.add_textbox(Inches(0.7), Inches(0.75), Inches(12.0), Inches(0.8))
     p = tb.text_frame.paragraphs[0]
@@ -628,7 +628,7 @@ def add_closing_slide(prs: Presentation, *,
         cb = s.shapes.add_textbox(Inches(0.7), Inches(6.5), Inches(12.0), Inches(0.5))
         p = cb.text_frame.paragraphs[0]; p.alignment = PP_ALIGN.LEFT
         r = p.add_run(); r.text = contact
-        set_run(r, size=12, color=COLOR_TEXT_SUB)
+        set_run(r, size=20, color=COLOR_TEXT_SUB)
 
     if page_brand:
         pb = s.shapes.add_textbox(Inches(0.7), Inches(7.05), Inches(4.0), Inches(0.35))

--- a/skills/present-paper/tests/test_builder_no_chrome.py
+++ b/skills/present-paper/tests/test_builder_no_chrome.py
@@ -40,10 +40,23 @@ from build_pptx_nature_lancet import (  # noqa: E402
 
 DETECTOR = SKILL / "scripts" / "check_slide_tells.py"
 
+# A real deck's worth of content slides, not three. The earlier version of this test built
+# three, and three is below every threshold in the detector — so it certified a builder that
+# tripped SHAPE_MONOTONY the moment anyone built a normal-length deck with it. A gate whose
+# fixture is smaller than the thing it guards is not a gate.
 TITLES = [
     "Seeding followed the catheter tract in 9 of 11 cases",
     "Recurrence halved with adjunctive ablation (12% vs 26%)",
     "The effect did not depend on tumour size",
+    "Ablation added 40 minutes to the procedure",
+    "Two centres accounted for most of the variance",
+    "The learning curve flattened after 20 cases",
+    "Grade 3 complications were unchanged",
+    "Cost per avoided recurrence was $4,100",
+    "The benefit persisted at three years",
+    "Operator experience predicted success better than device",
+    "No seeding occurred where the tract was ablated",
+    "The registry under-reports minor complications",
 ]
 
 
@@ -97,6 +110,36 @@ def main() -> int:
             print("  PASS  restoring the old eyebrow-everywhere default is CAUGHT")
         else:
             print("  FAIL  the old default was NOT caught — this gate is decorative "
+                  f"(found: {sorted(found) or 'nothing'})")
+            ok = False
+
+        # 3. The rule under the title is a LINE. Draw it as a thin rectangle instead — which
+        #    looks identical and is what the builder used to do — and the deck becomes a stack
+        #    of one repeated box. This is not hypothetical: it shipped.
+        import build_pptx_nature_lancet as b  # noqa: PLC0415
+        from pptx.enum.shapes import MSO_SHAPE  # noqa: PLC0415
+        from pptx.util import Emu, Inches  # noqa: PLC0415
+
+        real_rule = b._rule
+
+        def rule_as_rectangle(s, *, x, y, w, color, pt=2.0):
+            r = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
+                                   Inches(x), Inches(y), Inches(w), Emu(20000))
+            r.fill.solid(); r.fill.fore_color.rgb = color
+            r.line.fill.background()
+            return r
+
+        b._rule = rule_as_rectangle
+        try:
+            regressed = tmp / "rule_as_rect.pptx"
+            build(regressed, chrome_on_every_slide=False)
+        finally:
+            b._rule = real_rule
+        found = verdicts(regressed)
+        if "SHAPE_MONOTONY" in found:
+            print("  PASS  drawing the rule as a rectangle is CAUGHT (SHAPE_MONOTONY)")
+        else:
+            print("  FAIL  a deck of identical thin rectangles was NOT caught "
                   f"(found: {sorted(found) or 'nothing'})")
             ok = False
 

--- a/skills/present-paper/tests/test_builder_no_chrome.py
+++ b/skills/present-paper/tests/test_builder_no_chrome.py
@@ -60,7 +60,7 @@ TITLES = [
 ]
 
 
-def build(path: Path, chrome_on_every_slide: bool) -> None:
+def build(path: Path, chrome_on_every_slide: bool, figure: Path | None = None) -> None:
     prs = new_presentation()
     # The title slide and the dividers keep their eyebrow: there it orients someone who just
     # walked in. That is the whole distinction being tested.
@@ -68,14 +68,18 @@ def build(path: Path, chrome_on_every_slide: bool) -> None:
                     subtitle="What the registry shows", meta_top="Journal club",
                     meta_bottom="Presenter", notes="notes")
     add_section_divider(prs, num="01", title="Findings", subtitle="registry", time_min=5)
-    for t in TITLES:
+    for i, t in enumerate(TITLES):
         kwargs = {}
         if chrome_on_every_slide:  # the old, wrong default
             kwargs = {"eyebrow": "TRACT SEEDING", "page_brand": "2026 · JOURNAL CLUB"}
+        if figure is not None and i % 4 == 0:
+            kwargs |= {"figure_path": figure, "fig_caption": "Registry cohort",
+                       "footnote": "Source 2024"}
         add_content_slide(prs, title=t, subtitle="n = 412",
                           bullets=["Median follow-up 3.2 years", "  Consistent across centres"],
                           notes="notes", **kwargs)
-    add_closing_slide(prs, title="Take-home", bullets=["Ablate the tract."], notes="notes")
+    add_closing_slide(prs, title="Take-home", bullets=["Ablate the tract."],
+                      contact="a@b.c", notes="notes")
     prs.save(str(path))
 
 
@@ -142,6 +146,33 @@ def main() -> int:
             print("  FAIL  a deck of identical thin rectangles was NOT caught "
                   f"(found: {sorted(found) or 'nothing'})")
             ok = False
+
+        # 4. The builder must also clear the OTHER gate. Its eyebrow, its meta line, its
+        #    "SECTION 01" label, its "5 MIN" badge, its figure caption and its contact line
+        #    were all set below the 20-pt floor every academic archetype declares — so a deck
+        #    built exactly as documented failed check_deck_budget. The style guide said one
+        #    thing and the gate said another; the gate is the one that is right, because a
+        #    caption nobody in the back row can read is decoration whatever the guide calls it.
+        from PIL import Image  # noqa: PLC0415  (python-pptx already requires Pillow)
+
+        fig = tmp / "fig.png"
+        Image.new("RGB", (400, 300), "white").save(fig)
+        full = tmp / "kitchen_sink.pptx"
+        build(full, chrome_on_every_slide=False, figure=fig)
+
+        budget = SKILL / "scripts" / "check_deck_budget.py"
+        out = subprocess.run(
+            [sys.executable, str(budget), str(full),
+             "--archetype", "conference_oral", "--minutes", "14"],
+            capture_output=True, text=True).stdout
+        if "TYPE_TOO_SMALL" in out:
+            small = [ln.strip() for ln in out.splitlines() if " pt — " in ln]
+            print("  FAIL  the builder's own type falls below the floor it is checked against:")
+            for ln in small[:6]:
+                print("          ", ln)
+            ok = False
+        else:
+            print("  PASS  the shipped builder clears the type floor (figures, meta, dividers)")
 
     print("----")
     print("test_builder_no_chrome:", "passed" if ok else "FAILED")


### PR DESCRIPTION
## We shipped the tell

Build a normal 15-slide deck with `build_pptx_nature_lancet.py`, following the house style exactly, and run the skill's own detector on it:

```
[SHAPE_MONOTONY] 13 of 16 drawn shapes are the same rect at the same size (~0.5" × 0.0").
                 A deck built out of one repeated box reads as generated.
```

The 13 boxes are the coral hairline under each title.

It is a **typographic rule** — but the builder drew it as a `RECTANGLE` 20,000 EMU tall. That looks identical on screen and is not the same object. `check_slide_tells` counts drawn shapes and **exempts `prst == "line"`**, correctly, because a rule is typography and not an idea. Faking one with a rectangle made every deck a stack of one repeated box, and the detector said so — about our own builder, following our own style guide.

So this tell was never something a careless user added. **We shipped it**, and `~/.claude/rules/academic-lecture-style.md` mandated it.

## The fix

Every rule now goes through `_rule()`, which draws a straight connector. Five sites converted — title-slide meta separator, content-slide hairline, TOC, glossary, closing. **Visually unchanged**; structurally a line, which is what it always was.

Before / after, same 15-slide deck:

```
before:  1 finding(s)  [SHAPE_MONOTONY] 13 of 16 drawn shapes are the same rect
after:   OK: carries none of the marks this checks for
```

## Why the existing test missed it

`test_builder_no_chrome.py` built **three** content slides. Three is below every threshold in the detector (`n >= 8 and n/total >= 0.5`). So it certified a builder that tripped the gate the moment anyone built a normal-length deck with it.

**A fixture smaller than the thing it guards is not a gate.** The test now builds twelve, and adds a third assertion: monkeypatch `_rule` back to a rectangle, and `SHAPE_MONOTONY` must fire. Without that half, the fix proves nothing — it would also "pass" if the detector were blind.

```
PASS  the shipped builder produces a deck with no tells
PASS  restoring the old eyebrow-everywhere default is CAUGHT
PASS  drawing the rule as a rectangle is CAUGHT (SHAPE_MONOTONY)
```

Found while rebuilding a real deck: the hairline had to be deleted from every slide to pass the gate, which made the deck ugly for no reason. The rule was never the problem. The rectangle was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)