### PR TITLE
fix(self-review): check_analysis_definitions was reading layout, not defect (#340 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/self-review` `check_analysis_definitions` was reading layout, not defect** (detector #66,
+  shipped hours earlier in #340). Two bugs, both caught on the *second* real manuscript:
+
+  1. **It could not see a CHEST manuscript at all.** `METHODS_RE` matched `Methods` /
+     `Materials and Methods` / `Patients and Methods`. CHEST *requires* `Study Design and Methods`, so the
+     gate emitted `SECTIONS_NOT_FOUND` and silently skipped the whole cross-check. Broadened to accept
+     `Study Design and Methods`, `Subjects and Methods`, `Design and Methods`, `Methods and Materials`.
+
+  2. **`MODEL_OUTCOME_UNDEFINED` was a formatting artifact.** It searched for the outcome declaration in a
+     400-character window around each model mention. A manuscript that declares its outcome once under
+     *Outcomes* and then specifies models under *Statistical Analysis* is following the **recommended**
+     structure — and the windowed search fired on it. It flagged a clean manuscript for exactly the reason
+     it flagged a rejected one. The declaration is now sought across the **whole Methods section**.
+
+  **This makes the check sound but deliberately narrower**, and the honest consequence must be stated: it
+  no longer fires on the rejected manuscript that motivated it. That paper declares three outcomes and
+  never says which one a given Cox model used — a real defect, and one a reader can see and a regex cannot.
+  The original detector appeared to catch it, but only because the outcome paragraph happened to sit more
+  than 400 characters from the model sentence, which is true of every well-structured paper. **One
+  manuscript, three findings matching three reviewer comments, and I called it validated. That was luck,
+  and the second manuscript exposed it.**
+
+  `REFERENCE_STANDARD_UNDEFINED` likewise now honours a declared outcome: *reference standard* is
+  diagnostic-accuracy vocabulary, and a prognostic model scores its predictions against the outcome it has
+  already declared. `MODEL_NOT_IN_METHODS`, `TIER_LABEL_UNDEFINED` and the informational `ANALYSIS_LOAD`
+  are unchanged.
+
 ### Added
 
 - **`/self-review` — every analysis you report must have been defined**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3978,8 +3978,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_analysis_definitions.py",
-      "size": 12304,
-      "sha256": "ee83bd422af3d0fb19567f4cf100eb67e6ce7adebed87aa64c55de4c062339bb"
+      "size": 13004,
+      "sha256": "a2942e15652ac7b19444bd04153023818f3385e5bd881cbc94482ed5e6009538"
     },
     {
       "path": "skills/self-review/scripts/check_analysis_definitions_challenge/expected/defined.txt",

--- a/skills/self-review/scripts/check_analysis_definitions.py
+++ b/skills/self-review/scripts/check_analysis_definitions.py
@@ -51,9 +51,14 @@ import re
 import sys
 from dataclasses import dataclass, field, asdict
 
+# Journals name this section differently and a gate that cannot find it is a gate
+# that silently passes. CHEST requires "Study Design and Methods"; others use
+# "Subjects and Methods", "Design and Methods", "Methods and Materials".
 METHODS_RE = re.compile(
-    r"^#{1,4}\s*\**\s*(?:\d+\.?\s*)?(?:materials?\s+and\s+methods?|methods?|"
-    r"patients?\s+and\s+methods?)\b", re.I | re.M)
+    r"^#{1,4}\s*\**\s*(?:\d+\.?\s*)?"
+    r"(?:(?:study\s+design|design|subjects?|patients?|participants?|materials?|"
+    r"methods?)\s+and\s+)?"
+    r"(?:methods?|materials?)\b", re.I | re.M)
 RESULTS_RE = re.compile(r"^#{1,4}\s*\**\s*(?:\d+\.?\s*)?results?\b", re.I | re.M)
 DISCUSSION_RE = re.compile(r"^#{1,4}\s*\**\s*(?:\d+\.?\s*)?discussion\b", re.I | re.M)
 
@@ -160,6 +165,7 @@ def audit(text: str, source: str) -> Report:
         return rep
 
     m_off = text.index(methods) if methods else 0
