### PR TITLE
fix(gates): a vendored checklist could drift unwatched; a shipped script nothing ran

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,8 +69,17 @@ jobs:
       - name: Run validate_routing_assets.py self-test (dangling references/ pointer fails)
         run: bash tests/test_routing_assets.sh
 
-      - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
+      - name: "Run check_domain_probe_sync.py (every vendored set byte-identical, none undeclared)"
         run: python3 scripts/check_domain_probe_sync.py --strict
+
+      - name: "Run vendoring-gate self-test (drifted checklist, drifted probe, undeclared pair all fail)"
+        run: bash tests/test_vendoring_sync.sh
+
+      - name: "Run check_script_reachability.py (a script no skill runs never runs)"
+        run: python3 scripts/check_script_reachability.py --strict
+
+      - name: "Run script-reachability self-test (de-wired script and undocumented allowlist entry fail)"
+        run: bash tests/test_script_reachability.sh
 
       - name: "Run check_bundled_media_license.py (an MIT package may only ship what it holds — including inside a .pptx)"
         run: python3 scripts/check_bundled_media_license.py --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,40 @@
   in a container, a loose image with no provenance, a file the LICENSE denies shipping, an
   undeclared payload) and asserts the gate **fails**, and that it stays silent on work that is ours.
 
+- **Two guards existed for one instance of a pattern and not for its twin.** Both were found by
+  asking, of an existing gate, "what else looks exactly like this, and is it watched?"
+
+  **A vendored set nothing checked.** Six risk-of-bias checklists (`RoB2`, `NOS`, `ROBINS_I`,
+  `QUADAS2`, `PROBAST`, `PRISMA_DTA`) are vendored byte-identical from `/check-reporting` into
+  `/meta-analysis` — the same build-time vendoring pattern as the 23 domain probes, which *are*
+  gated by `check_domain_probe_sync.py`. The checklists were gated by nothing. No drift had happened
+  yet, so nothing was broken; a hand-edit to either copy would have shipped two silently different
+  versions of the same appraisal tool. The gate is now **table-driven** (`VENDOR_SETS`) and covers
+  both sets — and, so a *third* set cannot be forgotten the same way, it hashes everything under
+  `skills/` and **fails on byte-identical content living in two skills that no entry declares**. The
+  table no longer has to be remembered, because an undeclared duplicate gets found. `--sync` still
+  repairs drift in one command. (`/check-reporting`, `/meta-analysis`, `/peer-review`, `/self-review`)
+
+  **A shipped, CI-tested script no skill ever ran.** `sync-submission/scripts/assemble_supplement.py`
+  (199 lines) — supplement index↔file integrity, duplicate/skipped `S{N}` detection, `_combined.md`
+  rebuild, callout coverage — was invoked by **no SKILL.md**. Its only caller was its own test. It had
+  a CI step, a manifest entry, a CHANGELOG line and a README mention; none of those make a script run.
+  Same disease as the five dormant detectors of #334, one category over: `check_detector_reachability.py`
+  guards the detector glob, and the "deliberately not named `check_*` so the catalog won't count it"
+  convention had quietly become an exemption from being used at all. It is now **Gate 14** of
+  `/sync-submission` (the supplement numbering lock, run before freeze), and the new
+  **`scripts/check_script_reachability.py`** (CI) fails if *any* script under `skills/*/scripts/` is
+  unreachable from a SKILL.md — resolving cross-skill shell-outs and same-directory Python imports,
+  because `from _yaml_frontmatter import …` contains no filename and a naive grep would report live
+  helpers as dead code. Run-once authoring tools stay exempt only via a `MAINTAINER_TOOLS` allowlist
+  that must name where each is documented, and the gate verifies the doc really mentions it.
+  (`/sync-submission`)
+
+  Both gates ship a self-test that **restores the real defect** and asserts failure — a drifted
+  vendored checklist, and `assemble_supplement.py` with its SKILL.md step removed — plus negative
+  fixtures proving they stay silent on good work (`/meta-analysis`'s local-only `JBI_Case_Series.md`;
+  an import-only helper; a shelled-out script). Taxonomy and wiring rules recorded in
+  `skills/MAINTENANCE.md` §3b/§3c. Detector count unchanged (repo-level gates are not detectors).
 
 ### Added
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -68,8 +68,8 @@
     },
     {
       "path": "skills/MAINTENANCE.md",
-      "size": 4061,
-      "sha256": "a4eaa6062e7d5879afcdac3bd954fcb783282707eea22b815d5a6f794d5a5217"
+      "size": 6555,
+      "sha256": "cf39c8c6015c7573aa40fb97631bba26acddab6a2fcb09c8d2a2ec5f49fdbd3f"
     },
     {
       "path": "skills/academic-aio/SKILL.md",
@@ -4298,8 +4298,8 @@
     },
     {
       "path": "skills/sync-submission/SKILL.md",
-      "size": 32406,
-      "sha256": "7633eaad3772477c54f5f52204c2e158b588984e712a3d87e52c955e106ce549"
+      "size": 33754,
+      "sha256": "a5045e252bdebf15fa569dee3156b83aa4bd03c4cb2ba07ffc21ef4fb5a762a2"
     },
     {
       "path": "skills/sync-submission/references/journal_availability_policy.json",

--- a/scripts/check_domain_probe_sync.py
+++ b/scripts/check_domain_probe_sync.py
@@ -1,37 +1,67 @@
 #!/usr/bin/env python3
-"""Domain-probe vendoring drift gate.
+"""Vendoring drift gate — every vendored set, not just the one we remembered.
 
-The domain-specific critique probe modules live
-canonically inside the peer-review skill and are vendored BYTE-IDENTICAL into the
-self-review skill.
-Skills are distributed
-individually (/publish-skill), so a runtime cross-skill import is forbidden;
-build-time vendoring with this drift gate is the portability-preserving pattern
-(see docs/dedup_audit.md; same idea as the vendored citation writer).
+Skills ship standalone (`/publish-skill`), so a runtime cross-skill import is forbidden.
+Build-time vendoring — keep one canonical copy, copy it byte-identical into the consuming skill —
+is the portability-preserving pattern (see docs/dedup_audit.md; same idea as the vendored citation
+writer). It is only safe if something asserts the copies never drift apart.
 
-This gate asserts the canonical set and the vendored set are identical:
-  - same file set (no module added/removed on one side only)
-  - byte-identical content (sha256 per module)
+This gate used to guard exactly ONE vendored set: the domain probes. Meanwhile SIX risk-of-bias
+checklists (RoB2, NOS, ROBINS_I, QUADAS2, PROBAST, PRISMA_DTA) were vendored from `/check-reporting`
+into `/meta-analysis` byte-identically and gated by NOTHING. No drift had happened yet — but the
+probes prove the maintainer already believes this guard is necessary, and the checklists were simply
+forgotten. A guard that exists for one instance of a pattern and not for its twin is not a guard;
+it is a coincidence.
+
+So the gate is now table-driven (`VENDOR_SETS`) AND self-discovering:
+
+  1. DECLARED SETS — for each set: same files on both sides, byte-identical (sha256).
+  2. UNDECLARED VENDORING — hash every file under skills/ and flag any content that appears in
+     TWO OR MORE skills without being declared above. This is the part that makes a THIRD vendored
+     set impossible to forget: you do not have to remember to add it to the table, because the gate
+     finds it and fails until you do.
+
+Step 2 is why this file does not need to be renamed every time a new pair is vendored. It is the
+vendoring gate, not the domain-probe gate; the filename is kept only because ~50 files (including
+the header of every vendored probe) point at it by name.
 
 Modes:
-  --strict (default behavior is report-only): exit 1 on any drift / missing /
-           extra module. Wire this into CI and validate_skills.sh.
-  --sync:  copy canonical -> vendored (the one-command fix after editing the
-           canonical copy). Mutually exclusive with --strict.
+  --strict : exit 1 on any drift / missing / extra / undeclared duplicate. Wired into CI and
+             validate_skills.sh.
+  --sync   : copy canonical -> vendored for every declared set (the one-command fix).
+  --root   : operate on an alternate tree (used by tests/test_vendoring_sync.sh).
 
-Stdlib-only. Exit codes: 0 in sync (or after --sync), 1 drift (with --strict),
-2 a canonical/vendored dir is missing.
+Stdlib-only. Exit codes: 0 in sync (or after --sync), 1 drift (with --strict), 2 a dir is missing.
 """
 
 from __future__ import annotations
 
 import argparse
+import collections
 import hashlib
 import shutil
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
-MODULES = (
+
+class VendorSet(NamedTuple):
+    """One canonical -> vendored relationship."""
+
+    name: str
+    canonical: str  # dir, relative to root
+    vendored: str  # dir, relative to root
+    files: tuple[str, ...]  # must exist on BOTH sides, byte-identical
+    # True  -> the canonical dir may hold NOTHING but `files` (every canonical file must be
+    #          vendored; adding one there without vendoring it is the drift we want to catch).
+    # False -> the canonical dir is a larger library and the vendored skill takes only a subset.
+    canonical_exhaustive: bool
+    # Files allowed to live in the vendored dir with no canonical counterpart. Named explicitly so
+    # a local-only file is a decision, not an accident.
+    vendored_local: tuple[str, ...] = ()
+
+
+DOMAIN_PROBES = (
     "sr_ma.md",
     "survival_prognostic.md",
     "clinical_prediction_model.md",
@@ -57,8 +87,45 @@ MODULES = (
     "self_improving_system.md",
 )
 
-CANONICAL_REL = "skills/peer-review/references/domain-probes"
-VENDORED_REL = "skills/self-review/references/domain-probes"
+# The risk-of-bias tools /meta-analysis actually applies during its own RoB step. /check-reporting
+# is the 46-checklist library and is NOT exhaustive here: adding a 47th checklist there must not
+# force it into /meta-analysis.
+ROB_CHECKLISTS = (
+    "RoB2.md",
+    "NOS.md",
+    "ROBINS_I.md",
+    "QUADAS2.md",
+    "PROBAST.md",
+    "PRISMA_DTA.md",
+)
+
+VENDOR_SETS: tuple[VendorSet, ...] = (
+    VendorSet(
+        name="domain-probes",
+        canonical="skills/peer-review/references/domain-probes",
+        vendored="skills/self-review/references/domain-probes",
+        files=DOMAIN_PROBES,
+        canonical_exhaustive=True,
+    ),
+    VendorSet(
+        name="rob-checklists",
+        canonical="skills/check-reporting/references/checklists",
+        vendored="skills/meta-analysis/references/checklists",
+        files=ROB_CHECKLISTS,
+        canonical_exhaustive=False,
+        # JBI critical-appraisal for case series: used by /meta-analysis, has no /check-reporting
+        # counterpart. Declared so the gate stays silent on it instead of crying wolf.
+        vendored_local=("JBI_Case_Series.md",),
+    ),
+)
+
+# Content that is byte-identical across skills but is NOT a vendoring relationship (a coincidental
+# collision — e.g. two trivially identical stubs). Empty today. A gate with no escape hatch gets
+# switched off, and takes the honest gates with it.
+UNDECLARED_EXEMPT: frozenset[str] = frozenset()
+
+# Fixtures prove a thing works; they are not shipped payload and may legitimately duplicate.
+SCAN_SKIP = ("/tests/", "_challenge/", "/challenge/")
 
 
 def repo_root() -> Path:
@@ -77,87 +144,154 @@ def listing(d: Path) -> set[str]:
     return {p.name for p in d.glob("*.md")} if d.is_dir() else set()
 
 
-def do_sync(canonical: Path, vendored: Path) -> int:
-    vendored.mkdir(parents=True, exist_ok=True)
-    for name in MODULES:
-        src = canonical / name
-        if not src.is_file():
-            print(f"ERROR: canonical module missing: {src}", file=sys.stderr)
-            return 2
-        shutil.copyfile(src, vendored / name)
-        print(f"synced  {name}")
-    # Remove any stray vendored files not in the canonical set.
-    for stray in sorted(listing(vendored) - set(MODULES)):
-        (vendored / stray).unlink()
-        print(f"removed stray vendored file  {stray}")
-    print(f"OK: {len(MODULES)} module(s) vendored canonical -> self-review")
+def do_sync(root: Path) -> int:
+    total = 0
+    for vs in VENDOR_SETS:
+        canonical, vendored = root / vs.canonical, root / vs.vendored
+        vendored.mkdir(parents=True, exist_ok=True)
+        for name in vs.files:
+            src = canonical / name
+            if not src.is_file():
+                print(f"ERROR: canonical file missing: {src}", file=sys.stderr)
+                return 2
+            shutil.copyfile(src, vendored / name)
+            print(f"synced  [{vs.name}] {name}")
+            total += 1
+        allowed = set(vs.files) | set(vs.vendored_local)
+        for stray in sorted(listing(vendored) - allowed):
+            (vendored / stray).unlink()
+            print(f"removed stray vendored file  [{vs.name}] {stray}")
+    print(f"OK: {total} file(s) vendored canonical -> vendored across {len(VENDOR_SETS)} set(s)")
     return 0
 
 
-def do_check(canonical: Path, vendored: Path, strict: bool) -> int:
+def check_set(root: Path, vs: VendorSet) -> tuple[list[str], int]:
+    """Returns (problems, fatal) — fatal=2 when a declared directory is absent."""
+    canonical, vendored = root / vs.canonical, root / vs.vendored
     if not canonical.is_dir():
         print(f"ERROR: canonical dir missing: {canonical}", file=sys.stderr)
-        return 2
+        return [], 2
     if not vendored.is_dir():
         print(f"ERROR: vendored dir missing: {vendored}", file=sys.stderr)
-        return 2
+        return [], 2
 
     problems: list[str] = []
-
-    # File-set equality (each side must hold exactly the expected modules).
     canon_set, vend_set = listing(canonical), listing(vendored)
-    for name in MODULES:
-        if name not in canon_set:
-            problems.append(f"canonical missing module: {name}")
-        if name not in vend_set:
-            problems.append(f"vendored missing module: {name}")
-    for extra in sorted(canon_set - set(MODULES)):
-        problems.append(f"unexpected file in canonical dir: {extra}")
-    for extra in sorted(vend_set - set(MODULES)):
-        problems.append(f"unexpected file in vendored dir: {extra}")
 
-    # Byte-identity per module.
-    for name in MODULES:
+    for name in vs.files:
+        if name not in canon_set:
+            problems.append(f"[{vs.name}] canonical missing file: {name}")
+        if name not in vend_set:
+            problems.append(f"[{vs.name}] vendored missing file: {name}")
+
+    if vs.canonical_exhaustive:
+        for extra in sorted(canon_set - set(vs.files)):
+            problems.append(
+                f"[{vs.name}] canonical file is not vendored: {extra} "
+                "(add it to this set's file list, or the consuming skill silently lacks it)"
+            )
+    for extra in sorted(vend_set - set(vs.files) - set(vs.vendored_local)):
+        problems.append(f"[{vs.name}] unexpected file in vendored dir: {extra}")
+
+    for name in vs.files:
         c, v = canonical / name, vendored / name
         if c.is_file() and v.is_file():
             ch, vh = sha256_file(c), sha256_file(v)
             if ch != vh:
                 problems.append(
-                    f"drift: {name} canonical={ch[:12]}... vendored={vh[:12]}..."
+                    f"[{vs.name}] drift: {name} canonical={ch[:12]}... vendored={vh[:12]}..."
                 )
+    return problems, 0
 
+
+def declared_paths(root: Path) -> set[Path]:
+    out: set[Path] = set()
+    for vs in VENDOR_SETS:
+        for name in vs.files:
+            out.add((root / vs.canonical / name).resolve())
+            out.add((root / vs.vendored / name).resolve())
+    return out
+
+
+def undeclared_duplicates(root: Path) -> list[str]:
+    """Byte-identical content living in 2+ skills without a declared vendoring set.
+
+    This is the anti-forgetting mechanism: a third vendored set cannot slip in ungated, because it
+    does not need to be remembered — it gets found.
+    """
+    skills = root / "skills"
+    if not skills.is_dir():
+        return []
+    known = declared_paths(root)
+    by_hash: dict[str, list[Path]] = collections.defaultdict(list)
+    for p in skills.rglob("*"):
+        if not p.is_file() or p.is_symlink():
+            continue
+        if any(t in "/" + str(p.relative_to(root)) for t in SCAN_SKIP):
+            continue
+        if p.resolve() in known or p.name in UNDECLARED_EXEMPT:
+            continue
+        try:
+            if p.stat().st_size == 0:
+                continue
+            by_hash[sha256_file(p)].append(p)
+        except OSError:
+            continue
+
+    problems: list[str] = []
+    for _h, paths in sorted(by_hash.items(), key=lambda kv: str(kv[1][0])):
+        owners = {p.relative_to(skills).parts[0] for p in paths}
+        if len(owners) < 2:
+            continue
+        rels = ", ".join(sorted(str(p.relative_to(root)) for p in paths))
+        problems.append(
+            f"[undeclared] identical content vendored across {sorted(owners)} but not declared: {rels}"
+        )
+    return problems
+
+
+def do_check(root: Path, strict: bool) -> int:
     print("=" * 41)
-    print(" Domain-Probe Vendoring Sync")
+    print(" Vendoring Sync (canonical -> vendored)")
     print("=" * 41)
-    print(f"canonical: {CANONICAL_REL}")
-    print(f"vendored:  {VENDORED_REL}")
+
+    problems: list[str] = []
+    for vs in VENDOR_SETS:
+        print(f"{vs.name:16s} {vs.canonical}\n{'':16s}  -> {vs.vendored}  ({len(vs.files)} file(s))")
+        found, fatal = check_set(root, vs)
+        if fatal:
+            return fatal
+        problems += found
+
+    problems += undeclared_duplicates(root)
+
     if not problems:
-        print(f"OK: {len(MODULES)} module(s) byte-identical across both skills.")
+        n = sum(len(v.files) for v in VENDOR_SETS)
+        print(f"\nOK: {n} vendored file(s) byte-identical across {len(VENDOR_SETS)} declared set(s);")
+        print("    no undeclared cross-skill duplicate content.")
         return 0
 
-    print(f"\nDOMAIN_PROBE_DRIFT ({len(problems)}):")
+    print(f"\nVENDORING_DRIFT ({len(problems)}):")
     for p in problems:
         print(f"  - {p}")
-    print("\nFix: python3 scripts/check_domain_probe_sync.py --sync")
+    print("\nFix (declared drift): python3 scripts/check_domain_probe_sync.py --sync")
+    print("Fix (undeclared):     add the pair to VENDOR_SETS in this script, or de-duplicate it.")
     return 1 if strict else 0
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Domain-probe vendoring drift gate.")
+    ap = argparse.ArgumentParser(description="Vendoring drift gate (all vendored sets).")
+    ap.add_argument("--root", default=None, help="operate on an alternate tree (tests)")
     mode = ap.add_mutually_exclusive_group()
-    mode.add_argument("--strict", action="store_true",
-                      help="Exit non-zero on any drift (CI gate).")
-    mode.add_argument("--sync", action="store_true",
-                      help="Copy canonical -> vendored (fix drift).")
+    mode.add_argument("--strict", action="store_true", help="Exit non-zero on any drift (CI gate).")
+    mode.add_argument("--sync", action="store_true", help="Copy canonical -> vendored (fix drift).")
     args = ap.parse_args()
 
-    root = repo_root()
-    canonical = root / CANONICAL_REL
-    vendored = root / VENDORED_REL
+    root = Path(args.root).resolve() if args.root else repo_root()
 
     if args.sync:
-        return do_sync(canonical, vendored)
-    return do_check(canonical, vendored, strict=args.strict)
+        return do_sync(root)
+    return do_check(root, strict=args.strict)
 
 
 if __name__ == "__main__":

--- a/scripts/check_script_reachability.py
+++ b/scripts/check_script_reachability.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""A script no skill runs is a script that never runs — the non-detector sibling of
+check_detector_reachability.py.
+
+That gate closed the hole for scripts matching the detector glob (`check_*`, `detect_*`, `derive_*`).
+It closed it for exactly those. Everything else under `skills/*/scripts/` — build helpers, assemblers,
+validators that were deliberately named so the catalog would NOT count them — walked straight through.
+
+`skills/sync-submission/scripts/assemble_supplement.py` (199 lines) is what walked through: shipped,
+CI-tested, listed in the distribution manifest, announced in the CHANGELOG and the README — and
+invoked by no SKILL.md. Its only caller was its own test. That is the same disease as the five
+dormant detectors of PR #334, one category over: the gate was verifying the tool instead of the
+*use* of the tool, and the "not a detector" naming convention that keeps the count honest had
+quietly become a way to be exempt from being used at all.
+
+A script is REACHABLE if:
+  * a SKILL.md names it (any skill's — a SKILL.md may shell out to another skill's script via
+    MEDSCI_SKILLS_ROOT, and six of them do), or
+  * a reachable script names it (a bundle runner shelling out), or
+  * a reachable Python script IMPORTS it from its own directory.
+
+That last edge is not optional. `from _yaml_frontmatter import split_yaml_front_matter` does not
+contain the string "_yaml_frontmatter.py", so a filename grep reports `_yaml_frontmatter.py` as
+dead code when two scripts depend on it. A gate that invents phantom orphans gets switched off, and
+takes the honest gates with it. Imports resolve within the script's own directory only — skills are
+self-contained and cross-skill imports are forbidden.
+
+A test, a challenge card, or a CI step does NOT make a script reachable. Those prove it works in a
+laboratory. They are exactly what assemble_supplement.py had.
+
+The escape hatch is MAINTAINER_TOOLS: a run-once authoring tool a maintainer invokes by hand is
+legitimately not user-facing, but it must be *documented as such*. Each entry names the file that
+documents it, and this gate verifies that file actually mentions it — otherwise the allowlist
+becomes the place dead code goes to hide.
+
+Usage:
+    check_script_reachability.py [--strict] [--skills-dir DIR]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SCRIPT_SUFFIXES = {".py", ".sh", ".R"}
+
+# Files that prove a script WORKS but never cause it to RUN for a user.
+TEST_MARKERS = ("/tests/", "_challenge/", "/challenge/")
+
+# Run-once authoring tools (skills/MAINTENANCE.md §3): invoked by a maintainer, never at skill
+# invocation. Value = the file that documents the tool. The gate asserts the doc names it, so an
+# entry here is a decision, not a hiding place.
+MAINTAINER_TOOLS: dict[str, str] = {
+    "make-figures/scripts/build_jacc_template.py": "skills/MAINTENANCE.md",
+    "make-figures/scripts/extract_exemplar_from_pdf.py": "skills/MAINTENANCE.md",
+}
+
+IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+([A-Za-z_][\w]*)", re.MULTILINE)
+
+
+def is_test_path(p: Path) -> bool:
+    return any(m in "/" + p.as_posix() for m in TEST_MARKERS)
+
+
+def scripts_of(skills: Path) -> list[Path]:
+    return sorted(
+        p
+        for p in skills.glob("*/scripts/*")
+        if p.is_file() and p.suffix in SCRIPT_SUFFIXES and not is_test_path(p)
+    )
+
+
+def reachable_set(skills: Path, all_scripts: list[Path]) -> set[Path]:
+    text = {p: p.read_text(encoding="utf-8", errors="ignore") for p in all_scripts}
+
+    def edges(p: Path) -> set[Path]:
+        out: set[Path] = set()
+        body = text[p]
+        # Shell-out by filename — repo-wide: preflight_gate.py (sync-submission) runs
+        # check_placeholders.py (write-paper).
+        for q in all_scripts:
+            if q is not p and q.name in body:
+                out.add(q)
+        # Python import — same directory only (skills are self-contained).
+        if p.suffix == ".py":
+            for mod in IMPORT_RE.findall(body):
+                cand = p.parent / f"{mod}.py"
+                if cand.is_file() and cand != p:
+                    out.add(cand)
+        return out
+
+    reach: set[Path] = set()
+    frontier: list[Path] = []
+    for skill_md in sorted(skills.glob("*/SKILL.md")):
+        body = skill_md.read_text(encoding="utf-8", errors="ignore")
+        for q in all_scripts:
+            if q.name in body and q not in reach:
+                reach.add(q)
+                frontier.append(q)
+    while frontier:
+        for q in edges(frontier.pop()):
+            if q not in reach:
+                reach.add(q)
+                frontier.append(q)
+    return reach
+
+
+def mentions(root: Path, doc_rel: str, name: str) -> bool:
+    doc = root / doc_rel
+    return doc.is_file() and name in doc.read_text(encoding="utf-8", errors="ignore")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any script is unreachable")
+    ap.add_argument("--skills-dir", default=None, help="alternate skills/ tree (tests)")
+    a = ap.parse_args()
+
+    skills = Path(a.skills_dir).resolve() if a.skills_dir else ROOT / "skills"
+    root = skills.parent
+    if not skills.is_dir():
+        print(f"ERROR: skills dir missing: {skills}", file=sys.stderr)
+        return 2
+
+    all_scripts = scripts_of(skills)
+    reach = reachable_set(skills, all_scripts)
+
+    problems: list[str] = []
+    orphans: list[Path] = []
+    for p in all_scripts:
+        if p in reach:
+            continue
+        rel = p.relative_to(skills).as_posix()
+        doc = MAINTAINER_TOOLS.get(rel)
+        if doc is None:
+            orphans.append(p)
+        elif not mentions(root, doc, p.name):
+            problems.append(
+                f"{rel} is allowlisted as a maintainer tool but {doc} never mentions it "
+                "— an undocumented allowlist entry is just dead code with permission"
+            )
+
+    # An allowlist entry for a file that no longer exists is stale bookkeeping; say so. Only
+    # meaningful against the real tree — MAINTAINER_TOOLS is keyed to this repo's layout, and a
+    # synthetic --skills-dir legitimately has none of those paths. Firing there would make the gate
+    # cry wolf on good work.
+    if a.skills_dir is None:
+        for rel, doc in MAINTAINER_TOOLS.items():
+            if not (skills / rel).is_file():
+                problems.append(
+                    f"MAINTAINER_TOOLS names {rel}, which does not exist (stale entry; doc={doc})"
+                )
+
+    total = len(all_scripts)
+    if not orphans and not problems:
+        print(
+            f"OK: all {total} skill scripts are reachable from a SKILL.md "
+            f"(directly, via a shell-out, or via a same-dir import); "
+            f"{len(MAINTAINER_TOOLS)} documented maintainer tool(s) exempt."
+        )
+        return 0
+
+    if orphans:
+        print(f"SCRIPT_UNREACHABLE: {len(orphans)} of {total} skill scripts are never invoked by any skill.\n")
+        for p in orphans:
+            rel = p.relative_to(skills).as_posix()
+            where = [
+                str(q.relative_to(root))
+                for q in skills.rglob("*")
+                if q.is_file() and q != p and q.suffix in {".md", ".sh", ".py", ".yml", ".yaml"}
+                and p.name in q.read_text(encoding="utf-8", errors="ignore")
+            ]
+            lab = [w for w in where if any(m in "/" + w for m in TEST_MARKERS)]
+            print(f"  {rel}")
+            if lab:
+                print(f"      mentioned only in: {', '.join(lab[:3])}")
+                print("      — a test and a CI step prove it WORKS. They do not make it RUN.")
+            elif where:
+                print(f"      mentioned in: {', '.join(where[:3])}")
+            else:
+                print("      — not mentioned anywhere. Dead code.")
+        print()
+
+    for m in problems:
+        print(f"  ALLOWLIST: {m}")
+    if problems:
+        print()
+
+    print("Fix: invoke it from the SKILL.md step it belongs to (see skills/MAINTENANCE.md §1-2), or")
+    print("— if it is a run-once authoring tool — add it to MAINTAINER_TOOLS here AND document it")
+    print("in skills/MAINTENANCE.md §3.")
+    return 1 if a.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -473,11 +473,18 @@ python3 "$REPO_ROOT/scripts/validate_skill_contracts.py"
 contract_status=$?
 echo ""
 
-# Domain-probe vendoring drift gate. Capture the exit status explicitly: this
-# script runs under `set -uo pipefail` (not `set -e`), so a bare call would not
-# abort and the failure would be silently buried before the summary.
+# Vendoring drift gate (all vendored sets: domain probes + RoB checklists + any undeclared
+# cross-skill duplicate). Capture the exit status explicitly: this script runs under
+# `set -uo pipefail` (not `set -e`), so a bare call would not abort and the failure would be
+# silently buried before the summary.
 python3 "$REPO_ROOT/scripts/check_domain_probe_sync.py" --strict
 domain_probe_status=$?
+echo ""
+
+# Script reachability. A script no SKILL.md invokes never runs for a user, however well it is
+# tested — the non-detector sibling of check_detector_reachability.py.
+python3 "$REPO_ROOT/scripts/check_script_reachability.py" --strict
+script_reach_status=$?
 echo ""
 
 if [ "$FAIL" -gt 0 ]; then
@@ -490,7 +497,10 @@ elif [ "$contract_status" -ne 0 ]; then
   echo -e "${RED}VALIDATION FAILED${NC} — skill contract validation failed"
   exit 1
 elif [ "$domain_probe_status" -ne 0 ]; then
-  echo -e "${RED}VALIDATION FAILED${NC} — domain-probe vendoring drift (run check_domain_probe_sync.py --sync)"
+  echo -e "${RED}VALIDATION FAILED${NC} — vendoring drift (run check_domain_probe_sync.py --sync)"
+  exit 1
+elif [ "$script_reach_status" -ne 0 ]; then
+  echo -e "${RED}VALIDATION FAILED${NC} — a skill script is never invoked by any SKILL.md (see check_script_reachability.py)"
   exit 1
 else
   echo -e "${GREEN}ALL CHECKS PASSED${NC}"

--- a/skills/MAINTENANCE.md
+++ b/skills/MAINTENANCE.md
@@ -33,16 +33,46 @@ plain verb (`fill_journal_abbrev.py`) so the detector glob never counts it. Help
 need their own SKILL.md step, but if a user runs them directly they should be listed in the
 skill's tool table (e.g. `manage-refs` documents `fill_journal_abbrev.py`).
 
+A helper is reachable through its **import**, not its filename: `from _yaml_frontmatter import …`
+never contains the string `_yaml_frontmatter.py`. `scripts/check_script_reachability.py` resolves
+same-directory imports for exactly this reason — a gate that reports live helpers as dead code gets
+switched off, and takes the honest gates with it.
+
 ## 3. Run-once authoring tool
 
 A generator a maintainer runs by hand to (re)build a committed asset — NOT invoked at skill
 invocation. These are intentionally not wired into any SKILL.md step. Keep them; document
-their purpose in their own docstring. Current run-once tools:
+their purpose in their own docstring **and list them here** — `check_script_reachability.py`
+exempts only the paths in its `MAINTAINER_TOOLS` allowlist, and it verifies that this file
+actually names each one. An allowlist entry its own documentation never mentions is just dead
+code with permission, and the gate fails on it. Current run-once tools:
 
 - `skills/make-figures/scripts/build_jacc_template.py` — rebuilds the committed JACC Central
   Illustration PPTX template (`references/visual_abstract_templates/jacc_central_illustration.pptx`).
 - `skills/make-figures/scripts/extract_exemplar_from_pdf.py` — extracts a figure region from a
   PDF page to grow the make-figures Critic-Loop exemplar reference set.
+
+## 3b. Every other script MUST be invoked by a SKILL.md
+
+Categories 1–3 cover a counted detector, a helper reached by import, and a documented run-once
+tool. Anything else under `skills/*/scripts/` — an assembler, a builder, a non-counted validator —
+is user-facing tooling and must be named in a **SKILL.md step**, in the phase it belongs to. A test,
+a challenge card, a CHANGELOG line and a manifest entry all prove a script *works*; none of them
+make it *run*. `assemble_supplement.py` had every one of those and was invoked by nothing for months.
+
+`scripts/check_script_reachability.py --strict` (CI) enforces this for **all** scripts, resolving
+shell-outs (including cross-skill ones, which are legitimate — six SKILL.md files call another
+skill's script via `MEDSCI_SKILLS_ROOT`) and same-directory Python imports.
+
+## 3c. Vendored content must be declared
+
+Skills are self-contained, so shared reference content is **vendored** — one canonical copy, copied
+byte-identical into the consuming skill (domain probes: `/peer-review` → `/self-review`; RoB
+checklists: `/check-reporting` → `/meta-analysis`). Declare every such set in `VENDOR_SETS` in
+`scripts/check_domain_probe_sync.py` and fix drift with `--sync`; never hand-edit one copy.
+
+You cannot quietly forget a new set: the same gate hashes everything under `skills/` and fails on
+byte-identical content living in two skills that no `VENDOR_SETS` entry declares.
 
 ## 4. Test fixture / regression test
 
@@ -61,6 +91,11 @@ When you add a detector and its test in the same PR, add the `validate.yml` step
    payload files and hashes; tests are excluded from the distributed payload but the manifest
    `--check` still gates on edited payload scripts).
 4. New/edited test → add its `run:` step to `.github/workflows/validate.yml`.
+5. **Any** new script (detector or not) → wire it into a `SKILL.md` step, or add it to
+   `MAINTAINER_TOOLS` in `scripts/check_script_reachability.py` **and** list it in §3 above.
+   `check_script_reachability.py --strict` fails otherwise (§3b).
+6. New vendored copy of shared content → declare it in `VENDOR_SETS` in
+   `scripts/check_domain_probe_sync.py` (§3c). The gate fails on undeclared duplicates.
 
 Run the full local CI-mirror before pushing (see the repo `CONTRIBUTING.md` / `validate.yml`
 gates): `validate_skills.sh`, the three `gen_*.py --check`, `validate_catalog_consistency.py`,

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -55,6 +55,7 @@ The registry is a project-local YAML mapping author identifiers (full names, nat
 | Sync audit | `qc/submission_sync_{journal}.json` | Drift result consumed by orchestrator |
 | Manifest update | `artifact_manifest.json` | Submission package registry |
 | Pre-flight gate | `qc/preflight_gate_report.json` | Aggregated halt-on-failure manifest (see "Pre-flight gate" below) |
+| Supplement structure | `qc/supplement_structure.json` | Gate 14: index↔file 1:1, sub-section gaps, callout coverage |
 
 ## Pre-flight gate (single command — last step before freeze)
 
@@ -140,6 +141,16 @@ remains the authoritative fabrication and author-name check before submission.
     --journal-profile "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/find-journal/references/journal_profiles/<Journal>.md" \
     --article-type "Original Article" --out qc/wordcount_cap.json --strict
   # or, deterministic: --limit 4000   (and --rendered-words N from the built DOCX when available)
+  ```
+
+- Gate 14 (supplement structure — the numbering lock): a cohort/SR supplement is a directory of `S{N}_*.md` sections plus an index, hand-concatenated into `_combined.md`. Across revision rounds that set desynchronizes silently: an index row with no file, a file the index never lists, two files claiming the same `S{N}`, or a sub-section gap after an insert (`S6.3` then `S6.5`). A reviewer opening "Supplementary Table S9" and finding the wrong content is the failure mode. Before freeze, run `scripts/assemble_supplement.py` to validate index↔file 1:1, rebuild `_combined.md` in index order (so the assembly is reproducible rather than hand-maintained), and — with `--manuscript` — report callout coverage: body callouts with no section file (`CALLOUT_WITHOUT_SECTION`) and section files the body never cites (`SECTION_UNCITED`). The four structural kinds are P0 under `--strict`; coverage findings are advisory.
+
+  ```bash
+  python3 "${CLAUDE_SKILL_DIR}/scripts/assemble_supplement.py" \
+    --dir submission/{journal}/supplementary --index 00_index.md \
+    --manuscript manuscript/manuscript.md \
+    --out submission/{journal}/supplementary/_combined.md \
+    --json qc/supplement_structure.json --strict
   ```
 
 ## Phase 4 — Cover-letter free-text drift

--- a/tests/test_script_reachability.sh
+++ b/tests/test_script_reachability.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_script_reachability.py.
+#
+# The defect: skills/sync-submission/scripts/assemble_supplement.py shipped for months — tested,
+# manifested, announced in the CHANGELOG — and no SKILL.md ever invoked it. Case 2 restores that
+# defect (drop the SKILL.md step) and asserts the gate FAILS.
+#
+#  1) live repo passes                              (assemble_supplement.py is now wired)
+#  2) SKILL.md step removed -> FAILS                <-- THE DEFECT
+#  3) allowlisted but undocumented -> FAILS         (the escape hatch cannot hide dead code)
+#  4) import-only helper stays silent               NEGATIVE FIXTURE — no phantom orphans
+#  5) shell-out from a reachable script stays silent NEGATIVE FIXTURE
+#  6) a genuine orphan FAILS
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE="$ROOT/scripts/check_script_reachability.py"
+
+# 1) live repo passes
+python3 "$GATE" --strict >/dev/null || { echo "FAIL: live repo should be fully reachable" >&2; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+cp -R "$ROOT/skills" "$tmp/skills"
+
+python3 "$GATE" --skills-dir "$tmp/skills" --strict >/dev/null \
+  || { echo "FAIL: an untouched copy must pass" >&2; exit 1; }
+
+# 2) THE DEFECT: remove the SKILL.md step that invokes assemble_supplement.py.
+#    Every other signal it has — its test, its CI step, its manifest entry — stays in place. If
+#    those made it "reachable", this case would pass, and that is precisely the bug.
+grep -v 'assemble_supplement.py' "$tmp/skills/sync-submission/SKILL.md" > "$tmp/stripped.md"
+mv "$tmp/stripped.md" "$tmp/skills/sync-submission/SKILL.md"
+if python3 "$GATE" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1; then
+  echo "FAIL: a script no SKILL.md invokes must exit 1 (its test must not count as a caller)" >&2
+  exit 1
+fi
+report="$(python3 "$GATE" --skills-dir "$tmp/skills" --strict 2>&1 || true)"
+grep -q "assemble_supplement.py" <<<"$report" \
+  || { echo "FAIL: the report must name the orphan" >&2; echo "$report" >&2; exit 1; }
+grep -q "do not make it RUN" <<<"$report" \
+  || { echo "FAIL: the report should say a test is not a caller" >&2; exit 1; }
+cp "$ROOT/skills/sync-submission/SKILL.md" "$tmp/skills/sync-submission/SKILL.md"   # restore
+
+# 3) the escape hatch must not hide dead code: allowlisted, but the doc no longer mentions it
+grep -v 'build_jacc_template.py' "$tmp/skills/MAINTENANCE.md" > "$tmp/m.md"
+mv "$tmp/m.md" "$tmp/skills/MAINTENANCE.md"
+if python3 "$GATE" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1; then
+  echo "FAIL: an allowlisted tool its own doc never mentions must exit 1" >&2; exit 1
+fi
+cp "$ROOT/skills/MAINTENANCE.md" "$tmp/skills/MAINTENANCE.md"                       # restore
+python3 "$GATE" --skills-dir "$tmp/skills" --strict >/dev/null \
+  || { echo "FAIL: restore should return the copy to clean" >&2; exit 1; }
+
+# --- synthetic tree: the edge cases, in isolation ---
+syn="$tmp/syn/skills"; mkdir -p "$syn/alpha/scripts" "$syn/beta/scripts"
+
+# alpha: SKILL.md invokes runner.py; runner.py imports _helper (NO filename string anywhere) and
+# shells out to beta's script by filename.
+cat > "$syn/alpha/SKILL.md" <<'MD'
+# Alpha
+Run `python3 scripts/runner.py --strict` before freeze.
+MD
+cat > "$syn/alpha/scripts/runner.py" <<'PY'
+from _helper import thing
+import subprocess
+subprocess.run(["python3", "../../beta/scripts/worker.py"])
+PY
+cat > "$syn/alpha/scripts/_helper.py" <<'PY'
+thing = 1
+PY
+cat > "$syn/beta/SKILL.md" <<'MD'
+# Beta
+MD
+cat > "$syn/beta/scripts/worker.py" <<'PY'
+print("worker")
+PY
+
+# 4+5) NEGATIVE FIXTURE: _helper.py is reached ONLY by `from _helper import thing` and worker.py
+#      ONLY by a shell-out from a reachable script. A filename grep would call both dead.
+python3 "$GATE" --skills-dir "$syn" --strict >/dev/null || {
+  echo "FAIL: import-resolved helper and shelled-out script must NOT be reported as orphans" >&2
+  python3 "$GATE" --skills-dir "$syn" --strict >&2 || true
+  exit 1
+}
+
+# 6) a genuine orphan
+cat > "$syn/beta/scripts/orphan.py" <<'PY'
+print("nobody calls me")
+PY
+if python3 "$GATE" --skills-dir "$syn" --strict >/dev/null 2>&1; then
+  echo "FAIL: a genuine orphan must exit 1" >&2; exit 1
+fi
+
+echo "PASS: script reachability gate — live repo clean; a de-wired script, an undocumented allowlist"
+echo "      entry and a genuine orphan all fail; import-only and shell-out targets stay silent."

--- a/tests/test_vendoring_sync.sh
+++ b/tests/test_vendoring_sync.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_domain_probe_sync.py (the vendoring drift gate).
+#
+# The defect this gate was extended to catch: six risk-of-bias checklists are vendored
+# byte-identical from /check-reporting into /meta-analysis and NOTHING asserted they stay in sync.
+# Case 3 restores that defect (drift a vendored checklist) and asserts the gate FAILS. Before the
+# extension, that case exited 0 — a gate that watched the probes and looked straight past the
+# checklists.
+#
+#  1) live repo passes                                    (no drift today)
+#  2) copied tree passes                                  NEGATIVE FIXTURE — silent on good work
+#  3) drifted vendored CHECKLIST fails                    <-- THE DEFECT (previously ungated)
+#  4) --sync repairs the drift
+#  5) drifted vendored PROBE fails                        (original behaviour preserved)
+#  6) an UNDECLARED vendored pair fails                   (a third set cannot be forgotten)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE="$ROOT/scripts/check_domain_probe_sync.py"
+
+CHECKLIST="skills/meta-analysis/references/checklists/RoB2.md"
+PROBE="skills/self-review/references/domain-probes/sr_ma.md"
+
+# 1) live repo passes
+python3 "$GATE" --strict >/dev/null || { echo "FAIL: live repo should be in sync" >&2; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/skills"
+for s in peer-review self-review check-reporting meta-analysis; do
+  cp -R "$ROOT/skills/$s" "$tmp/skills/$s"
+done
+
+# 2) NEGATIVE FIXTURE: an untouched copy must stay silent — including meta-analysis's local-only
+#    JBI_Case_Series.md, which has no canonical counterpart and must NOT be reported as a stray.
+python3 "$GATE" --root "$tmp" --strict >/dev/null \
+  || { echo "FAIL: an untouched tree must pass (gate fires on good work)" >&2; exit 1; }
+
+# 3) THE DEFECT: drift a vendored checklist by one byte -> must FAIL
+printf '\n<!-- drift -->\n' >> "$tmp/$CHECKLIST"
+if python3 "$GATE" --root "$tmp" --strict >/dev/null 2>&1; then
+  echo "FAIL: a drifted vendored CHECKLIST must exit 1 (this is the defect the gate exists for)" >&2
+  exit 1
+fi
+# the gate exits 1 here, so capture before grepping (pipefail would swallow the report)
+report="$(python3 "$GATE" --root "$tmp" --strict 2>&1 || true)"
+grep -q "rob-checklists.*drift: RoB2.md" <<<"$report" \
+  || { echo "FAIL: the report must name the drifted checklist" >&2; echo "$report" >&2; exit 1; }
+
+# 4) --sync repairs it
+python3 "$GATE" --root "$tmp" --sync >/dev/null
+python3 "$GATE" --root "$tmp" --strict >/dev/null \
+  || { echo "FAIL: --sync should restore byte-identity" >&2; exit 1; }
+cmp -s "$tmp/$CHECKLIST" "$ROOT/skills/check-reporting/references/checklists/RoB2.md" \
+  || { echo "FAIL: --sync must reproduce the canonical bytes" >&2; exit 1; }
+
+# 5) original behaviour preserved: a drifted vendored probe still fails
+printf '\n<!-- drift -->\n' >> "$tmp/$PROBE"
+if python3 "$GATE" --root "$tmp" --strict >/dev/null 2>&1; then
+  echo "FAIL: a drifted vendored PROBE must exit 1" >&2; exit 1
+fi
+python3 "$GATE" --root "$tmp" --sync >/dev/null
+python3 "$GATE" --root "$tmp" --strict >/dev/null || { echo "FAIL: --sync should repair probe" >&2; exit 1; }
+
+# 6) a THIRD vendored set nobody declared: identical bytes in two skills -> must FAIL.
+#    This is what makes forgetting structurally impossible: the table does not have to be
+#    remembered, because undeclared duplicate content is discovered.
+echo "shared vendored content" > "$tmp/skills/peer-review/references/_new_shared.md"
+cp "$tmp/skills/peer-review/references/_new_shared.md" "$tmp/skills/self-review/references/_new_shared.md"
+if python3 "$GATE" --root "$tmp" --strict >/dev/null 2>&1; then
+  echo "FAIL: an undeclared cross-skill duplicate must exit 1" >&2; exit 1
+fi
+report="$(python3 "$GATE" --root "$tmp" --strict 2>&1 || true)"
+grep -q "undeclared" <<<"$report" \
+  || { echo "FAIL: the report must flag it as undeclared vendoring" >&2; echo "$report" >&2; exit 1; }
+
+echo "PASS: vendoring gate — clean tree silent; drifted checklist, drifted probe and an undeclared"
+echo "      vendored pair all fail; --sync repairs."


### PR DESCRIPTION
Two guards the repo had for one instance of a pattern and not for its twin.

- **Vendored checklists were ungated.** Six files are byte-identical across `check-reporting` and `meta-analysis`. The domain probes have exactly this vendoring pattern and ARE gated (`check_domain_probe_sync.py`, CI-enforced). The checklists were gated by nothing. Generalised the existing gate into a table-driven vendoring check (29 files / 2 sets) that also catches an undeclared third vendored set — rather than cloning it.
- **A shipped, CI-tested script that no SKILL.md ran.** `assemble_supplement.py` (199 lines) was invoked by nothing but its own test — the signature of the three detectors fixed in #334. It is a real build/QA helper, so it was wired into `/sync-submission` as Gate 14, not deleted. Added `check_script_reachability.py`, the non-detector sibling of `check_detector_reachability.py`: every script under `skills/*/scripts/` must be reachable from a SKILL.md or listed as a maintainer tool.

Both gates ship a self-test that regresses the real defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)