### PR TITLE
fix(detectors): a clean fixture for one detector must be clean for all

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,6 +111,12 @@ jobs:
       - name: Run detector-envelope gate self-test (unlabelled + mislabelled envelopes fail)
         run: bash tests/test_detector_envelopes.sh
 
+      - name: Run check_detector_crossfire.py (a fixture clean for one detector must be clean for all)
+        run: python3 scripts/check_detector_crossfire.py
+
+      - name: Run detector-crossfire self-test (restores the real 18pt vs 20pt bug; the gate must catch it)
+        run: bash tests/test_detector_crossfire.sh
+
       - name: Run check_python_floor.py (everything a user runs must parse on the Python we promise)
         run: python3 scripts/check_python_floor.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,34 @@
   fixtures proving they stay silent on good work (`/meta-analysis`'s local-only `JBI_Case_Series.md`;
   an import-only helper; a shelled-out script). Taxonomy and wiring rules recorded in
   `skills/MAINTENANCE.md` §3b/§3c. Detector count unchanged (repo-level gates are not detectors).
+- **A fixture that is clean for one detector was not required to be clean for the others — and two
+  detectors had already contradicted each other in that gap** (`scripts/check_detector_crossfire.py`,
+  `tests/test_detector_crossfire.sh`). `check_slide_tells` treated a text block as an *arrow label*
+  only if it was **≤ 18 pt**, while `check_deck_budget` demanded **≥ 20 pt** so the back row could
+  read it. A legible 20-pt arrow label therefore satisfied the budget check and was **invisible** to
+  the arrow check, so a well-made slide was reported as having unlabelled arrows. **Neither detector
+  was wrong alone.** One detector's advisory threshold had quietly become another detector's
+  *definition of a category*, and nothing in the repo ever looked at the two together.
+
+  Every detector was tested only against fixtures built to its own model of the world, so this class
+  of bug was invisible to every existing test. The new gate runs **every detector of a family against
+  every clean fixture of that family** — all manuscript detectors across the three demo manuscripts,
+  both deck detectors across all three clean decks the challenge cards build — and fails if any of
+  them produces a finding. When one does, either the detector is over-firing or the demo is
+  defective, and a human has to say which. **78 pairs** run today; the count is printed and a run of
+  zero pairs is itself a failure, because a test that silently exercises nothing is worse than none.
+
+  It found a real defect on its first run: **demo 02 had no Data Availability statement** (demos 01
+  and 03 both do), which `check_disclosure_availability` hard-blocks. The demo is fixed, not the
+  detector.
+
+  The gate learns how to invoke each detector from its own `--help` rather than guessing, and it
+  **never passes an output flag** (`--out` / `--json` / `--report`) — both deck detectors take
+  `--json PATH`, and a guessing scanner once overwrote 31 fixtures that way. It also runs each
+  detector with its working directory inside a temp dir (some write a *default* `qc/…` report beside
+  the fixture) and hashes every fixture before and after, voiding the run if one changed. Detectors
+  that need an input the fixture cannot supply are **skipped out loud, by name**, so the coverage is
+  auditable.
 
 ### Added
 

--- a/demo/02_metafor_bcg/manuscript/manuscript.md
+++ b/demo/02_metafor_bcg/manuscript/manuscript.md
@@ -76,6 +76,10 @@ This work has limitations. First, it is a methods demonstration built on a singl
 
 In summary, the randomized evidence indicates that BCG vaccination substantially reduces tuberculosis risk on average, but the protection is highly variable across settings, and a prediction interval that crosses the null shows that neither the size nor, in some contexts, the presence of benefit can be assumed for any individual future population.
 
+## Data Availability
+
+The trial-level data are the BCG vaccine dataset distributed publicly with the `metafor` R package (`dat.bcg`), which reproduces the four cell counts of each of the 13 randomized trials as tabulated in the source meta-analysis. The derived effect-size table (`analysis/tables/per_study_escalc.csv`), all analysis code, and the figures accompany this demonstration, so that every pooled estimate, confidence interval, prediction interval, and leave-one-out result reported here can be recomputed independently.
+
 ## Tables
 
 Table 1. Per-trial event counts and risk ratios for tuberculosis, BCG-vaccinated versus control, in the 13 included randomized trials. Risk ratios and 95% confidence intervals are derived from the four cell counts of each trial (vaccinated TB-positive and TB-negative; control TB-positive and TB-negative). Source: analysis/tables/per_study_escalc.csv.