+    outcome_declared = bool(OUTCOME_DECL_RE.search(methods))
 
     # --- models -----------------------------------------------------------
     for label, pat in MODELS.items():
@@ -174,11 +180,11 @@ def audit(text: str, source: str) -> Report:
             continue
         if not m_hits:
             continue
-        # Does *any* mention of this model in Methods sit near an outcome declaration?
-        defined = any(
-            OUTCOME_DECL_RE.search(methods[max(0, h.start() - 400): h.end() + 400])
-            for h in m_hits)
-        if not defined:
+        # Search the WHOLE Methods section, not a window around the model. A
+        # manuscript that declares its outcome once under "Outcomes" and then
+        # specifies models under "Statistical Analysis" is doing it *correctly*;
+        # a windowed search punishes the recommended structure.
+        if not outcome_declared:
             rep.findings.append(Finding(
                 "MODEL_OUTCOME_UNDEFINED", "MAJOR",
                 _line_of(text, m_off + m_hits[0].start()),
@@ -187,8 +193,11 @@ def audit(text: str, source: str) -> Report:
                 f"variable and the censoring rule"))
 
     # --- discrimination / calibration -------------------------------------
+    # "Reference standard" is diagnostic-accuracy vocabulary. A prognostic model
+    # scores its predictions against the outcome it already declared, so a declared
+    # outcome satisfies this too. Fire only when neither exists.
     perf_hit = PERF_RE.search(results) or PERF_RE.search(methods)
-    if perf_hit and not REFSTD_DECL_RE.search(methods):
+    if perf_hit and not REFSTD_DECL_RE.search(methods) and not outcome_declared:
         where = results if PERF_RE.search(results) else methods
         base = text.index(where)
         rep.findings.append(Finding(


### PR DESCRIPTION
Detector #66 shipped in #340 a few hours ago. Two bugs, **both caught on the second real manuscript.** The first one got through because I validated on **one** paper, got three findings matching three reviewer comments, and called it validated. That was luck.

## 1. It could not see a CHEST manuscript at all

`METHODS_RE` matched `Methods` / `Materials and Methods` / `Patients and Methods`. **CHEST *requires* `Study Design and Methods`** — so the gate emitted `SECTIONS_NOT_FOUND` and **silently skipped the entire cross-check**.

A gate that cannot find its section is a gate that passes. Broadened to accept `Study Design and Methods`, `Subjects and Methods`, `Design and Methods`, `Methods and Materials`.

## 2. `MODEL_OUTCOME_UNDEFINED` was a formatting artifact

It searched for the outcome declaration in a **400-character window** around each model mention.

A manuscript that declares its outcome once under *Outcomes* and then specifies its models under *Statistical Analysis* is following the **recommended** structure — and the windowed search **fired on it**. It flagged a clean manuscript for **exactly the reason** it flagged a rejected one.

The declaration is now sought across the **whole Methods section**.

## The honest consequence

The check is now **sound but narrower**, and **it no longer fires on the rejected manuscript that motivated it.**

That paper declares three outcomes and never says which one a given Cox model used. That is a **real defect** — the reviewer asked for it twice. But a reader can see it and a regex cannot. Pretending otherwise produced a detector that fired on good papers, which is worse than a detector that stays quiet.

`REFERENCE_STANDARD_UNDEFINED` likewise now honours a declared outcome: *reference standard* is diagnostic-accuracy vocabulary; a prognostic model scores against the outcome it has already declared. `MODEL_NOT_IN_METHODS`, `TIER_LABEL_UNDEFINED` and the informational `ANALYSIS_LOAD` are unchanged.

## Verification (three manuscripts, not one)

| | before | after |
|---|---|---|
| well-structured CHEST paper | `SECTIONS_NOT_FOUND`, then 2 false MAJORs once readable | **OK** ✓ |
| rejected paper | 3 MAJORs — but for the wrong reason | OK (honest miss) |
| synthetic fixture (no outcome anywhere) | flagged | **flagged** ✓ |

CI mirror green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)