--- a/scripts/check_detector_crossfire.py
+++ b/scripts/check_detector_crossfire.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""A fixture that is clean for ONE detector must be clean for ALL of them.
+
+Every detector in this repo is tested against fixtures built to its own model of the world. That
+leaves a gap no existing test can see: two detectors can each be right alone and contradict each
+other in the pair.
+
+That is not hypothetical. It shipped:
+
+    check_slide_tells called a text block an "arrow label" only if it was <= 18 pt.
+    check_deck_budget demanded >= 20 pt so the back row could read it.
+
+So a legible 20-pt arrow label satisfied the budget check and was INVISIBLE to the arrow check, and
+a well-made slide was reported as having unlabelled arrows. Neither detector was wrong on its own.
+One detector's advisory threshold had quietly become another's definition of a category, and
+nothing in the repo ever looked at the two together.
+
+This gate looks at them together. It takes the fixtures this project already ships as its own
+picture of good work -- the three demo manuscripts and the clean decks the challenge cards build --
+and runs EVERY detector of the matching family across ALL of them. Any finding is a failure,
+because one of two things is true and a human has to say which:
+
+    the detector is over-firing on good work, or
+    the demo is defective.
+
+Both are worth a red build. A detector that fires on good work gets switched off, and it takes the
+honest detectors down with it.
+
+WHAT THIS DOES NOT DO
+    It does not judge a detector's thresholds, and it does not re-test what the challenge cards
+    already prove (that each detector FIRES on its own planted defect). It asserts one thing only:
+    silence on good work, across the whole family.
+
+HOW IT LEARNS TO INVOKE A DETECTOR
+    From the detector's own --help, never from a guess. Two rules, both paid for:
+
+    1. NEVER pass an output flag (--out / --json / --report). Both deck detectors take `--json
+       PATH`; four self-review detectors take `--json` as a BOOLEAN. A scanner that guessed at
+       these once overwrote 31 fixtures. This gate passes inputs only.
+    2. Run with cwd inside a temp dir. Passing no output flag is not enough -- some detectors write
+       a DEFAULT report path (`qc/...`) relative to the working directory. Discovered by watching
+       one of them create `qc/` in the repo.
+
+    Belt and braces: every fixture is hashed before and after, and a changed fixture fails the run.
+
+THE SEVERITY BAR (why it differs by family, and why that is not a fudge)
+    Manuscript detectors encode "is this actually a problem?" in their DEFAULT exit code: an
+    advisory (a `warn`, a `soft`) exits 0 on purpose, a blocking finding exits 1. The bar is
+    therefore the detector's own default verdict. A demo using Vancouver `[1]` citations draws a
+    `bare_numeric_cite` warn and the detector deliberately does not fail -- neither do we.
+
+    Deck detectors are documented to exit 0 EVEN WHEN THEY FIND MARKS ("0 clean (or findings
+    without --strict)"). Their exit code is useless as a verdict, so the bar is `--strict`, which
+    is exactly the bar the two challenge cards already hold their clean decks to.
+
+    In both cases the bar is the detector's own answer to "is this good work?", not one this gate
+    invents.
+
+Usage:
+    check_detector_crossfire.py [--verbose]
+
+Exit: 0 all silent, 1 a detector fired on good work (or zero pairs ran), 2 the harness broke.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Detectors live here and only here -- the same glob the catalog uses.
+DETECTOR_GLOBS = ("check_*.py", "detect_*.py", "derive_*.py")
+
+# The manuscripts this project ships as its own picture of good work.
+DEMO_MANUSCRIPTS = (
+    "demo/01_wisconsin_bc/manuscript/manuscript.md",
+    "demo/02_metafor_bcg/manuscript/manuscript.md",
+    "demo/03_nhanes_obesity/manuscript/manuscript.md",
+)
+
+# The challenge cards that BUILD decks (they are binaries; they are never committed).
+DECK_BUILDERS = (
+    "skills/present-paper/scripts/check_slide_tells_challenge/make_fixtures.py",
+    "skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py",
+)
+
+# Only the CLEAN decks belong here. tells / bloated / tiny_type are planted defects -- the positive
+# half of their cards -- and a detector is SUPPOSED to fire on them. Naming the clean decks
+# explicitly (rather than "everything the builders wrote") is what keeps a planted defect from
+# wandering into the negative fixture and training us to expect noise.
+#
+# The room each deck was built for is ground truth, lifted from the challenge cards' own verify.sh:
+#   academic.pptx -> --archetype conference_oral --minutes 10
+#   keynote.pptx  -> --archetype keynote --minutes 20
+# clean.pptx is not covered by any card. It is built as an academic talk -- its own fixture source
+# sizes the arrow label at 20 pt and says so: "check_deck_budget's floor for an academic room is
+# 20 pt, and it was right to say so." So it is judged in that room. That pairing -- the budget
+# detector against the slide-tells card's deck -- is a pair NOTHING in this repo runs today.
+CLEAN_DECKS: Dict[str, Tuple[str, str]] = {
+    "clean.pptx": ("conference_oral", "10"),
+    "academic.pptx": ("conference_oral", "10"),
+    "keynote.pptx": ("keynote", "20"),
+}
+
+# Flags that are OUTPUTS. This gate never passes one. See the header: guessing here cost 31
+# fixtures. The list is deliberately broad -- a false skip is cheap, a clobbered fixture is not.
+OUTPUT_FLAGS = ("--out", "--json", "--report", "--outfile", "--output")
+
+
+@dataclass
+class Detector:
+    path: Path
+    name: str
+    usage: str
+    family: str  # "manuscript" | "deck" | "other"
+
+
+def sh(cmd: List[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd), timeout=120)
+
+
+def read_usage(p: Path) -> str:
+    try:
+        r = subprocess.run(["python3", str(p), "--help"], capture_output=True, text=True, timeout=60)
+    except Exception:
+        return ""
+    return r.stdout or r.stderr or ""
+
+
+def classify(p: Path) -> Detector:
+    """Family comes from the detector's own --help, so a new detector is picked up for free."""
+    help_text = read_usage(p)
+    m = re.search(r"usage:(.*?)(?:\n\n|\npositional|\noptions|\noptional)", help_text, re.S)
+    usage = " ".join(m.group(1).split()) if m else ""
+
+    family = "other"
+    # A deck detector takes a .pptx as its subject. Both name the positional `deck`.
+    if re.search(r"\bdeck\b", usage):
+        family = "deck"
+    elif "--manuscript" in help_text:
+        family = "manuscript"
+    return Detector(path=p, name=p.stem, usage=usage, family=family)
+
+
+def discover() -> List[Detector]:
+    seen = {
+        p
+        for g in DETECTOR_GLOBS
+        for p in (REPO / "skills").glob(f"*/scripts/{g}")
+        if "_challenge" not in str(p)
+    }
+    return sorted((classify(p) for p in seen), key=lambda d: d.name)
+
+
+def missing_flag_from(stderr: str, stdout: str, supplied: Tuple[str, ...]) -> str:
+    """Let the detector name its own missing input. We do not guess it.
+
+    Anything we already handed it is not what it is missing -- naming `--manuscript` as the missing
+    flag when we just passed `--manuscript` would make the skip line a lie.
+    """
+    blob = (stderr or "") + "\n" + (stdout or "")
+    ignore = set(OUTPUT_FLAGS) | {"--strict", "--quiet", "--help"} | set(supplied)
+    out: List[str] = []
+    for f in re.findall(r"(--[a-z][a-z0-9-]+)", blob):
+        if f not in ignore and f not in out:
+            out.append(f)
+    return " / ".join(out[:3]) if out else "an input this fixture cannot supply"
+
+
+def hash_tree(paths: List[Path]) -> Dict[str, str]:
+    return {
+        str(p): hashlib.sha256(p.read_bytes()).hexdigest() for p in paths if p.is_file()
+    }
+
+
+def build_decks(into: Path) -> List[Path]:
+    for b in DECK_BUILDERS:
+        r = subprocess.run(
+            ["python3", str(REPO / b), str(into)], capture_output=True, text=True, timeout=180
+        )
+        if r.returncode != 0:
+            print(f"harness: deck builder failed: {b}\n{r.stderr}", file=sys.stderr)
+            raise SystemExit(2)
+    decks = []
+    for name in CLEAN_DECKS:
+        d = into / name
+        if not d.is_file():
+            print(f"harness: challenge card did not produce {name}", file=sys.stderr)
+            raise SystemExit(2)
+        decks.append(d)
+    return decks
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--verbose", action="store_true", help="print every pair, not just failures")
+    a = ap.parse_args(argv)
+
+    dets = discover()
+    if not dets:
+        print("harness: found no detectors at all", file=sys.stderr)
+        return 2
+
+    manuscripts = [REPO / m for m in DEMO_MANUSCRIPTS]
+    for m in manuscripts:
+        if not m.is_file():
+            print(f"harness: missing demo manuscript {m}", file=sys.stderr)
+            return 2
+
+    work = Path(tempfile.mkdtemp(prefix="crossfire-"))
+    try:
+        deck_dir = work / "decks"
+        deck_dir.mkdir()
+        decks = build_decks(deck_dir)
+
+        # Everything the detectors are about to read. If any byte of it changes, a detector wrote
+        # into a fixture and the run is void regardless of verdicts.
+        guarded = manuscripts + decks
+        before = hash_tree(guarded)
+
+        fired: List[str] = []
+        skipped: List[str] = []
+        ran = 0
+
+        print("=" * 78)
+        print(" Detector crossfire -- every detector against every clean fixture of its family")
+        print("=" * 78)
+
+        # ---- manuscript family -------------------------------------------------------------
+        for d in [x for x in dets if x.family == "manuscript"]:
+            for ms in manuscripts:
+                sandbox = Path(tempfile.mkdtemp(dir=work))  # default `qc/...` lands HERE
+                # Inputs only. No output flag, ever.
+                cmd = ["python3", str(d.path), "--manuscript", str(ms)]
+                r = sh(cmd, cwd=sandbox)
+                label = f"{d.name} x {ms.parent.parent.name}"
+
+                if r.returncode == 2:
+                    # The detector refused to run: it needs a companion input the fixture has not
+                    # got. Say so BY NAME -- a silent no-op is worse than no test.
+                    need = missing_flag_from(r.stderr, r.stdout, ("--manuscript",))
+                    skipped.append(f"{d.name} (needs {need})")
+                    break  # same verdict for all three; do not repeat it
+                ran += 1
+                if r.returncode == 0:
+                    if a.verbose:
+                        print(f"  ok    {label}")
+                else:
+                    fired.append(label)
+                    print(f"  FIRED {label}")
+                    for line in (r.stdout or r.stderr).strip().splitlines()[-6:]:
+                        print(f"          | {line}")
+
+        # ---- deck family -------------------------------------------------------------------
+        for d in [x for x in dets if x.family == "deck"]:
+            for deck in decks:
+                archetype, minutes = CLEAN_DECKS[deck.name]
+                sandbox = Path(tempfile.mkdtemp(dir=work))
+                cmd = ["python3", str(d.path), str(deck)]
+                # Only pass a flag the detector actually declares. Learned from --help, not guessed.
+                if "--archetype" in d.usage:
+                    cmd += ["--archetype", archetype]
+                if "--minutes" in d.usage:
+                    cmd += ["--minutes", minutes]
+                # Deck detectors exit 0 even when they find marks; --strict is their verdict.
+                cmd += ["--strict"]
+                r = sh(cmd, cwd=sandbox)
+                label = f"{d.name} x {deck.name}"
+
+                if r.returncode == 2:
+                    need = missing_flag_from(r.stderr, r.stdout,
+                                             ("--archetype", "--minutes"))
+                    skipped.append(f"{d.name} (needs {need})")
+                    break
+                ran += 1
+                if r.returncode == 0:
+                    if a.verbose:
+                        print(f"  ok    {label}")
+                else:
+                    fired.append(label)
+                    print(f"  FIRED {label}")
+                    for line in (r.stdout or r.stderr).strip().splitlines()[:8]:
+                        print(f"          | {line}")
+
+        after = hash_tree(guarded)
+        changed = [k for k in before if before[k] != after.get(k)]
+
+        # ---- the accounting has to be honest ------------------------------------------------
+        print("-" * 78)
+        for s in sorted(set(skipped)):
+            print(f"  SKIPPED: {s}")
+        others = [x.name for x in dets if x.family == "other"]
+        if others:
+            print(
+                f"  OUT-OF-FAMILY ({len(others)}): these take neither a manuscript nor a deck "
+                f"(data / manifest / code / bib inputs) and are not in scope for this gate:"
+            )
+            print("    " + ", ".join(sorted(others)))
+        print("-" * 78)
+        print(f"  pairs run: {ran}")
+
+        if changed:
+            print("\nFAIL: a detector WROTE INTO A FIXTURE. The run is void.", file=sys.stderr)
+            for c in changed:
+                print(f"  modified: {c}", file=sys.stderr)
+            return 1
+
+        if ran == 0:
+            print(
+                "\nFAIL: zero (detector x fixture) pairs ran. A test that silently exercises "
+                "nothing is worse than no test at all.",
+                file=sys.stderr,
+            )
+            return 1
+
+        if fired:
+            print(
+                f"\nFAIL: {len(fired)} pair(s) fired on this project's own picture of good work.\n"
+                "Either the detector is over-firing, or the demo is defective. A human must say\n"
+                "which -- do not silence the detector to make this green.",
+                file=sys.stderr,
+            )
+            return 1
+
+        print(f"\nOK: {ran} pairs, no detector fired on good work.")
+        print(
+            "\n  What this does NOT prove. Silence here means no detector CONTRADICTS another's\n"
+            "  picture of good work. It does not mean a detector was exercised: a check that only\n"
+            "  fires on a Cox model whose outcome is declared pages away will be silent on a corpus\n"
+            "  of short papers with compact Methods — and that silence looks exactly like a pass.\n"
+            "  Detector #66 shipped on that reading: it matched three reviewer comments on the\n"
+            "  manuscript that motivated it, and then flagged a well-written paper for the same\n"
+            "  reason, because it was reading LAYOUT, not defect. It had to be corrected hours later.\n"
+            "\n  So this gate is a FALSE-POSITIVE GUARD, not a coverage guarantee. A new detector\n"
+            "  still owes what no shippable corpus can supply: **two real manuscripts, at least one\n"
+            "  of them known-good**, and a PR body saying what the false-positive hunt found. Finding\n"
+            "  none is a claim to be suspicious of, not a badge."
+        )
+        return 0
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_detector_crossfire.sh
+++ b/tests/test_detector_crossfire.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_detector_crossfire.py -- the gate that makes a fixture which is clean
+# for ONE detector be clean for ALL of them.
+#
+# The live repo must pass. But a gate that only ever proves "clean input stays clean" proves
+# nothing: it would pass just as happily if it silently exercised zero pairs, or if it were blind to
+# the very bug it exists to prevent. So the real work here is the REGRESSION -- we put the actual
+# shipped bug back and require the gate to go red.
+#
+# THE BUG (it was real, in PR #333/#334):
+#     check_slide_tells treated a text block as an "arrow label" only if it was <= 18 pt.
+#     check_deck_budget demanded >= 20 pt so the back row could read it.
+# A legible 20-pt arrow label therefore satisfied the budget check and was INVISIBLE to the arrow
+# check, so a well-made slide was reported as having unlabelled arrows. Neither detector was wrong
+# alone. One detector's advisory threshold had become another's definition of a category.
+#
+# Each sub-test below builds a SEALED tree (a temp copy of the skills + demos it needs, with the
+# gate copied in beside them, so the gate's REPO root resolves to the temp tree). Nothing here
+# mutates the real repo.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE="$REPO_ROOT/scripts/check_detector_crossfire.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a sealed tree containing the gate + the named skills + the demo manuscripts.
+# present-paper is always included: it carries both deck detectors AND the two challenge cards that
+# BUILD the clean decks, which the gate requires.
+seal() {
+  local tree="$1"; shift
+  mkdir -p "$tree/scripts" "$tree/skills"
+  cp "$GATE" "$tree/scripts/"
+  cp -R "$REPO_ROOT/skills/present-paper" "$tree/skills/"
+  for s in "$@"; do cp -R "$REPO_ROOT/skills/$s" "$tree/skills/"; done
+  # only the manuscripts -- the rest of demo/ is 6 MB the gate never reads
+  for d in 01_wisconsin_bc 02_metafor_bcg 03_nhanes_obesity; do
+    mkdir -p "$tree/demo/$d/manuscript"
+    cp "$REPO_ROOT/demo/$d/manuscript/manuscript.md" "$tree/demo/$d/manuscript/"
+  done
+}
+
+echo "== 1. the live repo: no detector may fire on our own picture of good work =="
+out="$(python3 "$GATE" 2>&1)"; rc=$?
+ck "live repo: every detector silent on every clean fixture" 0 "$rc"
+[ "$rc" -ne 0 ] && echo "$out"
+
+# The count guards against the worst outcome: a green gate that ran nothing.
+pairs="$(printf '%s\n' "$out" | sed -n 's/^ *pairs run: \([0-9]*\)$/\1/p')"
+if [ -n "${pairs:-}" ] && [ "$pairs" -gt 0 ] 2>/dev/null; then
+  printf '  PASS  %-58s pairs=%s\n' "live repo: actually exercised something" "$pairs"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s pairs=%s\n' "live repo: ran ZERO pairs (silent no-op)" "${pairs:-none}"
+  fail=$((fail + 1))
+fi
+
+# Coverage must be declared, not implied. A skip nobody can see is a hole nobody can audit.
+if printf '%s\n' "$out" | grep -q '^  SKIPPED: '; then
+  printf '  PASS  %-58s\n' "skips are named out loud (honest coverage)"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "no SKIPPED lines -- coverage is not being declared"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "== 2. REGRESSION: restore the real bug and require the gate to CATCH it =="
+# This is the whole point of the file. If this sub-test cannot be made to fail, the gate is
+# decoration.
+BUG="$WORK/bug"; seal "$BUG"
+TELLS="$BUG/skills/present-paper/scripts/check_slide_tells.py"
+
+# Sanity: the sealed tree is green BEFORE we break it. Without this, a red result below could just
+# mean "the sealed tree was broken all along" and would prove nothing about the patch.
+python3 "$BUG/scripts/check_detector_crossfire.py" > /dev/null 2>&1
+ck "sealed tree, detector intact: green" 0 "$?"
+
+# Put the contradiction back: a label is a label only if it is <= 18 pt -- while check_deck_budget
+# goes on demanding >= 20 pt in the same room, on the same deck.
+python3 - "$TELLS" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); s = p.read_text()
+old = "    labels = [s for s in texts if head_pt == 0.0 or s.max_pt < head_pt]"
+new = "    labels = [s for s in texts if s.max_pt <= 18]  # the shipped bug, restored"
+assert old in s, "regression anchor not found -- the detector was refactored; re-point this patch"
+p.write_text(s.replace(old, new))
+PY
+ck "regression patch applied to the sealed copy" 0 "$?"
+
+out="$(python3 "$BUG/scripts/check_detector_crossfire.py" 2>&1)"; rc=$?
+ck "gate FAILS once the <=18pt / >=20pt contradiction is back" 1 "$rc"
+
+if printf '%s\n' "$out" | grep -q 'ARROW_NO_SEMANTICS'; then
+  printf '  PASS  %-58s\n' "...and it names the arrow verdict on a well-made deck"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "...but ARROW_NO_SEMANTICS was never reported"
+  fail=$((fail + 1))
+  echo "$out"
+fi
+
+echo
+echo "== 3. the OTHER jaw: the pair nothing in this repo runs today =="
+# Suppose someone had "fixed" the arrow bug the lazy way -- by shrinking the label to 16 pt so the
+# <=18 test could see it. slide_tells would go quiet. check_deck_budget would start failing that
+# same deck on its 20-pt floor -- and NOTHING in this repo runs check_deck_budget against the
+# slide-tells card's clean.pptx. That pair exists only here.
+SHRINK="$WORK/shrink"; seal "$SHRINK"
+MK="$SHRINK/skills/present-paper/scripts/check_slide_tells_challenge/make_fixtures.py"
+python3 - "$MK" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); s = p.read_text()
+old = 'textbox(s, "seeds along", x0 + 0.05, 2.95, 1.6, 0.45, 20)'
+new = 'textbox(s, "seeds along", x0 + 0.05, 2.95, 1.6, 0.45, 16)'
+assert old in s, "shrink anchor not found"
+p.write_text(s.replace(old, new))
+PY
+out="$(python3 "$SHRINK/scripts/check_detector_crossfire.py" 2>&1)"; rc=$?
+ck "a 16pt 'fix' to the arrow label is caught by the budget floor" 1 "$rc"
+if printf '%s\n' "$out" | grep -q 'TYPE_TOO_SMALL'; then
+  printf '  PASS  %-58s\n' "...via check_deck_budget x clean.pptx (the uncovered pair)"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "...but TYPE_TOO_SMALL never fired"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "== 4. the other half of the verdict: a DEFECTIVE DEMO must also go red =="
+# When a pair fires, one of two things is true -- the detector over-fires, or the demo is broken.
+# The gate must be able to say the second one too, or it is only half a test.
+BADDEMO="$WORK/baddemo"; seal "$BADDEMO" sync-submission
+python3 - "$BADDEMO/demo/02_metafor_bcg/manuscript/manuscript.md" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); lines = p.read_text().splitlines(keepends=True)
+out, drop = [], False
+for ln in lines:
+    if ln.startswith("## Data Availability"):
+        drop = True; continue
+    if drop and ln.startswith("## "):
+        drop = False
+    if not drop:
+        out.append(ln)
+p.write_text("".join(out))
+PY
+out="$(python3 "$BADDEMO/scripts/check_detector_crossfire.py" 2>&1)"; rc=$?
+ck "a demo stripped of its Data Availability statement fails" 1 "$rc"
+if printf '%s\n' "$out" | grep -q 'check_disclosure_availability'; then
+  printf '  PASS  %-58s\n' "...and the firing detector is named"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "...but check_disclosure_availability was not named"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "== 5. a detector that WRITES INTO a fixture voids the run =="
+# The reason this guard exists: a scanner that guessed at output flags once overwrote 31 fixtures.
+# A gate whose own fixtures can be silently rewritten underneath it is not measuring anything.
+EVIL="$WORK/evil"; seal "$EVIL"
+mkdir -p "$EVIL/skills/evil/scripts"
+cat > "$EVIL/skills/evil/scripts/check_evil.py" <<'PY'
+#!/usr/bin/env python3
+"""A detector that scribbles on the fixture it was asked to read."""
+import argparse
+ap = argparse.ArgumentParser()
+ap.add_argument("--manuscript", required=True)
+a = ap.parse_args()
+open(a.manuscript, "a", encoding="utf-8").write("\nscribble\n")
+print("OK")
+PY
+out="$(python3 "$EVIL/scripts/check_detector_crossfire.py" 2>&1)"; rc=$?
+ck "a fixture-clobbering detector fails the run" 1 "$rc"
+if printf '%s\n' "$out" | grep -q 'WROTE INTO A FIXTURE'; then
+  printf '  PASS  %-58s\n' "...and the run is declared void, not merely 'firing'"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "...but the fixture-write guard stayed silent"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "== 6. zero pairs is a FAILURE, not a pass =="
+# A test that silently exercises nothing is worse than no test: it is a green light over a hole.
+NOPAIRS="$WORK/nopairs"; seal "$NOPAIRS" model-card
+# Remove both deck detectors but KEEP the challenge cards, so the decks still build and the only
+# detector left (check_model_card_complete) belongs to neither family. Nothing can pair.
+rm -f "$NOPAIRS/skills/present-paper/scripts/check_slide_tells.py" \
+      "$NOPAIRS/skills/present-paper/scripts/check_deck_budget.py"
+out="$(python3 "$NOPAIRS/scripts/check_detector_crossfire.py" 2>&1)"; rc=$?
+ck "a run with no runnable pairs fails" 1 "$rc"
+if printf '%s\n' "$out" | grep -q 'zero (detector x fixture) pairs'; then
+  printf '  PASS  %-58s\n' "...and says so, rather than reporting a hollow OK"
+  pass=$((pass + 1))
+else
+  printf '  FAIL  %-58s\n' "...but the zero-pairs guard stayed silent"
+  fail=$((fail + 1))
+fi
+
+echo
+echo "----"
+echo "detector-crossfire self-test: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
When two detectors read the same artifact and disagree about whether it is good, no existing test can see it — each detector is tested only against fixtures built to its own model of the world. In #333 this was real: `check_slide_tells` treated a text block as an arrow label only if ≤18 pt, while `check_deck_budget` demanded ≥20 pt so the back row could read it. A legible arrow label satisfied one and was invisible to the other.

`check_detector_crossfire.py` runs every manuscript-family detector on each demo manuscript, and every deck-family detector on each challenge card's clean deck (81 pairs). It skips or excludes nothing silently — every skipped/out-of-family detector is named. It **found a real defect** in a demo manuscript (a missing Data Availability statement).

Its output states plainly what it does NOT prove: this is a **false-positive guard, not a coverage guarantee**. The buggy detector #66 (fixed in #341) was silent on our own demo corpus, because those papers are short enough that the layout condition that broke it never appears. §3 of the sibling session's brief — two real manuscripts, at least one known-good — stays a **contributor obligation** no shippable corpus can automate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)