### PR TITLE
fix(skills): fifteen phases billed every invocation for text most runs never read

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,7 +69,13 @@ jobs:
       - name: Run validate_routing_assets.py self-test (dangling references/ pointer fails)
         run: bash tests/test_routing_assets.sh
 
-      - name: "Run check_domain_probe_sync.py (every vendored set byte-identical, none undeclared)"
+      - name: "Run check_phase_budget.py (a SKILL.md phase over 80 lines is a bill paid on every invocation)"
+        run: python3 scripts/check_phase_budget.py --strict
+
+      - name: "Run phase-budget self-test (the real 209-line phase must still fail the gate)"
+        run: bash tests/test_phase_budget.sh
+
+      - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 
       - name: "Run vendoring-gate self-test (drifted checklist, drifted probe, undeclared pair all fail)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,36 @@
   the fixture) and hashes every fixture before and after, voiding the run if one changed. Detectors
   that need an input the fixture cannot supply are **skipped out loud, by name**, so the coverage is
   auditable.
+- **Fifteen SKILL.md phases were billing every invocation for text most runs never read**
+  (`scripts/check_phase_budget.py`, CI-enforced; `tests/test_phase_budget.sh`). A SKILL.md is
+  loaded **in full** the moment its skill is invoked — before the agent knows what the user wants.
+  The project already had the rule (*any phase over 80 lines gets extracted to `references/`,
+  leaving a trigger table and a load-on-demand pointer* — it is why `/present-paper` Phase 0 went
+  from ~14,000 tokens to ~6,700). Nothing enforced it, so it quietly stopped applying.
+
+  The worst offender was `/write-paper` **Phase 7: Polish at 270 lines**, and `/write-paper`
+  **Phase 0 at 127** — read *before the skill knows the paper type*, yet carrying full Case Report
+  and Case Series modes that a manuscript can only ever need one of. Also split: `/self-review`
+  Phase 2 (209), 2.5f (176), 2.5b (119), 2.5a (90), 2.5d (87); `/meta-analysis` Phase 4 (174) and
+  Phase 3 (135); `/design-study` Phase 2 (146, whose 85-line reader-elicitation section applies
+  only to studies with a human-rater arm); `/check-reporting` Step 5 (128, almost entirely output
+  templates); `/add-journal` 3.2 (117, a single fill-in template); `/manage-project init` (109, a
+  directory tree the init script already writes); `/make-figures` Study-Type Figure Sets (104);
+  `/peer-review` Phase 3 (86).
+
+  Each keeps its control flow, its gate invocations, and every HALT condition inline — what the
+  agent needs *before* it knows the ask — and moves the reference material behind a trigger table
+  that states what a blind read costs. **No exemptions were needed** (`EXEMPT` ships empty).
+
+  The gate is **fence-aware**, and that is not cosmetic: a `## heading` inside a code fence is an
+  output template, not a section boundary. A fence-blind parser chopped `/write-paper` Phase 7 in
+  two at an embedded log-block template and reported it as 139 lines, and let four more over-budget
+  sections hide the same way — so a long phase could evade the budget simply by containing one.
+  The self-test pins this, and regresses the real defect: the 209-line `/self-review` Phase 2 is
+  frozen byte-for-byte in `tests/fixtures/phase_budget/`, and the gate must still fail on it.
+
+  Also repointed a dangling `/write-paper` reference (`references/check_xref_symptoms.md`, a file
+  that never existed) at the reference that now carries the cross-reference fix routes.
 
 ### Added
 

--- a/docs/skills/add-journal.md
+++ b/docs/skills/add-journal.md
@@ -30,6 +30,12 @@
 
 **Evidence** — `manual_workflow`
 
+## Bundled resources
+
+**References** (`skills/add-journal/references/`):
+
+- `write_paper_profile_template.md`
+
 ## Source
 
 Canonical definition: [`skills/add-journal/SKILL.md`](../../skills/add-journal/SKILL.md)

--- a/docs/skills/check-reporting.md
+++ b/docs/skills/check-reporting.md
@@ -40,6 +40,7 @@
 - `checklists/` (46 files)
 - `critical_item_floor.md`
 - `genai_image_study_object_decision_aid.md`
+- `report_templates.md`
 - `step4c_registration_timing.md`
 - `step4d_prisma_figure_audit.md`
 

--- a/docs/skills/design-study.md
+++ b/docs/skills/design-study.md
@@ -36,6 +36,7 @@
 **References** (`skills/design-study/references/`):
 
 - `dag_adjustment.md`
+- `reader_elicitation_design.md`
 - `target_trial_emulation.md`
 
 **Scripts** (`skills/design-study/scripts/`):

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -41,8 +41,10 @@
 - `design_principles.md`
 - `exemplar_diagrams/` (33 files)
 - `exemplar_plots/` (12 files)
+- `figure_manifest.md`
 - `figure_specs.md`
 - `flow_diagram_lessons.md`
+- `flow_diagram_recipe.md`
 - `jacc_central_illustration_principles.md`
 - `medical_illustration_sources.md`
 - `pipeline_concepts_medical_ai.md`

--- a/docs/skills/manage-project.md
+++ b/docs/skills/manage-project.md
@@ -34,6 +34,7 @@
 
 **References** (`skills/manage-project/references/`):
 
+- `init_scaffold.md`
 - `pre_submission_checklist.md`
 - `project_state_template.json`
 - `scaffold_templates.md`

--- a/docs/skills/meta-analysis.md
+++ b/docs/skills/meta-analysis.md
@@ -44,6 +44,8 @@
 - `empirical_lessons.md`
 - `icmje_coi_guide.md`
 - `phase10_recovery.md`
+- `phase3_screening_detail.md`
+- `phase4_extraction_detail.md`
 - `phase4_km_composite.md`
 - `phase6_statistical_synthesis.md`
 - `phase9_circulation.md`

--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -42,6 +42,7 @@
 - `domain-probes/` (23 files)
 - `exemplar_reviews/` (7 files)
 - `narrative_review_audit.md`
+- `review_draft_template.md`
 - `reviewer_calibration/` (2 files)
 - `reviewer_profiles/` (6 files)
 

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -52,7 +52,7 @@
 - `domain-probes/` (23 files)
 - `exemplar_findings/` (8 files)
 - `panel_review_template.md`
-- `phases/` (1 file)
+- `phases/` (6 files)
 
 **Scripts** (`skills/self-review/scripts/`):
 

--- a/docs/skills/write-paper.md
+++ b/docs/skills/write-paper.md
@@ -49,7 +49,9 @@
 - `exemplar_results/` (6 files)
 - `journal_profiles/` (55 files)
 - `paper_types/` (10 files)
+- `phase0_init_detail.md`
 - `phase7_integrity_audits.md`
+- `phase7_polish_detail.md`
 - `section_guides/` (7 files)
 - `section_templates/` (1 file)
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -163,8 +163,13 @@
     },
     {
       "path": "skills/add-journal/SKILL.md",
-      "size": 16351,
-      "sha256": "6aea8833a3981d0e84a915e2174b8b4180f2ed64fded63eb57e7bc34ada2bc03"
+      "size": 15266,
+      "sha256": "a472f46e92b65d27460b0400a902efeecac4285aed1caf37f45cf3debb64b4c6"
+    },
+    {
+      "path": "skills/add-journal/references/write_paper_profile_template.md",
+      "size": 3202,
+      "sha256": "75ce89f650ccda8f4c98ea9f27c3a6afb15e705d6cd50568158b29709bb70643"
     },
     {
       "path": "skills/add-journal/skill.yml",
@@ -593,8 +598,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 40628,
-      "sha256": "ad375c3cc13ab13172c9e65af2a4afbb25278d0c8b56461e079b10a086ae8bde"
+      "size": 38433,
+      "sha256": "01c44b3ba95f475584999e27c55949647d92e4f935ef84bb29f100b097b564f8"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -852,6 +857,11 @@
       "sha256": "34f79571566ef06eee0fc4c8c646be530806fca658720902d16642faadc8844b"
     },
     {
+      "path": "skills/check-reporting/references/report_templates.md",
+      "size": 5775,
+      "sha256": "60ef41961934dd32ca9eda4db139441a67519222c661fe7de8a97476fbab3648"
+    },
+    {
       "path": "skills/check-reporting/references/step4c_registration_timing.md",
       "size": 4197,
       "sha256": "e0e76c5fb061ac2df0b61048461124abfa16217ea72cd9eed41f83d372343310"
@@ -1103,13 +1113,18 @@
     },
     {
       "path": "skills/design-study/SKILL.md",
-      "size": 20296,
-      "sha256": "98644b7750b65ff9bb38af7cb6e0b3300169f498332a3f143394cc35f5ba7ff7"
+      "size": 15269,
+      "sha256": "7d21b57aa8b94728a21ddf2fd57f8fd332a95a1e1a16cddb40780b5c5ce92a9a"
     },
     {
       "path": "skills/design-study/references/dag_adjustment.md",
       "size": 4390,
       "sha256": "8b6c9d2b2d4e79652b355cf30f0d56f4232619cad8589489707107f85bef9de3"
+    },
+    {
+      "path": "skills/design-study/references/reader_elicitation_design.md",
+      "size": 6864,
+      "sha256": "01984bc2cd4a88616ae4fe94fa9da80cdf52e433a0c542d9c0afc0a3b8ec9e83"
     },
     {
       "path": "skills/design-study/references/target_trial_emulation.md",
@@ -1868,8 +1883,8 @@
     },
     {
       "path": "skills/make-figures/SKILL.md",
-      "size": 51245,
-      "sha256": "6943882db21d9143866699ba4ffe433b7de3938fb58b57a717b3d215b43cfcd5"
+      "size": 46155,
+      "sha256": "2a567bfe908a813acc02b2e9b9ba5500de23702b2088d915329483651630f5dd"
     },
     {
       "path": "skills/make-figures/references/critic_rubrics/data_plot.md",
@@ -2112,6 +2127,11 @@
       "sha256": "02c483cd89b2598726bcb071c4e9e2e5baec0383487c7847c0ed2edf5c190a8f"
     },
     {
+      "path": "skills/make-figures/references/figure_manifest.md",
+      "size": 2215,
+      "sha256": "4f581ac3b6c40504c7e29e2d760265fab30b516ad06b0f97bb13a75f39d988e3"
+    },
+    {
       "path": "skills/make-figures/references/figure_specs.md",
       "size": 11529,
       "sha256": "45a04e5e1e68e670a805aa1cd79199cf67c00abeb7272c401d881d7daee4e04e"
@@ -2120,6 +2140,11 @@
       "path": "skills/make-figures/references/flow_diagram_lessons.md",
       "size": 10201,
       "sha256": "576f11e654bace6bb93775c87fff31bd7533854dc236162fb410c654a4811706"
+    },
+    {
+      "path": "skills/make-figures/references/flow_diagram_recipe.md",
+      "size": 5136,
+      "sha256": "5b232a37d236e64d1e100151e92cce942aafc8ca0f60ec9a51ce335dfd537fd2"
     },
     {
       "path": "skills/make-figures/references/jacc_central_illustration_principles.md",
@@ -2293,8 +2318,13 @@
     },
     {
       "path": "skills/manage-project/SKILL.md",
-      "size": 12315,
-      "sha256": "40c3a0098a3729b839e132db3987ad0f3fc5f3eeaf1c5a56dd77673cffdb5dbd"
+      "size": 10322,
+      "sha256": "0517ccd1c5ec8352231cff9944d74510c8e4a111ed0f9aa7d7378513c36da429"
+    },
+    {
+      "path": "skills/manage-project/references/init_scaffold.md",
+      "size": 5266,
+      "sha256": "01ea1f161b6ca66e99ed462cbac966c5f1da125e0b3893b06046223ea4a4eb2c"
     },
     {
       "path": "skills/manage-project/references/pre_submission_checklist.md",
@@ -2498,8 +2528,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 49604,
-      "sha256": "4947eae188dc2fcfba68ed991ba126da8315dc79deac0649d2beea558e73025e"
+      "size": 40107,
+      "sha256": "946a0fb14b629488cb62c0d43300308ff574a3ec4c832e6bfbd6c038c1e502aa"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2570,6 +2600,16 @@
       "path": "skills/meta-analysis/references/phase10_recovery.md",
       "size": 6145,
       "sha256": "d76a832de5f89a0c7c754290a10ad0155eaaf3d9df4824226826c10c6856d399"
+    },
+    {
+      "path": "skills/meta-analysis/references/phase3_screening_detail.md",
+      "size": 9132,
+      "sha256": "9fbd21fc09da3952f50aaa942e408262284951f98d6e4adb064b1e1df0244229"
+    },
+    {
+      "path": "skills/meta-analysis/references/phase4_extraction_detail.md",
+      "size": 11199,
+      "sha256": "6aee96c0d9ab99e1a014d849de2e6b6fb711e673b96e6eb593fd56afe16c10e3"
     },
     {
       "path": "skills/meta-analysis/references/phase4_km_composite.md",
@@ -3008,8 +3048,8 @@
     },
     {
       "path": "skills/peer-review/SKILL.md",
-      "size": 78803,
-      "sha256": "2599190d0b175bdb29cfda93b67bdbc5ee89991e9d94cd802cc9a2961b8708bb"
+      "size": 78563,
+      "sha256": "63dfbcba8799036b171961ace420699c5e80776d42fa3b8a76fd17e9d2d9ce9c"
     },
     {
       "path": "skills/peer-review/references/aczel_2021_reviewer2_patterns.md",
@@ -3170,6 +3210,11 @@
       "path": "skills/peer-review/references/narrative_review_audit.md",
       "size": 5278,
       "sha256": "a4c47641de46c7950498dd56d9249a15e982a03539e4b69b28ef29af3bd80ade"
+    },
+    {
+      "path": "skills/peer-review/references/review_draft_template.md",
+      "size": 1792,
+      "sha256": "94cfb6369b3ba17da0ba18361d189b479a84033e77d4aa8ef28725371e0baf2d"
     },
     {
       "path": "skills/peer-review/references/reviewer_calibration/README.md",
@@ -3803,8 +3848,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 108013,
-      "sha256": "d32ede7bb778496600069ac2fb090fea1158717b3f0605bc06b9e09637f197e1"
+      "size": 78161,
+      "sha256": "fc5ffe1fcabd79904d8294b1109c763f9a8114a0e41984d04d10f4c8359eae62"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",
@@ -3970,6 +4015,31 @@
       "path": "skills/self-review/references/phases/confounding_completeness.md",
       "size": 5344,
       "sha256": "051f2b066d2d708b161c1e97d666d9e214d128f1413a9c4822f0333e748bda14"
+    },
+    {
+      "path": "skills/self-review/references/phases/phase2_5a_source_fidelity.md",
+      "size": 5989,
+      "sha256": "565eb2ee2f2eaa0be92f04ab2781c5b3ede5d716c9e5caa40b1fea82f87b53ff"
+    },
+    {
+      "path": "skills/self-review/references/phases/phase2_5b_screening_counts.md",
+      "size": 7535,
+      "sha256": "0d594614b1f41692d6a6034f9fc88d90bcdd3ba90b8ba6b4697cdfcb0a62cef2"
+    },
+    {
+      "path": "skills/self-review/references/phases/phase2_5d_xref_qc.md",
+      "size": 4974,
+      "sha256": "81756d0713842faa1f603a34500dd6aaa699be6526ee6fbbc1ace06467b10143"
+    },
+    {
+      "path": "skills/self-review/references/phases/phase2_5f_claim_artifact.md",
+      "size": 11616,
+      "sha256": "f95dea63f14cfca4cf40c5e8c858b8c7a0679b1c54b6fcd65acc68424e770bac"
+    },
+    {
+      "path": "skills/self-review/references/phases/phase2_systematic_check.md",
+      "size": 18988,
+      "sha256": "d78e98cc0eee08b56b13539c9a61836485a7357a2b4b53b6db7d6329d2443da8"
     },
     {
       "path": "skills/self-review/scripts/check_analysis_definitions.py",
@@ -4493,8 +4563,8 @@
     },
     {
       "path": "skills/write-paper/SKILL.md",
-      "size": 68059,
-      "sha256": "d05e1bbde228a87abf459ec19484e560dc08b7e88213e36655b680ebecf7dd8f"
+      "size": 49536,
+      "sha256": "a36ddb90db795de04bca34a4623c62be128305b023e42b256bedc0a0c16a5774"
     },
     {
       "path": "skills/write-paper/references/exemplar_abstract.md",
@@ -4932,9 +5002,19 @@
       "sha256": "20af90805a78bd3017786180c339881d831f9f3c81561e2124ac106f1bd476a6"
     },
     {
+      "path": "skills/write-paper/references/phase0_init_detail.md",
+      "size": 11788,
+      "sha256": "7336d02942a9308420946d286b5942a9dd8548d1ff63cfe6a1776e8eb5837f2f"
+    },
+    {
       "path": "skills/write-paper/references/phase7_integrity_audits.md",
       "size": 12540,
       "sha256": "53adeb794576bc580bd34b0173b14cf2483396e25cde12051903145426fd91e3"
+    },
+    {
+      "path": "skills/write-paper/references/phase7_polish_detail.md",
+      "size": 19036,
+      "sha256": "5c44f6ccdfc6eaa64587c62d68fe0911175e6df7a37bfc7f71b65a7f6d5a1c12"
     },
     {
       "path": "skills/write-paper/references/section_guides/discussion.md",

--- a/scripts/check_phase_budget.py
+++ b/scripts/check_phase_budget.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""SKILL.md phase-budget gate.
+
+A SKILL.md is loaded IN FULL into the context window the moment the skill is
+invoked -- before the agent has done anything, before it knows what the user
+wants. Its length is a bill the user pays on every invocation, whether or not a
+single line of it turns out to be relevant. A 200-line phase buried at the
+bottom of a skill is 200 lines of tax on every run that never reaches it.
+
+The project rule (the one that cut /present-paper Phase 0 from ~14,000 tokens to
+~6,700) is:
+
+    Any phase over 80 lines gets extracted to references/, leaving a trigger
+    table and a load-on-demand pointer.
+
+Nothing enforced it, so twelve sections across five skills drifted over. This
+validator enforces it: every `##` / `###` section in every skills/*/SKILL.md must
+have a body of at most --max-lines lines (default 80), measured as the lines
+between the heading and the next heading of the same or finer granularity.
+
+A section that genuinely cannot be split lives in EXEMPT with a one-line reason,
+so that a long section is a decision someone wrote down -- not a rule that
+quietly stopped applying.
+
+Top-level `scripts/` validator (not a `skills/*/scripts/` detector) -- it audits
+the context budget of the skill surface, not a manuscript, so it is NOT part of
+the MedSci-Audit detector count.
+
+Usage:
+  python3 scripts/check_phase_budget.py --strict
+  python3 scripts/check_phase_budget.py --max-lines 80 --json
+  python3 scripts/check_phase_budget.py --skills-dir <dir> --strict
+Exit: 0 when every section is within budget (or exempt); with --strict, 1 on any
+over-budget section; 2 on a read error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Sections that are deliberately over budget. Key is "<skill>::<section title>",
+# value is the one-line reason. Keep this near-empty: an exemption is a decision
+# someone wrote down, and every entry here is context every user pays for.
+EXEMPT: dict[str, str] = {}
+
+# A section starts at a level-2 or level-3 ATX heading and ends at the next one.
+HEADING_RE = re.compile(r"^(#{2,3})\s+(\S.*?)\s*$")
+# Fenced code blocks may contain lines that look like headings (`## comment`).
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+# What a compliant fix looks like. Printed on failure -- the gate should teach
+# the shape of the fix, not merely name the offender.
+TRIGGER_TABLE_SHAPE = """\
+  Leave in SKILL.md a short prose lead plus a trigger table, and move the body to
+  skills/<skill>/references/<phase-slug>.md:
+
+      Read on demand -- after the ask tells you which one you need:
+
+      | File | Read it when | Cost if read blindly |
+      |---|---|---|
+      | `references/<phase-slug>.md` | <the condition that makes it relevant> | ~N tokens you will not use |
+
+      **Load-on-demand**: read `${CLAUDE_SKILL_DIR}/references/<phase-slug>.md`
+      when <condition>.
+
+  One question decides every one of these reads:
+
+      *** Does the agent need this BEFORE it knows what the user wants, or after? ***
+
+  BEFORE  -> it stays in SKILL.md (control flow, the routing question, the gate
+             that must run on every path).
+  AFTER   -> it goes to references/ behind a trigger row (the detector table, the
+             worked example, the long enumeration, the branch that one ask in ten
+             will take).
+
+  A section that genuinely cannot be split goes in EXEMPT in this script with a
+  one-line reason -- so it is a decision on the record, not a rule that quietly
+  stopped applying."""
+
+
+def sections(md_path: Path) -> list[tuple[str, int, int]]:
+    """Return (title, start_line_1based, body_line_count) for each ##/### section."""
+    lines = md_path.read_text(encoding="utf-8").splitlines()
+    in_fence = False
+    heads: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = HEADING_RE.match(line)
+        if m:
+            heads.append((i, m.group(2)))
+
+    out: list[tuple[str, int, int]] = []
+    for n, (i, title) in enumerate(heads):
+        end = heads[n + 1][0] if n + 1 < len(heads) else len(lines)
+        out.append((title, i + 1, end - i - 1))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--skills-dir", default=str(ROOT / "skills"))
+    ap.add_argument("--max-lines", type=int, default=80,
+                    help="maximum body lines per ##/### section (default: 80)")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 when any section is over budget")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args(argv)
+
+    skills_dir = Path(args.skills_dir)
+    try:
+        skill_mds = sorted(skills_dir.glob("*/SKILL.md"))
+        scanned = 0
+        total = 0
+        over: list[dict[str, object]] = []
+        exempted: list[dict[str, object]] = []
+        for md in skill_mds:
+            skill = md.parent.name
+            scanned += 1
+            for title, line, body in sections(md):
+                total += 1
+                if body <= args.max_lines:
+                    continue
+                key = f"{skill}::{title}"
+                rec: dict[str, object] = {
+                    "skill": skill,
+                    "section": title,
+                    "file": str(md.relative_to(skills_dir.parent))
+                    if skills_dir.parent in md.parents else str(md),
+                    "line": line,
+                    "body_lines": body,
+                    "budget": args.max_lines,
+                    "over_by": body - args.max_lines,
+                }
+                if key in EXEMPT:
+                    rec["reason"] = EXEMPT[key]
+                    exempted.append(rec)
+                else:
+                    over.append(rec)
+    except OSError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    over.sort(key=lambda r: -int(r["body_lines"]))
+    verdict = "PHASE_BUDGET_EXCEEDED" if over else "OK"
+
+    if args.json:
+        print(json.dumps(
+            {
+                "verdict": verdict,
+                "budget": args.max_lines,
+                "skills_scanned": scanned,
+                "sections_scanned": total,
+                "over_budget": over,
+                "exempt": exempted,
+            },
+            indent=2,
+        ))
+    else:
+        print("=" * 41)
+        print(" SKILL.md Phase Budget")
+        print("=" * 41)
+        print(f"Scanned {scanned} SKILL.md, {total} sections; budget {args.max_lines} lines/section"
+              f"; {len(exempted)} exempt.")
+        if not over:
+            print("OK: every section is within budget.")
+            for rec in exempted:
+                print(f"  exempt: {rec['skill']}::{rec['section']} "
+                      f"({rec['body_lines']} lines) -- {rec['reason']}")
+        else:
+            print(f"\nOVER BUDGET ({len(over)}) -- each of these is loaded in full, "
+                  f"on every invocation of the skill,\nbefore the agent knows whether it "
+                  f"is relevant:\n")
+            for rec in over:
+                print(f"  {int(rec['body_lines']):4} lines (+{rec['over_by']:>3} over)  "
+                      f"{rec['skill']}/SKILL.md:{rec['line']}  {rec['section']}")
+            print()
+            print(TRIGGER_TABLE_SHAPE)
+            print(f"\nPHASE_BUDGET_EXCEEDED: {len(over)} section(s) over the "
+                  f"{args.max_lines}-line budget.", file=sys.stderr)
+
+    return 1 if (args.strict and over) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/add-journal/SKILL.md
+++ b/skills/add-journal/SKILL.md
@@ -191,122 +191,37 @@ Also read ONE existing find-journal profile from any field for the compact forma
 
 ### 3.2 Generate Write-Paper Profile
 
-Follow the canonical 11-section order exactly:
+The detailed profile `/write-paper` loads when drafting for this journal. Copy the literal
+template from `${CLAUDE_SKILL_DIR}/references/write_paper_profile_template.md` and fill it.
 
-```markdown
-# Journal Profile: {Full Name}
+**Follow the canonical 11-section order exactly.** `/write-paper` Phase 7 and `/find-journal` read
+these profiles positionally — a reordered, renamed, or omitted section silently degrades both:
 
-## Journal Identity
+1. **Journal Identity** — full name, abbreviation, publisher, ISSN, frequency, impact factor, OA
+   model, acceptance rate, peer-review type
+2. **Manuscript Types and Word Limits**
+3. **Abstract Requirements** — word cap and heading structure
+4. **Required Sections (Original Article)**
+5. **Statistical Reporting**
+6. **Figures**
+7. **Common Rejection Reasons**
+8. **Cover Letter**
+9. **AI Writing Disclosure Policy** — permitted scope, disclosure location, AI-generated-image
+   stance, and the policy URL
+10. **Author Guidelines URL**
+11. **Positioning** — when to submit here, when *not* to, and the comparison table against two
+    competitor journals
 
-- **Full name**: {name}
-- **Abbreviation**: {abbrev}
-- **Publisher**: {publisher}
-- **ISSN**: {print} (print), {online} (online)
-- **Frequency**: {frequency}
-- **Impact Factor**: ~{IF} (JCR {year})
-- **Open Access**: {OA model}
-- **Acceptance rate**: ~{rate}
-- **Peer review**: {type}
+**Fill rules.** Never guess a value. Tag any uncertain field with `[VERIFY]` rather than inventing
+a plausible number — an invented word limit or abstract structure propagates straight into a
+drafted manuscript. Where the journal publishes no dedicated AI policy, cite the publisher-level
+policy and say so explicitly.
 
-## Manuscript Types and Word Limits
+**Read on demand:**
 
-| Type | Body Word Limit | Abstract | References | Figures/Tables |
-|------|----------------|----------|------------|----------------|
-| Original Article | {limit} | {limit} | {limit} | {limit} |
-| ... | ... | ... | ... | ... |
-
----
-
-## Abstract Requirements
-
-{Structured or unstructured. Show format as code block if structured.}
-
----
-
-## Required Sections (Original Article)
-
-1. **Introduction**
-2. **Methods**
-   - {subsections}
-3. **Results**
-4. **Discussion**
-5. **{Other required sections if any}**
-
----
-
-## Statistical Reporting
-
-- {p-value format}
-- {CI requirements}
-- {Effect size requirements}
-- {Software identification requirement}
-- {Journal-specific statistical requirements}
-
----
-
-## Figures
-
-- **Maximum**: {N figures/tables}
-- **Resolution**: {DPI} minimum
-- **Format**: {accepted formats}
-- **Color**: {policy}
-
----
-
-## Common Rejection Reasons
-
-1. {reason}
-2. {reason}
-3. {reason}
-4. {reason}
-5. {reason}
-
----
-
-## Cover Letter
-
-Should include:
-- {requirements}
-
----
-
-## AI Writing Disclosure Policy
-
-- **Requirement level:** {Required / Recommended / Not specified — follows ICMJE recommendations}
-- **Permitted scope:** {Language editing only / All tasks / describe specific policy}
-- **Disclosure location:** {Methods / Acknowledgments / Cover letter / Submission form}
-- **AI-generated images:** {Banned / Must be declared / Not specified}
-- **Policy URL:** {URL to journal's AI policy page, or author guidelines URL if no dedicated page}
-
-<!-- Use WebFetch to check the journal's Author Guidelines for AI policy.
-     If no specific AI policy found, use ICMJE default:
-     - Requirement level: Not specified — follows ICMJE recommendations
-     - Permitted scope: Language editing only — per ICMJE 2025
-     - Disclosure location: Methods
-     - AI-generated images: Not specified
-     - Policy URL: [author guidelines URL] (no dedicated AI policy page)
-     Add [VERIFY] tag if uncertain about any field. -->
-
----
-
-## Author Guidelines URL
-
-{URL}
-
----
-
-## Positioning
-
-{When to submit here. When NOT to submit here.}
-
-| Dimension | {This Journal} | {Competitor 1} | {Competitor 2} |
-|-----------|---------------|----------------|----------------|
-| Society | ... | ... | ... |
-| Scope | ... | ... | ... |
-| Impact factor | ... | ... | ... |
-| Emphasis | ... | ... | ... |
-```
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/write_paper_profile_template.md` | you are writing the profile and need the literal fill-in template | ~1,800 tokens of pure template; the section order above is all you need to plan the fetch |
 ### 3.3 Generate Find-Journal Profile
 
 Follow the canonical 5-section format exactly:

--- a/skills/add-journal/references/write_paper_profile_template.md
+++ b/skills/add-journal/references/write_paper_profile_template.md
@@ -1,0 +1,124 @@
+# Write-paper journal profile — canonical template
+
+Load-on-demand companion to `/add-journal` Step 3.2. SKILL.md keeps the canonical
+11-section order and the fill rules; this file is the literal template to copy.
+
+Read it when you are actually writing a `write-paper` profile. Follow the 11-section
+order exactly — `/write-paper` Phase 7 and `/find-journal` both read these files
+positionally, so a reordered or renamed section silently degrades them.
+
+Follow the canonical 11-section order exactly:
+
+```markdown
+# Journal Profile: {Full Name}
+
+## Journal Identity
+
+- **Full name**: {name}
+- **Abbreviation**: {abbrev}
+- **Publisher**: {publisher}
+- **ISSN**: {print} (print), {online} (online)
+- **Frequency**: {frequency}
+- **Impact Factor**: ~{IF} (JCR {year})
+- **Open Access**: {OA model}
+- **Acceptance rate**: ~{rate}
+- **Peer review**: {type}
+
+## Manuscript Types and Word Limits
+
+| Type | Body Word Limit | Abstract | References | Figures/Tables |
+|------|----------------|----------|------------|----------------|
+| Original Article | {limit} | {limit} | {limit} | {limit} |
+| ... | ... | ... | ... | ... |
+
+---
+
+## Abstract Requirements
+
+{Structured or unstructured. Show format as code block if structured.}
+
+---
+
+## Required Sections (Original Article)
+
+1. **Introduction**
+2. **Methods**
+   - {subsections}
+3. **Results**
+4. **Discussion**
+5. **{Other required sections if any}**
+
+---
+
+## Statistical Reporting
+
+- {p-value format}
+- {CI requirements}
+- {Effect size requirements}
+- {Software identification requirement}
+- {Journal-specific statistical requirements}
+
+---
+
+## Figures
+
+- **Maximum**: {N figures/tables}
+- **Resolution**: {DPI} minimum
+- **Format**: {accepted formats}
+- **Color**: {policy}
+
+---
+
+## Common Rejection Reasons
+
+1. {reason}
+2. {reason}
+3. {reason}
+4. {reason}
+5. {reason}
+
+---
+
+## Cover Letter
+
+Should include:
+- {requirements}
+
+---
+
+## AI Writing Disclosure Policy
+
+- **Requirement level:** {Required / Recommended / Not specified — follows ICMJE recommendations}
+- **Permitted scope:** {Language editing only / All tasks / describe specific policy}
+- **Disclosure location:** {Methods / Acknowledgments / Cover letter / Submission form}
+- **AI-generated images:** {Banned / Must be declared / Not specified}
+- **Policy URL:** {URL to journal's AI policy page, or author guidelines URL if no dedicated page}
+
+<!-- Use WebFetch to check the journal's Author Guidelines for AI policy.
+     If no specific AI policy found, use ICMJE default:
+     - Requirement level: Not specified — follows ICMJE recommendations
+     - Permitted scope: Language editing only — per ICMJE 2025
+     - Disclosure location: Methods
+     - AI-generated images: Not specified
+     - Policy URL: [author guidelines URL] (no dedicated AI policy page)
+     Add [VERIFY] tag if uncertain about any field. -->
+
+---
+
+## Author Guidelines URL
+
+{URL}
+
+---
+
+## Positioning
+
+{When to submit here. When NOT to submit here.}
+
+| Dimension | {This Journal} | {Competitor 1} | {Competitor 2} |
+|-----------|---------------|----------------|----------------|
+| Society | ... | ... | ... |
+| Scope | ... | ... | ... |
+| Impact factor | ... | ... | ... |
+| Emphasis | ... | ... | ... |
+```

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -359,133 +359,55 @@ critical item and the journal's own required elements.
 
 ### Step 5: Generate Report
 
-Produce a structured compliance report in two parts.
+Produce a structured compliance report in four parts.
 
 This report is an **internal working audit** — it carries auto-fix annotations, a
-machine-readable JSON block (`compliance_pct`, `fixable_by_ai`, …), and Action
-Items. It is **NOT** the official reporting checklist a journal expects (that is
-the blank guideline form with `Item | Recommendation | Reported in page/section`,
-which the authors fill in). Never submit this report as the submission checklist.
-To make the file self-identifying so it cannot be reused by filename into a later
-submission package, **the report MUST begin with the NOT-FOR-SUBMISSION banner
-below** as its very first line. (`/sync-submission`'s `check_checklist_dump_leak`
-gate also catches this dump if it ever lands in a submission directory.)
-
-#### Part A: Summary
+machine-readable JSON block (`compliance_pct`, `fixable_by_ai`, …), and Action Items. It is
+**NOT** the official reporting checklist a journal expects (that is the blank guideline form with
+`Item | Recommendation | Reported in page/section`, which the authors fill in). **Never submit
+this report as the submission checklist.** So that the file is self-identifying and cannot be
+reused by filename into a later submission package, **the report MUST begin with this banner as
+its very first line**:
 
 ```
 <!-- INTERNAL AUDIT — NOT FOR SUBMISSION. This is the /check-reporting working
 report, not the official journal checklist. Do not upload to a submission portal. -->
-
-## Reporting Guideline Compliance Report
-
-Manuscript: {title}
-Target manuscript file: {manuscript filename, e.g. manuscript_v8.md}
-Target version: {version token from the filename or frontmatter, e.g. v8}
-Guideline: {name and version}
-Date: {YYYY-MM-DD}
-Assessed by: Claude (automated pre-screening)
-
-### Summary
-
-| Status | Count | Percentage |
-|--------|-------|------------|
-| PRESENT | {n} | {%} |
-| PARTIAL | {n} | {%} |
-| MISSING | {n} | {%} |
-| N/A | {n} | {%} |
-| **Total** | **{n}** | **100%** |
-
-Overall compliance: {PRESENT count}/{applicable count} ({%})
-
-Critical items (Step 4f): {present}/{total} present.{ if any missing: " Critical gap — " + each MISSING critical item with the section it belongs in. This, not the percentage, is the headline.}
 ```
 
-#### Part B: Item-by-Item Checklist
+(`/sync-submission`'s `check_checklist_dump_leak` gate also catches this dump if it ever lands in
+a submission directory — but the banner is what makes it catchable.)
 
-```
-### Detailed Checklist
+**The four parts** — literal templates in `${CLAUDE_SKILL_DIR}/references/report_templates.md`:
 
-| # | Section | Item | Status | Location | Notes |
-|---|---------|------|--------|----------|-------|
-| 1 | Title/Abstract | {item text} | PRESENT | Title | {notes} |
-| 2 | Introduction | {item text} | MISSING | -- | {suggestion} |
-| ... | ... | ... | ... | ... | ... |
-```
+- **Part A — Summary.** Header (manuscript file, version token, guideline, date), the
+  PRESENT/PARTIAL/MISSING/N-A count table, and overall compliance. The **headline is the critical
+  items (Step 4f)**, not the percentage: report `{present}/{total}` and name every missing
+  critical item with the section it belongs in.
+- **Part B — Item-by-item checklist.** One row per item: `# | Section | Item | Status | Location | Notes`.
+- **Part C — Action items** (MISSING and PARTIAL only), ordered by: items most journals enforce
+  strictly (ethics approval, registration, sample size) → items in Methods (easiest to fix) →
+  everything else.
+- **Part D — Machine-readable JSON**, appended as a fenced block. **MUST** be present under
+  `--json` or when called from `/write-paper` Phase 7, which parses it.
 
-#### Part C: Action Items (for MISSING and PARTIAL)
+**JSON field contract** (the part other skills depend on — get these right):
 
-```
-### Action Items (Priority Order)
+- `compliance_pct` — `present / (total_items - na) * 100`, one decimal.
+- `action_items` — MISSING and PARTIAL only; PRESENT and N/A are excluded.
+- `fixable_by_ai` — `true` when the fix inserts or expands text using information already in the
+  manuscript or inferable from it; `false` when it needs external facts the author alone holds
+  (registration number, IRB approval number, protocol details).
+- `suggested_fix` — concrete draft text, insertable as written.
+- `source_sha256` — first 12 hex chars of the SHA-256 of the manuscript bytes, so a stale report
+  cannot be silently attributed to a newer manuscript.
 
-1. **[MISSING] Item {N}: {item name}**
-   - Required: {what needs to be added}
-   - Suggested location: {section, paragraph}
-   - Example text: "{draft sentence or phrase}"
+**Read on demand:**
 
-2. **[PARTIAL] Item {N}: {item name}**
-   - Current: {what was found}
-   - Needed: {what additional detail is required}
-   - Suggested revision: "{draft revision}"
-```
-
-Order action items by:
-1. Items most journals enforce strictly (e.g., ethics approval, registration, sample size)
-2. Items in the Methods section (easiest to fix)
-3. Items in other sections
-
-#### Part D: Machine-Readable JSON Summary
-
-Append a fenced JSON block at the end of the report. This enables `/write-paper` Phase 7 and `/orchestrate` to parse compliance results programmatically. This block **MUST** be present when invoked with `--json` flag or when called from `/write-paper` Phase 7. It SHOULD also be present in standard invocations (appended after Part C).
-
-```json
-{
-  "check_reporting_version": "1.1",
-  "manuscript_title": "...",
-  "target_manuscript": "manuscript_v8.md",
-  "target_version": "v8",
-  "source_sha256": "<first 12 hex chars of sha256 of the manuscript file bytes>",
-  "guideline": "STARD-AI",
-  "guideline_version": "2025",
-  "date": "YYYY-MM-DD",
-  "total_items": 40,
-  "present": 32,
-  "partial": 4,
-  "missing": 3,
-  "na": 1,
-  "compliance_pct": 88.9,
-  "action_items": [
-    {
-      "item_number": 12,
-      "section": "Methods",
-      "item_name": "Sample size justification",
-      "status": "MISSING",
-      "suggested_location": "Methods, after participant description",
-      "suggested_fix": "Add: 'The sample size was determined based on [rationale]. A minimum of [N] cases was required to achieve [target] precision for the primary endpoint.'",
-      "fixable_by_ai": true
-    },
-    {
-      "item_number": 7,
-      "section": "Methods",
-      "item_name": "Blinding of index test to reference standard",
-      "status": "PARTIAL",
-      "current_text": "Readers were blinded",
-      "needed": "Specify what readers were blinded to (reference standard results, clinical information, other reader results)",
-      "suggested_fix": "Expand to: 'Readers interpreted [index test] images blinded to the reference standard results, clinical information, and other readers' assessments.'",
-      "fixable_by_ai": true
-    }
-  ]
-}
-```
-
-**Field definitions:**
-- `compliance_pct`: `present / (total_items - na) * 100`, rounded to one decimal
-- `action_items`: Array of MISSING and PARTIAL items only (PRESENT and N/A excluded)
-- `fixable_by_ai`: `true` if the fix involves inserting or expanding text with information available in the manuscript or inferable from context; `false` if it requires external information (e.g., registration number, IRB approval number, specific protocol details only the author knows)
-- `suggested_fix`: Concrete draft text that can be inserted or used to expand an existing sentence
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/report_templates.md` | you have finished the audit and are writing the report | ~1,900 tokens of pure output format — it informs no part of the assessment itself |
 
 ---
-
 ## Assessment Standards
 
 ### Be Strict

--- a/skills/check-reporting/references/report_templates.md
+++ b/skills/check-reporting/references/report_templates.md
@@ -1,0 +1,140 @@
+# Step 5 — Report templates (Parts A–D)
+
+Load-on-demand companion to `/check-reporting` Step 5. SKILL.md keeps the
+NOT-FOR-SUBMISSION rule, the part list, and the JSON field contract; this file carries
+the four literal output templates — Part A (summary), Part B (item-by-item checklist),
+Part C (action items), and Part D (the machine-readable JSON block).
+
+Read it when you are writing the report. Everything here is an output format: none of it
+informs the audit itself.
+
+**The banner is not optional.** The report MUST begin with the NOT-FOR-SUBMISSION comment
+as its very first line — this is an internal working audit, never the official journal
+checklist an author fills in and uploads.
+
+Produce a structured compliance report in two parts.
+
+This report is an **internal working audit** — it carries auto-fix annotations, a
+machine-readable JSON block (`compliance_pct`, `fixable_by_ai`, …), and Action
+Items. It is **NOT** the official reporting checklist a journal expects (that is
+the blank guideline form with `Item | Recommendation | Reported in page/section`,
+which the authors fill in). Never submit this report as the submission checklist.
+To make the file self-identifying so it cannot be reused by filename into a later
+submission package, **the report MUST begin with the NOT-FOR-SUBMISSION banner
+below** as its very first line. (`/sync-submission`'s `check_checklist_dump_leak`
+gate also catches this dump if it ever lands in a submission directory.)
+
+#### Part A: Summary
+
+```
+<!-- INTERNAL AUDIT — NOT FOR SUBMISSION. This is the /check-reporting working
+report, not the official journal checklist. Do not upload to a submission portal. -->
+
+## Reporting Guideline Compliance Report
+
+Manuscript: {title}
+Target manuscript file: {manuscript filename, e.g. manuscript_v8.md}
+Target version: {version token from the filename or frontmatter, e.g. v8}
+Guideline: {name and version}
+Date: {YYYY-MM-DD}
+Assessed by: Claude (automated pre-screening)
+
+### Summary
+
+| Status | Count | Percentage |
+|--------|-------|------------|
+| PRESENT | {n} | {%} |
+| PARTIAL | {n} | {%} |
+| MISSING | {n} | {%} |
+| N/A | {n} | {%} |
+| **Total** | **{n}** | **100%** |
+
+Overall compliance: {PRESENT count}/{applicable count} ({%})
+
+Critical items (Step 4f): {present}/{total} present.{ if any missing: " Critical gap — " + each MISSING critical item with the section it belongs in. This, not the percentage, is the headline.}
+```
+
+#### Part B: Item-by-Item Checklist
+
+```
+### Detailed Checklist
+
+| # | Section | Item | Status | Location | Notes |
+|---|---------|------|--------|----------|-------|
+| 1 | Title/Abstract | {item text} | PRESENT | Title | {notes} |
+| 2 | Introduction | {item text} | MISSING | -- | {suggestion} |
+| ... | ... | ... | ... | ... | ... |
+```
+
+#### Part C: Action Items (for MISSING and PARTIAL)
+
+```
+### Action Items (Priority Order)
+
+1. **[MISSING] Item {N}: {item name}**
+   - Required: {what needs to be added}
+   - Suggested location: {section, paragraph}
+   - Example text: "{draft sentence or phrase}"
+
+2. **[PARTIAL] Item {N}: {item name}**
+   - Current: {what was found}
+   - Needed: {what additional detail is required}
+   - Suggested revision: "{draft revision}"
+```
+
+Order action items by:
+1. Items most journals enforce strictly (e.g., ethics approval, registration, sample size)
+2. Items in the Methods section (easiest to fix)
+3. Items in other sections
+
+#### Part D: Machine-Readable JSON Summary
+
+Append a fenced JSON block at the end of the report. This enables `/write-paper` Phase 7 and `/orchestrate` to parse compliance results programmatically. This block **MUST** be present when invoked with `--json` flag or when called from `/write-paper` Phase 7. It SHOULD also be present in standard invocations (appended after Part C).
+
+```json
+{
+  "check_reporting_version": "1.1",
+  "manuscript_title": "...",
+  "target_manuscript": "manuscript_v8.md",
+  "target_version": "v8",
+  "source_sha256": "<first 12 hex chars of sha256 of the manuscript file bytes>",
+  "guideline": "STARD-AI",
+  "guideline_version": "2025",
+  "date": "YYYY-MM-DD",
+  "total_items": 40,
+  "present": 32,
+  "partial": 4,
+  "missing": 3,
+  "na": 1,
+  "compliance_pct": 88.9,
+  "action_items": [
+    {
+      "item_number": 12,
+      "section": "Methods",
+      "item_name": "Sample size justification",
+      "status": "MISSING",
+      "suggested_location": "Methods, after participant description",
+      "suggested_fix": "Add: 'The sample size was determined based on [rationale]. A minimum of [N] cases was required to achieve [target] precision for the primary endpoint.'",
+      "fixable_by_ai": true
+    },
+    {
+      "item_number": 7,
+      "section": "Methods",
+      "item_name": "Blinding of index test to reference standard",
+      "status": "PARTIAL",
+      "current_text": "Readers were blinded",
+      "needed": "Specify what readers were blinded to (reference standard results, clinical information, other reader results)",
+      "suggested_fix": "Expand to: 'Readers interpreted [index test] images blinded to the reference standard results, clinical information, and other readers' assessments.'",
+      "fixable_by_ai": true
+    }
+  ]
+}
+```
+
+**Field definitions:**
+- `compliance_pct`: `present / (total_items - na) * 100`, rounded to one decimal
+- `action_items`: Array of MISSING and PARTIAL items only (PRESENT and N/A excluded)
+- `fixable_by_ai`: `true` if the fix involves inserting or expanding text with information available in the manuscript or inferable from context; `false` if it requires external information (e.g., registration number, IRB approval number, specific protocol details only the author knows)
+- `suggested_fix`: Concrete draft text that can be inserted or used to expand an existing sentence
+
+---

--- a/skills/design-study/SKILL.md
+++ b/skills/design-study/SKILL.md
@@ -153,94 +153,22 @@ Classify:
 - external validation
 - multi-center external validation
 
-#### E. Reader / Expert-Elicitation Study Design
+#### E. Reader / expert-elicitation studies (load on demand)
 
-When the study elicits expert ratings (reader study, annotation panel, AI-output evaluation), check
-the following before data collection.
+When the study elicits expert ratings — a reader study, an annotation panel, an AI-output
+evaluation — the design decisions that matter are made **before data collection**, and the
+acceptance ceiling of a perceptual / reader AI study is fixed at design time: no quality of
+execution lifts a ceiling baked into the comparator, the estimand, or the reader cohort.
 
-**Rubric design**
-- **Decouple the axes.** Each rated dimension should measure one construct. Keep "is the finding
-  valid/correct" separate from "is it novel", "is it feasible to measure", "does it add value over
-  current tools", and "would it change action". A candidate can be high-validity yet low-added-value
-  ("real but redundant"); a single blended score hides this.
-- **Anchor every Likert point** with a short verbal descriptor; pilot the anchors with at least one
-  reviewer before locking.
-- **Pre-specify discriminant validity**: hypothesize which dimensions should correlate vs be
-  orthogonal, then report the full inter-dimension correlation matrix to confirm the rubric measures
-  distinct constructs.
+For an AI-system-versus-human-expert benchmark specifically, route to `/design-ai-benchmarking`,
+which extends this subsection with arm definition, LLM-as-judge versus human-as-judge
+adjudication, and a structured export schema.
 
-**Calibration probes (planted control items)**
-Insert a small number of deliberate control items, blinded and randomized across raters (record who
-received which, e.g. a `probe_arm` flag), to (i) anchor the scale, (ii) measure rater drift and
-fatigue, and (iii) audit the rubric and pipeline itself. Four useful flavors:
-- **Positive control / "too-good" item** — a known-strong or near-tautological item; tests whether
-  raters equate "largest effect" with "best", and whether an upstream construct-independence gate works.
-- **Known-bad negative control** — an engineered defect (fabricated reference, missing key statistic);
-  expected to score low.
-- **Instability item** — an estimate that reverses or fails to replicate on holdout; tests caveat handling.
-- **Mechanism-contradiction item** — an empirical direction that opposes the proposed mechanism.
-
-Report inter-rater reliability **on the control items separately** as primary evidence of rubric and
-scale validity; a low overall ICC is interpretable only if raters at least converge on the controls.
-
-**Operational rigor**
-- Randomize item order **per reviewer** (not one global seed); analyze order and fatigue effects.
-- Collect reviewer metadata (years of experience, prior AI-evaluation experience, subspecialty) for
-  descriptive reporting.
-- Define a structured export schema (per-item ratings, free-text justifications, follow-ups, timing) up front.
-- Require each item to be judged standalone; discourage cross-item references in free-text, which
-  signal non-independent rating.
-
-**Human-as-operator arm (interactive / promptable AI).** The reader-study patterns above assume the
-human is a *rater / reference* judging outputs. Interactive / promptable segmentation (SAM2, MedSAM2,
-nnInteractive) inverts this: the human is the *operator* who places the prompts, so the measured object
-is the human-operated system's **accuracy + interaction count + time + learning curve**, not a rating.
-Design for it explicitly:
-- Define the operator population and their onboarding; a **learning curve** (performance vs case index)
-  is a first-class outcome, not noise to average away.
-- Fix the prompting protocol (allowed prompt types, stopping rule, target Dice) identically to any
-  simulated-prompting arm so the two are comparable — **protocol fidelity**, checked in `/model-validation`.
-- Pre-specify the interaction and timing metrics; their deterministic reporting gate is
-  `/model-evaluation --task interactive`. (A design document is free-form prose, so the deterministic
-  anchor for these items sits at the reporting stage, not on the protocol text.)
-
-For an AI-system-versus-human-expert benchmark specifically, route to `/design-ai-benchmarking`, which
-extends this subsection with arm definition, LLM-as-judge versus human-as-judge adjudication, and a
-structured export schema.
-
-**Perceptual / reader AI study — design-stage ceiling gate**
-
-For a reader/observer/perceptual or diagnostic-accuracy AI study (visual Turing test, AI-vs-human
-detection, image-provenance/deepfake, observer study), the acceptance ceiling is fixed **at design
-time, not at analysis time** — excellent execution cannot lift a ceiling baked into the comparator,
-the estimand, or the reader cohort. Walk these six before data lock and, for each, take the
-higher-ambition option or record an explicit, defensible reason not to (set each at the impact level
-of the journal you actually want):
-
-1. **Comparator realism (biggest lever).** A curated teaching-repository "authentic" arm scopes the
-   claim to "teaching-quality", not clinical. Use consecutive, de-identified clinical-acquisition
-   images (the real PACS spectrum), or add a clinical-spectrum validation arm.
-2. **Format / non-content confound matching.** Match every non-content attribute (aspect ratio,
-   resolution, compression, color profile) across arms by construction, and pre-specify a
-   confound-classifier ceiling check (format-only AUC must be ≪ reader AUC) as a *primary* gate.
-3. **Synthetic / index-arm denominator (survivorship).** Pre-specify how failed/low-quality
-   generations are counted; report the full generation denominator rather than evaluating only the
-   convincing survivors.
-4. **Reader independence and breadth.** Recruit an independent, non-author, multi-site (ideally
-   multi-national) reader cohort; collect reader characteristics; blind readers to the hypothesis
-   where feasible.
-5. **Estimand and power (generalize, don't condition).** Power the reader-AND-case generalization as
-   the **primary** estimand from the start, so the two-way interval — not a pool-conditional number —
-   supports the headline claim.
-6. **Novelty positioning vs scoop, and venue-fit.** Scan for close prior work at design time; if a
-   flagship precedent exists, make the differentiation categorical (new modality class, clinical
-   spectrum, outcome linkage), not incremental; pick the venue whose audience values the likely
-   result (a rigorous null fits a methodology-forward journal better than an impact-first one).
-
-The meta-rule: set the comparator, the confound-matching, the reader cohort, and the estimand at the
-target journal's impact level **before** data collection — do not plan to out-write a structural
-ceiling in revision.
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/reader_elicitation_design.md` | the design has a human-rater or expert-elicitation arm — rubric axes, calibration probes, operational rigor, human-as-operator, and the six ceiling decisions | ~2,400 tokens, none of which applies to a design with no reader arm |
+| `references/dag_adjustment.md` | confounding control needs an explicit adjustment set | — |
+| `references/target_trial_emulation.md` | the design emulates a target trial | — |
 ### Phase 3: Clinical framing
 
 Ask whether the comparator and endpoint support the stated claim:

--- a/skills/design-study/references/reader_elicitation_design.md
+++ b/skills/design-study/references/reader_elicitation_design.md
@@ -1,0 +1,97 @@
+# Reader / expert-elicitation study design
+
+Load-on-demand companion to `/design-study` Phase 2, section E. Read it when the study
+elicits expert ratings — a reader study, an annotation panel, or an AI-output evaluation.
+A design with no human-rater arm needs none of it.
+
+It covers rubric design (decoupled axes, anchored Likert points, pre-specified discriminant
+validity), planted calibration probes, operational rigor, the human-as-**operator** arm for
+interactive / promptable AI, and the six design-stage ceiling decisions for a perceptual /
+reader AI study — the ones that fix the acceptance ceiling before a single reader sees an
+image, and that no amount of good execution can lift afterwards.
+
+When the study elicits expert ratings (reader study, annotation panel, AI-output evaluation), check
+the following before data collection.
+
+**Rubric design**
+- **Decouple the axes.** Each rated dimension should measure one construct. Keep "is the finding
+  valid/correct" separate from "is it novel", "is it feasible to measure", "does it add value over
+  current tools", and "would it change action". A candidate can be high-validity yet low-added-value
+  ("real but redundant"); a single blended score hides this.
+- **Anchor every Likert point** with a short verbal descriptor; pilot the anchors with at least one
+  reviewer before locking.
+- **Pre-specify discriminant validity**: hypothesize which dimensions should correlate vs be
+  orthogonal, then report the full inter-dimension correlation matrix to confirm the rubric measures
+  distinct constructs.
+
+**Calibration probes (planted control items)**
+Insert a small number of deliberate control items, blinded and randomized across raters (record who
+received which, e.g. a `probe_arm` flag), to (i) anchor the scale, (ii) measure rater drift and
+fatigue, and (iii) audit the rubric and pipeline itself. Four useful flavors:
+- **Positive control / "too-good" item** — a known-strong or near-tautological item; tests whether
+  raters equate "largest effect" with "best", and whether an upstream construct-independence gate works.
+- **Known-bad negative control** — an engineered defect (fabricated reference, missing key statistic);
+  expected to score low.
+- **Instability item** — an estimate that reverses or fails to replicate on holdout; tests caveat handling.
+- **Mechanism-contradiction item** — an empirical direction that opposes the proposed mechanism.
+
+Report inter-rater reliability **on the control items separately** as primary evidence of rubric and
+scale validity; a low overall ICC is interpretable only if raters at least converge on the controls.
+
+**Operational rigor**
+- Randomize item order **per reviewer** (not one global seed); analyze order and fatigue effects.
+- Collect reviewer metadata (years of experience, prior AI-evaluation experience, subspecialty) for
+  descriptive reporting.
+- Define a structured export schema (per-item ratings, free-text justifications, follow-ups, timing) up front.
+- Require each item to be judged standalone; discourage cross-item references in free-text, which
+  signal non-independent rating.
+
+**Human-as-operator arm (interactive / promptable AI).** The reader-study patterns above assume the
+human is a *rater / reference* judging outputs. Interactive / promptable segmentation (SAM2, MedSAM2,
+nnInteractive) inverts this: the human is the *operator* who places the prompts, so the measured object
+is the human-operated system's **accuracy + interaction count + time + learning curve**, not a rating.
+Design for it explicitly:
+- Define the operator population and their onboarding; a **learning curve** (performance vs case index)
+  is a first-class outcome, not noise to average away.
+- Fix the prompting protocol (allowed prompt types, stopping rule, target Dice) identically to any
+  simulated-prompting arm so the two are comparable — **protocol fidelity**, checked in `/model-validation`.
+- Pre-specify the interaction and timing metrics; their deterministic reporting gate is
+  `/model-evaluation --task interactive`. (A design document is free-form prose, so the deterministic
+  anchor for these items sits at the reporting stage, not on the protocol text.)
+
+For an AI-system-versus-human-expert benchmark specifically, route to `/design-ai-benchmarking`, which
+extends this subsection with arm definition, LLM-as-judge versus human-as-judge adjudication, and a
+structured export schema.
+
+**Perceptual / reader AI study — design-stage ceiling gate**
+
+For a reader/observer/perceptual or diagnostic-accuracy AI study (visual Turing test, AI-vs-human
+detection, image-provenance/deepfake, observer study), the acceptance ceiling is fixed **at design
+time, not at analysis time** — excellent execution cannot lift a ceiling baked into the comparator,
+the estimand, or the reader cohort. Walk these six before data lock and, for each, take the
+higher-ambition option or record an explicit, defensible reason not to (set each at the impact level
+of the journal you actually want):
+
+1. **Comparator realism (biggest lever).** A curated teaching-repository "authentic" arm scopes the
+   claim to "teaching-quality", not clinical. Use consecutive, de-identified clinical-acquisition
+   images (the real PACS spectrum), or add a clinical-spectrum validation arm.
+2. **Format / non-content confound matching.** Match every non-content attribute (aspect ratio,
+   resolution, compression, color profile) across arms by construction, and pre-specify a
+   confound-classifier ceiling check (format-only AUC must be ≪ reader AUC) as a *primary* gate.
+3. **Synthetic / index-arm denominator (survivorship).** Pre-specify how failed/low-quality
+   generations are counted; report the full generation denominator rather than evaluating only the
+   convincing survivors.
+4. **Reader independence and breadth.** Recruit an independent, non-author, multi-site (ideally
+   multi-national) reader cohort; collect reader characteristics; blind readers to the hypothesis
+   where feasible.
+5. **Estimand and power (generalize, don't condition).** Power the reader-AND-case generalization as
+   the **primary** estimand from the start, so the two-way interval — not a pool-conditional number —
+   supports the headline claim.
+6. **Novelty positioning vs scoop, and venue-fit.** Scan for close prior work at design time; if a
+   flagship precedent exists, make the differentiation categorical (new modality class, clinical
+   spectrum, outcome linkage), not incremental; pick the venue whose audience values the likely
+   result (a rigorous null fits a methodology-forward journal better than an impact-first one).
+
+The meta-rule: set the comparator, the confound-matching, the reader cohort, and the estimand at the
+target journal's impact level **before** data collection — do not plan to out-write a structural
+ceiling in revision.

--- a/skills/make-figures/SKILL.md
+++ b/skills/make-figures/SKILL.md
@@ -455,96 +455,26 @@ When the study type is known (from `/write-paper` Phase 0 or user specification)
 | RCT (CONSORT) | CONSORT flow diagram, primary endpoint figure |
 | Case report / series (CARE) | Clinical timeline figure (`exemplar_plots/clinical_timeline.md`), annotated multimodality imaging panel when visually load-bearing (`exemplar_plots/imaging_panel.md`); for a series, an all-cases summary table |
 
-After generating all figures, create a structured manifest file at `figures/_figure_manifest.md`:
+**The manifest is mandatory.** After generating all figures, write
+`figures/_figure_manifest.md` — one row per figure (`Figure | Path | Type | Tool | Critic |
+Rounds | Description`) plus a `## Critic notes` section recording any residual PARTIAL items and
+why they were accepted. It is consumed by `/write-paper` Phase 2 (figure embedding) and Phase 7
+(DOCX build); verify it exists and is non-empty before finishing. Format and field definitions:
+`${CLAUDE_SKILL_DIR}/references/figure_manifest.md`.
 
-```markdown
-# Figure Manifest
-Generated: {YYYY-MM-DD}
-Study type: {study type or "custom"}
+**Flow diagram generation rule.** STARD / CONSORT / PRISMA / STROBE flow diagrams **MUST** use the
+standardized R pipeline `scripts/generate_flow_diagram.R` (DiagrammeR + Graphviz dot + rsvg) — the
+single canonical tool for all four. Do **NOT** use matplotlib `FancyBboxPatch` (manual coordinates
+break when text changes, and patches distort when embedded in DOCX). Do **NOT** use D2 for new
+flow diagrams (weak font control, overlap needs manual post-processing). Numbers in labels must be
+CSV-derived, or hand-written only when the value lives in a commit-tracked data artifact.
 
-| Figure | Path | Type | Tool | Critic | Rounds | Description |
-|--------|------|------|------|--------|--------|-------------|
-| Figure 1 | figures/fig1_stard_flow.svg | flow-diagram | D2 | yes | 2 | STARD participant flow diagram |
-| Figure 2 | figures/fig2_roc.pdf | roc-curve | matplotlib | yes | 1 | ROC curves for Model A vs B |
-| Figure 3 | figures/fig3_calibration.pdf | calibration | matplotlib | partial | 3 | Calibration plot; legend still crowded (see notes) |
+**Read on demand:**
 
-## Critic notes
-- Figure 3: after 3 rounds, legend placement remains crowded at the
-  double-column width. Candidate remediations documented but not applied
-  to avoid reducing data-point visibility.
-```
-
-**Manifest field definitions:**
-- **Path**: Relative path from project root
-- **Type**: One of: `flow-diagram`, `roc-curve`, `forest-plot`, `funnel-plot`, `calibration`, `km-curve`, `bland-altman`, `confusion-matrix`, `box-violin`, `bar-chart`, `heatmap`, `pipeline`, `visual-abstract`, `sroc-curve`, `other`
-- **Tool**: Tool used to generate (`matplotlib`, `D2`, `python-pptx`, `seaborn`, etc.)
-- **Critic**: `yes` (all rubric items PASS) / `partial` (some PARTIAL after max rounds) / `no` (never critiqued — avoid for submission figures) / `skip` (deliberately bypassed, e.g., panel figure assembled externally)
-- **Rounds**: Number of Critic Loop rounds executed (0 if skipped)
-- **Description**: One-line description suitable for figure legend context
-
-A `## Critic notes` section at the bottom of the manifest records any
-residual PARTIAL items and the rationale for accepting them.
-
-This manifest is consumed by `/write-paper` Phase 2 (figure embedding) and Phase 7 (DOCX build). It **MUST** exist after figure generation completes. Verify the file is non-empty before finishing.
-
-**Flow diagram generation rule:** STARD/CONSORT/PRISMA/STROBE flow diagrams **MUST** use the standardized R pipeline `scripts/generate_flow_diagram.R` (DiagrammeR + Graphviz dot + rsvg). This is the single canonical tool for all four reporting-guideline flow diagrams. Do NOT use matplotlib `FancyBboxPatch` (manual coordinates break when text changes, and patches distort when embedded in DOCX). Do NOT use D2 for new flow diagrams (font control is weak, overlap requires manual post-processing). The legacy D2 recipe remains documented below as a fallback only when R is unavailable.
-
-**R flow diagram recipe (mandatory for all flow diagrams):**
-
-The pipeline reads a YAML config describing nodes/edges and produces: a true vector PDF (journal submission), a 300 dpi PNG (review copy), and a 600 dpi PNG (RSNA/Eur Radiol line-art). Default style is single-color black outline with white fill in Arial, overriding D2's colored defaults and matplotlib's manual coordinates.
-
-```bash
-# 1. One-time system dependency:
-brew install librsvg
-Rscript -e 'install.packages(c("DiagrammeR","DiagrammeRsvg","rsvg","yaml"))'
-
-# 2. Author a YAML config. Templates for each type live at
-#    references/exemplar_diagrams/{strobe,consort,prisma,stard}/template_input.yaml
-# 3. Render:
-Rscript ${CLAUDE_SKILL_DIR}/scripts/generate_flow_diagram.R \
-    --type   {strobe|consort|prisma|stard} \
-    --config path/to/counts.yaml \
-    --out    figures/figure1_flow
-# Outputs: figure1_flow.pdf, figure1_flow.png (300 dpi), figure1_flow_600.png
-```
-
-**YAML schema highlights:**
-- `rankdir: TB` (top-down, default) or `LR` (left-to-right).
-- `nodes:` list with `id`, `label` (use literal `\n` for line breaks, real Unicode `–`, `≤`, `−`, `•`).
-- Optional per-node: `highlight: true` (thicker border), `shape: note` (side boxes), `rank_same_with: <other_id>` (place on same horizontal rank).
-- `edges:` list with `from`, `to`, optional `style: dashed`, `arrow: false` (no arrowhead), `constraint: false` (edge ignored by layout engine — use for exclusion side-links).
-- Numbers in labels **MUST** be CSV-derived in an upstream R script that emits the YAML, or hand-written only when the value lives in a commit-tracked data artifact. Follow numerical-safety rules.
-
-**Style is fixed (do not override in the YAML):**
-- Monochrome: all boxes `color=black, fillcolor=white, fontname="Arial"`.
-- Penwidth 1.2 default, 1.8 for highlighted cohort box.
-- Arrow style: black solid, arrowsize 0.75. Dashed without arrowhead for exclusion side-links.
-- Bullet alignment in multi-item labels: Graphviz `\l` (left-align), never `\n` (center). Each `\l` applies to text preceding it.
-- **No HTML-like labels** (`label=<...>` with `<B>`, `<I>`, `&#8226;`). Plain quoted labels with `\l` bullets produce tighter, more readable structure than HTML ragged wrapping. Do not reintroduce without explicit approval.
-- To add one emphasis color (e.g., Wong blue `#0072B2` for a single highlighted box), edit `scripts/generate_flow_diagram.R` — do not inline hex colors in YAML.
-
-**Per-project `create_figure1.R` pattern (preferred for complex flows):**
-
-When the flow has derived counts, `stopifnot()` reconciliation, multi-rank `{rank=same; ... }` constraints, or exclusion side-cars that the generic YAML dispatcher cannot express cleanly, write a per-project `create_figure1.R` directly (same DiagrammeR + DiagrammeRsvg + rsvg stack, sprintf'd `dot` string). This is the dominant pattern when the generic YAML dispatcher cannot capture the flow:
-
-- STROBE cohort: `<project>/manuscript/figures/create_figure1.R`
-- STARD: `<project>/Analysis/figures/create_figure1.R` or `<project>/figures/v2_monochrome/create_figure1.R`
-- PRISMA / PRISMA-DTA: `<project>/5_Figures/create_figure1.R` or `<project>/analysis/create_figure1.R`
-- CONSORT-edu (naturalistic allocation): `<project>/figures/v2_monochrome/create_figure1.R`
-
-Copy the `STYLE_HEADER` (graph/node/edge attrs) verbatim from any exemplar; then customise nodes, edges, and `{rank=same}` blocks. Use `read.csv()` for cohort counts when possible; if hardcoded, every number must have a source comment referencing manuscript line / CSV cell / screening log row.
-
-**Legacy D2 fallback (only when R unavailable):**
-
-```bash
-d2 --layout elk --theme 0 --pad 20 flow.d2 /tmp/raw.png --scale 2
-# Resize + 85% vertical compression via Pillow; then render PDF:
-d2 --layout elk --theme 0 --pad 20 flow.d2 figures/fig1_flow.pdf
-```
-
-Use `font-size: 20-24`, `stroke: black`, `fill: white`. D2 PDF is vector; D2 PNG needs the resize step to match publication density.
-
----
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/flow_diagram_recipe.md` | you are generating a STARD / CONSORT / PRISMA / STROBE flow diagram | ~2,200 tokens — a ROC curve or forest plot needs none of it |
+| `references/figure_manifest.md` | you are writing `_figure_manifest.md` | ~700 tokens of output format |
 
 ## Tool Selection Guide
 

--- a/skills/make-figures/references/figure_manifest.md
+++ b/skills/make-figures/references/figure_manifest.md
@@ -1,0 +1,38 @@
+# `figures/_figure_manifest.md` — format and field definitions
+
+Load-on-demand companion to `/make-figures`. SKILL.md states that the manifest is
+mandatory and who consumes it; this file is the literal format.
+
+Read it when you are writing the manifest.
+
+After generating all figures, create a structured manifest file at `figures/_figure_manifest.md`:
+
+```markdown
+# Figure Manifest
+Generated: {YYYY-MM-DD}
+Study type: {study type or "custom"}
+
+| Figure | Path | Type | Tool | Critic | Rounds | Description |
+|--------|------|------|------|--------|--------|-------------|
+| Figure 1 | figures/fig1_stard_flow.svg | flow-diagram | D2 | yes | 2 | STARD participant flow diagram |
+| Figure 2 | figures/fig2_roc.pdf | roc-curve | matplotlib | yes | 1 | ROC curves for Model A vs B |
+| Figure 3 | figures/fig3_calibration.pdf | calibration | matplotlib | partial | 3 | Calibration plot; legend still crowded (see notes) |
+
+## Critic notes
+- Figure 3: after 3 rounds, legend placement remains crowded at the
+  double-column width. Candidate remediations documented but not applied
+  to avoid reducing data-point visibility.
+```
+
+**Manifest field definitions:**
+- **Path**: Relative path from project root
+- **Type**: One of: `flow-diagram`, `roc-curve`, `forest-plot`, `funnel-plot`, `calibration`, `km-curve`, `bland-altman`, `confusion-matrix`, `box-violin`, `bar-chart`, `heatmap`, `pipeline`, `visual-abstract`, `sroc-curve`, `other`
+- **Tool**: Tool used to generate (`matplotlib`, `D2`, `python-pptx`, `seaborn`, etc.)
+- **Critic**: `yes` (all rubric items PASS) / `partial` (some PARTIAL after max rounds) / `no` (never critiqued — avoid for submission figures) / `skip` (deliberately bypassed, e.g., panel figure assembled externally)
+- **Rounds**: Number of Critic Loop rounds executed (0 if skipped)
+- **Description**: One-line description suitable for figure legend context
+
+A `## Critic notes` section at the bottom of the manifest records any
+residual PARTIAL items and the rationale for accepting them.
+
+This manifest is consumed by `/write-paper` Phase 2 (figure embedding) and Phase 7 (DOCX build). It **MUST** exist after figure generation completes. Verify the file is non-empty before finishing.

--- a/skills/make-figures/references/flow_diagram_recipe.md
+++ b/skills/make-figures/references/flow_diagram_recipe.md
@@ -1,0 +1,68 @@
+# Flow diagrams (STARD / CONSORT / PRISMA / STROBE) — the R recipe
+
+Load-on-demand companion to `/make-figures`. SKILL.md states the mandatory rule (the
+standardized R pipeline, never matplotlib `FancyBboxPatch`, never D2 for new diagrams);
+this file is the recipe: the YAML schema, the fixed style, the per-project
+`create_figure1.R` pattern, and the legacy D2 fallback.
+
+Read it when you are actually generating a reporting-guideline flow diagram. A figure set
+with no flow diagram (a ROC curve, a forest plot, a calibration plot) needs none of it.
+
+**Flow diagram generation rule:** STARD/CONSORT/PRISMA/STROBE flow diagrams **MUST** use the standardized R pipeline `scripts/generate_flow_diagram.R` (DiagrammeR + Graphviz dot + rsvg). This is the single canonical tool for all four reporting-guideline flow diagrams. Do NOT use matplotlib `FancyBboxPatch` (manual coordinates break when text changes, and patches distort when embedded in DOCX). Do NOT use D2 for new flow diagrams (font control is weak, overlap requires manual post-processing). The legacy D2 recipe remains documented below as a fallback only when R is unavailable.
+
+**R flow diagram recipe (mandatory for all flow diagrams):**
+
+The pipeline reads a YAML config describing nodes/edges and produces: a true vector PDF (journal submission), a 300 dpi PNG (review copy), and a 600 dpi PNG (RSNA/Eur Radiol line-art). Default style is single-color black outline with white fill in Arial, overriding D2's colored defaults and matplotlib's manual coordinates.
+
+```bash
+# 1. One-time system dependency:
+brew install librsvg
+Rscript -e 'install.packages(c("DiagrammeR","DiagrammeRsvg","rsvg","yaml"))'
+
+# 2. Author a YAML config. Templates for each type live at
+#    references/exemplar_diagrams/{strobe,consort,prisma,stard}/template_input.yaml
+# 3. Render:
+Rscript ${CLAUDE_SKILL_DIR}/scripts/generate_flow_diagram.R \
+    --type   {strobe|consort|prisma|stard} \
+    --config path/to/counts.yaml \
+    --out    figures/figure1_flow
+# Outputs: figure1_flow.pdf, figure1_flow.png (300 dpi), figure1_flow_600.png
+```
+
+**YAML schema highlights:**
+- `rankdir: TB` (top-down, default) or `LR` (left-to-right).
+- `nodes:` list with `id`, `label` (use literal `\n` for line breaks, real Unicode `–`, `≤`, `−`, `•`).
+- Optional per-node: `highlight: true` (thicker border), `shape: note` (side boxes), `rank_same_with: <other_id>` (place on same horizontal rank).
+- `edges:` list with `from`, `to`, optional `style: dashed`, `arrow: false` (no arrowhead), `constraint: false` (edge ignored by layout engine — use for exclusion side-links).
+- Numbers in labels **MUST** be CSV-derived in an upstream R script that emits the YAML, or hand-written only when the value lives in a commit-tracked data artifact. Follow numerical-safety rules.
+
+**Style is fixed (do not override in the YAML):**
+- Monochrome: all boxes `color=black, fillcolor=white, fontname="Arial"`.
+- Penwidth 1.2 default, 1.8 for highlighted cohort box.
+- Arrow style: black solid, arrowsize 0.75. Dashed without arrowhead for exclusion side-links.
+- Bullet alignment in multi-item labels: Graphviz `\l` (left-align), never `\n` (center). Each `\l` applies to text preceding it.
+- **No HTML-like labels** (`label=<...>` with `<B>`, `<I>`, `&#8226;`). Plain quoted labels with `\l` bullets produce tighter, more readable structure than HTML ragged wrapping. Do not reintroduce without explicit approval.
+- To add one emphasis color (e.g., Wong blue `#0072B2` for a single highlighted box), edit `scripts/generate_flow_diagram.R` — do not inline hex colors in YAML.
+
+**Per-project `create_figure1.R` pattern (preferred for complex flows):**
+
+When the flow has derived counts, `stopifnot()` reconciliation, multi-rank `{rank=same; ... }` constraints, or exclusion side-cars that the generic YAML dispatcher cannot express cleanly, write a per-project `create_figure1.R` directly (same DiagrammeR + DiagrammeRsvg + rsvg stack, sprintf'd `dot` string). This is the dominant pattern when the generic YAML dispatcher cannot capture the flow:
+
+- STROBE cohort: `<project>/manuscript/figures/create_figure1.R`
+- STARD: `<project>/Analysis/figures/create_figure1.R` or `<project>/figures/v2_monochrome/create_figure1.R`
+- PRISMA / PRISMA-DTA: `<project>/5_Figures/create_figure1.R` or `<project>/analysis/create_figure1.R`
+- CONSORT-edu (naturalistic allocation): `<project>/figures/v2_monochrome/create_figure1.R`
+
+Copy the `STYLE_HEADER` (graph/node/edge attrs) verbatim from any exemplar; then customise nodes, edges, and `{rank=same}` blocks. Use `read.csv()` for cohort counts when possible; if hardcoded, every number must have a source comment referencing manuscript line / CSV cell / screening log row.
+
+**Legacy D2 fallback (only when R unavailable):**
+
+```bash
+d2 --layout elk --theme 0 --pad 20 flow.d2 /tmp/raw.png --scale 2
+# Resize + 85% vertical compression via Pillow; then render PDF:
+d2 --layout elk --theme 0 --pad 20 flow.d2 figures/fig1_flow.pdf
+```
+
+Use `font-size: 20-24`, `stroke: black`, `fill: white`. D2 PDF is vector; D2 PNG needs the resize step to match publication density.
+
+---

--- a/skills/manage-project/SKILL.md
+++ b/skills/manage-project/SKILL.md
@@ -24,12 +24,17 @@ Create a complete project scaffold for a new research paper.
 - `{name}` -- Project identifier (e.g., `nnunet-skull-fracture`, `rfa-meta-analysis`)
 - `--type` -- Paper type: `original | meta | case | animal | technical | ai_validation | letter`
 - `--journal` -- Target journal: `RYAI | AJR | Radiology | European_Radiology | KJR | INSI | AJNR | generic`
-- `--ssot` -- Emit `SSOT.yaml` (schema v1) from `templates/SSOT.yaml.template` instead of legacy `project.yaml`. Required for Phase 1C auto-enforce (PostToolUse verify-refs hook blocks instead of warns). New projects on or after 2026-04-24 should pass `--ssot`. Legacy in-flight projects stay on `project.yaml` until `/manage-project migrate-ssot` is run.
-- `--zotero-collection NAME` -- Optional. Create a new Zotero collection with `NAME` via pyzotero and populate `library_id` + `collection_key` in the contract. Requires env vars `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` (and optionally `ZOTERO_LIBRARY_TYPE`, default `user`). Graceful degrade: if pyzotero is not installed or credentials are missing, the contract is scaffolded with `library_id: null` / `collection_key: null` and a WARN is printed.
+- `--ssot` -- Emit `SSOT.yaml` (schema v1) from `templates/SSOT.yaml.template` instead of legacy `project.yaml`. Required for Phase 1C auto-enforce (the PostToolUse verify-refs hook blocks instead of warns). New projects should pass `--ssot`; legacy in-flight projects stay on `project.yaml` until `/manage-project migrate-ssot` is run.
+- `--zotero-collection NAME` -- Optional. Create a Zotero collection via pyzotero and populate `library_id` + `collection_key` in the contract. Requires `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` (optionally `ZOTERO_LIBRARY_TYPE`, default `user`). **Graceful degrade:** with pyzotero missing or credentials absent, the contract is scaffolded with `library_id: null` / `collection_key: null` and a WARN is printed.
 
-**SSOT template substitutions:** `{{PROJECT_ID}}` → `{name}`, `{{PROJECT_TYPE}}` → SSOT `project_type` enum mapped from `--type` (`original → original_research`, `meta → meta_analysis`, `case → case_report`, `ai_validation → ai_validation`, else `other`). Without `--zotero-collection`, `library_id` / `collection_key` stay `null` — populated manually when the owner links an existing Zotero collection.
+**SSOT template substitutions:** `{{PROJECT_ID}}` → `{name}`; `{{PROJECT_TYPE}}` → the SSOT
+`project_type` enum mapped from `--type` (`original → original_research`, `meta → meta_analysis`,
+`case → case_report`, `ai_validation → ai_validation`, else `other`). Without
+`--zotero-collection`, `library_id` / `collection_key` stay `null` until the owner links an
+existing collection.
 
-**Implementation:** `/manage-project init` is backed by `scripts/init_project.py`. Invoke directly when running outside the skill harness:
+**Implementation:** backed by `scripts/init_project.py`. Invoke it directly when running outside
+the skill harness (from the `medsci-skills` repo root):
 
 ```bash
 python3 scripts/init_project.py \
@@ -37,95 +42,22 @@ python3 scripts/init_project.py \
     --project-root {target_dir}
 ```
 
-(Run from the `medsci-skills` repo root.)
+The helper writes the contract file (`SSOT.yaml` with `--ssot`, else legacy `project.yaml`), the
+directory scaffold, the minimal stubs `scripts/validate_project_contract.py` requires
+(`manuscript/index.qmd`, `artifact_manifest.json`, `qc/status.json`), the memory-file templates,
+and `project_state.json`. **`qc/migration_complete` is NOT written by init** — that marker belongs
+to the migrate pipeline.
 
-The helper writes the contract file (`SSOT.yaml` with `--ssot`, otherwise legacy `project.yaml`), the directory scaffold, minimal stubs required by `scripts/validate_project_contract.py` (`manuscript/index.qmd`, `artifact_manifest.json`, `qc/status.json`), the memory-file templates, and `project_state.json`. `qc/migration_complete` is **not** written by init — the migrate pipeline is responsible for that marker.
+**Do not hand-build the scaffold.** The script is the source of truth for the tree and for
+`project_state.json`; a hand-built one drifts from what the contract validator expects.
 
-**What it creates:**
+**Read on demand:**
 
-```
-{name}/
-├── paper/
-│   ├── main.qmd               <- Main manuscript (Quarto)
-│   ├── sections/
-│   │   ├── abstract.qmd
-│   │   ├── introduction.qmd
-│   │   ├── methods.qmd
-│   │   ├── results.qmd
-│   │   ├── discussion.qmd
-│   │   └── conclusion.qmd
-│   ├── figures/
-│   │   └── .gitkeep
-│   ├── tables/
-│   │   └── table_shells.md    <- Table structure designed before prose
-│   └── supplementary/
-│       └── .gitkeep
-├── analysis/
-│   ├── scripts/
-│   │   └── .gitkeep
-│   └── outputs/
-│       └── .gitkeep
-├── references/
-│   ├── library.bib
-│   └── checklist_{GUIDELINE}.md  <- Loaded from /check-reporting
-├── revision/
-│   └── .gitkeep
-├── submission/
-│   └── .gitkeep
-├── PROJECT.md                <- Project identity and scope
-├── STATUS.md                 <- Current phase, blockers, next actions
-├── CLAIMS.md                 <- Claim-to-result map
-├── DATA_DICTIONARY.md        <- Variable and outcome definitions
-├── ANALYSIS_PLAN.md          <- Primary/secondary analyses
-├── REVIEW_LOG.md             <- Reviewer comments and responses
-├── project_state.json         <- Progress tracking
-└── README.md                  <- Project overview
-```
-
-**Also creates** `project_state.json`:
-
-```json
-{
-  "name": "{name}",
-  "type": "{type}",
-  "journal": "{journal}",
-  "created": "YYYY-MM-DD",
-  "target_submission": null,
-  "current_phase": 0,
-  "phases": {
-    "0_init": "complete",
-    "1_outline": "pending",
-    "2_tables_figures": "pending",
-    "3_methods": "pending",
-    "4_results": "pending",
-    "5_discussion": "pending",
-    "6_intro_abstract": "pending",
-    "7_polish": "pending"
-  },
-  "word_counts": {
-    "abstract": 0,
-    "introduction": 0,
-    "methods": 0,
-    "results": 0,
-    "discussion": 0,
-    "total": 0
-  },
-  "checklist_status": "pending",
-  "citation_status": "unverified",
-  "revision_round": null,
-  "memory_files": {
-    "PROJECT.md": true,
-    "STATUS.md": true,
-    "CLAIMS.md": true,
-    "DATA_DICTIONARY.md": true,
-    "ANALYSIS_PLAN.md": true,
-    "REVIEW_LOG.md": true
-  }
-}
-```
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/init_scaffold.md` | you need to know where a scaffolded file lands, or what a `project_state.json` field means | ~1,400 tokens describing output the script already produces for you |
 
 ---
-
 ### `/manage-project migrate-ssot [--no-mark-complete]`
 
 Thin wrapper over `scripts/migrate_project_to_ssot.py` that converts a legacy `project.yaml` project into SSOT.yaml form and, by default, touches `qc/migration_complete` so Phase 1C `auto` mode switches from `warn` to `enforce`.

--- a/skills/manage-project/references/init_scaffold.md
+++ b/skills/manage-project/references/init_scaffold.md
@@ -1,0 +1,118 @@
+# `/manage-project init` — the scaffold it emits
+
+Load-on-demand companion to `/manage-project init`. SKILL.md keeps the parameters, the
+SSOT substitutions, and the invocation; this file records **what `scripts/init_project.py`
+writes** — the full directory tree and the `project_state.json` shape.
+
+Read it when you need to know where a scaffolded file lands, or what a field in
+`project_state.json` means. You do not need it to *run* init: the script builds all of
+this. Never hand-build the tree — a hand-built scaffold drifts from what
+`scripts/validate_project_contract.py` expects.
+
+Create a complete project scaffold for a new research paper.
+
+**Parameters:**
+- `{name}` -- Project identifier (e.g., `nnunet-skull-fracture`, `rfa-meta-analysis`)
+- `--type` -- Paper type: `original | meta | case | animal | technical | ai_validation | letter`
+- `--journal` -- Target journal: `RYAI | AJR | Radiology | European_Radiology | KJR | INSI | AJNR | generic`
+- `--ssot` -- Emit `SSOT.yaml` (schema v1) from `templates/SSOT.yaml.template` instead of legacy `project.yaml`. Required for Phase 1C auto-enforce (PostToolUse verify-refs hook blocks instead of warns). New projects on or after 2026-04-24 should pass `--ssot`. Legacy in-flight projects stay on `project.yaml` until `/manage-project migrate-ssot` is run.
+- `--zotero-collection NAME` -- Optional. Create a new Zotero collection with `NAME` via pyzotero and populate `library_id` + `collection_key` in the contract. Requires env vars `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` (and optionally `ZOTERO_LIBRARY_TYPE`, default `user`). Graceful degrade: if pyzotero is not installed or credentials are missing, the contract is scaffolded with `library_id: null` / `collection_key: null` and a WARN is printed.
+
+**SSOT template substitutions:** `{{PROJECT_ID}}` → `{name}`, `{{PROJECT_TYPE}}` → SSOT `project_type` enum mapped from `--type` (`original → original_research`, `meta → meta_analysis`, `case → case_report`, `ai_validation → ai_validation`, else `other`). Without `--zotero-collection`, `library_id` / `collection_key` stay `null` — populated manually when the owner links an existing Zotero collection.
+
+**Implementation:** `/manage-project init` is backed by `scripts/init_project.py`. Invoke directly when running outside the skill harness:
+
+```bash
+python3 scripts/init_project.py \
+    --name {name} --type {type} --journal {journal} [--ssot] \
+    --project-root {target_dir}
+```
+
+(Run from the `medsci-skills` repo root.)
+
+The helper writes the contract file (`SSOT.yaml` with `--ssot`, otherwise legacy `project.yaml`), the directory scaffold, minimal stubs required by `scripts/validate_project_contract.py` (`manuscript/index.qmd`, `artifact_manifest.json`, `qc/status.json`), the memory-file templates, and `project_state.json`. `qc/migration_complete` is **not** written by init — the migrate pipeline is responsible for that marker.
+
+**What it creates:**
+
+```
+{name}/
+├── paper/
+│   ├── main.qmd               <- Main manuscript (Quarto)
+│   ├── sections/
+│   │   ├── abstract.qmd
+│   │   ├── introduction.qmd
+│   │   ├── methods.qmd
+│   │   ├── results.qmd
+│   │   ├── discussion.qmd
+│   │   └── conclusion.qmd
+│   ├── figures/
+│   │   └── .gitkeep
+│   ├── tables/
+│   │   └── table_shells.md    <- Table structure designed before prose
+│   └── supplementary/
+│       └── .gitkeep
+├── analysis/
+│   ├── scripts/
+│   │   └── .gitkeep
+│   └── outputs/
+│       └── .gitkeep
+├── references/
+│   ├── library.bib
+│   └── checklist_{GUIDELINE}.md  <- Loaded from /check-reporting
+├── revision/
+│   └── .gitkeep
+├── submission/
+│   └── .gitkeep
+├── PROJECT.md                <- Project identity and scope
+├── STATUS.md                 <- Current phase, blockers, next actions
+├── CLAIMS.md                 <- Claim-to-result map
+├── DATA_DICTIONARY.md        <- Variable and outcome definitions
+├── ANALYSIS_PLAN.md          <- Primary/secondary analyses
+├── REVIEW_LOG.md             <- Reviewer comments and responses
+├── project_state.json         <- Progress tracking
+└── README.md                  <- Project overview
+```
+
+**Also creates** `project_state.json`:
+
+```json
+{
+  "name": "{name}",
+  "type": "{type}",
+  "journal": "{journal}",
+  "created": "YYYY-MM-DD",
+  "target_submission": null,
+  "current_phase": 0,
+  "phases": {
+    "0_init": "complete",
+    "1_outline": "pending",
+    "2_tables_figures": "pending",
+    "3_methods": "pending",
+    "4_results": "pending",
+    "5_discussion": "pending",
+    "6_intro_abstract": "pending",
+    "7_polish": "pending"
+  },
+  "word_counts": {
+    "abstract": 0,
+    "introduction": 0,
+    "methods": 0,
+    "results": 0,
+    "discussion": 0,
+    "total": 0
+  },
+  "checklist_status": "pending",
+  "citation_status": "unverified",
+  "revision_round": null,
+  "memory_files": {
+    "PROJECT.md": true,
+    "STATUS.md": true,
+    "CLAIMS.md": true,
+    "DATA_DICTIONARY.md": true,
+    "ANALYSIS_PLAN.md": true,
+    "REVIEW_LOG.md": true
+  }
+}
+```
+
+---

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -148,45 +148,34 @@ Auto-detect type from the research question or accept user specification.
 
 **Goal**: Systematic title/abstract and full-text screening with two independent reviewers.
 
-#### 3a. Round 1 — Initial Title/Abstract Screening (single reviewer)
-1. Define exclusion codes from protocol (e.g., E1=Not target population, E2=Not intervention, E3=Ineligible type, E4=Non-human, E5=Duplicate).
-2. For each record, screen title+abstract against eligibility criteria.
-3. Mark each record as INCLUDE / EXCLUDE / MAYBE with reason code.
-4. Output: `round1_{date}.tsv` with color-coded decisions.
+**3a. Round 1 — initial title/abstract screening (single reviewer).** Define the exclusion codes
+from the protocol (E1=Not target population, E2=Not intervention, E3=Ineligible type, E4=Non-human,
+E5=Duplicate). Mark every record INCLUDE / EXCLUDE / MAYBE with a reason code → `round1_{date}.tsv`.
 
-#### 3b. Round 2 — Dual Independent Title/Abstract Screening
-1. A second independent reviewer (or AI as a documented second-pass tool with human verification) re-screens all R1 records.
-2. Compute Cohen's kappa at title/abstract stage; report in Methods.
-3. Tag each record's `round2_tag` as INCLUDE / EXCLUDE / MAYBE based on R1+R2 agreement (MAYBE = disagreement OR either reviewer flagged uncertain).
-4. Output: `round2_{date}.tsv` (adds `round2_tag`, `round2_reason` columns).
+**3b. Round 2 — dual independent title/abstract screening.** A second independent reviewer (or AI
+as a *documented* second-pass tool with human verification) re-screens all R1 records. Compute
+Cohen's κ and report it in Methods. `round2_tag` = INCLUDE / EXCLUDE / MAYBE, where MAYBE means
+disagreement **or** either reviewer flagged uncertainty → `round2_tag`, `round2_reason` columns.
 
-#### 3c. Round 3 — Adjudication of Disagreements (first reviewer)
-1. Build R3 sheet: all MAYBE records first, followed by INCLUDE records (which receive a brief confirmation pass).
-2. The **first reviewer** independently adjudicates each row, recording `round3_decision` (INCLUDE/EXCLUDE) and `round3_reason` (only when overturning R2).
-3. **Optional AI-assisted pre-screening** to compress R3 effort:
-   - Use `references/ai_pre_screening_template.py` (customize per project).
-   - Pre-screen produces `ai_suggestion` (INCLUDE/EXCLUDE/UNCERTAIN/CONFIRM-INCLUDE) + `ai_reason` columns.
-   - Sort priority: UNCERTAIN → EXCLUDE → INCLUDE → CONFIRM-INCLUDE.
-   - First reviewer must independently confirm or overturn every AI suggestion against the title, abstract, and (when needed) full text. AI suggestions are **not** final decisions.
-   - Methods boilerplate: "Round 3 adjudication was performed by the first reviewer with AI-assisted pre-screening ({model name and version}). The AI was prompted with the prespecified PECOS criteria and produced a suggestion plus brief justification for each record; the first reviewer independently confirmed or overturned every suggestion. AI suggestions were not used as final inclusion decisions."
-4. Output: `round3_{date}.tsv` with finalized `round3_decision`.
+**3c. Round 3 — adjudication of disagreements (first reviewer).** Build the R3 sheet with all MAYBE
+records first, then INCLUDE records for a brief confirmation pass. The first reviewer independently
+adjudicates each row (`round3_decision`, plus `round3_reason` only when overturning R2). Optional
+AI-assisted pre-screening can compress the effort — but **AI suggestions are not decisions**: the
+reviewer independently confirms or overturns every one. Template, sort priority, and the required
+Methods boilerplate are in the reference file.
 
-#### 3d. Round 4 — Full-text Screening
-1. For records with `round3_decision = INCLUDE`, retrieve full-text PDFs (use `/fulltext-retrieval`).
-2. Apply full-text exclusion criteria (F1=No extractable outcome, F2=No comparative data, F3=Cannot separate target population data, F4=Inadequate sample/follow-up, F5=Full-text unavailable).
-3. Two independent reviewers; compute Cohen's kappa at full-text stage.
-4. Resolve disagreements by consensus or third reviewer.
-5. Flag comparative studies for priority extraction.
+**3d. Round 4 — full-text screening.** Retrieve full texts for `round3_decision = INCLUDE` (use
+`/fulltext-retrieval`), apply the full-text exclusion codes (F1=No extractable outcome, F2=No
+comparative data, F3=Cannot separate target population, F4=Inadequate sample/follow-up,
+F5=Full-text unavailable), with two independent reviewers, Cohen's κ, and consensus or a third
+reviewer for disagreements. Flag comparative studies for priority extraction.
 
-#### 3e. PRISMA Flow
-Track numbers at each stage for PRISMA flow diagram (R1 → R2 → R3 → R4 → final included).
-Use `/make-figures` to generate PRISMA flow diagram when numbers are finalized.
+**3e. PRISMA flow.** Track counts at every stage (R1 → R2 → R3 → R4 → final included); generate the
+diagram with `/make-figures` once the numbers are final.
 
-#### 3f. Post-Consensus Count Reconciliation Gate (MANDATORY before Phase 5 write-up)
-
-Before handing the screening artifacts to Phase 5 (statistical synthesis) or to `/write-paper` / `/self-review`, run an explicit ID-set reconciliation and record the canonical totals in a single source-of-truth file (typically `2_Screening/screening_consensus.md` §Net Impact or equivalent):
-
-Use the deterministic helper when TSV/CSV artifacts are available:
+**3f. Post-consensus count reconciliation gate (MANDATORY before Phase 5 write-up).** Reconcile the
+counts from the **raw ID sets, never from prose summaries**, and record the canonical totals in one
+source-of-truth file:
 
 ```bash
 python "${CLAUDE_SKILL_DIR}/scripts/screening_reconcile.py" \
@@ -196,265 +185,119 @@ python "${CLAUDE_SKILL_DIR}/scripts/screening_reconcile.py" \
   --output 2_Screening/screening_consensus.json
 ```
 
-Downstream stages should consume `screening_consensus.json` for counts and
-ID sets. The Markdown consensus document remains the human explanation.
+Downstream stages consume `screening_consensus.json` for counts and ID sets; the Markdown consensus
+document remains the human explanation. Two hard rules:
 
-1. **Enumerate ID sets from raw artifacts (not from prose summaries):**
-   - A = screening TSV INCLUDE IDs
-   - B = consensus spreadsheet Exclude IDs
-   - C = consensus spreadsheet Include-qualitative IDs (FLAG-resolved additions)
-   - T = Table 1 / bivariate-eligible IDs (2×2-extractable studies)
+1. **List the narrative-only IDs explicitly.** The highest-yield red flag is a numeric claim ("10
+   narrative-only studies") that does not match the enumerable set `(A ∪ C) \ B \ T`.
+2. **No "N → M" transition without ID receipts.** "k rose from 30 to 32 after FLAG consensus" must
+   cite the added/removed IDs. A transition claim with no enumerable ID set is a **P0** and blocks
+   the Phase 5 hand-off.
 
-2. **Compute canonical totals via set algebra:**
-   - k_qualitative = |A \ B| + |C|
-   - k_bivariate = |T|
-   - k_narrative-only = k_qualitative − k_bivariate
-   - k_FT-excluded = |full-text reviewed| − k_qualitative
+The set algebra, the reconciliation-table template, and the precedent (a manuscript shipped 32/10/46
+where the ID sets said 24/2/54, with four artifacts echoing the same unreconciled prose total) are
+in the reference file.
 
-3. **List the narrative-only IDs explicitly.** The highest-yield red flag is a numeric claim ("10 narrative-only studies") that does not match the enumerable ID set (A ∪ C) \ B \ T.
+**3f.5 Pool composition lock (MANDATORY at adjudication freeze).** Once 3f passes, freeze the pool
+into a single source-of-truth YAML that every downstream artifact can be checked against:
 
-4. **Prohibit "N → M" transitions without ID receipts.** Any sentence of the form "k rose from 30 to 32 after FLAG consensus" must cite the specific added/removed IDs. A transition claim with no enumerable ID set is a P0 error and blocks the Phase 5 hand-off.
+```bash
+cp "${CLAUDE_SKILL_DIR}/templates/FINAL_POOL_LOCK.yaml.template" 2_Data/FINAL_POOL_LOCK.yaml
+# fill counts + UID lists from 3f, compute the SHA-256 over the sorted UID list,
+# and COMMIT THE LOCK before any Phase 4 extraction
+```
 
-5. **Record in a reconciliation table** inside the screening-consensus document:
+- **Never re-derive `k included` from the extraction TSV at manuscript build time** — always
+  reference `final_pool_n` from the lock.
+- **Aggregate patient/lesion totals are locked too**, not just study counts. Distinguish
+  **arm-separable** from **both-arm** rows: a study contributing one arm must not have its
+  full-cohort count folded into a pooled total. A hand-carried headline total that does not
+  re-derive from the locked per-study values is a **P0**.
+- A late post-freeze change to the pool is a **formal PROSPERO amendment**: file it, re-freeze as
+  `FINAL_POOL_LOCK_v2.yaml`, and propagate to every artifact.
 
-   | Quantity | v_prev draft | v_current (ID-verified) | Derivation |
-   |---|---|---|---|
-   | k_full-text | ... | ... | ... |
-   | k_FT-excluded | ... | ... | |TSV EXCLUDE| + |consensus-downgrades| |
-   | k_qualitative | ... | ... | |A \ B| + |C| |
-   | k_bivariate | ... | ... | |T| |
-   | k_narrative-only | ... | ... (explicit IDs listed) | (A ∪ C) \ B \ T |
+**Read on demand:**
 
-**Precedent incident (a PRISMA-DTA meta-analysis revision):** a late-revision manuscript shipped with k_qualitative = 32 / k_narrative-only = 10 / k_FT-excluded = 46. ID-set reconciliation (performed only after an adversarial audit at post-Stage 4 QC) revealed true counts 24/2/54. An early-draft prose total ("30 → 32 after FLAG consensus") had been carried forward without ever being reconciled against the screening TSV intersected with the consensus spreadsheet; four downstream artifacts echoed the same wrong total. This gate would have caught the drift at the Phase 5 hand-off.
-
-#### 3f.5 Pool composition lock (MANDATORY at adjudication freeze)
-
-After Phase 3f reconciliation passes, freeze the pool composition into a
-single source-of-truth YAML so every downstream artifact (extraction TSV,
-manuscript prose counts, PRISMA flow caption, supplementary INDEX, cover
-letter free-text) can be checked against it.
-
-Why this lock exists
-^^^^^^^^^^^^^^^^^^^^
-
-Cross-project precedent (anonymized): an LLM reporting-quality SR carried
-five documents that disagreed on INCLUDE (63 vs 64) and EXCLUDE
-(108/109/111). Three EXCLUDE rows existed in the extraction sheet without
-matching INCLUDE. The drift traced to a late round-3 adjudication whose
-result was applied to some artifacts and not others — there was no single
-canonical post-freeze count to reference.
-
-How to lock
-^^^^^^^^^^^
-
-1. Copy the template:
-   ```bash
-   cp "${CLAUDE_SKILL_DIR}/templates/FINAL_POOL_LOCK.yaml.template" \
-       2_Data/FINAL_POOL_LOCK.yaml
-   ```
-2. Fill in counts and UID lists from the reconciliation in Phase 3f.
-3. Compute the SHA-256 integrity hash from the sorted UID list.
-4. Commit the lock to git BEFORE starting Phase 4 extraction.
-
-Downstream gates
-^^^^^^^^^^^^^^^^
-
-- `/meta-analysis` Phase 4 entry: extraction TSV's UID set MUST equal
-  `include_uids` ∪ `mixed_uids` from the lock. See Phase 4 entry gate.
-- `/sync-submission` Phase 5
-  (`scripts/cross_document_n_check.py --pool-lock`): every numeric claim
-  in manuscript / abstract / supplementary that maps to a locked
-  category must match the locked value.
-- Manuscript prose: NEVER re-derive `k included` from extraction TSV at
-  manuscript build time. Always reference `final_pool_n` from the lock.
-- **Aggregate patient/lesion totals are locked too, not just study counts.**
-  The Abstract/Results aggregate denominators ("a total of 483 patients /
-  531 lesions") are derived from the lock, never hand-carried. Lock them as
-  explicit fields and distinguish **arm-separable** from **both-arm** rows:
-  a study contributing one arm to a comparison must not have its full-cohort
-  patient count folded into a pooled total. A hand-carried headline total that
-  does not re-derive from the locked per-study values is a P0 (the analysis-side
-  mirror of `/self-review` `check_cohort_arithmetic.py` partition checks).
-
-If a late post-freeze decision changes the pool, treat it as a formal
-PROSPERO amendment: file the amendment, re-freeze the lock as a new
-file (`FINAL_POOL_LOCK_v2.yaml`), and propagate to every artifact.
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phase3_screening_detail.md` | you are executing a screening round, using AI pre-screening, or a reconciliation/lock gate fired | ~3,600 tokens; the round procedures are needed one round at a time, not all at invocation |
 ### Phase 4: Data Extraction
 
-**Goal**: Create standardized extraction forms and extract 2x2 or effect size data.
+**Goal**: Create standardized extraction forms and extract 2x2 or effect-size data.
 
-#### 4.0 Entry gate (MANDATORY): pool composition lock ↔ adjudication TSV
-
-Before any extraction work begins, run the deterministic UID-set check
-to confirm that the round-3 adjudication TSV and `FINAL_POOL_LOCK.yaml`
-(produced in Phase 3f.5) agree on which UIDs are included.
+**4.0 Entry gate (MANDATORY) — pool composition lock ↔ adjudication TSV.** Before any extraction
+work begins, confirm the round-3 adjudication TSV and `FINAL_POOL_LOCK.yaml` (Phase 3f.5) agree on
+which UIDs are included:
 
 ```bash
 python "${CLAUDE_SKILL_DIR}/scripts/check_pool_consistency.py" \
     --lock 2_Data/FINAL_POOL_LOCK.yaml \
     --adjudication-tsv 2_Screening/round3_adjudication.tsv \
-    --decision-col round3_decision \
-    --uid-col uid \
+    --decision-col round3_decision --uid-col uid \
     --include-labels "INCLUDE,INCLUDE_MIXED" \
     --out qc/pool_consistency.json
 ```
 
-Output `qc/pool_consistency.json`:
+**The gate fails closed: any UID disagreement blocks extraction.** Resolve by re-freezing the lock
+with the corrected UID set (and propagating downstream) or by correcting a mis-labelled TSV row. Do
+NOT proceed with a mismatch — the extraction matrix will not align with the locked pool, and the
+drift surfaces as a fabrication-grade red flag at peer review.
 
-```json
-{
-  "submission_safe": false,
-  "match": false,
-  "lock_include_n": 42,
-  "tsv_include_n": 43,
-  "in_lock_not_tsv": ["UID_007"],
-  "in_tsv_not_lock": ["UID_055"]
-}
-```
+> **Failure-mode cross-ref** → `references/data_integrity_checklist.md` DI-1~DI-5 are mandatory
+> during extraction (2x2 arm-swap, KM audit trail, methodology mismatch, PRISMA 5-way drift,
+> single-source k).
 
-The gate fails closed: any UID disagreement blocks extraction. To
-resolve, either (a) re-freeze the lock with the corrected set of UIDs
-and propagate to downstream artifacts, or (b) correct the adjudication
-TSV if a row was mis-labeled. Do NOT proceed to Phase 4 with a
-mismatch — the resulting extraction matrix will not align with the
-locked pool, and the drift surfaces as a fabrication-grade red flag at
-peer review.
+**Extraction form.** For an SR-MA targeting high-impact radiology / medical AI journals use
+`${CLAUDE_SKILL_DIR}/templates/extraction_form_v2.md` — its dual-extractor, source-page-reference,
+and verbatim-quote columns are what close the 2x2 cell-swap and cohort-overlap blind spots. The
+DTA and intervention field lists are in the reference file.
 
+**AI-drafted starting document — treat as hallucination-suspect.** If a mentor or collaborator
+shared an AI-drafted study list, 2x2 set, or effect estimates (*even* flagged "for reference
+only"): save it with a `_DO_NOT_USE_VERBATIM` suffix and re-verify **every** N, denominator, event
+count, OR/CI, and author/year against the source PDF. Trust hierarchy: **source PDF + own analysis
+stdout > the mentor's direct text > the attached AI draft** — never promote a draft up that ladder.
+Procedure and precedent: reference file.
 
-> **Failure-mode cross-ref** → `references/data_integrity_checklist.md` DI-1~DI-5 are mandatory during extraction (2x2 arm-swap, KM audit trail, methodology mismatch, PRISMA 5-way drift, single-source k).
+**4b. Special cases (KM reconstruction, composite exposure).** When studies report outcomes only as
+Kaplan-Meier curves, or the intervention is a composite of techniques, load
+`${CLAUDE_SKILL_DIR}/references/phase4_km_composite.md` for the WebPlotDigitizer → `IPDfromKM`
+procedure (cite Guyot et al. 2012, doi:10.1186/1471-2288-12-9) and the 4-path composite-exposure
+decision tree. Pre-specify a sensitivity analysis excluding composite-exposure studies.
 
-**Recommended extraction form**: For SR-MA targeting high-impact radiology / medical AI journals, use `${CLAUDE_SKILL_DIR}/templates/extraction_form_v2.md`. Dual-extractor + source-page-reference + verbatim-quote columns prevent the 2x2 cell-swap and cohort-overlap blind spots surfaced in recent SR-MA peer-review cycles. New required columns: `cohort_source`, `source_page_ref`, `source_verbatim_quote`, `extraction_consensus_status`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool`.
+**Cross-verification (≥2 independent reviewers).** Report inter-reviewer agreement (% or Cohen's
+κ) at title/abstract and full-text stages. Verify denominator consistency — **the denominator may
+differ across outcomes within one study**, so for each outcome back-calculate `event ÷ denominator`
+and confirm it reproduces the paper's reported percentage. Distinguish KM-curve estimates from raw
+event counts and record the data source (Table / KM / text). Log every consensus decision in
+`{project}/consensus_log.md`, then **lock the dataset**; later changes need a dated justification.
 
-#### 4.0 AI-drafted starting document gate
-
-Before opening the extraction form: if a senior mentor or collaborator has shared an AI-drafted starting document (Claude / ChatGPT / Gemini draft of the study list, 2x2 cells, or effect estimates) — even when the sender flags it as "for reference only" — apply `~/.claude/rules/ai-drafted-document-policy.md`:
-
-- Save the file with a `_DO_NOT_USE_VERBATIM` (or `_AI_DRAFT_REFERENCE_ONLY`) filename suffix.
-- Treat every per-study N, denominator, event count, OR/CI, and author/year as **hallucination-suspect** until re-verified against the source PDF + own analysis script. AI-drafts collapse multiple denominator definitions (treatment-naïve / full-cohort / per-arm) into one and silently mis-route counts.
-- Record any reconciled discrepancy in `extraction_consensus_log.md` with a verbatim quote of the AI-draft value and the corrected value with PDF page coordinate.
-- Trust hierarchy for this phase: **SSOT (source PDF + own analysis stdout) > mentor's direct text (email / track-changes) > attached AI-draft**. Do not promote an AI-draft from tier 3 to tier 2.
-
-Precedent (an active meta-analysis project): Ishikawa 2017 "treatment support 5/70 vs no support 12/33" in Claude-drafted directive → source PDF was 35/68 (single arm). Verbatim absorption would have produced a denominator-hallucinated meta-analysis.
-
-#### 4.0.1 AI-assisted extraction suggestions (optional, suggestions not decisions)
-
-To scaffold (not replace) manual extraction from a full-text paper, use the
-deterministic helper `scripts/extract_assist.py`. It scans a Markdown full text
-(e.g. `/fulltext-retrieval`'s PDF→MD output) for schema-defined fields and emits
-**candidate values, each with a `source_page_ref` and a verbatim source quote** —
-the extraction-stage analog of the screening-stage `ai_pre_screening_template.py`.
+**4c. Extraction QC & cohort overlap.** After dual-extractor consensus, run both before locking:
 
 ```bash
-python3 scripts/extract_assist.py \
-  --md paper.md --schema schema.yaml --study-id StudyA_2021 --out suggestions.tsv
-```
-
-- **Suggestions, never decisions.** Every row is `extraction_consensus_status =
-  AI_SUGGESTED` and `needs_review = true`. The tool invents nothing — values and
-  quotes are copied literally from the text; absent fields become explicit
-  `not_found` rows; unit-ambiguous values (e.g. `92%` vs `0.92`) are emitted as
-  multiple candidates side by side so the reviewer reconciles them.
-- **Human confirmation is mandatory.** Apply the 4.0 gate: treat every candidate
-  N / denominator / 2x2 cell / effect estimate as hallucination-suspect until
-  confirmed against the source PDF, recording reconciliations in
-  `extraction_consensus_log.md`. Confirm or overturn each suggestion into the
-  `extraction_form_v2.md` columns.
-- **Then, and only then, QC.** Build the confirmed DTA CSV and run
-  `dta_extraction_qc.py` on **that** table — never on the suggestion TSV.
-  Passing QC is not extract-assist's acceptance criterion; per-cell human
-  confirmation is.
-
-A deterministic, network-free challenge card demonstrating the full
-suggestions → confirm → QC pipeline lives in
-`scripts/extract_assist_challenge/` (synthetic paper + schema + expected output
-+ `verify.sh`).
-
-#### DTA Meta-Analysis:
-Generate a data extraction form with:
-- Study ID (first author, year)
-- Study characteristics (country, design, setting, enrollment period)
-- Population (n, age, sex, disease prevalence)
-- Index test details (technique, threshold, manufacturer, reader experience)
-- Reference standard details
-- 2x2 table (TP, FP, FN, TN)
-- Additional outcomes (AUC per study, if reported)
-- Notes on partial verification, differential verification, uninterpretable results
-
-#### Intervention Meta-Analysis:
-Generate a data extraction form with:
-- Study ID
-- Study characteristics
-- Population
-- Intervention / comparator details
-- Outcome data (means, SDs, event counts, sample sizes)
-- Effect measures (OR, RR, HR, MD, SMD as appropriate)
-
-Output: Excel/CSV template for data entry.
-
-#### 4b. Special cases (KM reconstruction, composite exposure)
-
-When studies report outcomes only as Kaplan-Meier curves (no raw event counts) or
-when the intervention is a composite of multiple techniques, load
-`${CLAUDE_SKILL_DIR}/references/phase4_km_composite.md` for the WebPlotDigitizer
-→ `IPDfromKM` reconstruction procedure (cite Guyot et al. 2012,
-doi:10.1186/1471-2288-12-9) and the 4-path composite-exposure disaggregation
-decision tree. Pre-specify a sensitivity analysis excluding composite-exposure
-studies and document extraction strategy in the form's Notes column.
-
-#### Data Extraction Cross-Verification
-
-When comparing extraction results between independent reviewers (minimum 2), check:
-
-0. **Inter-reviewer agreement**: Calculate and report screening agreement: % agreement or Cohen's kappa at title/abstract and full-text stages. If kappa was not calculated, report the exact number of discrepant records and the resolution method.
-
-1. **Denominator consistency**: Verify sample sizes match between reviewers.
-   Watch for per-patient vs per-lesion/per-tumor unit confusion.
-   **CRITICAL**: The denominator may differ across outcomes within the same study
-   (e.g., LTP assessed only among treatment-naive nodules, but complications assessed
-   among all treated tumors). For each outcome, back-calculate: `event ÷ denominator`
-   must equal the percentage reported in the paper's Tables. If it does not match,
-   investigate the analysis population definition in the Methods section.
-   If denominators differ, return to the original paper's Tables/Flow diagram.
-2. **Arithmetic verification**: Back-calculate proportions from event/total counts and cross-check against original text (e.g., 78/91 = 85.7%).
-3. **Kaplan-Meier estimate distinction**: KM curve estimates differ from raw event counts. Always record the data source (Table vs KM curve vs text) during extraction.
-4. **Discrepancy resolution**: List all discrepancies → verify against original text → reach consensus → if consensus fails, use third reviewer. Log all consensus decisions in `{project}/consensus_log.md`.
-5. **Dataset lock**: After resolving all discrepancies, lock the final dataset. Any subsequent changes require documented justification with date.
-
-#### Phase 4c: Extraction QC & Cohort Overlap Detection
-
-After dual-extractor consensus, run two QC scripts before locking the extraction table for statistical synthesis.
-
-**1. 2x2 Cell Integrity Check** -- `scripts/dta_extraction_qc.py`:
-
-Validates manuscript forest-plot cells (TP / FN / TN / FP) against source-paper-reported sens/spec within a tolerance (default 0.02). Catches sens/spec swap at extraction stage -- a common error pattern where a single-study k=1 subgroup outlier flips conclusions due to cell-assignment swap.
-
-```bash
+# 2x2 cell integrity: validates TP/FN/TN/FP against source-reported sens/spec (catches arm-swap)
 python3 "${CLAUDE_SKILL_DIR}/scripts/dta_extraction_qc.py" \
-  --input 2_Extraction/extraction.csv \
-  --tolerance 0.02 \
+  --input 2_Extraction/extraction.csv --tolerance 0.02 \
   --out 2_Extraction/qc/dta_extraction_qc.tsv
-```
 
-Any `FLAG_SWAP` or `FLAG_MISMATCH` row requires third-reviewer adjudication before Phase 6 statistical synthesis.
-
-**Flag → form-edit forced transition.** A confirmed flag is not resolved until the extraction form itself is edited. Track each flag through `confirmed → acted`: after the adjudicator confirms a `FLAG_SWAP`/`FLAG_MISMATCH`/unit-of-analysis violation, the extraction CSV row MUST be corrected and the QC re-run to clear it. A flag that is "confirmed" but whose form row is unchanged (the correction lived only in a review note) silently re-enters synthesis. Verify the form's mtime advanced and the re-run QC shows zero open flags before locking.
-
-**2. Cohort Overlap Check** -- `scripts/cohort_overlap_check.py`:
-
-Clusters included studies by (a) shared public ICU/EHR database (MIMIC-IV, eICU, MIMIC-III, KNHIS, UK Biobank, Optum, MarketScan, TriNetX, IBM), (b) same institution + overlapping enrollment period, (c) shared first-author surname + ±2y year proximity. Flags HIGH / MEDIUM overlap confidence.
-
-```bash
+# cohort overlap: shared public DB / same institution+period / same first author ±2y
 python3 "${CLAUDE_SKILL_DIR}/scripts/cohort_overlap_check.py" \
-  --input 2_Extraction/studies.csv \
-  --enrich \
+  --input 2_Extraction/studies.csv --enrich \
   --out 2_Extraction/qc/cohort_overlap.md
 ```
 
-HIGH-confidence overlap pairs require Limitations acknowledgment + sensitivity analysis excluding one of the pair.
+Any `FLAG_SWAP` / `FLAG_MISMATCH` requires third-reviewer adjudication before Phase 6. **A
+confirmed flag is not resolved until the extraction form itself is edited** — a flag corrected only
+in a review note silently re-enters synthesis, so re-run the QC and confirm zero open flags before
+locking. HIGH-confidence overlap pairs require a Limitations acknowledgment plus a sensitivity
+analysis excluding one of the pair. Cross-links: `/peer-review` Phase 2A P1 + P2.
 
-Cross-links: `/peer-review` Phase 2A P1 (cell integrity) + P2 (cohort overlap).
+**Read on demand:**
 
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phase4_extraction_detail.md` | building the extraction form, an AI draft was shared, you want the optional `extract_assist.py` scaffolding, or a QC flag fired | ~4,700 tokens; a clean dual-extraction with no AI draft needs none of it |
+| `references/phase4_km_composite.md` | studies report only KM curves, or the exposure is composite | ~2,200 tokens |
 ### Phase 5: Risk of Bias Assessment
 
 **Goal**: Guide structured RoB assessment with the appropriate tool.

--- a/skills/meta-analysis/references/phase3_screening_detail.md
+++ b/skills/meta-analysis/references/phase3_screening_detail.md
@@ -1,0 +1,148 @@
+# Phase 3 — Screening & Selection: round procedures and gate detail
+
+Load-on-demand companion to `/meta-analysis` Phase 3. SKILL.md keeps the four screening
+rounds, the two MANDATORY gates (3f reconciliation, 3f.5 pool lock), and their hard rules;
+this file carries the detail.
+
+Read the block you need:
+
+- **Rounds 3a–3d** — exclusion-code sets, the AI-assisted pre-screening template and its
+  Methods boilerplate, the full-text exclusion codes.
+- **3f reconciliation** — the ID-set algebra, the reconciliation-table template, and the
+  precedent incident where four downstream artifacts echoed one unreconciled prose total.
+- **3f.5 pool lock** — why the lock exists, how to build it, and every downstream gate that
+  reads it.
+
+**Goal**: Systematic title/abstract and full-text screening with two independent reviewers.
+
+#### 3a. Round 1 — Initial Title/Abstract Screening (single reviewer)
+1. Define exclusion codes from protocol (e.g., E1=Not target population, E2=Not intervention, E3=Ineligible type, E4=Non-human, E5=Duplicate).
+2. For each record, screen title+abstract against eligibility criteria.
+3. Mark each record as INCLUDE / EXCLUDE / MAYBE with reason code.
+4. Output: `round1_{date}.tsv` with color-coded decisions.
+
+#### 3b. Round 2 — Dual Independent Title/Abstract Screening
+1. A second independent reviewer (or AI as a documented second-pass tool with human verification) re-screens all R1 records.
+2. Compute Cohen's kappa at title/abstract stage; report in Methods.
+3. Tag each record's `round2_tag` as INCLUDE / EXCLUDE / MAYBE based on R1+R2 agreement (MAYBE = disagreement OR either reviewer flagged uncertain).
+4. Output: `round2_{date}.tsv` (adds `round2_tag`, `round2_reason` columns).
+
+#### 3c. Round 3 — Adjudication of Disagreements (first reviewer)
+1. Build R3 sheet: all MAYBE records first, followed by INCLUDE records (which receive a brief confirmation pass).
+2. The **first reviewer** independently adjudicates each row, recording `round3_decision` (INCLUDE/EXCLUDE) and `round3_reason` (only when overturning R2).
+3. **Optional AI-assisted pre-screening** to compress R3 effort:
+   - Use `references/ai_pre_screening_template.py` (customize per project).
+   - Pre-screen produces `ai_suggestion` (INCLUDE/EXCLUDE/UNCERTAIN/CONFIRM-INCLUDE) + `ai_reason` columns.
+   - Sort priority: UNCERTAIN → EXCLUDE → INCLUDE → CONFIRM-INCLUDE.
+   - First reviewer must independently confirm or overturn every AI suggestion against the title, abstract, and (when needed) full text. AI suggestions are **not** final decisions.
+   - Methods boilerplate: "Round 3 adjudication was performed by the first reviewer with AI-assisted pre-screening ({model name and version}). The AI was prompted with the prespecified PECOS criteria and produced a suggestion plus brief justification for each record; the first reviewer independently confirmed or overturned every suggestion. AI suggestions were not used as final inclusion decisions."
+4. Output: `round3_{date}.tsv` with finalized `round3_decision`.
+
+#### 3d. Round 4 — Full-text Screening
+1. For records with `round3_decision = INCLUDE`, retrieve full-text PDFs (use `/fulltext-retrieval`).
+2. Apply full-text exclusion criteria (F1=No extractable outcome, F2=No comparative data, F3=Cannot separate target population data, F4=Inadequate sample/follow-up, F5=Full-text unavailable).
+3. Two independent reviewers; compute Cohen's kappa at full-text stage.
+4. Resolve disagreements by consensus or third reviewer.
+5. Flag comparative studies for priority extraction.
+
+#### 3e. PRISMA Flow
+Track numbers at each stage for PRISMA flow diagram (R1 → R2 → R3 → R4 → final included).
+Use `/make-figures` to generate PRISMA flow diagram when numbers are finalized.
+
+#### 3f. Post-Consensus Count Reconciliation Gate (MANDATORY before Phase 5 write-up)
+
+Before handing the screening artifacts to Phase 5 (statistical synthesis) or to `/write-paper` / `/self-review`, run an explicit ID-set reconciliation and record the canonical totals in a single source-of-truth file (typically `2_Screening/screening_consensus.md` §Net Impact or equivalent):
+
+Use the deterministic helper when TSV/CSV artifacts are available:
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/screening_reconcile.py" \
+  --screening 2_Screening/fulltext_screening.tsv \
+  --consensus 2_Screening/consensus_decisions.tsv \
+  --table1 6_Tables/table1_studies.csv \
+  --output 2_Screening/screening_consensus.json
+```
+
+Downstream stages should consume `screening_consensus.json` for counts and
+ID sets. The Markdown consensus document remains the human explanation.
+
+1. **Enumerate ID sets from raw artifacts (not from prose summaries):**
+   - A = screening TSV INCLUDE IDs
+   - B = consensus spreadsheet Exclude IDs
+   - C = consensus spreadsheet Include-qualitative IDs (FLAG-resolved additions)
+   - T = Table 1 / bivariate-eligible IDs (2×2-extractable studies)
+
+2. **Compute canonical totals via set algebra:**
+   - k_qualitative = |A \ B| + |C|
+   - k_bivariate = |T|
+   - k_narrative-only = k_qualitative − k_bivariate
+   - k_FT-excluded = |full-text reviewed| − k_qualitative
+
+3. **List the narrative-only IDs explicitly.** The highest-yield red flag is a numeric claim ("10 narrative-only studies") that does not match the enumerable ID set (A ∪ C) \ B \ T.
+
+4. **Prohibit "N → M" transitions without ID receipts.** Any sentence of the form "k rose from 30 to 32 after FLAG consensus" must cite the specific added/removed IDs. A transition claim with no enumerable ID set is a P0 error and blocks the Phase 5 hand-off.
+
+5. **Record in a reconciliation table** inside the screening-consensus document:
+
+   | Quantity | v_prev draft | v_current (ID-verified) | Derivation |
+   |---|---|---|---|
+   | k_full-text | ... | ... | ... |
+   | k_FT-excluded | ... | ... | |TSV EXCLUDE| + |consensus-downgrades| |
+   | k_qualitative | ... | ... | |A \ B| + |C| |
+   | k_bivariate | ... | ... | |T| |
+   | k_narrative-only | ... | ... (explicit IDs listed) | (A ∪ C) \ B \ T |
+
+**Precedent incident (a PRISMA-DTA meta-analysis revision):** a late-revision manuscript shipped with k_qualitative = 32 / k_narrative-only = 10 / k_FT-excluded = 46. ID-set reconciliation (performed only after an adversarial audit at post-Stage 4 QC) revealed true counts 24/2/54. An early-draft prose total ("30 → 32 after FLAG consensus") had been carried forward without ever being reconciled against the screening TSV intersected with the consensus spreadsheet; four downstream artifacts echoed the same wrong total. This gate would have caught the drift at the Phase 5 hand-off.
+
+#### 3f.5 Pool composition lock (MANDATORY at adjudication freeze)
+
+After Phase 3f reconciliation passes, freeze the pool composition into a
+single source-of-truth YAML so every downstream artifact (extraction TSV,
+manuscript prose counts, PRISMA flow caption, supplementary INDEX, cover
+letter free-text) can be checked against it.
+
+Why this lock exists
+^^^^^^^^^^^^^^^^^^^^
+
+Cross-project precedent (anonymized): an LLM reporting-quality SR carried
+five documents that disagreed on INCLUDE (63 vs 64) and EXCLUDE
+(108/109/111). Three EXCLUDE rows existed in the extraction sheet without
+matching INCLUDE. The drift traced to a late round-3 adjudication whose
+result was applied to some artifacts and not others — there was no single
+canonical post-freeze count to reference.
+
+How to lock
+^^^^^^^^^^^
+
+1. Copy the template:
+   ```bash
+   cp "${CLAUDE_SKILL_DIR}/templates/FINAL_POOL_LOCK.yaml.template" \
+       2_Data/FINAL_POOL_LOCK.yaml
+   ```
+2. Fill in counts and UID lists from the reconciliation in Phase 3f.
+3. Compute the SHA-256 integrity hash from the sorted UID list.
+4. Commit the lock to git BEFORE starting Phase 4 extraction.
+
+Downstream gates
+^^^^^^^^^^^^^^^^
+
+- `/meta-analysis` Phase 4 entry: extraction TSV's UID set MUST equal
+  `include_uids` ∪ `mixed_uids` from the lock. See Phase 4 entry gate.
+- `/sync-submission` Phase 5
+  (`scripts/cross_document_n_check.py --pool-lock`): every numeric claim
+  in manuscript / abstract / supplementary that maps to a locked
+  category must match the locked value.
+- Manuscript prose: NEVER re-derive `k included` from extraction TSV at
+  manuscript build time. Always reference `final_pool_n` from the lock.
+- **Aggregate patient/lesion totals are locked too, not just study counts.**
+  The Abstract/Results aggregate denominators ("a total of 483 patients /
+  531 lesions") are derived from the lock, never hand-carried. Lock them as
+  explicit fields and distinguish **arm-separable** from **both-arm** rows:
+  a study contributing one arm to a comparison must not have its full-cohort
+  patient count folded into a pooled total. A hand-carried headline total that
+  does not re-derive from the locked per-study values is a P0 (the analysis-side
+  mirror of `/self-review` `check_cohort_arithmetic.py` partition checks).
+
+If a late post-freeze decision changes the pool, treat it as a formal
+PROSPERO amendment: file the amendment, re-freeze the lock as a new
+file (`FINAL_POOL_LOCK_v2.yaml`), and propagate to every artifact.

--- a/skills/meta-analysis/references/phase4_extraction_detail.md
+++ b/skills/meta-analysis/references/phase4_extraction_detail.md
@@ -1,0 +1,189 @@
+# Phase 4 — Data Extraction: gate detail and extraction forms
+
+Load-on-demand companion to `/meta-analysis` Phase 4. SKILL.md keeps the mandatory
+entry gate, the two QC commands, and the fail-closed rules; this file carries the
+detail behind them.
+
+Read the block you need:
+
+- **AI-drafted starting document gate** — only when a mentor/collaborator has shared an
+  AI-drafted study list, 2x2 set, or effect estimates.
+- **AI-assisted extraction suggestions** (`extract_assist.py`) — optional scaffolding;
+  suggestions, never decisions.
+- **Extraction form fields** — the DTA and intervention field lists.
+- **Cross-verification** — the six dual-reviewer checks, in full.
+- **QC rationale** — what `dta_extraction_qc.py` and `cohort_overlap_check.py` catch, and
+  the flag → form-edit forced transition.
+
+**Goal**: Create standardized extraction forms and extract 2x2 or effect size data.
+
+#### 4.0 Entry gate (MANDATORY): pool composition lock ↔ adjudication TSV
+
+Before any extraction work begins, run the deterministic UID-set check
+to confirm that the round-3 adjudication TSV and `FINAL_POOL_LOCK.yaml`
+(produced in Phase 3f.5) agree on which UIDs are included.
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/check_pool_consistency.py" \
+    --lock 2_Data/FINAL_POOL_LOCK.yaml \
+    --adjudication-tsv 2_Screening/round3_adjudication.tsv \
+    --decision-col round3_decision \
+    --uid-col uid \
+    --include-labels "INCLUDE,INCLUDE_MIXED" \
+    --out qc/pool_consistency.json
+```
+
+Output `qc/pool_consistency.json`:
+
+```json
+{
+  "submission_safe": false,
+  "match": false,
+  "lock_include_n": 42,
+  "tsv_include_n": 43,
+  "in_lock_not_tsv": ["UID_007"],
+  "in_tsv_not_lock": ["UID_055"]
+}
+```
+
+The gate fails closed: any UID disagreement blocks extraction. To
+resolve, either (a) re-freeze the lock with the corrected set of UIDs
+and propagate to downstream artifacts, or (b) correct the adjudication
+TSV if a row was mis-labeled. Do NOT proceed to Phase 4 with a
+mismatch — the resulting extraction matrix will not align with the
+locked pool, and the drift surfaces as a fabrication-grade red flag at
+peer review.
+
+
+> **Failure-mode cross-ref** → `references/data_integrity_checklist.md` DI-1~DI-5 are mandatory during extraction (2x2 arm-swap, KM audit trail, methodology mismatch, PRISMA 5-way drift, single-source k).
+
+**Recommended extraction form**: For SR-MA targeting high-impact radiology / medical AI journals, use `${CLAUDE_SKILL_DIR}/templates/extraction_form_v2.md`. Dual-extractor + source-page-reference + verbatim-quote columns prevent the 2x2 cell-swap and cohort-overlap blind spots surfaced in recent SR-MA peer-review cycles. New required columns: `cohort_source`, `source_page_ref`, `source_verbatim_quote`, `extraction_consensus_status`, `overlap_flag_reviewer1/2`, `sample_n_dta_pool` vs `sample_n_prognostic_pool`.
+
+#### 4.0 AI-drafted starting document gate
+
+Before opening the extraction form: if a senior mentor or collaborator has shared an AI-drafted starting document (Claude / ChatGPT / Gemini draft of the study list, 2x2 cells, or effect estimates) — even when the sender flags it as "for reference only" — apply `~/.claude/rules/ai-drafted-document-policy.md`:
+
+- Save the file with a `_DO_NOT_USE_VERBATIM` (or `_AI_DRAFT_REFERENCE_ONLY`) filename suffix.
+- Treat every per-study N, denominator, event count, OR/CI, and author/year as **hallucination-suspect** until re-verified against the source PDF + own analysis script. AI-drafts collapse multiple denominator definitions (treatment-naïve / full-cohort / per-arm) into one and silently mis-route counts.
+- Record any reconciled discrepancy in `extraction_consensus_log.md` with a verbatim quote of the AI-draft value and the corrected value with PDF page coordinate.
+- Trust hierarchy for this phase: **SSOT (source PDF + own analysis stdout) > mentor's direct text (email / track-changes) > attached AI-draft**. Do not promote an AI-draft from tier 3 to tier 2.
+
+Precedent (an active meta-analysis project): Ishikawa 2017 "treatment support 5/70 vs no support 12/33" in Claude-drafted directive → source PDF was 35/68 (single arm). Verbatim absorption would have produced a denominator-hallucinated meta-analysis.
+
+#### 4.0.1 AI-assisted extraction suggestions (optional, suggestions not decisions)
+
+To scaffold (not replace) manual extraction from a full-text paper, use the
+deterministic helper `scripts/extract_assist.py`. It scans a Markdown full text
+(e.g. `/fulltext-retrieval`'s PDF→MD output) for schema-defined fields and emits
+**candidate values, each with a `source_page_ref` and a verbatim source quote** —
+the extraction-stage analog of the screening-stage `ai_pre_screening_template.py`.
+
+```bash
+python3 scripts/extract_assist.py \
+  --md paper.md --schema schema.yaml --study-id StudyA_2021 --out suggestions.tsv
+```
+
+- **Suggestions, never decisions.** Every row is `extraction_consensus_status =
+  AI_SUGGESTED` and `needs_review = true`. The tool invents nothing — values and
+  quotes are copied literally from the text; absent fields become explicit
+  `not_found` rows; unit-ambiguous values (e.g. `92%` vs `0.92`) are emitted as
+  multiple candidates side by side so the reviewer reconciles them.
+- **Human confirmation is mandatory.** Apply the 4.0 gate: treat every candidate
+  N / denominator / 2x2 cell / effect estimate as hallucination-suspect until
+  confirmed against the source PDF, recording reconciliations in
+  `extraction_consensus_log.md`. Confirm or overturn each suggestion into the
+  `extraction_form_v2.md` columns.
+- **Then, and only then, QC.** Build the confirmed DTA CSV and run
+  `dta_extraction_qc.py` on **that** table — never on the suggestion TSV.
+  Passing QC is not extract-assist's acceptance criterion; per-cell human
+  confirmation is.
+
+A deterministic, network-free challenge card demonstrating the full
+suggestions → confirm → QC pipeline lives in
+`scripts/extract_assist_challenge/` (synthetic paper + schema + expected output
++ `verify.sh`).
+
+#### DTA Meta-Analysis:
+Generate a data extraction form with:
+- Study ID (first author, year)
+- Study characteristics (country, design, setting, enrollment period)
+- Population (n, age, sex, disease prevalence)
+- Index test details (technique, threshold, manufacturer, reader experience)
+- Reference standard details
+- 2x2 table (TP, FP, FN, TN)
+- Additional outcomes (AUC per study, if reported)
+- Notes on partial verification, differential verification, uninterpretable results
+
+#### Intervention Meta-Analysis:
+Generate a data extraction form with:
+- Study ID
+- Study characteristics
+- Population
+- Intervention / comparator details
+- Outcome data (means, SDs, event counts, sample sizes)
+- Effect measures (OR, RR, HR, MD, SMD as appropriate)
+
+Output: Excel/CSV template for data entry.
+
+#### 4b. Special cases (KM reconstruction, composite exposure)
+
+When studies report outcomes only as Kaplan-Meier curves (no raw event counts) or
+when the intervention is a composite of multiple techniques, load
+`${CLAUDE_SKILL_DIR}/references/phase4_km_composite.md` for the WebPlotDigitizer
+→ `IPDfromKM` reconstruction procedure (cite Guyot et al. 2012,
+doi:10.1186/1471-2288-12-9) and the 4-path composite-exposure disaggregation
+decision tree. Pre-specify a sensitivity analysis excluding composite-exposure
+studies and document extraction strategy in the form's Notes column.
+
+#### Data Extraction Cross-Verification
+
+When comparing extraction results between independent reviewers (minimum 2), check:
+
+0. **Inter-reviewer agreement**: Calculate and report screening agreement: % agreement or Cohen's kappa at title/abstract and full-text stages. If kappa was not calculated, report the exact number of discrepant records and the resolution method.
+
+1. **Denominator consistency**: Verify sample sizes match between reviewers.
+   Watch for per-patient vs per-lesion/per-tumor unit confusion.
+   **CRITICAL**: The denominator may differ across outcomes within the same study
+   (e.g., LTP assessed only among treatment-naive nodules, but complications assessed
+   among all treated tumors). For each outcome, back-calculate: `event ÷ denominator`
+   must equal the percentage reported in the paper's Tables. If it does not match,
+   investigate the analysis population definition in the Methods section.
+   If denominators differ, return to the original paper's Tables/Flow diagram.
+2. **Arithmetic verification**: Back-calculate proportions from event/total counts and cross-check against original text (e.g., 78/91 = 85.7%).
+3. **Kaplan-Meier estimate distinction**: KM curve estimates differ from raw event counts. Always record the data source (Table vs KM curve vs text) during extraction.
+4. **Discrepancy resolution**: List all discrepancies → verify against original text → reach consensus → if consensus fails, use third reviewer. Log all consensus decisions in `{project}/consensus_log.md`.
+5. **Dataset lock**: After resolving all discrepancies, lock the final dataset. Any subsequent changes require documented justification with date.
+
+#### Phase 4c: Extraction QC & Cohort Overlap Detection
+
+After dual-extractor consensus, run two QC scripts before locking the extraction table for statistical synthesis.
+
+**1. 2x2 Cell Integrity Check** -- `scripts/dta_extraction_qc.py`:
+
+Validates manuscript forest-plot cells (TP / FN / TN / FP) against source-paper-reported sens/spec within a tolerance (default 0.02). Catches sens/spec swap at extraction stage -- a common error pattern where a single-study k=1 subgroup outlier flips conclusions due to cell-assignment swap.
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/dta_extraction_qc.py" \
+  --input 2_Extraction/extraction.csv \
+  --tolerance 0.02 \
+  --out 2_Extraction/qc/dta_extraction_qc.tsv
+```
+
+Any `FLAG_SWAP` or `FLAG_MISMATCH` row requires third-reviewer adjudication before Phase 6 statistical synthesis.
+
+**Flag → form-edit forced transition.** A confirmed flag is not resolved until the extraction form itself is edited. Track each flag through `confirmed → acted`: after the adjudicator confirms a `FLAG_SWAP`/`FLAG_MISMATCH`/unit-of-analysis violation, the extraction CSV row MUST be corrected and the QC re-run to clear it. A flag that is "confirmed" but whose form row is unchanged (the correction lived only in a review note) silently re-enters synthesis. Verify the form's mtime advanced and the re-run QC shows zero open flags before locking.
+
+**2. Cohort Overlap Check** -- `scripts/cohort_overlap_check.py`:
+
+Clusters included studies by (a) shared public ICU/EHR database (MIMIC-IV, eICU, MIMIC-III, KNHIS, UK Biobank, Optum, MarketScan, TriNetX, IBM), (b) same institution + overlapping enrollment period, (c) shared first-author surname + ±2y year proximity. Flags HIGH / MEDIUM overlap confidence.
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cohort_overlap_check.py" \
+  --input 2_Extraction/studies.csv \
+  --enrich \
+  --out 2_Extraction/qc/cohort_overlap.md
+```
+
+HIGH-confidence overlap pairs require Limitations acknowledgment + sensitivity analysis excluding one of the pair.
+
+Cross-links: `/peer-review` Phase 2A P1 (cell integrity) + P2 (cohort overlap).

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -399,64 +399,12 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/check_review_request_types.py" \
 
 Generate `{manuscript_id}_review_draft.md`:
 
-```markdown
-# {manuscript_id} — Review Draft
-
-**Manuscript**: {title}
-**Journal**: {journal}
-**Type**: {Original Research | Review | Technical Note | ...}
-**Recommendation**: {Major Revision | Minor Revision}
-
----
-
-## {Journal-specific scores section, if applicable}
-
----
-
-## CONFIDENTIAL COMMENTS TO THE EDITOR
-
-{100-150 words: summary + strengths + key concerns + fatal flaw hierarchy if applicable + recommendation}
-**Clinical Impact**: {High/Moderate/Low} — {1 sentence on implications}
-
----
-
-## COMMENTS TO THE AUTHORS
-
-**Research Summary & General Comments**
-
-{2-3 sentences summarizing objective, design, key finding (in your own words)}
-
-Major strengths:
-1. {Specific strength}
-2. {Specific strength}
-3. {Specific strength (optional)}
-
-{Scope + feasibility: 1-2 sentences — "I have suggestions focused on [areas]. Achievable within existing data."}
-
-(80-150 words total)
-
-**Major Comments**
-
-1) **{Issue title}**
-
-{Problem 1-2 sentences. Location cited.}
-
-Suggested revisions:
-- {Fix 1}
-- {Fix 2}
-
-2) **{Issue title}**
-...
-
-**Minor Comments**
-
-1) {One sentence, location cited.}
-2) ...
-
-**Closing Remark**
-
-{2-3 sentences, constructive.}
-```
+Generate `{manuscript_id}_review_draft.md` from the skeleton in
+`${CLAUDE_SKILL_DIR}/references/review_draft_template.md`. It has three blocks: a
+**Confidential Comments to the Editor** block (100–150 words: summary, strengths, key
+concerns, fatal-flaw hierarchy, recommendation, clinical impact) and a **Comments to the
+Authors** block (research summary + strengths, then Major, Minor, and a closing remark).
+**The two blocks must never be transposed** — the recommendation lives only in the editor's.
 
 **Length targets (3-tier, data-grounded)**:
 
@@ -468,6 +416,13 @@ Suggested revisions:
 - **Hard cap 1400 words**. Measure with `awk + wc` (no estimation) — at Phase 3 mid-checkpoint and Phase 6 final.
 - Each Major: 5-8 lines (Tier 1-2) or 8-12 lines (Tier 3, with Why it matters + alternative framings).
 - **Reference-baseline ratio** (self-QC metric): compute `your_wc / 545` and report. Ratio > 2.0 (above 1090w) flags trim candidate. Ratio < 1.0 may indicate insufficient design-level rigor for AI/methodology critique reviews.
+
+**Read on demand:**
+
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/review_draft_template.md` | you are writing the draft and need the literal skeleton | ~800 tokens of output format; it shapes nothing about *what* you find |
+| `references/exemplar_reviews/` | you need a model for the finding type at hand | one file per finding type — read the one that matches, not the set |
 
 ### Phase 4: Self-QC
 

--- a/skills/peer-review/references/review_draft_template.md
+++ b/skills/peer-review/references/review_draft_template.md
@@ -1,0 +1,71 @@
+# `{manuscript_id}_review_draft.md` — the literal template
+
+Load-on-demand companion to `/peer-review` Phase 3. SKILL.md keeps what governs the
+*content* of a review — the request-type discipline (disclosure vs computation) and the
+3-tier length targets. This file is the output skeleton.
+
+Read it when you sit down to write the draft.
+
+Both comment blocks below are load-bearing and **must not be transposed**: the
+Confidential-to-Editor block carries the recommendation and must never reach the authors.
+Verify the split on the rendered proof, not on this draft — the portal's two free-text
+boxes are adjacent and unvalidated.
+
+```markdown
+# {manuscript_id} — Review Draft
+
+**Manuscript**: {title}
+**Journal**: {journal}
+**Type**: {Original Research | Review | Technical Note | ...}
+**Recommendation**: {Major Revision | Minor Revision}
+
+---
+
+## {Journal-specific scores section, if applicable}
+
+---
+
+## CONFIDENTIAL COMMENTS TO THE EDITOR
+
+{100-150 words: summary + strengths + key concerns + fatal flaw hierarchy if applicable + recommendation}
+**Clinical Impact**: {High/Moderate/Low} — {1 sentence on implications}
+
+---
+
+## COMMENTS TO THE AUTHORS
+
+**Research Summary & General Comments**
+
+{2-3 sentences summarizing objective, design, key finding (in your own words)}
+
+Major strengths:
+1. {Specific strength}
+2. {Specific strength}
+3. {Specific strength (optional)}
+
+{Scope + feasibility: 1-2 sentences — "I have suggestions focused on [areas]. Achievable within existing data."}
+
+(80-150 words total)
+
+**Major Comments**
+
+1) **{Issue title}**
+
+{Problem 1-2 sentences. Location cited.}
+
+Suggested revisions:
+- {Fix 1}
+- {Fix 2}
+
+2) **{Issue title}**
+...
+
+**Minor Comments**
+
+1) {One sentence, location cited.}
+2) ...
+
+**Closing Remark**
+
+{2-3 sentences, constructive.}
+```

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -98,69 +98,58 @@ their own first-class output (Phase 3), not folded silently into the "add this" 
 ### Phase 2: Systematic Check
 
 Run the manuscript through each applicable category below. For each item, assess whether
-a reviewer would raise it as a Major or Minor comment.
+a reviewer would raise it as a Major or Minor comment. Use the Research-Type Adaptation
+table (below) to determine which categories apply fully, partially, or not at all.
 
-Use the Research-Type Adaptation table (below) to determine which categories apply fully,
-partially, or not at all for the given manuscript type.
+**The categories (A–L).** The per-item check tables — what to look for under each — live
+in `references/phases/phase2_systematic_check.md`; read it once you have the manuscript
+and know its type, and work the categories the adaptation table marks as applicable.
 
-#### A. Study Design & Data Integrity
+| | Category | What it asks |
+|---|---|---|
+| **A** | Study Design & Data Integrity | patient-level splits, leakage, input-text contamination, analysis unit |
+| **B** | Reference Standard & Ground Truth | definition specificity, timing, annotator independence |
+| **C** | Validation & Statistical Reporting | CIs, **calibration**, comparator, effect size, power-aware nulls, equivalence margins, interaction anchoring |
+| **D** | Clinical Framing & Importance | intended use, overclaiming, novelty, **endpoint↔conclusion scope** |
+| **E** | Reproducibility | preprocessing, model detail, hardware/software, data & code availability |
+| **F** | Reporting Completeness | abstract↔body consistency, flow diagram, ethics, missing data, word cap |
+| **G** | Reporting Guideline Compliance | match the type to its checklist; `/check-reporting` does the item-level audit |
+| **H** | Circularity | label–feature overlap, tautological prediction, circular validation |
+| **I** | Protocol Heterogeneity | multi-site acquisition, harmonization, temporal protocol drift |
+| **J** | Method Transparency | model provenance, fine-tuning, classical-style body conventions |
+| **K** | Reviewer-team consistency | *SR/MA only* — dual-vs-single conjunction, LLM-as-reviewer (both fabrication-grade) |
+| **L** | Editorial impression & defensiveness | *advisory, never blocking* — the ceiling category: REMOVE / MOVE / TIGHTEN |
 
-| Check | What to look for |
-|-------|-----------------|
-| Patient-level splitting | Are train/val/test splits at the patient level? Is this explicitly stated? |
-| Leakage risk | Any postoperative variable used in a preoperative model? Cohort-wide preprocessing before split? |
-| Input-text contamination | For NLP/LLM extraction tasks, does any supplied report text (clinical history, indication, impression, prior diagnosis, referral text) already contain the target label? If yes, mark as Major unless the input was masked or a no-leaky-field sensitivity analysis is reported. |
-| Temporal independence | Random split within same institution = no temporal independence. Acknowledged? |
-| Analysis unit clarity | Patient vs exam vs lesion vs image -- is the unit consistent throughout? |
-| Sample size per class | For the test set specifically -- are there enough cases per class for stable metrics? |
-
-#### B. Reference Standard & Ground Truth
-
-| Check | What to look for |
-|-------|-----------------|
-| Definition specificity | Is the reference standard precisely defined? (e.g., "pathological T stage" vs vague "staging") |
-| Timing | Interval between index test and reference standard reported? |
-| Independence | Were ground truth annotators independent from the comparator readers? |
-| Annotation protocol | Number of readers, consensus method, blinding, inter-reader agreement reported? |
-
-#### C. Validation & Statistical Reporting
-
-| Check | What to look for |
-|-------|-----------------|
-| Confidence intervals | All primary metrics have 95% CIs? |
-| Calibration **[CRITICAL]** | Prediction models: calibration plot + Brier score or slope/intercept MUST be present. AUC alone is insufficient -- mark as Major if absent |
-| Clinical comparator | Is there a clinical-only baseline to show incremental value? |
-| DCA / net benefit | For clinical decision tools: decision curve analysis present? |
-| Fine-tuning baseline | For LLM/NLP fine-tuning, LoRA, prompt-engineering, or multi-agent claims, is there a same-backbone zero-shot or few-shot comparator on the same input, schema, and test split? |
-| Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
-| Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
-| Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
-| Power-aware null interpretation | Scored separately from significance, for any **non-significant primary result** (p > 0.05, 95% CI crossing the null): is the analysis powered to *exclude* a clinically meaningful effect? An underpowered null is "not yet established," not "no effect" -- if the upper CI bound still includes a meaningful effect size, a flat "X was not associated with Y" claim overreads the data. Look for reported observed power or a minimum detectable effect that justifies a negative conclusion, and watch for **bilateral over-correction** (a prior "independently associated" overclaim swinging to an equally unsupported "not associated" claim during revision). Undocumented null = Minor; a null that drives a clinical recommendation or a headline negative conclusion without power/CI-compatibility justification = Major. |
-| Equivalence-margin discipline | A claim that two groups/methods are "equivalent," "non-inferior," "indistinguishable," or show "no difference" requires a **pre-stated margin** — a TOST procedure, or the CI compared against a declared MCID. Grep `indistinguishable\|equivalent\|non-inferior\|no difference` and check for an adjacent `margin\|TOST\|MCID\|non-inferiority`; a margin-free equivalence claim is a Major (it converts a failure to reject into positive evidence of no effect). |
-| Interaction-anchor discipline | When synergy / interaction / effect-modification **is** the research question, the null must be anchored to the **interaction parameter** (a likelihood-ratio test of the interaction term, or the interaction OR/HR on one consistent scale), not to a main-effect OR whose upper CI is then read as "no synergy." Grep `synergy\|interaction\|joint effect\|effect modification`; if present, confirm Results carries an `OR_int\|β_int\|LRT\|p_interaction` term. A synergy conclusion resting on a main-effect estimate is a model mis-specification (Major), even when each main effect is individually correct. |
-| Difference-in-significance discipline | A between-group claim that an association is "more X / stronger / more pronounced in group A than group B" must rest on a **formal interaction test**, not on group A being significant (p < 0.05) while group B is not (p = NS). The difference between "significant" and "non-significant" is **not** itself significant. Grep `more (clearly\|strongly\|pronounced)\|stronger in\|(only\|chiefly) in (men\|women\|older\|younger\|the [A-Za-z]+ subgroup)` near two stratum-specific estimates with discordant p-values; if no interaction term (`p_interaction\|OR_int\|LRT`) is reported for that contrast, flag it (difference-in-significance fallacy). A subgroup-difference conclusion built this way is a Major; the fix is to report the interaction test or soften to "associations were observed in group A; the interaction was not formally tested." |
-
-#### D. Clinical Framing & Importance
-
-| Check | What to look for |
-|-------|-----------------|
-| Intended use | Is the clinical decision point clearly stated? (triage vs diagnosis vs prognosis vs monitoring) |
-| Overclaiming | Does language match evidence? ("will improve" -> "may potentially"; "superior" with overlapping CIs?) |
-| Terminology precision | Key terms defined? (e.g., "perioperative" = when exactly?) |
-| Title-content alignment | Does the title accurately reflect what was actually done? |
-| Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
-| Substantive novelty differentiation | For AI/LLM extraction papers, does the Introduction name 2-3 close prior papers/systems and state the concrete delta (new task, dataset, workflow, method, validation, or clinical decision point), rather than merely saying the method is novel? |
-| Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
-| Decision impact | Does the manuscript state what decision, workflow step, or downstream action would change if the model is correct? A text-only phenotype that does not alter triage, treatment, surveillance, enrichment, or research operations has weak clinical utility even if accuracy is high. |
-| Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
-| Endpoint↔conclusion scope **[CRITICAL]** | Does the conclusion's *action* exceed what the design or endpoint supports? A cross-sectional / single-visit study cannot license a prognostic or surveillance claim (rescreen interval, disease progression); a binary surrogate endpoint (present/absent, >0) is risk stratification, not a care directive (defer/withhold/initiate therapy). Both are documented anti-patterns. |
-
-Run the deterministic scope gate:
+**Run the deterministic gates.** These are greps and counts, so they belong in a gate rather
+than in eyeballing. Run them at Phase 2 entry, on every path:
 
 ```bash
+# D. endpoint↔conclusion scope
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_scope_coherence.py" \
   --manuscript manuscript.md --out qc/scope_coherence.json --strict
+
+# J. classical-style body conventions
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_classical_style.py" \
+  --manuscript manuscript.md --out qc/classical_style.json --strict
+
+# K. reviewer-team consistency (SR/MA only; pass the extraction JSON file or directory)
+python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
+    --manuscript manuscript.md --prospero prospero/record.md \
+    --extraction-json extraction/ --out _audit_self/reviewer_team_consistency.md
+
+# L. editorial impression (advisory; exits 0 even under --strict)
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_editorial_impression.py" \
+  --manuscript manuscript.md --out qc/editorial_impression.json
 ```
+
+Verdict mapping: `CROSS_SECTIONAL_PROGNOSTIC`, `SURROGATE_CARE_DIRECTIVE`, `SECTION_SYMBOL`,
+`INBODY_AI_DISCLOSURE`, and any reviewer-team hit (exit 1) are Anticipated **Major** Comments.
+`CROSS_SECTIONAL_YIELD_LANGUAGE`, `ELIGIBILITY_PROSE`, `DECIMAL_INCONSISTENCY`,
+`EM_DASH_OVERUSE`, and every `check_editorial_impression` verdict are **Minor**. The
+per-verdict rationale and the resolution paths are in the reference file.
+
+**Read on demand:**
+
 
 **Then check that every analysis you report was ever defined.** Twenty-four detectors in this skill ask whether a number is *correct*. None asks whether the analysis that produced it was *defined* — and that is the gap a reviewer walks straight into:
 
@@ -175,149 +164,9 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/check_analysis_definitions.py" \
 
 `ANALYSIS_LOAD` is **informational and never a verdict.** The reviewer who wrote *"too many analyses have been performed and reported"* also named the mechanism — *"this appears to have contributed to omissions of critical information in the Materials and Methods section"* — while a second reviewer of the same manuscript listed its sensitivity analyses as a **strength**. **Load is the cause, not the crime.** Do not cut analyses to satisfy this gate; restore the definitions the analyses crowded out. If load is genuinely high, move the defensive analyses to the supplement — same defence, far less reader burden and far less attack surface.
 
-`CROSS_SECTIONAL_PROGNOSTIC` and `SURROGATE_CARE_DIRECTIVE` are Anticipated Major Comments (category: D. Clinical Framing). `CROSS_SECTIONAL_YIELD_LANGUAGE` is an Anticipated **Minor** Comment — a cross-sectional / prevalence design using incidence-flavored screening vocabulary ("yield", "detection rate", "number-needed-to-screen/image", "rescreen interval") without defining "yield" once as cross-sectional report-positive prevalence. The gate is conservative — it fires only when a design/endpoint signal and a conclusion-region action verb (or the yield lexicon) co-occur.
-
-#### E. Reproducibility
-
-| Check | What to look for |
-|-------|-----------------|
-| Preprocessing details | All steps listed in order? Normalization, augmentation, resampling specified? |
-| Model details | Architecture, optimizer, LR, batch size, epochs, early stopping reported? |
-| Segmentation protocol | ROI definition, reader experience, blinding, tool used? |
-| Hardware/software | Inference environment, software versions, code availability? |
-| Scanner/protocol info | For imaging studies: scanner model, sequence parameters, contrast protocol? |
-| Data/code availability | Is a data availability statement included? Code shared or reason for not sharing stated? |
-
-#### F. Reporting Completeness
-
-| Check | What to look for |
-|-------|-----------------|
-| Abstract-body consistency | Numbers in Abstract match Tables/Results? |
-| Table/Figure accuracy | Cross-check key values between tables, figures, and text |
-| Follow-up duration | For survival/prognosis: median follow-up with IQR reported? |
-| Ethics | All participating institutions' IRB approval documented? Patient consent described? |
-| Missing data | Handling of incomplete cases described? |
-| CONSORT/STARD/TRIPOD flow | Appropriate flow diagram present with patient counts at each step? |
-| Body word count vs journal cap | Is the body within the target journal's word limit? A revise loop monotonically adds words and silently breaches the cap. Run `/sync-submission` `scripts/check_wordcount_cap.py` (`--journal-profile` or `--limit`; the binding number is the rendered DOCX count). Over cap → Major; within 0.95× → Minor (a further pass will likely breach). |
-| Funding & COI | Funding sources and competing interests disclosed? |
-
-#### G. Reporting Guideline Compliance
-
-Match the manuscript type to the appropriate checklist and verify key items:
-
-| Manuscript type | Checklist | Critical items to verify |
-|----------------|-----------|------------------------|
-| Diagnostic accuracy | STARD / STARD-AI | Flow diagram, reference standard, spectrum |
-| Prediction model (non-AI) | TRIPOD 2015 | Model development vs validation, calibration, missing data |
-| Prediction model (AI/ML) | TRIPOD+AI 2024 | Model development vs validation, calibration, leakage, fairness |
-| AI / Radiomics | CLAIM 2024 / CLEAR | Feature selection transparency, external validation |
-| RCT | CONSORT / CONSORT-AI | Randomization, blinding, ITT |
-| Systematic review (interventions) | PRISMA 2020 | Search strategy, screening, risk of bias |
-| Meta-analysis (observational) | MOOSE + PRISMA 2020 | Confounding assessment, heterogeneity, publication bias |
-| Observational | STROBE | Confounding, selection bias, missing data |
-| Reliability / agreement | GRRAS | ICC model/type, rater description, measurement protocol |
-| Educational | SQUIRE 2.0 | Intervention description, outcome measures, context |
-| Case report | CARE | Timeline, diagnostic reasoning, informed consent |
-| Surgical | STROBE-Surgery | Surgeon experience, technique details, complications |
-
-For a full item-by-item audit, run `/check-reporting` on this manuscript. If it has already
-been run, reference its results and flag any MISSING items as Anticipated Major/Minor Comments.
-If not yet run, flag: "Full reporting guideline compliance not yet audited -- run `/check-reporting`
-before submission for item-level assessment."
-
-#### H. Circularity
-
-| Check | What to look for |
-|-------|-----------------|
-| Label-feature overlap | Is the prediction label derived from the same data source as any input features? (e.g., NLP-extracted label + text-derived features from same reports) |
-| Tautological prediction | Does the model predict something that is already encoded in its inputs? |
-| Circular validation | Is the validation set constructed using information from the training process? |
-
-#### I. Protocol Heterogeneity
-
-| Check | What to look for |
-|-------|-----------------|
-| Multi-site acquisition | If multi-site: are scanner models, protocols, and acquisition parameters reported per site? |
-| Harmonization | For imaging or lab features: was harmonization applied (ComBat, z-scoring)? If not, acknowledged? |
-| Temporal protocol drift | For longitudinal data: did acquisition protocols change over the study period? |
-
-#### J. Method Transparency
-
-| Check | What to look for |
-|-------|-----------------|
-| Model provenance | Is it clear where the model came from? (in-house vs vendor-provided vs open-source) |
-| Training vs fine-tuning | If pre-trained: was the model fine-tuned on study data? If vendor-provided: any access to training data composition? |
-| Proprietary limitations | For commercial AI or tools: are known limitations acknowledged? Can results be independently reproduced? |
-| Classical-style body conventions | Does the body carry an AI tell or a policy violation a senior reviewer flags on sight — a `§` symbol, an in-body AI-disclosure paragraph, eligibility criteria as prose, mixed OR/HR decimal places, or em-dash overuse? |
-
-Run the deterministic classical-style lint (these are all greps, so they belong in a gate, not eyeballing):
-
-```bash
-python3 "${CLAUDE_SKILL_DIR}/scripts/check_classical_style.py" \
-  --manuscript manuscript.md --out qc/classical_style.json --strict
-```
-
-`SECTION_SYMBOL` and `INBODY_AI_DISCLOSURE` are Major (the `§` count must be 0; the AI-disclosure paragraph belongs on the title page for a classical / senior-MA target, not the body). `ELIGIBILITY_PROSE`, `DECIMAL_INCONSISTENCY`, and `EM_DASH_OVERUSE` are Minor. This is the self-review-side mirror of `/write-paper` Step 7.1's classical QC (manuscript-style-classical §5/§6/§7/§8).
-
-#### K. Reviewer-team consistency (SR/MA-only; fabrication-grade)
-
-| Check | What to look for |
-|-------|-----------------|
-| DUAL vs SINGLE conjunction **[CRITICAL]** | Methods or PROSPERO claims dual independent reviewers AND Discussion/Limitations admits single primary reviewer + 20% sample (or "deferred to before submission")? Mark as **MAJOR**, fabrication-grade. |
-| LLM-as-reviewer **[CRITICAL]** | A per-study extraction JSON whose `reviewer`/`screener`/`extractor` field is an LLM (Claude, GPT-4, Gemini, "LLM")? An LLM is a tool, not an independent reviewer — listing it as one misrepresents the team. **Fatal**, regardless of the prose. |
-| Deferred mitigation | A future-tense mitigation promise — "a 20% sample **will be completed before submission**" — unmet at circulation? The future tense is the tell that the work is not done. **MAJOR**. |
-
-Run the deterministic check at Phase 2 entry (pass the extraction JSON — a file or
-a directory of per-study JSONs — so the prose↔JSON↔confession 3-way is covered):
-
-```bash
-python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
-    --manuscript manuscript.md \
-    --prospero prospero/record.md \
-    --extraction-json extraction/ \
-    --out _audit_self/reviewer_team_consistency.md
-```
-
-Exit 1 = MAJOR red flag. The JSON sidecar carries `dual_hits`, `single_hits`,
-`llm_reviewer_hits`, and `deferred_mitigation_hits`. Any of the DUAL+SINGLE
-conjunction, an LLM reviewer field, or a deferred mitigation trips it. Either of
-the dual/single claims alone is fine; the conjunction is read by reviewers as
-fabrication. Resolution path:
-1. Honest Methods/PROSPERO update (single-reviewer execution disclosed), OR
-2. Limitations confession rewritten if dual review was actually completed.
-
-#### L. Editorial impression & defensiveness (advisory; the counterweight)
-
-This is the **ceiling** category (see "Two Objectives" above) and the inverse of the floor
-gates: where A–K and the numerical gates ask "what is missing or wrong?" (and answer by
-**adding**), L asks "does the accurate manuscript read confidently, or has it over-defended?"
-(and answers by **subtracting**). Every L finding is **advisory (Minor / impression) and
-non-blocking** — it never converts to a Major and never blocks submission. The fixes are
-REMOVE / MOVE / TIGHTEN, not "add a caveat."
-
-| Check | What to look for | Action |
-|-------|-----------------|--------|
-| Hedge density | Defensive-caveat tokens stacking up per 1,000 narrative words — the prose hedges faster than it asserts. Keep the load-bearing caveats; cut the reflexive ones. | TIGHTEN |
-| Repeated caveat | The same caveat motif ("no deployable claim", "not generalizable", "hypothesis-generating") repeated across body + Abstract. Say it once, firmly. | TIGHTEN |
-| Audit minutiae in body | Provenance tokens (SHA / git commit / unit-test / post-lock timeline / manifest / seed=N / audit trail) in the Introduction / Results / Discussion narrative. Reproducibility detail belongs in a Methods statement or a supplement. | MOVE |
-| Limitations volume | A Limitations passage that enumerates a long list of discrete items reads as a rebuttal letter; consolidate related items. | TIGHTEN |
-| Abstract caveat load | The Abstract carries several caveat clauses, burying the headline result before a reader reaches it. Lead with the result; keep one or two essential qualifiers. | TIGHTEN |
-| Buried defense | A strong numeric robustness / sensitivity result sitting only in Limitations or the supplement, with no robustness mention in Results. Promote it into Results — it is *evidence for* the finding, not a caveat against it. (The inverse of the scope-coherence gate, which pushes a *weak* analysis out of Results.) | MOVE |
-
-Run the deterministic gate (Phase 2.5g) rather than eyeballing it — these are all counts and placements:
-
-```bash
-python3 "${CLAUDE_SKILL_DIR}/scripts/check_editorial_impression.py" \
-  --manuscript manuscript.md --out qc/editorial_impression.json
-```
-
-`HEDGE_DENSITY`, `HEDGE_REPEAT`, `AUDIT_IN_BODY`, `LIMITATIONS_VOLUME`, `ABSTRACT_CAVEAT_LOAD`,
-and `BURIED_DEFENSE` are Anticipated **Minor** Comments (category: L. Editorial impression),
-each carrying a REMOVE / MOVE / TIGHTEN `action`. The gate never blocks (it has no Major and
-exits 0 even under `--strict`); thresholds are tunable (`--hedge-per-1k`, `--repeat-threshold`,
-`--limitations-max`, `--abstract-caveat-max`). It is conservative — each probe fires only on an
-explicit, locatable signal.
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phases/phase2_systematic_check.md` | you are working the A–L manual pass and know the manuscript type | ~5,600 tokens — and a run that halts at Phase 1, or a panel-mode review, never reaches it |
 ### Research-Type Adaptation
 
 Not all categories apply equally to every study type. Use this routing table:
@@ -435,95 +284,46 @@ diagnostic-accuracy work.
 
 ### Phase 2.5a: Numerical Source-Fidelity Audit (External)
 
-Internal consistency (Phase 2.5) is necessary but not sufficient. Numbers can be fully self-
-consistent across Abstract / Table / Text and still be wrong at the source — a single
-transcription error propagates cleanly through every downstream stage.
+Internal consistency (Phase 2.5) is necessary but not sufficient. Numbers can be fully
+self-consistent across Abstract / Table / Text and still be wrong **at the source** — a single
+transcription error propagates cleanly through every downstream stage, and every internal check
+then confirms it. Only a traversal back to the primary source catches it.
 
-Also run the **displayed-arithmetic** gate — a stated difference must equal the subtraction of
-its two displayed component values at the SAME precision:
+Run the **displayed-arithmetic** gate first — a stated difference must equal the subtraction of
+its two displayed component values at the *same* precision:
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_rounded_delta.py" \
   --manuscript manuscript.md --out qc/rounded_delta.json
 ```
 
-`ROUNDED_DELTA_MISMATCH` (Minor) fires when e.g. AUCs are shown as `0.70` and `0.73` (a displayed
-gap of 0.03) while the between-arm difference is stated as `0.02` — self-consistent only on the
-unrounded values. Fix: report components and the delta at one precision, or footnote that the delta
-is computed on unrounded values. A higher-precision component pair (`0.703` vs `0.726`) with a 2-dp
-delta is the legitimate unrounded case and is not flagged.
+`ROUNDED_DELTA_MISMATCH` (Minor) fires when AUCs shown as `0.70` and `0.73` (a displayed gap of
+0.03) are reported with a between-arm difference of `0.02` — self-consistent only on the
+unrounded values. A higher-precision component pair (`0.703` vs `0.726`) with a 2-dp delta is
+the legitimate unrounded case and is not flagged.
 
-**Precedent failure pattern:**
-> A revision-era comparative meta-analysis reported a safety-outcome 2x2 with the
-> arm-level events direction-reversed relative to the primary-source Table. Internal
-> consistency passed because Abstract, Discussion, Table, and the R script all echoed
-> the same wrong values. The reversal was caught only by an explicit second-pass audit
-> that randomly sampled claims and traced each back to the primary paper.
+**When to run the external audit:** MA revisions, submissions, or any review where the user says
+"check against the source", "verify extraction", or "random sample". Skip otherwise.
 
-**When to run:** MA revisions, submissions, or any review where the user mentions "check
-against the source," "verify extraction," or "random sample."
+**The audit, in one line:** draw a stratified sample of 5 numerical claims — always including one
+comparative-arm value and one revision-introduced number, the two highest-yield strata — and
+trace each through three layers (manuscript → extraction CSV → primary-source page; plus analysis
+script → CSV where a script produced it). **Any mismatch is a Major Comment**, and one that
+reverses a direction or crosses a significance boundary is a P0 blocker. Every `[VERIFY-CSV]` tag
+is a mandatory audit item regardless of sample size.
 
-**Inputs the reviewer should expect:**
-- `manuscript.md` (or .docx converted to .md)
-- `extraction_final.csv` (or equivalent data-extraction spreadsheet)
-- A directory of primary-source PDFs (or equivalent accessible text)
+The traversal procedure, the recording table, the sampling strata, and the four prose-judgement
+rules it also applies — hand-entered analysis-script inputs, prose↔table **statistic-type**
+mismatches (a median in the text against a mean in Table 1), stale derived CSVs after a
+model/adjustment-set change (the analytic `n` is the fastest tell, and the conflict can flip
+significance), and the precedent direction-reversal that internal consistency could not see —
+are in the reference file.
 
-**Procedure:**
+**Read on demand:**
 
-1. **Inventory numerical claims** in Abstract, Results, and Discussion (patterns: `\\d+/\\d+`,
-   `\\d+\\.\\d+%`, `(95% CI:`, `p\\s*=\\s*0\\.`, `I\\^2`, `n\\s*=`, etc.).
-
-2. **Stratified random sample** — draw 5 claims across: (a) pooled estimates, (b) subgroup
-   / sensitivity results, (c) comparative-arm specific values, (d) study-level numbers
-   (first-cited in narrative), (e) a claim introduced during revision if the draft is post-v1.
-   Comparative-arm specific values and revision-introduced numbers are the two highest-
-   yield strata — always include one of each.
-
-3. **For each sampled claim, traverse 3 layers:**
-   - **Layer 1 (Manuscript → CSV):** Find the row / column in the extraction CSV.
-   - **Layer 2 (CSV → Primary source):** Locate the exact Table, Figure, or paragraph in the
-     original paper. Record page number.
-   - **Layer 3 (Analysis script → CSV):** If the claim came from an analysis script, read the
-     script and confirm its input value matches the CSV cell.
-
-4. **Record results in a table** and append to the report:
-
-   | Claim (manuscript location) | CSV row/col | Primary source (paper, Table/Fig, page) | Script input | Match? |
-   |---|---|---|---|---|
-
-5. **Any mismatch is a Major Comment (M-level), not Minor.** Mismatches that reverse a
-   direction or change a significance boundary are P0 blockers for submission.
-
-**Revision-specific rule:** If the manuscript contains `[VERIFY-CSV]` tags, treat each as a
-mandatory audit item regardless of the sampling size. The tag exists precisely because that
-number was introduced after the initial extraction pass and has not yet been independently
-checked.
-
-**Hand-entered analysis-script inputs are a code smell.** When Layer 3 reveals a `matrix(...)`,
-`c(1, 2, 3)`, or `data.frame(...)` line with numerical data and no CSV-coordinate comment,
-escalate to a Major Comment even if the audited values happen to match — the next revision
-will re-introduce the same risk.
-
-**Statistic-type fidelity (not just the value).** A prose sentence must match the table/CSV not
-only on the **number** but on the **statistic type**. A body sentence that reports a *median*
-("median eGFR 92.8") while Table 1 reports a *mean* ("mean 91.3") for the same variable cannot
-be reconciled by a reviewer comparing the two — and the mismatch usually means one of them was
-not regenerated after a Table 1 rule change (see the mean/median-by-skewness rule in
-`/analyze-stats` `table-types/table1_demographics.md`). Treat a prose↔table statistic-type
-mismatch (mean vs median, SD vs IQR, n vs %) as a Minor Comment, or Major if it sits on a
-primary characteristic the conclusion leans on. Also re-check that any descriptive figure the
-prose quotes (e.g. "78.4% male") matches the *current* table value, not a stale earlier one.
-
-**Stale derived CSVs after a model/adjustment-set change (n mismatch).** When the primary model
-or adjustment set changes mid-revision, **every** derived CSV (Table 2, sensitivity tables,
-supplements) must be regenerated, or a stale file silently contradicts the new primary. The
-fastest tell is the analytic **n**: if a derived CSV's `n` differs from the manuscript's current
-primary n, suspect it is stale — and the conflict can flip a result's significance (a proteinuria
-sensitivity CSV left at the old `n = 4,914` / OR 4.52 contradicted the new primary `n = 4,214` /
-OR 3.99, significant ↔ not). Grep each derived CSV's `n` against the primary n; any divergence
-that is not explained by a stated sub-analysis restriction is a Major Comment, `requires_reanalysis`
-(re-run, not a prose edit — see Phase 4).
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phases/phase2_5a_source_fidelity.md` | you are running the external audit — tracing sampled claims back to primary sources | ~2,500 tokens; a first-draft review with no extraction CSV and no primary sources cannot use any of it |
 ### Phase 2.5a-2: Design & Power Statistic Provenance (computed, not extracted)
 
 Phase 2.5a traces data-derived numbers back to a CSV and a primary source. **Design and power
@@ -589,124 +389,58 @@ grid; treat a non-reproducible headline power/MDE as Major.
 
 ### Phase 2.5b: Screening-Count Reconciliation from ID Sets (SR/MA + observational tier/stratum)
 
-Internal consistency across Abstract/Methods/Results (Phase 2.5) + source fidelity of 2×2 and
-effect-size numbers (Phase 2.5a) do **not** cover study-count arithmetic. The latter is a
-separate failure mode: a prior-draft prose total ("30 → 32 after FLAG consensus") can survive
-every downstream pass because Abstract, Methods, Results, Discussion, Figure 1 caption, and
-even the supplementary consensus file all cite the same wrong number back to each other.
+Internal consistency across Abstract/Methods/Results (Phase 2.5) and source fidelity of 2×2 and
+effect-size numbers (Phase 2.5a) do **not** cover study-count arithmetic. That is a separate
+failure mode: a prior-draft prose total ("30 → 32 after FLAG consensus") survives every
+downstream pass because Abstract, Methods, Results, Discussion, the Figure 1 caption, and even
+the supplementary consensus file all cite the same wrong number back to each other. The only
+thing that catches it is a recount from the **ID sets**.
 
-**Precedent failure pattern (a PRISMA-DTA meta-analysis revision):**
-> A late-revision manuscript reported study counts of k_qualitative = 32, k_narrative-only = 10,
-> k_FT-excluded = 46. An ID-level recount against the screening TSV and consensus sheet (with
-> FLAG additions reconciled) yielded k_qualitative = 24 with only 2 narrative-only studies
-> (k_FT-excluded = 54). The original 32/10/46 figures came from an early-draft assumption that
-> was never reconciled against the ID-level artifacts; downstream files (consensus markdown,
-> supplementary tables, edit plans) propagated the same wrong total. Caught only by an explicit
-> ID-set recount against the screening TSV and consensus spreadsheet, verified independently
-> by an adversarial audit.
+**When to run:** any SR/MA manuscript revision, regardless of stage (run before Phase 3); or any
+observational manuscript presenting an ordinal tier / mutually-exclusive stratum split. Skip
+otherwise.
 
-**When to run:** any SR/MA manuscript revision, regardless of stage. Run before Phase 3.
+**A. SR/MA — recount from the ID sets.** Enumerate A (INCLUDE in the screening TSV), B (Exclude
+in the consensus sheet), C (Include-qualitative), T (studies in Table 1), then derive
+`k_qualitative = |A \ B| + |C|`, `k_bivariate = |T|`, and `k_narrative-only = |(A ∪ C) \ B \ T|`.
+**List the narrative-only IDs explicitly** — the highest-yield cross-check, and the one that
+turns "10 narrative-only studies" into "2 (IDs 120, 474)". Compare every derived total against
+the prose claim in Abstract, Methods, Results, the Figure 1 caption, and Limitations; any
+mismatch is a **P0 Major, blocking submission**. Any `N → M` transition claim not backed by an
+enumerable ID addition/subtraction set is itself a **Major** — it is unverifiable by downstream
+audit. The full procedure and the reconciliation-block template are in the reference file.
 
-**Inputs:**
-- Screening TSV with one row per full-text-reviewed record and an include/exclude column
-- Consensus spreadsheet (Excel/CSV) with one row per record requiring adjudication and a
-  `Consensus` column (typical values: `Exclude`, `Include-qualitative`, `Include-bivariate`)
-- Any FLAG-adjudicated inclusion log documenting records added to the qualitative pool
-  outside the primary screening TSV
-- The manuscript's Table 1 (or equivalent): the definitive list of studies contributing to
-  the primary quantitative synthesis
-
-**Procedure:**
-
-1. **Enumerate the ID sets:**
-   - A = set of IDs marked INCLUDE in the screening TSV
-   - B = set of IDs marked Exclude in the consensus spreadsheet
-   - C = set of IDs marked Include-qualitative in the consensus spreadsheet
-   - T = set of IDs represented in Table 1 (via author/year cross-match)
-
-2. **Derive canonical totals:**
-   - k_qualitative = |A \ B| + |C|
-   - k_bivariate = |T|
-   - k_narrative-only = k_qualitative − k_bivariate = |(A ∪ C) \ B \ T|
-   - k_FT-excluded = |screening TSV rows| − |A| + |B ∩ A| + |(B \ A) encountered at FT stage|
-
-3. **List the narrative-only IDs explicitly** — this is the highest-yield cross-check. A
-   manuscript claiming "10 narrative-only studies" while the (A ∪ C) \ B \ T set contains
-   only 2 IDs is an immediate P0 finding.
-
-4. **Compare each derived total against the manuscript's prose claim** in Abstract, Methods
-   §Study Selection, Results §Study Selection, Figure 1 caption, Discussion §Limitations,
-   and any References §Narrative-Only heading. Any mismatch between derived total and
-   manuscript prose = P0 Major Comment, blocking submission.
-
-5. **Record results in a short reconciliation block** and append to the report:
-
-   ```
-   | Quantity | Manuscript claim | ID-derived value | Status |
-   |---|---|---|---|
-   | k_full-text | 78 | 78 | ✓ |
-   | k_qualitative | 32 | 24 | ✗ P0 |
-   | k_bivariate | 22 | 22 | ✓ |
-   | k_narrative-only | 10 | 2 (IDs 120, 474) | ✗ P0 |
-   | k_FT-excluded | 46 | 54 | ✗ P0 |
-   ```
-
-**Any "N → M" transition claim in a consensus summary (e.g., "30 → 32 after FLAG
-consensus") that is not backed by an enumerable ID addition/subtraction set is itself a
-Major Comment**, because the transition is unverifiable by downstream audit. Require
-conversion of every such claim to explicit ID lists before closing the report.
-
-**Observational tier/stratum branch.** The same set-recount logic applies when a cohort
-manuscript presents an ordinal tier or mutually-exclusive stratum split. A partition that
-is claimed to be disjoint must satisfy `Σ(stratum N) == unique total` and
-`Σ(stratum events) == total events`; denominators that sum *above* the unique cohort
-double-count subjects, and a table where every stratum n equals the grand total is a
-stratum-total mis-entry rather than a partition. Run `check_cohort_arithmetic.py`
-(Phase 2.5 above) with the stratum CSV — its `PARTITION_OVERLAP` verdict is the cohort
-analogue of an ID-set mismatch and is a P0 Major:
+**B. Observational tier/stratum — the same set logic, as arithmetic.** A partition claimed to be
+disjoint must satisfy `Σ(stratum N) == unique total` and `Σ(stratum events) == total events`.
+Denominators summing *above* the unique cohort double-count subjects; a table where every
+stratum n equals the grand total is a mis-entry, not a partition. Confirm the reference
+(baseline) row of any stratified hazard/odds table is present and labelled — without it the
+other strata are uninterpretable.
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_cohort_arithmetic.py" \
   --manuscript manuscript.md --data analysis/strata.csv --strict
 ```
 
-Also confirm the reference (baseline) row of any stratified hazard/odds table is present
-and labelled; a missing reference category makes the other strata uninterpretable.
-
-**Cross-script cut-point consistency (root cause of stratum-N drift).** When the same cohort
-is re-stratified in more than one analysis script — a primary table in one file, a sensitivity
-or secondary analysis in another — the derived categorical (age band, BMI category, eGFR stage,
-risk tier) must use one identical cut definition: same breaks, same interval closure
-(`right=`), same labels. If two scripts bin the same variable differently, per-stratum Ns drift
-between tables while the grand total still reconciles, and a stratum can spuriously cross a
-threshold — a `PARTITION_OVERLAP`/stratum-N check on the manuscript alone will not localize the
-cause. `check_binning_consistency.py` parses the analysis source (R/Python) and emits
-`BINNING_DRIFT` (Major) when one variable is derived with ≥2 different `(breaks, right)`
-signatures across files:
+**C. Cross-script cut-point consistency — the root cause of stratum-N drift.** When the same
+cohort is re-stratified in more than one analysis script, the derived categorical must use one
+identical cut definition (same breaks, same `right=` closure, same labels). Two scripts binning
+one variable differently drift the per-stratum Ns while the grand total still reconciles — so a
+manuscript-only check cannot localize it. The same gate covers the composite-indicator sibling
+(a derived 0/1 criterion rebuilt in a second script with a clause dropped).
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_binning_consistency.py" \
   --root analysis --root scripts --strict
 ```
 
-Precedent: a screening cohort binned age with `breaks=c(-Inf,45,50,60,Inf), right=FALSE` in the
-primary script and `breaks=c(-Inf,44,49,59,Inf), right=TRUE` in a threshold sensitivity script;
-fractional ages fell into different bands, shifting hundreds of participants and producing a
-spurious "reached" stratum in the sensitivity table that vanished once the binning was
-harmonized. Fix at the source by defining each cut once in a shared helper that every script
-sources.
+`PARTITION_OVERLAP`, `BINNING_DRIFT`, and `DERIVED_DEF_DRIFT` are all **P0 Major**.
 
-The same gate also covers the **composite-indicator** sibling failure: a derived 0/1 component
-(e.g. a metabolic-syndrome criterion built from `as.integer(a >= x | b == 1 | c == 1)`) that is
-re-built in a second script with a clause dropped or added. It splits each definition into
-comparison atoms on the top-level `|`, compares them as a SET (clause order, whitespace, outer
-parentheses, dataframe `df$` qualifiers and commutative `&`-operands are normalized away), and
-emits `DERIVED_DEF_DRIFT` (Major) when one variable carries ≥2 distinct atom sets across scripts.
-Precedent: `mets_bp <- as.integer(bl_he_sbp>=130 | bl_he_dbp>=85 | bl_tx_hypertension_med==1 |
-bl_hypertension==1)` in the benchmark script vs the same name without the final
-`| bl_hypertension==1` in a re-analysis script — the metabolic-syndrome C-index then read 0.6704
-in one table and 0.6712 in another.
+**Read on demand:**
 
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phases/phase2_5b_screening_counts.md` | this is an SR/MA (ID-set recount) or a stratified cohort, and you are doing the recount | ~3,300 tokens — nothing in it applies to a single-cohort manuscript with no strata |
 ### Phase 2.5c: Reference Hallucination Scan
 
 Numerical audits (2.5/2.5a/2.5b) cover in-text numbers; they do **not** cover reference-list integrity. LLM-drafted or co-author-handed-in bibliographies frequently contain fabricated DOIs, wrong author/year combinations for a real DOI, or plausible-looking references that never existed. These slip past human proofreading because the surface form looks canonical.
@@ -804,92 +538,56 @@ Phase 2.5c covers reference **integrity** — are the cited references real (fab
 
 ### Phase 2.5d: Cross-Reference QC (Manuscript ↔ rendered DOCX)
 
-Before the DOCX is built, run the **markdown-stage orphan gate** — every captioned
-`Figure N.` / `Table N.` must be cited at least once elsewhere in the body:
+Reference-list integrity (Phase 2.5c) does **not** cover Table/Figure cross-references. That is a
+separate failure mode: an in-text citation ("Supplementary Table S4 reports a sensitivity
+analysis") resolves to a *different* caption in the rendered DOCX ("Supp Table S4 = a diagnostics
+table") because the build script carries its own legacy SSOT. Internal consistency (Phase 2.5)
+cannot see it — the prose and the build artifact each echo their own divergent truth cleanly.
+
+**Markdown stage (always).** Every captioned `Figure N.` / `Table N.` must be cited at least once
+elsewhere in the body:
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_figure_citation.py" \
   --manuscript manuscript.md --out qc/figure_citation.json
 ```
 
-`FIGURE_ORPHAN` / `TABLE_ORPHAN` (Minor) catch a newly-added float that has a legend
-but no in-text citation — the early, no-build counterpart to `check_xref`'s `UNCITED`
-verdict, which catches the same class on the rendered DOCX (below).
+`FIGURE_ORPHAN` / `TABLE_ORPHAN` (Minor) catch a newly-added float that has a legend but no
+in-text citation — the early, no-build counterpart to `check_xref`'s `UNCITED`.
 
-Reference-list integrity (Phase 2.5c) does **not** cover Table/Figure
-cross-references. This is a separate failure mode where in-text citations
-("Supplementary Table S4 reports a sensitivity analysis") resolve to a different
-caption in the rendered DOCX ("Supp Table S4 = a diagnostics table") because the
-build script carries its own legacy SSOT. Internal consistency (Phase 2.5)
-cannot detect it — both the prose and the build artifact echo their own
-divergent truths cleanly.
+**DOCX stage (when a rendered DOCX exists** — circulation drafts, post-build pre-submission
+checks. Skip on early drafts with no build):
 
-**Precedent failure pattern (an STROBE cohort manuscript revision):**
-> Body prose cited Supp Table S4 as a sensitivity analysis; the rendered DOCX
-> S4 instead contained a diagnostics table. S1, S6, S7 also mismatched. S8 and S9
-> were cited in the manuscript but absent from the rendered DOCX entirely.
-> Caught only on co-author circulation review.
+```bash
+python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs/scripts/check_xref.py" \
+  --md manuscript/manuscript.md --docx manuscript/manuscript_final.docx \
+  --out qc/xref_audit.json [--allow-separate-attachments]
+```
 
-**When to run:** every manuscript at self-review when a rendered DOCX exists
-(e.g., circulation drafts, post-build pre-submission checks). Skip only if no
-DOCX build has occurred yet (early drafts).
+Severity depends on the journal's figure/table submission policy. Many radiology and medical
+journals (European Radiology, Radiology, AJR) accept figures and tables as **separate
+attachments** rather than inline — pass `--allow-separate-attachments` there so a legitimate
+attachment style is not read as a blocker.
 
-**Procedure:**
+| Status | Default policy | With `--allow-separate-attachments` |
+|---|---|---|
+| `MISSING_DOCX` | **Major (P0)** — cited Table/Figure absent from rendered output | **Minor** — separately attached per journal policy |
+| `MISSING_BODY` | **Major (P0)** — build SSOT drift; rendered caption has no body definition | **Major (P0)** (no change) |
+| `MISMATCH` | **Major (P0)** — caption text disagrees between body and rendered DOCX | **Major (P0)** (no change) |
+| `UNCITED` | Minor — orphan caption; cite it or remove it | Minor (no change) |
 
-1. **Locate inputs.** `manuscript/manuscript.md` (or the SSOT `truth.manuscript_md`)
-   and the rendered DOCX (typically `manuscript/manuscript_final.docx` or the
-   most recent circulation `.docx`).
+`MISSING_BODY` and `MISMATCH` stay P0 under every policy: they are SSOT drift, not a style choice.
 
-2. **Invoke the shared script** (lives in `/manage-refs`):
+**Do NOT auto-fix cross-reference defects in `--fix` mode.** Rewriting a caption in the body
+without re-running the DOCX build merely moves the mismatch. Emit each P0 row as its own
+`M`-numbered Major Comment with `category: "F"` and `fixable_by_ai: false`, and route the user to
+`/write-paper` Step 7.6a for the pipeline-side fix.
 
-   ```bash
-   python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs/scripts/check_xref.py" \
-     --md manuscript/manuscript.md \
-     --docx manuscript/manuscript_final.docx \
-     --out qc/xref_audit.json \
-     [--allow-separate-attachments]
-   ```
+**Read on demand:**
 
-   The script writes `qc/xref_audit.json` with per-label rows tagged
-   `OK | MISSING_DOCX | MISSING_BODY | MISMATCH | UNCITED | NOT_CITED_NO_BODY`,
-   a top-level `submission_safe` boolean, and a `policy.allow_separate_attachments`
-   field that records which severity policy applied.
-
-3. **Translate findings to anticipated comments.** Severity mapping depends on
-   the journal's figure/table submission policy. Many radiology and medical
-   journals (e.g., European Radiology, Radiology, AJR) accept figures and tables
-   as separate attachment files rather than inline in the manuscript DOCX; for
-   those workflows pass `--allow-separate-attachments` so MISSING_DOCX is not
-   treated as a P0 blocker. `MISSING_BODY` and `MISMATCH` remain P0 regardless,
-   because they indicate SSOT drift between body markdown and rendered DOCX
-   rather than a legitimate attachment style.
-
-   | Status | Default policy | With `--allow-separate-attachments` |
-   |---|---|---|
-   | `MISSING_DOCX` | **Major (P0)** — cited Table/Figure absent from rendered output | **Minor** — figure/table is separately attached per journal policy |
-   | `MISSING_BODY` | **Major (P0)** — build SSOT drift; rendered caption has no body definition | **Major (P0)** (no change) |
-   | `MISMATCH` | **Major (P0)** — caption text disagrees between body and rendered DOCX | **Major (P0)** (no change) |
-   | `UNCITED` | Minor — orphan caption that should be cited or removed | Minor (no change) |
-
-4. **Append a reconciliation block to the Phase 3 report:**
-
-   ```
-   | Label | Status | Body caption | DOCX caption | Verdict |
-   |---|---|---|---|---|
-   | Supplementary Table S4 | MISMATCH | Sensitivity analysis | Diagnostics table | ✗ P0 |
-   | Supplementary Table S8 | MISSING_DOCX | (defined in body) | — | ✗ P0 |
-   | Figure 2 | UNCITED | Forest plot of subgroups | Forest plot of subgroups | △ Minor |
-   ```
-
-5. **Emit each P0 row as a separate `M`-numbered Major Comment** with
-   `category: "F"` (Reporting Completeness) and `fixable_by_ai: false`
-   (build script changes are out of scope for the auto-fix loop — they
-   require pipeline-side fixes per `/write-paper` Step 7.6a routing).
-
-**Do NOT auto-fix cross-reference defects in `--fix` mode.** Caption rewrites
-in the body without re-running the DOCX build will simply move the mismatch.
-Surface as Major Comments and let the user route to `/write-paper` Step 7.6a.
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phases/phase2_5d_xref_qc.md` | the xref gate fired and you are writing up the reconciliation | ~2,400 tokens; an early draft with no DOCX build never reaches this stage |
 ### Phase 2.5e: Confounding Completeness (observational only)
 
 **When to run:** the manuscript is observational (cohort, case-control, cross-sectional,
@@ -922,181 +620,77 @@ complete-case frame, not the full frame); and the rest of the observational prob
 
 ### Phase 2.5f: Claim-vs-Artifact Cross-Check
 
-Phases 2.5–2.5e check numbers and adjustment sets. This phase checks **claims
-against the external artifacts they should trace to** — the pre-registration, the
-protocol, the analysis outputs. These are the errors that survive a single-pass
-review because the manuscript prose is internally consistent yet disagrees with
-the registration or the analysis it reports. The first scope is the two highest-
-value, deterministic instances; figure/flow-count reconciliation, Methods-promised-
-analysis completeness, and imputation-input integrity are separate subchecks (run
-`/make-figures` legend reconciliation and `/write-paper`'s Methods-promised gate).
+Phases 2.5–2.5e check numbers and adjustment sets. This phase checks **claims against the
+external artifacts they should trace to** — the pre-registration, the protocol, the analysis
+outputs. These are the errors that survive a single-pass review because the manuscript prose
+is internally consistent yet disagrees with the registration or the analysis it reports: a
+primary re-designated after the results were known, an E-value that does not recompute from
+the estimate it is quoted against, an analysis promised in Methods that never reaches Results.
 
-**Precedent failure pattern:**
-> A manuscript reported a null primary association from a multiple-imputation model
-> and described it as "pre-specified," while the registered primary had been the
-> complete-case model that was significant — the primary had been re-designated after
-> the results were known. In the same paper an E-value of 2.79 was attached to the
-> primary HR of 1.34, but 2.79 does not recompute from 1.34 (it came from a different,
-> non-primary estimate), and a second E-value bounded an exploratory cancer-specific
-> hazard, not the headline contrast. None of these tripped the internal-consistency
-> checks; all three are deterministic against the registration and the arithmetic.
+**Run the gates** (all deterministic; pass the supplement so the corpus is complete):
 
-**Procedure:**
+```bash
+# 1. claims ↔ pre-registration/protocol: estimand provenance + E-value arithmetic
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_claim_artifact.py" \
+  --manuscript manuscript.md --prereg prereg.md \
+  --out qc/claim_artifact.json --strict
 
-1. **Run the cross-check** with the manuscript and (if available) the pre-registration
-   / protocol / `project.yaml`:
+# 2. Methods ↔ Results ↔ disk coverage (both directions: promised-absent AND run-but-unreported)
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_artifact_coverage.py" \
+  --manuscript manuscript.md --supplement supplement.md --analysis-dir output/analysis \
+  --out qc/artifact_coverage.json --strict
 
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_claim_artifact.py" \
-     --manuscript manuscript.md --prereg prereg.md \
-     --out qc/claim_artifact.json --strict
-   ```
+# 3. reader-facing residue in EVERY rendered artifact, not just the body
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_supplement_hygiene.py" \
+  --supplement supplement.md --supplement tables.md --supplement captions.md \
+  --manuscript manuscript.md --out qc/supplement_hygiene.json --strict
 
-2. **Estimand provenance.** The script raises `PRIMARY_REASSIGNED` (Major,
-   category: A. Study Design & Data Integrity) only on **explicit** language that the
-   primary was re-designated / switched / chosen post-hoc after results were known — a
-   genuine P0. The fix is to report the pre-specified and the revised models
-   **coequally** and disclose the change in the Abstract and Limitations, not to
-   silently lead with the more favourable estimate. Two related verdicts are
-   **advisory, not Major** — surface them as Anticipated Minor Comments to confirm,
-   never as a blocker: `ESTIMAND_DRIFT` (the fuzzy manuscript↔registration primary
-   token overlap is below threshold — noisy; confirm against the actual registration
-   before treating it as drift) and `PRIMARY_DISCLOSURE_NOTE` (the manuscript discloses
-   a manuscript-stage analytical decision — the honest disclosure estimand-provenance
-   guidance *recommends writing*; confirm it is reported coequally, do not penalise it).
+# 4. float citation order — a desk-reject item the hygiene gate does not cover
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_citation_order.py" \
+  --manuscript manuscript.md --out qc/citation_order.json --strict
 
-3. **E-value.** `EVALUE_ARITHMETIC` means the reported E-value does not recompute from
-   its adjacent effect estimate (the value was likely produced for a different estimate);
-   `EVALUE_NON_PRIMARY` means the E-value is attached to a secondary/exploratory estimate
-   but presented as if it bounded the headline claim. Both warrant a Major/Minor comment —
-   recompute the E-value for the **declared primary** estimate and its near-null confidence
-   limit, and quote it there.
+# 5. a headline null is uninterpretable without a precision statement
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_null_calibration.py" \
+  --manuscript manuscript.md --out qc/null_calibration.json --strict
 
-4. **Primary-change guard.** Independently of the script, if the manuscript reports two
-   models for the same contrast where one is significant and the other null and the
-   significant one is foregrounded, confirm which was pre-specified; an outcome-dependent
-   choice of primary model is a Major comment even when each model is individually correct.
+# 6. reader/observer study only — prove the (call × confidence) → score encoding is strictly
+#    monotonic; a folded score silently mis-estimates the AUC and no prose review can see it
+python3 "${MEDSCI_SKILLS_ROOT}/skills/analyze-stats/scripts/rating_monotonicity.py" \
+  --encoding score_def.json
+```
 
-5. **Headline vs own-sensitivity direction.** Read the sensitivity series (S1 etc.) the
-   manuscript itself reports. If the headline causal/association claim points the *opposite*
-   way from the authors' own adjusted or sensitivity estimate — a positive lead sentence over
-   a sensitivity model that attenuates to the null, or vice versa — that is a Major: the paper
-   is contradicting its own robustness check. This is a prose judgement, not a script verdict.
+**Verdict → severity.** The rationale and the resolution path for each are in the reference file.
 
-6. **Methods ↔ Results ↔ disk coverage.** Run the deterministic coverage gate:
+| Verdict | Severity |
+|---|---|
+| `PRIMARY_REASSIGNED` | **Major** — the primary was re-designated after results were known |
+| `EVALUE_ARITHMETIC`, `EVALUE_NON_PRIMARY` | **Major** — recompute for the *declared primary* estimate |
+| `PROMISED_ABSENT`, `DISK_UNREPORTED`, `PROMISED_STAT_NO_VALUE` | **Major** |
+| `SUPP_INTERNAL_LABEL`, `SUPP_PLACEHOLDER`, `SUPP_BUILD_MARKER`, `SUPP_RESPONSE_FRAMING`, `SUPP_PLANNING_RESIDUE`, `SUPP_XREF_UNRESOLVED` | **Major** — a slip in a supplement is as fatal at a technical check as one in the body |
+| `CITATION_ORDER` | **Major**; `CITATION_GAP` **Minor** |
+| `CONFIRM_NULL_NO_MDE` | **Major** |
+| `ESTIMAND_DRIFT`, `PRIMARY_DISCLOSURE_NOTE` | **Advisory Minor — never a blocker.** The provenance match is fuzzy (token overlap); confirm against the actual registration first. `PRIMARY_DISCLOSURE_NOTE` flags the honest disclosure the guidance *recommends writing* — do not penalise it. |
 
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_artifact_coverage.py" \
-     --manuscript manuscript.md --analysis-dir output/analysis \
-     --out qc/artifact_coverage.json --strict
-   ```
+**Four checks no script makes** (prose judgement — the reference file has the full text):
 
-   `PROMISED_ABSENT` (an analysis named in Methods that never reaches Results) and
-   `DISK_UNREPORTED` (an analysis output on disk — an added-value DeLong CSV, a calibration
-   table — never mentioned in the manuscript) are Anticipated Major Comments. The reverse
-   direction matters because a run-but-unreported result can be the one that undercuts the
-   headline. When an `_analysis_outputs.md` manifest exists the gate uses it as the source of
-   truth; otherwise it globs `--analysis-dir` and only escalates analysis-bearing file names.
+1. **Primary-change guard** — two models for one contrast, one significant and one null, the
+   significant one foregrounded: confirm which was pre-specified.
+2. **Headline vs own-sensitivity direction** — if the headline claim points the opposite way
+   from the authors' own sensitivity estimate, the paper contradicts its own robustness check.
+3. **Rating → AUC monotonicity** — a *folded* (call × confidence) score silently mis-estimates
+   the AUC, and prose review cannot see an estimator bug.
+4. **Figure-embedded numbers are grep-blind** — every numeric audit above is blind to numbers
+   *inside* a rasterised figure. Read each figure page visually before submission.
 
-   The same gate also flags `PROMISED_STAT_NO_VALUE`: a statistic framed as a **bound/
-   ceiling/de-confounded** value (e.g. "the de-confounded reader AUC is reported in
-   Table S16", "the classifier ceiling AUC") promised with a reporting verb but never
-   given a numeric value anywhere in the manuscript **or supplement** — the bound that
-   makes the primary estimand interpretable, sometimes marked "Addressed" in a checklist
-   yet absent from every table. Pass the rendered supplement so the corpus is complete:
+Also re-run `/sync-submission`'s `check_cross_artifact_stale.py` **after** any reframe, not just
+once at the start. For time-to-event manuscripts, apply probe **S8 (estimand provenance)** of
+`references/domain-probes/survival_prognostic.md`.
 
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_artifact_coverage.py" \
-     --manuscript manuscript.md --supplement supplement.md \
-     --out qc/artifact_coverage.json --strict
-   ```
+**Read on demand:**
 
-7. **Supplement / tables / caption hygiene.** Phases 2.5–2.5e and the classical-style
-   gate lint `manuscript.md` only; the rendered **supplement, a separately-built tables
-   file, and figure-caption files** are never linted — yet that is where technical-check-
-   fatal residue hides (internal §/§L SAP labels, unfilled `Table SX`/`[Authors]`
-   placeholders, `[VERIFY]`/`TODO` build markers, response-to-reviewers framing, planning
-   residue, and body↔supplement cross-reference numbers that do not resolve). Run the
-   supplement-hygiene gate over **every** rendered reader-facing artifact:
-
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_supplement_hygiene.py" \
-     --supplement supplement.md --supplement tables.md --supplement captions.md \
-     --manuscript manuscript.md --out qc/supplement_hygiene.json --strict
-   ```
-
-   All verdicts (`SUPP_INTERNAL_LABEL`, `SUPP_PLACEHOLDER`, `SUPP_BUILD_MARKER`,
-   `SUPP_RESPONSE_FRAMING`, `SUPP_PLANNING_RESIDUE`, `SUPP_XREF_UNRESOLVED`) are
-   Anticipated Major Comments — a reader-facing slip in a supplement is as fatal at a
-   technical check as one in the body.
-
-   **Float citation order (same technical-check pass).** Editorial offices "unsubmit"
-   manuscripts *before* peer review when numbered floats are not cited in ascending
-   order of first appearance — a fully deterministic desk-check item the hygiene gate
-   above does not cover (it lints xref *resolution*, not *order*). Run the citation-order
-   gate, which checks each series independently (main Tables, main Figures, Supplementary
-   Tables, Supplementary Figures), scanning only the narrative body (it auto-excludes the
-   Figure Legends / back-matter so an in-order legends block cannot mask an out-of-order
-   body):
-
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_citation_order.py" \
-     --manuscript manuscript.md --out qc/citation_order.json --strict
-   ```
-
-   `CITATION_ORDER` (Major) — a series cited out of numerical order (e.g. Table 3 before
-   Tables 1–2, or Supplementary Tables cited S4, S9, S16, S12, …); fix by renumbering the
-   series by first-citation order (and reordering the float/supplement document + remapping
-   every cross-reference, expanding ranges like `S12–S15` by hand and leaving non-float
-   sensitivity-spec labels such as `S1–S6` untouched) or by rephrasing away the early
-   citation. `CITATION_GAP` (Minor) — cited numbers not contiguous from 1 (a possible
-   missing/mis-numbered float).
-
-8. **Re-run cross-artifact staleness after any audit or reframe.** When a headline number
-   is corrected or an analysis is re-framed, the fix often lands only in the body while a
-   supplement footnote or a figure-source data file keeps the stale (sometimes *reversed*)
-   value. Re-run `/sync-submission`'s `check_cross_artifact_stale.py` across the body, the
-   supplement, and any figure-source data immediately **after** the reframe — not just once
-   at the start — so a corrected body never ships next to a stale supplement.
-
-9. **Power-aware null interpretation.** A headline negative claim ("no synergy", "not
-   associated", "showed no difference") is interpretable only next to a precision
-   statement — a minimum-detectable-effect, a power calculation, an equivalence
-   margin/TOST, or a CI-compatibility sentence. Run the null-calibration gate:
-
-   ```bash
-   python3 "${CLAUDE_SKILL_DIR}/scripts/check_null_calibration.py" \
-     --manuscript manuscript.md --out qc/null_calibration.json --strict
-   ```
-
-   `CONFIRM_NULL_NO_MDE` (Major) fires when a negative/equivalence claim in the Title/
-   Abstract/Conclusion has no such token anywhere in those regions — a non-significant
-   result is not evidence of no effect without one. (A single MDE/power/equivalence/CI-
-   compatibility sentence suppresses it.) Pair with the interaction-scale checks (`O14`)
-   when the null is a synergy/interaction claim.
-
-10. **Confidence-weighted / rating → AUC monotonicity.** For an observer or reader study
-    that collapses a (binary-call × confidence) rating into a single score used as the
-    ROC/AUC predictor, verify the encoding is **strictly monotonic** across the full
-    ladder — a *folded* score (`cws = confidence if positive-call else 6 − confidence`)
-    collapses opposite (call × confidence) cells and silently mis-estimates the AUC; a
-    prose review cannot see an estimator bug. Run the encoding through the reusable
-    monotonicity probe and ship its 10-combination unit test:
-    `python3 "${MEDSCI_SKILLS_ROOT}/skills/analyze-stats/scripts/rating_monotonicity.py" --encoding score_def.json`.
-
-11. **Figure-embedded numbers are text-grep blind.** PRISMA/flow/forest/statistic figures
-    are rasterised, so every numeric audit above is blind to the numbers *inside* them.
-    Before submission, (a) **visually** read each such figure page in the rendered/blind
-    PDF, and (b) reconcile the **hard-coded integers** in the figure-generation script
-    (`create_figure*.R`, `make_*.py`) against the body/flow-source counts
-    (`grep -nE '<-\s*[0-9]+|=\s*[0-9]+' figures/*.R`). See `submission-portal-verification`
-    §9.5 (figure-image DATA drift) for the full procedure.
-
-The script is deterministic but its provenance match is fuzzy (token overlap): read the
-reconciliation in `qc/claim_artifact.json` and confirm against the actual registration
-before raising `ESTIMAND_DRIFT`. For time-to-event manuscripts, also apply probe **S8
-(estimand provenance)** of `references/domain-probes/survival_prognostic.md`.
-
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phases/phase2_5f_claim_artifact.md` | a gate above fired and you need the rationale + resolution path, or there is a pre-registration to reconcile | ~4,800 tokens; a manuscript with no registration and no firing gate needs none of it |
 ### Phase 2.5g: Editorial-Impression / Defensiveness Scan (the ceiling pass)
 
 Run this **after** the floor gates (Phases 2.5–2.5f), because it reads the *accurate* manuscript

--- a/skills/self-review/references/phases/phase2_5a_source_fidelity.md
+++ b/skills/self-review/references/phases/phase2_5a_source_fidelity.md
@@ -1,0 +1,98 @@
+# Phase 2.5a — Numerical Source-Fidelity Audit (External)
+
+Load-on-demand companion to `/self-review` Phase 2.5a. SKILL.md keeps the entry
+condition, the displayed-arithmetic gate, and the escalation rule; this file carries
+the 3-layer traversal procedure, the sampling strata, the precedent failure, and the
+four prose-judgement rules (hand-entered script inputs, statistic-type fidelity, stale
+derived CSVs, `[VERIFY-CSV]` tags).
+
+Read it when you are actually tracing sampled claims back to their primary sources.
+
+Internal consistency (Phase 2.5) is necessary but not sufficient. Numbers can be fully self-
+consistent across Abstract / Table / Text and still be wrong at the source — a single
+transcription error propagates cleanly through every downstream stage.
+
+Also run the **displayed-arithmetic** gate — a stated difference must equal the subtraction of
+its two displayed component values at the SAME precision:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_rounded_delta.py" \
+  --manuscript manuscript.md --out qc/rounded_delta.json
+```
+
+`ROUNDED_DELTA_MISMATCH` (Minor) fires when e.g. AUCs are shown as `0.70` and `0.73` (a displayed
+gap of 0.03) while the between-arm difference is stated as `0.02` — self-consistent only on the
+unrounded values. Fix: report components and the delta at one precision, or footnote that the delta
+is computed on unrounded values. A higher-precision component pair (`0.703` vs `0.726`) with a 2-dp
+delta is the legitimate unrounded case and is not flagged.
+
+**Precedent failure pattern:**
+> A revision-era comparative meta-analysis reported a safety-outcome 2x2 with the
+> arm-level events direction-reversed relative to the primary-source Table. Internal
+> consistency passed because Abstract, Discussion, Table, and the R script all echoed
+> the same wrong values. The reversal was caught only by an explicit second-pass audit
+> that randomly sampled claims and traced each back to the primary paper.
+
+**When to run:** MA revisions, submissions, or any review where the user mentions "check
+against the source," "verify extraction," or "random sample."
+
+**Inputs the reviewer should expect:**
+- `manuscript.md` (or .docx converted to .md)
+- `extraction_final.csv` (or equivalent data-extraction spreadsheet)
+- A directory of primary-source PDFs (or equivalent accessible text)
+
+**Procedure:**
+
+1. **Inventory numerical claims** in Abstract, Results, and Discussion (patterns: `\\d+/\\d+`,
+   `\\d+\\.\\d+%`, `(95% CI:`, `p\\s*=\\s*0\\.`, `I\\^2`, `n\\s*=`, etc.).
+
+2. **Stratified random sample** — draw 5 claims across: (a) pooled estimates, (b) subgroup
+   / sensitivity results, (c) comparative-arm specific values, (d) study-level numbers
+   (first-cited in narrative), (e) a claim introduced during revision if the draft is post-v1.
+   Comparative-arm specific values and revision-introduced numbers are the two highest-
+   yield strata — always include one of each.
+
+3. **For each sampled claim, traverse 3 layers:**
+   - **Layer 1 (Manuscript → CSV):** Find the row / column in the extraction CSV.
+   - **Layer 2 (CSV → Primary source):** Locate the exact Table, Figure, or paragraph in the
+     original paper. Record page number.
+   - **Layer 3 (Analysis script → CSV):** If the claim came from an analysis script, read the
+     script and confirm its input value matches the CSV cell.
+
+4. **Record results in a table** and append to the report:
+
+   | Claim (manuscript location) | CSV row/col | Primary source (paper, Table/Fig, page) | Script input | Match? |
+   |---|---|---|---|---|
+
+5. **Any mismatch is a Major Comment (M-level), not Minor.** Mismatches that reverse a
+   direction or change a significance boundary are P0 blockers for submission.
+
+**Revision-specific rule:** If the manuscript contains `[VERIFY-CSV]` tags, treat each as a
+mandatory audit item regardless of the sampling size. The tag exists precisely because that
+number was introduced after the initial extraction pass and has not yet been independently
+checked.
+
+**Hand-entered analysis-script inputs are a code smell.** When Layer 3 reveals a `matrix(...)`,
+`c(1, 2, 3)`, or `data.frame(...)` line with numerical data and no CSV-coordinate comment,
+escalate to a Major Comment even if the audited values happen to match — the next revision
+will re-introduce the same risk.
+
+**Statistic-type fidelity (not just the value).** A prose sentence must match the table/CSV not
+only on the **number** but on the **statistic type**. A body sentence that reports a *median*
+("median eGFR 92.8") while Table 1 reports a *mean* ("mean 91.3") for the same variable cannot
+be reconciled by a reviewer comparing the two — and the mismatch usually means one of them was
+not regenerated after a Table 1 rule change (see the mean/median-by-skewness rule in
+`/analyze-stats` `table-types/table1_demographics.md`). Treat a prose↔table statistic-type
+mismatch (mean vs median, SD vs IQR, n vs %) as a Minor Comment, or Major if it sits on a
+primary characteristic the conclusion leans on. Also re-check that any descriptive figure the
+prose quotes (e.g. "78.4% male") matches the *current* table value, not a stale earlier one.
+
+**Stale derived CSVs after a model/adjustment-set change (n mismatch).** When the primary model
+or adjustment set changes mid-revision, **every** derived CSV (Table 2, sensitivity tables,
+supplements) must be regenerated, or a stale file silently contradicts the new primary. The
+fastest tell is the analytic **n**: if a derived CSV's `n` differs from the manuscript's current
+primary n, suspect it is stale — and the conflict can flip a result's significance (a proteinuria
+sensitivity CSV left at the old `n = 4,914` / OR 4.52 contradicted the new primary `n = 4,214` /
+OR 3.99, significant ↔ not). Grep each derived CSV's `n` against the primary n; any divergence
+that is not explained by a stated sub-analysis restriction is a Major Comment, `requires_reanalysis`
+(re-run, not a prose edit — see Phase 4).

--- a/skills/self-review/references/phases/phase2_5b_screening_counts.md
+++ b/skills/self-review/references/phases/phase2_5b_screening_counts.md
@@ -1,0 +1,127 @@
+# Phase 2.5b — Screening-Count Reconciliation from ID Sets
+
+Load-on-demand companion to `/self-review` Phase 2.5b. SKILL.md keeps the entry
+condition and the two deterministic gates; this file carries the ID-set recount
+procedure, the reconciliation-block template, and the precedent failures.
+
+Read it when the manuscript is an SR/MA (the ID-set recount), or when a cohort
+manuscript presents an ordinal tier / mutually-exclusive stratum split whose Ns
+must partition (the binning and composite-indicator branch).
+
+Internal consistency across Abstract/Methods/Results (Phase 2.5) + source fidelity of 2×2 and
+effect-size numbers (Phase 2.5a) do **not** cover study-count arithmetic. The latter is a
+separate failure mode: a prior-draft prose total ("30 → 32 after FLAG consensus") can survive
+every downstream pass because Abstract, Methods, Results, Discussion, Figure 1 caption, and
+even the supplementary consensus file all cite the same wrong number back to each other.
+
+**Precedent failure pattern (a PRISMA-DTA meta-analysis revision):**
+> A late-revision manuscript reported study counts of k_qualitative = 32, k_narrative-only = 10,
+> k_FT-excluded = 46. An ID-level recount against the screening TSV and consensus sheet (with
+> FLAG additions reconciled) yielded k_qualitative = 24 with only 2 narrative-only studies
+> (k_FT-excluded = 54). The original 32/10/46 figures came from an early-draft assumption that
+> was never reconciled against the ID-level artifacts; downstream files (consensus markdown,
+> supplementary tables, edit plans) propagated the same wrong total. Caught only by an explicit
+> ID-set recount against the screening TSV and consensus spreadsheet, verified independently
+> by an adversarial audit.
+
+**When to run:** any SR/MA manuscript revision, regardless of stage. Run before Phase 3.
+
+**Inputs:**
+- Screening TSV with one row per full-text-reviewed record and an include/exclude column
+- Consensus spreadsheet (Excel/CSV) with one row per record requiring adjudication and a
+  `Consensus` column (typical values: `Exclude`, `Include-qualitative`, `Include-bivariate`)
+- Any FLAG-adjudicated inclusion log documenting records added to the qualitative pool
+  outside the primary screening TSV
+- The manuscript's Table 1 (or equivalent): the definitive list of studies contributing to
+  the primary quantitative synthesis
+
+**Procedure:**
+
+1. **Enumerate the ID sets:**
+   - A = set of IDs marked INCLUDE in the screening TSV
+   - B = set of IDs marked Exclude in the consensus spreadsheet
+   - C = set of IDs marked Include-qualitative in the consensus spreadsheet
+   - T = set of IDs represented in Table 1 (via author/year cross-match)
+
+2. **Derive canonical totals:**
+   - k_qualitative = |A \ B| + |C|
+   - k_bivariate = |T|
+   - k_narrative-only = k_qualitative − k_bivariate = |(A ∪ C) \ B \ T|
+   - k_FT-excluded = |screening TSV rows| − |A| + |B ∩ A| + |(B \ A) encountered at FT stage|
+
+3. **List the narrative-only IDs explicitly** — this is the highest-yield cross-check. A
+   manuscript claiming "10 narrative-only studies" while the (A ∪ C) \ B \ T set contains
+   only 2 IDs is an immediate P0 finding.
+
+4. **Compare each derived total against the manuscript's prose claim** in Abstract, Methods
+   §Study Selection, Results §Study Selection, Figure 1 caption, Discussion §Limitations,
+   and any References §Narrative-Only heading. Any mismatch between derived total and
+   manuscript prose = P0 Major Comment, blocking submission.
+
+5. **Record results in a short reconciliation block** and append to the report:
+
+   ```
+   | Quantity | Manuscript claim | ID-derived value | Status |
+   |---|---|---|---|
+   | k_full-text | 78 | 78 | ✓ |
+   | k_qualitative | 32 | 24 | ✗ P0 |
+   | k_bivariate | 22 | 22 | ✓ |
+   | k_narrative-only | 10 | 2 (IDs 120, 474) | ✗ P0 |
+   | k_FT-excluded | 46 | 54 | ✗ P0 |
+   ```
+
+**Any "N → M" transition claim in a consensus summary (e.g., "30 → 32 after FLAG
+consensus") that is not backed by an enumerable ID addition/subtraction set is itself a
+Major Comment**, because the transition is unverifiable by downstream audit. Require
+conversion of every such claim to explicit ID lists before closing the report.
+
+**Observational tier/stratum branch.** The same set-recount logic applies when a cohort
+manuscript presents an ordinal tier or mutually-exclusive stratum split. A partition that
+is claimed to be disjoint must satisfy `Σ(stratum N) == unique total` and
+`Σ(stratum events) == total events`; denominators that sum *above* the unique cohort
+double-count subjects, and a table where every stratum n equals the grand total is a
+stratum-total mis-entry rather than a partition. Run `check_cohort_arithmetic.py`
+(Phase 2.5 above) with the stratum CSV — its `PARTITION_OVERLAP` verdict is the cohort
+analogue of an ID-set mismatch and is a P0 Major:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_cohort_arithmetic.py" \
+  --manuscript manuscript.md --data analysis/strata.csv --strict
+```
+
+Also confirm the reference (baseline) row of any stratified hazard/odds table is present
+and labelled; a missing reference category makes the other strata uninterpretable.
+
+**Cross-script cut-point consistency (root cause of stratum-N drift).** When the same cohort
+is re-stratified in more than one analysis script — a primary table in one file, a sensitivity
+or secondary analysis in another — the derived categorical (age band, BMI category, eGFR stage,
+risk tier) must use one identical cut definition: same breaks, same interval closure
+(`right=`), same labels. If two scripts bin the same variable differently, per-stratum Ns drift
+between tables while the grand total still reconciles, and a stratum can spuriously cross a
+threshold — a `PARTITION_OVERLAP`/stratum-N check on the manuscript alone will not localize the
+cause. `check_binning_consistency.py` parses the analysis source (R/Python) and emits
+`BINNING_DRIFT` (Major) when one variable is derived with ≥2 different `(breaks, right)`
+signatures across files:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_binning_consistency.py" \
+  --root analysis --root scripts --strict
+```
+
+Precedent: a screening cohort binned age with `breaks=c(-Inf,45,50,60,Inf), right=FALSE` in the
+primary script and `breaks=c(-Inf,44,49,59,Inf), right=TRUE` in a threshold sensitivity script;
+fractional ages fell into different bands, shifting hundreds of participants and producing a
+spurious "reached" stratum in the sensitivity table that vanished once the binning was
+harmonized. Fix at the source by defining each cut once in a shared helper that every script
+sources.
+
+The same gate also covers the **composite-indicator** sibling failure: a derived 0/1 component
+(e.g. a metabolic-syndrome criterion built from `as.integer(a >= x | b == 1 | c == 1)`) that is
+re-built in a second script with a clause dropped or added. It splits each definition into
+comparison atoms on the top-level `|`, compares them as a SET (clause order, whitespace, outer
+parentheses, dataframe `df$` qualifiers and commutative `&`-operands are normalized away), and
+emits `DERIVED_DEF_DRIFT` (Major) when one variable carries ≥2 distinct atom sets across scripts.
+Precedent: `mets_bp <- as.integer(bl_he_sbp>=130 | bl_he_dbp>=85 | bl_tx_hypertension_med==1 |
+bl_hypertension==1)` in the benchmark script vs the same name without the final
+`| bl_hypertension==1` in a re-analysis script — the metabolic-syndrome C-index then read 0.6704
+in one table and 0.6712 in another.

--- a/skills/self-review/references/phases/phase2_5d_xref_qc.md
+++ b/skills/self-review/references/phases/phase2_5d_xref_qc.md
@@ -1,0 +1,94 @@
+# Phase 2.5d — Cross-Reference QC (Manuscript ↔ rendered DOCX)
+
+Load-on-demand companion to `/self-review` Phase 2.5d. SKILL.md keeps the two gates,
+the severity policy table, and the no-auto-fix rule; this file carries the precedent
+failure, the input-location procedure, the reconciliation-block template, and the
+comment-emission convention.
+
+Read it when a rendered DOCX exists and the xref gate has fired.
+
+Before the DOCX is built, run the **markdown-stage orphan gate** — every captioned
+`Figure N.` / `Table N.` must be cited at least once elsewhere in the body:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_figure_citation.py" \
+  --manuscript manuscript.md --out qc/figure_citation.json
+```
+
+`FIGURE_ORPHAN` / `TABLE_ORPHAN` (Minor) catch a newly-added float that has a legend
+but no in-text citation — the early, no-build counterpart to `check_xref`'s `UNCITED`
+verdict, which catches the same class on the rendered DOCX (below).
+
+Reference-list integrity (Phase 2.5c) does **not** cover Table/Figure
+cross-references. This is a separate failure mode where in-text citations
+("Supplementary Table S4 reports a sensitivity analysis") resolve to a different
+caption in the rendered DOCX ("Supp Table S4 = a diagnostics table") because the
+build script carries its own legacy SSOT. Internal consistency (Phase 2.5)
+cannot detect it — both the prose and the build artifact echo their own
+divergent truths cleanly.
+
+**Precedent failure pattern (an STROBE cohort manuscript revision):**
+> Body prose cited Supp Table S4 as a sensitivity analysis; the rendered DOCX
+> S4 instead contained a diagnostics table. S1, S6, S7 also mismatched. S8 and S9
+> were cited in the manuscript but absent from the rendered DOCX entirely.
+> Caught only on co-author circulation review.
+
+**When to run:** every manuscript at self-review when a rendered DOCX exists
+(e.g., circulation drafts, post-build pre-submission checks). Skip only if no
+DOCX build has occurred yet (early drafts).
+
+**Procedure:**
+
+1. **Locate inputs.** `manuscript/manuscript.md` (or the SSOT `truth.manuscript_md`)
+   and the rendered DOCX (typically `manuscript/manuscript_final.docx` or the
+   most recent circulation `.docx`).
+
+2. **Invoke the shared script** (lives in `/manage-refs`):
+
+   ```bash
+   python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs/scripts/check_xref.py" \
+     --md manuscript/manuscript.md \
+     --docx manuscript/manuscript_final.docx \
+     --out qc/xref_audit.json \
+     [--allow-separate-attachments]
+   ```
+
+   The script writes `qc/xref_audit.json` with per-label rows tagged
+   `OK | MISSING_DOCX | MISSING_BODY | MISMATCH | UNCITED | NOT_CITED_NO_BODY`,
+   a top-level `submission_safe` boolean, and a `policy.allow_separate_attachments`
+   field that records which severity policy applied.
+
+3. **Translate findings to anticipated comments.** Severity mapping depends on
+   the journal's figure/table submission policy. Many radiology and medical
+   journals (e.g., European Radiology, Radiology, AJR) accept figures and tables
+   as separate attachment files rather than inline in the manuscript DOCX; for
+   those workflows pass `--allow-separate-attachments` so MISSING_DOCX is not
+   treated as a P0 blocker. `MISSING_BODY` and `MISMATCH` remain P0 regardless,
+   because they indicate SSOT drift between body markdown and rendered DOCX
+   rather than a legitimate attachment style.
+
+   | Status | Default policy | With `--allow-separate-attachments` |
+   |---|---|---|
+   | `MISSING_DOCX` | **Major (P0)** — cited Table/Figure absent from rendered output | **Minor** — figure/table is separately attached per journal policy |
+   | `MISSING_BODY` | **Major (P0)** — build SSOT drift; rendered caption has no body definition | **Major (P0)** (no change) |
+   | `MISMATCH` | **Major (P0)** — caption text disagrees between body and rendered DOCX | **Major (P0)** (no change) |
+   | `UNCITED` | Minor — orphan caption that should be cited or removed | Minor (no change) |
+
+4. **Append a reconciliation block to the Phase 3 report:**
+
+   ```
+   | Label | Status | Body caption | DOCX caption | Verdict |
+   |---|---|---|---|---|
+   | Supplementary Table S4 | MISMATCH | Sensitivity analysis | Diagnostics table | ✗ P0 |
+   | Supplementary Table S8 | MISSING_DOCX | (defined in body) | — | ✗ P0 |
+   | Figure 2 | UNCITED | Forest plot of subgroups | Forest plot of subgroups | △ Minor |
+   ```
+
+5. **Emit each P0 row as a separate `M`-numbered Major Comment** with
+   `category: "F"` (Reporting Completeness) and `fixable_by_ai: false`
+   (build script changes are out of scope for the auto-fix loop — they
+   require pipeline-side fixes per `/write-paper` Step 7.6a routing).
+
+**Do NOT auto-fix cross-reference defects in `--fix` mode.** Caption rewrites
+in the body without re-running the DOCX build will simply move the mismatch.
+Surface as Major Comments and let the user route to `/write-paper` Step 7.6a.

--- a/skills/self-review/references/phases/phase2_5f_claim_artifact.md
+++ b/skills/self-review/references/phases/phase2_5f_claim_artifact.md
@@ -1,0 +1,183 @@
+# Phase 2.5f — Claim-vs-Artifact Cross-Check: procedure and verdict rationale
+
+Load-on-demand companion to `/self-review` Phase 2.5f. SKILL.md keeps the gate
+invocations and the verdict-severity map; this file carries the precedent failure,
+the per-verdict rationale, the resolution paths, and the four checks no script makes.
+
+Read it when a Phase 2.5f gate fires and you need to know what the verdict means and
+how to resolve it — or when the manuscript has a pre-registration to reconcile against.
+
+Phases 2.5–2.5e check numbers and adjustment sets. This phase checks **claims
+against the external artifacts they should trace to** — the pre-registration, the
+protocol, the analysis outputs. These are the errors that survive a single-pass
+review because the manuscript prose is internally consistent yet disagrees with
+the registration or the analysis it reports. The first scope is the two highest-
+value, deterministic instances; figure/flow-count reconciliation, Methods-promised-
+analysis completeness, and imputation-input integrity are separate subchecks (run
+`/make-figures` legend reconciliation and `/write-paper`'s Methods-promised gate).
+
+**Precedent failure pattern:**
+> A manuscript reported a null primary association from a multiple-imputation model
+> and described it as "pre-specified," while the registered primary had been the
+> complete-case model that was significant — the primary had been re-designated after
+> the results were known. In the same paper an E-value of 2.79 was attached to the
+> primary HR of 1.34, but 2.79 does not recompute from 1.34 (it came from a different,
+> non-primary estimate), and a second E-value bounded an exploratory cancer-specific
+> hazard, not the headline contrast. None of these tripped the internal-consistency
+> checks; all three are deterministic against the registration and the arithmetic.
+
+**Procedure:**
+
+1. **Run the cross-check** with the manuscript and (if available) the pre-registration
+   / protocol / `project.yaml`:
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_claim_artifact.py" \
+     --manuscript manuscript.md --prereg prereg.md \
+     --out qc/claim_artifact.json --strict
+   ```
+
+2. **Estimand provenance.** The script raises `PRIMARY_REASSIGNED` (Major,
+   category: A. Study Design & Data Integrity) only on **explicit** language that the
+   primary was re-designated / switched / chosen post-hoc after results were known — a
+   genuine P0. The fix is to report the pre-specified and the revised models
+   **coequally** and disclose the change in the Abstract and Limitations, not to
+   silently lead with the more favourable estimate. Two related verdicts are
+   **advisory, not Major** — surface them as Anticipated Minor Comments to confirm,
+   never as a blocker: `ESTIMAND_DRIFT` (the fuzzy manuscript↔registration primary
+   token overlap is below threshold — noisy; confirm against the actual registration
+   before treating it as drift) and `PRIMARY_DISCLOSURE_NOTE` (the manuscript discloses
+   a manuscript-stage analytical decision — the honest disclosure estimand-provenance
+   guidance *recommends writing*; confirm it is reported coequally, do not penalise it).
+
+3. **E-value.** `EVALUE_ARITHMETIC` means the reported E-value does not recompute from
+   its adjacent effect estimate (the value was likely produced for a different estimate);
+   `EVALUE_NON_PRIMARY` means the E-value is attached to a secondary/exploratory estimate
+   but presented as if it bounded the headline claim. Both warrant a Major/Minor comment —
+   recompute the E-value for the **declared primary** estimate and its near-null confidence
+   limit, and quote it there.
+
+4. **Primary-change guard.** Independently of the script, if the manuscript reports two
+   models for the same contrast where one is significant and the other null and the
+   significant one is foregrounded, confirm which was pre-specified; an outcome-dependent
+   choice of primary model is a Major comment even when each model is individually correct.
+
+5. **Headline vs own-sensitivity direction.** Read the sensitivity series (S1 etc.) the
+   manuscript itself reports. If the headline causal/association claim points the *opposite*
+   way from the authors' own adjusted or sensitivity estimate — a positive lead sentence over
+   a sensitivity model that attenuates to the null, or vice versa — that is a Major: the paper
+   is contradicting its own robustness check. This is a prose judgement, not a script verdict.
+
+6. **Methods ↔ Results ↔ disk coverage.** Run the deterministic coverage gate:
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_artifact_coverage.py" \
+     --manuscript manuscript.md --analysis-dir output/analysis \
+     --out qc/artifact_coverage.json --strict
+   ```
+
+   `PROMISED_ABSENT` (an analysis named in Methods that never reaches Results) and
+   `DISK_UNREPORTED` (an analysis output on disk — an added-value DeLong CSV, a calibration
+   table — never mentioned in the manuscript) are Anticipated Major Comments. The reverse
+   direction matters because a run-but-unreported result can be the one that undercuts the
+   headline. When an `_analysis_outputs.md` manifest exists the gate uses it as the source of
+   truth; otherwise it globs `--analysis-dir` and only escalates analysis-bearing file names.
+
+   The same gate also flags `PROMISED_STAT_NO_VALUE`: a statistic framed as a **bound/
+   ceiling/de-confounded** value (e.g. "the de-confounded reader AUC is reported in
+   Table S16", "the classifier ceiling AUC") promised with a reporting verb but never
+   given a numeric value anywhere in the manuscript **or supplement** — the bound that
+   makes the primary estimand interpretable, sometimes marked "Addressed" in a checklist
+   yet absent from every table. Pass the rendered supplement so the corpus is complete:
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_artifact_coverage.py" \
+     --manuscript manuscript.md --supplement supplement.md \
+     --out qc/artifact_coverage.json --strict
+   ```
+
+7. **Supplement / tables / caption hygiene.** Phases 2.5–2.5e and the classical-style
+   gate lint `manuscript.md` only; the rendered **supplement, a separately-built tables
+   file, and figure-caption files** are never linted — yet that is where technical-check-
+   fatal residue hides (internal §/§L SAP labels, unfilled `Table SX`/`[Authors]`
+   placeholders, `[VERIFY]`/`TODO` build markers, response-to-reviewers framing, planning
+   residue, and body↔supplement cross-reference numbers that do not resolve). Run the
+   supplement-hygiene gate over **every** rendered reader-facing artifact:
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_supplement_hygiene.py" \
+     --supplement supplement.md --supplement tables.md --supplement captions.md \
+     --manuscript manuscript.md --out qc/supplement_hygiene.json --strict
+   ```
+
+   All verdicts (`SUPP_INTERNAL_LABEL`, `SUPP_PLACEHOLDER`, `SUPP_BUILD_MARKER`,
+   `SUPP_RESPONSE_FRAMING`, `SUPP_PLANNING_RESIDUE`, `SUPP_XREF_UNRESOLVED`) are
+   Anticipated Major Comments — a reader-facing slip in a supplement is as fatal at a
+   technical check as one in the body.
+
+   **Float citation order (same technical-check pass).** Editorial offices "unsubmit"
+   manuscripts *before* peer review when numbered floats are not cited in ascending
+   order of first appearance — a fully deterministic desk-check item the hygiene gate
+   above does not cover (it lints xref *resolution*, not *order*). Run the citation-order
+   gate, which checks each series independently (main Tables, main Figures, Supplementary
+   Tables, Supplementary Figures), scanning only the narrative body (it auto-excludes the
+   Figure Legends / back-matter so an in-order legends block cannot mask an out-of-order
+   body):
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_citation_order.py" \
+     --manuscript manuscript.md --out qc/citation_order.json --strict
+   ```
+
+   `CITATION_ORDER` (Major) — a series cited out of numerical order (e.g. Table 3 before
+   Tables 1–2, or Supplementary Tables cited S4, S9, S16, S12, …); fix by renumbering the
+   series by first-citation order (and reordering the float/supplement document + remapping
+   every cross-reference, expanding ranges like `S12–S15` by hand and leaving non-float
+   sensitivity-spec labels such as `S1–S6` untouched) or by rephrasing away the early
+   citation. `CITATION_GAP` (Minor) — cited numbers not contiguous from 1 (a possible
+   missing/mis-numbered float).
+
+8. **Re-run cross-artifact staleness after any audit or reframe.** When a headline number
+   is corrected or an analysis is re-framed, the fix often lands only in the body while a
+   supplement footnote or a figure-source data file keeps the stale (sometimes *reversed*)
+   value. Re-run `/sync-submission`'s `check_cross_artifact_stale.py` across the body, the
+   supplement, and any figure-source data immediately **after** the reframe — not just once
+   at the start — so a corrected body never ships next to a stale supplement.
+
+9. **Power-aware null interpretation.** A headline negative claim ("no synergy", "not
+   associated", "showed no difference") is interpretable only next to a precision
+   statement — a minimum-detectable-effect, a power calculation, an equivalence
+   margin/TOST, or a CI-compatibility sentence. Run the null-calibration gate:
+
+   ```bash
+   python3 "${CLAUDE_SKILL_DIR}/scripts/check_null_calibration.py" \
+     --manuscript manuscript.md --out qc/null_calibration.json --strict
+   ```
+
+   `CONFIRM_NULL_NO_MDE` (Major) fires when a negative/equivalence claim in the Title/
+   Abstract/Conclusion has no such token anywhere in those regions — a non-significant
+   result is not evidence of no effect without one. (A single MDE/power/equivalence/CI-
+   compatibility sentence suppresses it.) Pair with the interaction-scale checks (`O14`)
+   when the null is a synergy/interaction claim.
+
+10. **Confidence-weighted / rating → AUC monotonicity.** For an observer or reader study
+    that collapses a (binary-call × confidence) rating into a single score used as the
+    ROC/AUC predictor, verify the encoding is **strictly monotonic** across the full
+    ladder — a *folded* score (`cws = confidence if positive-call else 6 − confidence`)
+    collapses opposite (call × confidence) cells and silently mis-estimates the AUC; a
+    prose review cannot see an estimator bug. Run the encoding through the reusable
+    monotonicity probe and ship its 10-combination unit test:
+    `python3 "${MEDSCI_SKILLS_ROOT}/skills/analyze-stats/scripts/rating_monotonicity.py" --encoding score_def.json`.
+
+11. **Figure-embedded numbers are text-grep blind.** PRISMA/flow/forest/statistic figures
+    are rasterised, so every numeric audit above is blind to the numbers *inside* them.
+    Before submission, (a) **visually** read each such figure page in the rendered/blind
+    PDF, and (b) reconcile the **hard-coded integers** in the figure-generation script
+    (`create_figure*.R`, `make_*.py`) against the body/flow-source counts
+    (`grep -nE '<-\s*[0-9]+|=\s*[0-9]+' figures/*.R`). See `submission-portal-verification`
+    §9.5 (figure-image DATA drift) for the full procedure.
+
+The script is deterministic but its provenance match is fuzzy (token overlap): read the
+reconciliation in `qc/claim_artifact.json` and confirm against the actual registration
+before raising `ESTIMAND_DRIFT`. For time-to-event manuscripts, also apply probe **S8
+(estimand provenance)** of `references/domain-probes/survival_prognostic.md`.

--- a/skills/self-review/references/phases/phase2_systematic_check.md
+++ b/skills/self-review/references/phases/phase2_systematic_check.md
@@ -1,0 +1,214 @@
+# Phase 2 — Systematic Check: the A–L category detail
+
+Load-on-demand companion to `/self-review` Phase 2. SKILL.md keeps the category
+index and the deterministic gates; this file carries the per-category check
+tables — the long enumeration you only need once you have the manuscript in hand
+and know its type.
+
+Run the manuscript through each applicable category. For each item, assess whether
+a reviewer would raise it as a Major or Minor comment. Use the Research-Type
+Adaptation table in SKILL.md to decide which categories apply fully, partially, or
+not at all for this manuscript type.
+
+
+## A. Study Design & Data Integrity
+
+| Check | What to look for |
+|-------|-----------------|
+| Patient-level splitting | Are train/val/test splits at the patient level? Is this explicitly stated? |
+| Leakage risk | Any postoperative variable used in a preoperative model? Cohort-wide preprocessing before split? |
+| Input-text contamination | For NLP/LLM extraction tasks, does any supplied report text (clinical history, indication, impression, prior diagnosis, referral text) already contain the target label? If yes, mark as Major unless the input was masked or a no-leaky-field sensitivity analysis is reported. |
+| Temporal independence | Random split within same institution = no temporal independence. Acknowledged? |
+| Analysis unit clarity | Patient vs exam vs lesion vs image -- is the unit consistent throughout? |
+| Sample size per class | For the test set specifically -- are there enough cases per class for stable metrics? |
+
+## B. Reference Standard & Ground Truth
+
+| Check | What to look for |
+|-------|-----------------|
+| Definition specificity | Is the reference standard precisely defined? (e.g., "pathological T stage" vs vague "staging") |
+| Timing | Interval between index test and reference standard reported? |
+| Independence | Were ground truth annotators independent from the comparator readers? |
+| Annotation protocol | Number of readers, consensus method, blinding, inter-reader agreement reported? |
+
+## C. Validation & Statistical Reporting
+
+| Check | What to look for |
+|-------|-----------------|
+| Confidence intervals | All primary metrics have 95% CIs? |
+| Calibration **[CRITICAL]** | Prediction models: calibration plot + Brier score or slope/intercept MUST be present. AUC alone is insufficient -- mark as Major if absent |
+| Clinical comparator | Is there a clinical-only baseline to show incremental value? |
+| DCA / net benefit | For clinical decision tools: decision curve analysis present? |
+| Fine-tuning baseline | For LLM/NLP fine-tuning, LoRA, prompt-engineering, or multi-agent claims, is there a same-backbone zero-shot or few-shot comparator on the same input, schema, and test split? |
+| Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
+| Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
+| Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
+| Power-aware null interpretation | Scored separately from significance, for any **non-significant primary result** (p > 0.05, 95% CI crossing the null): is the analysis powered to *exclude* a clinically meaningful effect? An underpowered null is "not yet established," not "no effect" -- if the upper CI bound still includes a meaningful effect size, a flat "X was not associated with Y" claim overreads the data. Look for reported observed power or a minimum detectable effect that justifies a negative conclusion, and watch for **bilateral over-correction** (a prior "independently associated" overclaim swinging to an equally unsupported "not associated" claim during revision). Undocumented null = Minor; a null that drives a clinical recommendation or a headline negative conclusion without power/CI-compatibility justification = Major. |
+| Equivalence-margin discipline | A claim that two groups/methods are "equivalent," "non-inferior," "indistinguishable," or show "no difference" requires a **pre-stated margin** — a TOST procedure, or the CI compared against a declared MCID. Grep `indistinguishable\|equivalent\|non-inferior\|no difference` and check for an adjacent `margin\|TOST\|MCID\|non-inferiority`; a margin-free equivalence claim is a Major (it converts a failure to reject into positive evidence of no effect). |
+| Interaction-anchor discipline | When synergy / interaction / effect-modification **is** the research question, the null must be anchored to the **interaction parameter** (a likelihood-ratio test of the interaction term, or the interaction OR/HR on one consistent scale), not to a main-effect OR whose upper CI is then read as "no synergy." Grep `synergy\|interaction\|joint effect\|effect modification`; if present, confirm Results carries an `OR_int\|β_int\|LRT\|p_interaction` term. A synergy conclusion resting on a main-effect estimate is a model mis-specification (Major), even when each main effect is individually correct. |
+| Difference-in-significance discipline | A between-group claim that an association is "more X / stronger / more pronounced in group A than group B" must rest on a **formal interaction test**, not on group A being significant (p < 0.05) while group B is not (p = NS). The difference between "significant" and "non-significant" is **not** itself significant. Grep `more (clearly\|strongly\|pronounced)\|stronger in\|(only\|chiefly) in (men\|women\|older\|younger\|the [A-Za-z]+ subgroup)` near two stratum-specific estimates with discordant p-values; if no interaction term (`p_interaction\|OR_int\|LRT`) is reported for that contrast, flag it (difference-in-significance fallacy). A subgroup-difference conclusion built this way is a Major; the fix is to report the interaction test or soften to "associations were observed in group A; the interaction was not formally tested." |
+
+## D. Clinical Framing & Importance
+
+| Check | What to look for |
+|-------|-----------------|
+| Intended use | Is the clinical decision point clearly stated? (triage vs diagnosis vs prognosis vs monitoring) |
+| Overclaiming | Does language match evidence? ("will improve" -> "may potentially"; "superior" with overlapping CIs?) |
+| Terminology precision | Key terms defined? (e.g., "perioperative" = when exactly?) |
+| Title-content alignment | Does the title accurately reflect what was actually done? |
+| Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
+| Substantive novelty differentiation | For AI/LLM extraction papers, does the Introduction name 2-3 close prior papers/systems and state the concrete delta (new task, dataset, workflow, method, validation, or clinical decision point), rather than merely saying the method is novel? |
+| Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
+| Decision impact | Does the manuscript state what decision, workflow step, or downstream action would change if the model is correct? A text-only phenotype that does not alter triage, treatment, surveillance, enrichment, or research operations has weak clinical utility even if accuracy is high. |
+| Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
+| Endpoint↔conclusion scope **[CRITICAL]** | Does the conclusion's *action* exceed what the design or endpoint supports? A cross-sectional / single-visit study cannot license a prognostic or surveillance claim (rescreen interval, disease progression); a binary surrogate endpoint (present/absent, >0) is risk stratification, not a care directive (defer/withhold/initiate therapy). Both are documented anti-patterns. |
+
+Run the deterministic scope gate:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_scope_coherence.py" \
+  --manuscript manuscript.md --out qc/scope_coherence.json --strict
+```
+
+`CROSS_SECTIONAL_PROGNOSTIC` and `SURROGATE_CARE_DIRECTIVE` are Anticipated Major Comments (category: D. Clinical Framing). `CROSS_SECTIONAL_YIELD_LANGUAGE` is an Anticipated **Minor** Comment — a cross-sectional / prevalence design using incidence-flavored screening vocabulary ("yield", "detection rate", "number-needed-to-screen/image", "rescreen interval") without defining "yield" once as cross-sectional report-positive prevalence. The gate is conservative — it fires only when a design/endpoint signal and a conclusion-region action verb (or the yield lexicon) co-occur.
+
+## E. Reproducibility
+
+| Check | What to look for |
+|-------|-----------------|
+| Preprocessing details | All steps listed in order? Normalization, augmentation, resampling specified? |
+| Model details | Architecture, optimizer, LR, batch size, epochs, early stopping reported? |
+| Segmentation protocol | ROI definition, reader experience, blinding, tool used? |
+| Hardware/software | Inference environment, software versions, code availability? |
+| Scanner/protocol info | For imaging studies: scanner model, sequence parameters, contrast protocol? |
+| Data/code availability | Is a data availability statement included? Code shared or reason for not sharing stated? |
+
+## F. Reporting Completeness
+
+| Check | What to look for |
+|-------|-----------------|
+| Abstract-body consistency | Numbers in Abstract match Tables/Results? |
+| Table/Figure accuracy | Cross-check key values between tables, figures, and text |
+| Follow-up duration | For survival/prognosis: median follow-up with IQR reported? |
+| Ethics | All participating institutions' IRB approval documented? Patient consent described? |
+| Missing data | Handling of incomplete cases described? |
+| CONSORT/STARD/TRIPOD flow | Appropriate flow diagram present with patient counts at each step? |
+| Body word count vs journal cap | Is the body within the target journal's word limit? A revise loop monotonically adds words and silently breaches the cap. Run `/sync-submission` `scripts/check_wordcount_cap.py` (`--journal-profile` or `--limit`; the binding number is the rendered DOCX count). Over cap → Major; within 0.95× → Minor (a further pass will likely breach). |
+| Funding & COI | Funding sources and competing interests disclosed? |
+
+## G. Reporting Guideline Compliance
+
+Match the manuscript type to the appropriate checklist and verify key items:
+
+| Manuscript type | Checklist | Critical items to verify |
+|----------------|-----------|------------------------|
+| Diagnostic accuracy | STARD / STARD-AI | Flow diagram, reference standard, spectrum |
+| Prediction model (non-AI) | TRIPOD 2015 | Model development vs validation, calibration, missing data |
+| Prediction model (AI/ML) | TRIPOD+AI 2024 | Model development vs validation, calibration, leakage, fairness |
+| AI / Radiomics | CLAIM 2024 / CLEAR | Feature selection transparency, external validation |
+| RCT | CONSORT / CONSORT-AI | Randomization, blinding, ITT |
+| Systematic review (interventions) | PRISMA 2020 | Search strategy, screening, risk of bias |
+| Meta-analysis (observational) | MOOSE + PRISMA 2020 | Confounding assessment, heterogeneity, publication bias |
+| Observational | STROBE | Confounding, selection bias, missing data |
+| Reliability / agreement | GRRAS | ICC model/type, rater description, measurement protocol |
+| Educational | SQUIRE 2.0 | Intervention description, outcome measures, context |
+| Case report | CARE | Timeline, diagnostic reasoning, informed consent |
+| Surgical | STROBE-Surgery | Surgeon experience, technique details, complications |
+
+For a full item-by-item audit, run `/check-reporting` on this manuscript. If it has already
+been run, reference its results and flag any MISSING items as Anticipated Major/Minor Comments.
+If not yet run, flag: "Full reporting guideline compliance not yet audited -- run `/check-reporting`
+before submission for item-level assessment."
+
+## H. Circularity
+
+| Check | What to look for |
+|-------|-----------------|
+| Label-feature overlap | Is the prediction label derived from the same data source as any input features? (e.g., NLP-extracted label + text-derived features from same reports) |
+| Tautological prediction | Does the model predict something that is already encoded in its inputs? |
+| Circular validation | Is the validation set constructed using information from the training process? |
+
+## I. Protocol Heterogeneity
+
+| Check | What to look for |
+|-------|-----------------|
+| Multi-site acquisition | If multi-site: are scanner models, protocols, and acquisition parameters reported per site? |
+| Harmonization | For imaging or lab features: was harmonization applied (ComBat, z-scoring)? If not, acknowledged? |
+| Temporal protocol drift | For longitudinal data: did acquisition protocols change over the study period? |
+
+## J. Method Transparency
+
+| Check | What to look for |
+|-------|-----------------|
+| Model provenance | Is it clear where the model came from? (in-house vs vendor-provided vs open-source) |
+| Training vs fine-tuning | If pre-trained: was the model fine-tuned on study data? If vendor-provided: any access to training data composition? |
+| Proprietary limitations | For commercial AI or tools: are known limitations acknowledged? Can results be independently reproduced? |
+| Classical-style body conventions | Does the body carry an AI tell or a policy violation a senior reviewer flags on sight — a `§` symbol, an in-body AI-disclosure paragraph, eligibility criteria as prose, mixed OR/HR decimal places, or em-dash overuse? |
+
+Run the deterministic classical-style lint (these are all greps, so they belong in a gate, not eyeballing):
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_classical_style.py" \
+  --manuscript manuscript.md --out qc/classical_style.json --strict
+```
+
+`SECTION_SYMBOL` and `INBODY_AI_DISCLOSURE` are Major (the `§` count must be 0; the AI-disclosure paragraph belongs on the title page for a classical / senior-MA target, not the body). `ELIGIBILITY_PROSE`, `DECIMAL_INCONSISTENCY`, and `EM_DASH_OVERUSE` are Minor. This is the self-review-side mirror of `/write-paper` Step 7.1's classical QC (manuscript-style-classical §5/§6/§7/§8).
+
+## K. Reviewer-team consistency (SR/MA-only; fabrication-grade)
+
+| Check | What to look for |
+|-------|-----------------|
+| DUAL vs SINGLE conjunction **[CRITICAL]** | Methods or PROSPERO claims dual independent reviewers AND Discussion/Limitations admits single primary reviewer + 20% sample (or "deferred to before submission")? Mark as **MAJOR**, fabrication-grade. |
+| LLM-as-reviewer **[CRITICAL]** | A per-study extraction JSON whose `reviewer`/`screener`/`extractor` field is an LLM (Claude, GPT-4, Gemini, "LLM")? An LLM is a tool, not an independent reviewer — listing it as one misrepresents the team. **Fatal**, regardless of the prose. |
+| Deferred mitigation | A future-tense mitigation promise — "a 20% sample **will be completed before submission**" — unmet at circulation? The future tense is the tell that the work is not done. **MAJOR**. |
+
+Run the deterministic check at Phase 2 entry (pass the extraction JSON — a file or
+a directory of per-study JSONs — so the prose↔JSON↔confession 3-way is covered):
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
+    --manuscript manuscript.md \
+    --prospero prospero/record.md \
+    --extraction-json extraction/ \
+    --out _audit_self/reviewer_team_consistency.md
+```
+
+Exit 1 = MAJOR red flag. The JSON sidecar carries `dual_hits`, `single_hits`,
+`llm_reviewer_hits`, and `deferred_mitigation_hits`. Any of the DUAL+SINGLE
+conjunction, an LLM reviewer field, or a deferred mitigation trips it. Either of
+the dual/single claims alone is fine; the conjunction is read by reviewers as
+fabrication. Resolution path:
+1. Honest Methods/PROSPERO update (single-reviewer execution disclosed), OR
+2. Limitations confession rewritten if dual review was actually completed.
+
+## L. Editorial impression & defensiveness (advisory; the counterweight)
+
+This is the **ceiling** category (see "Two Objectives" above) and the inverse of the floor
+gates: where A–K and the numerical gates ask "what is missing or wrong?" (and answer by
+**adding**), L asks "does the accurate manuscript read confidently, or has it over-defended?"
+(and answers by **subtracting**). Every L finding is **advisory (Minor / impression) and
+non-blocking** — it never converts to a Major and never blocks submission. The fixes are
+REMOVE / MOVE / TIGHTEN, not "add a caveat."
+
+| Check | What to look for | Action |
+|-------|-----------------|--------|
+| Hedge density | Defensive-caveat tokens stacking up per 1,000 narrative words — the prose hedges faster than it asserts. Keep the load-bearing caveats; cut the reflexive ones. | TIGHTEN |
+| Repeated caveat | The same caveat motif ("no deployable claim", "not generalizable", "hypothesis-generating") repeated across body + Abstract. Say it once, firmly. | TIGHTEN |
+| Audit minutiae in body | Provenance tokens (SHA / git commit / unit-test / post-lock timeline / manifest / seed=N / audit trail) in the Introduction / Results / Discussion narrative. Reproducibility detail belongs in a Methods statement or a supplement. | MOVE |
+| Limitations volume | A Limitations passage that enumerates a long list of discrete items reads as a rebuttal letter; consolidate related items. | TIGHTEN |
+| Abstract caveat load | The Abstract carries several caveat clauses, burying the headline result before a reader reaches it. Lead with the result; keep one or two essential qualifiers. | TIGHTEN |
+| Buried defense | A strong numeric robustness / sensitivity result sitting only in Limitations or the supplement, with no robustness mention in Results. Promote it into Results — it is *evidence for* the finding, not a caveat against it. (The inverse of the scope-coherence gate, which pushes a *weak* analysis out of Results.) | MOVE |
+
+Run the deterministic gate (Phase 2.5g) rather than eyeballing it — these are all counts and placements:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_editorial_impression.py" \
+  --manuscript manuscript.md --out qc/editorial_impression.json
+```
+
+`HEDGE_DENSITY`, `HEDGE_REPEAT`, `AUDIT_IN_BODY`, `LIMITATIONS_VOLUME`, `ABSTRACT_CAVEAT_LOAD`,
+and `BURIED_DEFENSE` are Anticipated **Minor** Comments (category: L. Editorial impression),
+each carrying a REMOVE / MOVE / TIGHTEN `action`. The gate never blocks (it has no Major and
+exits 0 even under `--strict`); thresholds are tunable (`--hedge-per-1k`, `--repeat-threshold`,
+`--limitations-max`, `--abstract-caveat-max`). It is conservative — each probe fires only on an
+explicit, locatable signal.

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -37,122 +37,67 @@ Gather essential information from the user before any writing begins.
 5. **Available data**: what datasets, tables, analyses already exist
 
 **Optional flags:**
-- `--no-llm-disclosure`: Skip LLM writing assistance disclosure. Default is ON (disclosure included). See [LLM Disclosure](#llm-writing-disclosure) section below.
-- `--autonomous`: Run the full pipeline without user gates. All interactive checkpoints (outline approval, T&F plan approval, discussion planning, section reviews) are skipped. The pipeline executes Phases 0-7 sequentially without pausing. Default is OFF (all gates active). Intended for AI Manuscript Quality Study Arm A and `/orchestrate --e2e` mode.
+- `--no-llm-disclosure`: skip the LLM writing-assistance disclosure. Default is ON.
+- `--autonomous`: run Phases 0–7 without user gates (outline approval, T&F plan, discussion planning, section reviews all skipped). Default OFF.
 
 **Actions:**
-1. Load the journal profile. If no profile exists, ask the user for: word limits, abstract format, citation style, figure/table limits, special requirements.
-2. Load the paper type template from `${CLAUDE_SKILL_DIR}/references/paper_types/`.
-3. Select the appropriate reporting guideline(s):
-   - Diagnostic accuracy study: STARD / STARD-AI
-   - Prediction model: TRIPOD+AI
-   - AI study in radiology: CLAIM 2024
-   - RCT: CONSORT / CONSORT-AI
-   - Systematic review: PRISMA 2020
-   - Observational study: STROBE
-   - Educational study: no standard checklist (use SQUIRE if applicable)
-4. **AI/LLM design-stage reporting map**: for AI validation, LLM/MLLM, NLP extraction, or report-generation papers, map each required AI-reporting item to a manuscript section before drafting. At minimum record model/version/access date, input fields, prompt or fine-tuning protocol, same-backbone zero-shot/few-shot baseline if an adaptation claim is made, test-data independence/contamination assessment, repeatability/stochasticity handling, and the Methods subsection where each will appear. If any item cannot be placed, halt for design clarification rather than burying it as a Phase 7 limitation.
+1. Load the journal profile. If none exists, ask for word limits, abstract format, citation style, figure/table limits, and special requirements.
+2. Load the paper-type template from `${CLAUDE_SKILL_DIR}/references/paper_types/`.
+3. Select the reporting guideline: diagnostic accuracy → STARD / STARD-AI · prediction model → TRIPOD+AI · radiology AI → CLAIM 2024 · RCT → CONSORT / CONSORT-AI · systematic review → PRISMA 2020 · observational → STROBE · educational → SQUIRE if applicable.
+4. **AI/LLM design-stage reporting map** (AI validation, LLM/MLLM, NLP extraction, report generation): map every required AI-reporting item to a manuscript section *before* drafting — model/version/access date, input fields, prompt or fine-tuning protocol, same-backbone zero-shot/few-shot baseline if an adaptation claim is made, test-data independence/contamination, repeatability, and the Methods subsection each will land in. **If any item cannot be placed, halt for design clarification** rather than burying it as a Phase 7 limitation.
 5. Create or confirm the project scaffold directory.
-6. Check for `--no-llm-disclosure` flag. If absent, LLM disclosure is ON by default.
-   Check for `--autonomous` flag. If present, record autonomous mode as ON.
-   Record both flag states for use in Phase 1-7 gate logic.
+6. Record the `--no-llm-disclosure` and `--autonomous` flag states for Phase 1–7 gate logic.
+7. **Identify a backbone article** — scan `manuscript/_src/refs.bib` first and propose proactively; ask only as a fallback. Record the chosen citekey in `project.yaml::backbone_article`. The ranking and proposal behaviour are in the reference file. Then gate on its full text — **a backbone whose full text is not extracted is a backbone in name only; the draft would follow an abstract:**
 
-#### Case Report Mode
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/gate_backbone_fulltext.py \
+     --project project.yaml --refs manuscript/_src/refs.bib \
+     --fulltext-dir pdfs/ --strict
+   ```
 
-When paper type is "case report":
-1. Load `${CLAUDE_SKILL_DIR}/references/paper_types/case_report.md` (CARE structure).
-2. Load `${CLAUDE_SKILL_DIR}/references/exemplar_case_report.md` for the narrative flow,
-   150-word structured abstract anatomy, and case-report failure modes.
-2b. If the case is **imaging-led** (diagnostic radiology, nuclear medicine, or interventional
-    radiology — the contribution is the image or an image-guided procedure), also load
-    `${CLAUDE_SKILL_DIR}/references/exemplar_case_report_radiology.md` for per-modality
-    technique→findings→impression discipline, structured-reporting lexicons (BI-RADS/LI-RADS/
-    PI-RADS/TI-RADS/Lung-RADS/O-RADS), quantitative anchors with method/threshold honesty,
-    multimodality discordance, the IR procedure/complication subtype, incidental-finding reporting,
-    and DICOM de-identification / real alt text / device-vendor COI.
-3. Override word limits: total 1000-1500 words (excl. abstract, references, legends).
-4. Override abstract limit: 150 words, structured (Introduction, Case Presentation, Conclusion).
-5. Override reference limit: 15 references maximum.
-6. Apply CARE 2013 reporting guideline (mandatory; see `/check-reporting` `CARE.md`).
-7. Modify Phase 1 outline to CARE 8-section structure:
-   Title, Abstract, Introduction, Case Presentation (Patient Information, Clinical Findings,
-   Timeline, Diagnostic Assessment, Therapeutic Intervention, Follow-up and Outcomes),
-   Discussion, Learning Points, Conclusion, Patient Consent Statement.
-8. In Phase 2, default figures:
-   - Figure 1: Key imaging findings (annotated, typically 3-6 panels)
-   - Figure 2: Clinical timeline (if complex course)
-   - Table 1: Laboratory and clinical data at presentation
-9. In Phase 5 (Discussion), call `/search-lit` with query: `"[condition]" AND "case report"[Publication Type]`.
-   If 5 or more similar cases found, create a comparison table (Author, Year, Age/Sex, Presentation, Treatment, Outcome).
-   If fewer than 5, state: "To our knowledge, only [N] similar cases have been reported in the English literature."
-10. Skip Phase 5a Discussion Planning Gate — case reports are shorter; proceed directly to drafting.
-11. For extended case reports with literature review, user can specify `--extended` to raise
-    the word limit to 2000-3000 words and add a structured review section.
-
-#### Case Series Mode
-
-When paper type is "case series" (n≥2 patients reported together):
-1. Load `${CLAUDE_SKILL_DIR}/references/paper_types/case_series.md` — a case series is a
-   **methods-light mini-cohort**, not a stack of single case reports.
-2. Also load `${CLAUDE_SKILL_DIR}/references/exemplar_case_report.md` for per-case narrative
-   discipline (each vignette still follows the CARE moves).
-3. Typical word count: 1500–3000 words (scales with patient count).
-4. Apply CARE adapted for multiple patients; for ≥5 surgical cases consider PROCESS/SCARE.
-5. Modify Phase 1 outline to: Title → Abstract (structured) → Introduction → **Methods**
-   (design, setting, case identification, eligibility as a numbered list, protocol, assessment
-   process) → **Results** (mandatory all-cases summary table + consistent per-case vignettes,
-   grouped by subtype where a taxonomy exists) → Discussion (cross-case synthesis +
-   cohort-level limitations) → Conclusions → Ethics/Consent.
-6. In Phase 2, default a **summary Table 1 enumerating every case** (one row per patient) plus
-   representative figures labeled to each case number.
-7. In Discussion, enforce the case-series discipline: state selection/ascertainment and the
-   screened pool size; **report counts, not rates** (a referral/database series is not a
-   denominator of all disease); cohort-level limitations are mandatory and specific.
-
-7. **Identify a backbone article (auto-proposal first, ask only as fallback)**:
-   a. **Scan first** — if `manuscript/_src/refs.bib` exists, scan it for entries matching the current paper's study design (Phase 0 paper_type), imaging modality, and target journal (or comparable tier). Prefer entries whose Zotero record has a PDF attachment (full text locally available).
-   b. **Rank candidates** by: PDF available locally (+2), recency within 5 years (+1), same target journal (+2), same study design + modality (+2).
-   c. **Behavior**:
-      - **One strong candidate (score ≥ 5)** — propose it proactively: *"I found a likely backbone article: [citation]. Full text appears available. I will use it as the structural backbone unless you prefer another."* Proceed once user confirms or stays silent for one turn.
-      - **Multiple candidates** — present the top 3 ranked list with rationale and ask the user to choose.
-      - **No refs.bib, or no candidates** — ask the user to provide a published study (legacy behavior).
-   d. Record the chosen citekey in `project.yaml::backbone_article` so Methods, Tables, and Figures phases reuse it without re-asking.
-   e. **Full-text readiness gate (MANDATORY before any drafting).** A backbone whose full text is not extracted is a backbone in name only — the draft would follow an abstract. After recording the citekey, confirm its full text is retrieved and converted to Markdown, then gate on it:
-      ```bash
-      python3 ${CLAUDE_SKILL_DIR}/scripts/gate_backbone_fulltext.py \
-        --project project.yaml --refs manuscript/_src/refs.bib \
-        --fulltext-dir pdfs/ --strict
-      ```
-      `BACKBONE_FULLTEXT_MISSING` / `BACKBONE_FULLTEXT_THIN` means stop and retrieve it first — `/lit-sync` Phase 2.7 (open-access + Zotero "Find Available PDF") then `/fulltext-retrieval` `pdf_to_md.py` to convert the PDF to Markdown. Do **not** begin Methods drafting until this gate passes (addresses issues #4 and #8: the backbone is *used*, not merely *detected*). If the article is genuinely unavailable in full text, record that limitation explicitly and get user confirmation before proceeding on the abstract.
+   `BACKBONE_FULLTEXT_MISSING` / `BACKBONE_FULLTEXT_THIN` → **stop and retrieve it** (`/lit-sync` Phase 2.7, then `/fulltext-retrieval` `pdf_to_md.py`). Do not begin Methods drafting until this passes. If the article is genuinely unavailable in full text, record that limitation and get user confirmation before proceeding on the abstract alone.
 8. Summarize the setup to the user and confirm before proceeding.
 
-**Output:** Setup summary with journal constraints, paper type, reporting guideline, backbone article, directory path, and LLM disclosure status (ON/OFF).
+**Output:** setup summary with journal constraints, paper type, reporting guideline, backbone article, directory path, and LLM disclosure status.
 
 #### Phase 0 Gate: Citekey-only references
 
-Before any section drafting begins, this skill enforces citekey-only entry into
-the manuscript. LLM-generated reference strings in prose are a primary source of
-citation fabrication.
+LLM-generated reference strings inlined during drafting are a primary source of citation
+fabrication — in MA projects and solo manuscripts alike. Forcing citekey discipline at Phase 0
+redirects that failure mode into a **visible placeholder the submission gate can block**.
 
-**Hard rules (v1.1.1 Phase 1A.4)**:
+1. **Every in-text citation MUST be `[@citekey]`**, with `citekey` present in
+   `manuscript/_src/refs.bib`. Pandoc/Quarto style only — no "(Smith et al., 2024)" free text.
+2. For a citation intended but not yet imported, use `[@NEW:short-topic]` (kebab-case, ≤30 chars,
+   unique in the manuscript).
+3. **Never** fabricate a citekey that "looks real" (`[@Smith_2024_AI]`) when the entry is not in
+   `refs.bib`. `[@NEW:...]` is the *only* allowed placeholder.
+4. All `[@NEW:...]` placeholders must be resolved before Phase 7 (`/search-lit` → `/lit-sync`
+   imports verified entries; Better BibTeX refreshes `refs.bib`).
+5. Pre-submission check — must return zero matches before `/sync-submission` may freeze a package:
 
-1. **Every in-text citation MUST be `[@citekey]`**, where `citekey` exists in `manuscript/_src/refs.bib`. Pandoc/Quarto-style only. No "(Smith et al., 2024)" free text.
-2. **For a citation the user intends to add but has not yet imported to Zotero**, use the placeholder form `[@NEW:short-topic]` (e.g., `[@NEW:chest-xray-llm]`, `[@NEW:radbench-1]`). The topic slug is kebab-case, ≤30 characters, and must be unique within the manuscript.
-3. **Never** fabricate a citekey that "looks real" (e.g., `[@Smith_2024_AI]`) when the entry is not in `refs.bib`. The `[@NEW:...]` form is the only allowed placeholder.
-4. Before Phase 7 (Polish), ALL `[@NEW:...]` placeholders must be resolved:
-   - Owner runs `/search-lit` → `/lit-sync` to import verified entries into Zotero; Better BibTeX auto-export refreshes `refs.bib`; owner replaces `[@NEW:topic]` with the real citekey.
-   - Collaborators notify the owner (per `docs/zotero_policy.md`).
-5. Phase 7 pre-submission check: `grep -E '\[@NEW:[^]]+\]|\[N\]|\[N–N\]' manuscript/index.qmd` must return zero matches before `/sync-submission` is allowed to freeze a journal package. The bare numeric markers `[N]` / `[N–N]` are the failure mode where a manuscript is drafted outside this pipeline (no `refs.bib`) and method-load-bearing citations are left as unresolved placeholders; block them the same way as `[@NEW:...]`.
+   ```bash
+   grep -E '\[@NEW:[^]]+\]|\[N\]|\[N–N\]' manuscript/index.qmd
+   ```
 
-**Why this matters**: PRISMA citation fabrication in MA projects and reference hallucination in solo manuscripts both traced back to LLM-generated citation strings inlined during drafting. Forcing the citekey discipline at Phase 0 redirects that failure mode into a visible placeholder the submission gate can block.
+   The bare `[N]` / `[N–N]` markers are the failure mode of a manuscript drafted outside this
+   pipeline (no `refs.bib`), with method-load-bearing citations left unresolved. Block them
+   exactly like `[@NEW:...]`.
 
-**If refs.bib is absent (new project)**:
-- Create an empty `manuscript/_src/refs.bib` placeholder with a comment: `% refs.bib managed by /lit-sync via Zotero Better BibTeX. Do not hand-edit.`
-- Record in `SSOT.yaml` `reference_manager.required_for: project_owner` per Zotero policy.
-- Proceed; all early citations will be `[@NEW:...]` placeholders until the first `/lit-sync` run.
+If `refs.bib` is absent, create it empty with the comment
+`% refs.bib managed by /lit-sync via Zotero Better BibTeX. Do not hand-edit.`, record
+`reference_manager.required_for: project_owner` in `SSOT.yaml`, and proceed — early citations
+will all be `[@NEW:...]` until the first `/lit-sync` run.
+
+**Read on demand — once the paper type is known (step 2), and only the row that matches:**
+
+| File | Read it when | Cost if read blindly |
+|---|---|---|
+| `references/phase0_init_detail.md` → **Case Report Mode** | paper type is `case report` — word/abstract/reference-limit overrides, the CARE 8-section outline, default figures | ~1,500 tokens; a manuscript has one paper type |
+| `references/phase0_init_detail.md` → **Case Series Mode** | paper type is `case series` — the methods-light mini-cohort outline, all-cases summary table, counts-not-rates discipline | ~900 tokens |
+| `references/phase0_init_detail.md` → **Backbone ranking** | `refs.bib` exists and you are proposing a backbone | ~700 tokens |
 
 ---
-
 ### Phase 1: Outline
 
 Create a structured IMRAD outline with section-level word budgets that respect journal limits.
@@ -395,275 +340,83 @@ Write these LAST because they frame the paper and depend on knowing what was act
 
 ### Phase 7: Polish
 
-Final quality pass before submission.
+Final quality pass. **Strict sequential execution — each step MUST complete before the next
+begins.** Every HALT stops the pipeline; none is advisory. Rationale, tables and greps:
+`${CLAUDE_SKILL_DIR}/references/phase7_polish_detail.md`.
 
-**Actions (strict sequential execution — each step MUST complete before the next begins):**
+**7.1 — AI Pattern Scan.** Remove AI writing patterns (see AI Pattern Avoidance below), editing
+`manuscript/manuscript.md` in place. Then run the deterministic lint — the machine-checkable
+subset of the classical-style conventions a senior reviewer flags on sight:
+`python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_classical_style.py" --manuscript manuscript/manuscript.md --strict`.
+For an MA / systematic review, or when a senior co-author review is expected, also work the
+7-grep checklist in `references/section_guides/step7_1_classical_qc.md`. Pattern 19–21 body
+rewrites (§, self-reference, AI-disclosure boilerplate) go to `/humanize`.
 
-#### Step 7.1: AI Pattern Scan
+> **HALT — AI-disclosure meta-applicability.** An AI/LLM-use disclosure must itself satisfy the
+> items the manuscript critiques (FLAIR F1.6, TRIPOD-LLM, MI-CLEAR-LLM): **version**, **access
+> channel**, **date range**, **responsible party**, zero `[version]`/`TODO` placeholders. A paper
+> cannot fail a framework item it critiques. (Classical target: title page, not the body.)
 
-Scan for and remove AI writing patterns (see AI Pattern Avoidance below). Edit `manuscript/manuscript.md` in place.
+**7.2 — Reporting Guideline Check.** Call `/check-reporting`. Auto-insert only MISSING items whose
+`fixable_by_ai` is true; never invent items needing external facts (IRB / registration numbers).
+Log every insertion to `qc/_pipeline_log.md`.
 
-**Classical-style QC (for senior MA reviewers) — load on demand:**
+**7.3 — Citation Verification.** The placeholder gate first — **HARD STOP** on any hit of
+`grep -nE '\[@NEW:[^]]+\]' manuscript/index.qmd manuscript/manuscript.md`, looping back to
+`/search-lit` → `/lit-sync`. Then `/verify-refs`: parse `qc/reference_audit.json` and **stop the
+pipeline** if `submission_safe: false`, surfacing every `FABRICATED` / `MISMATCH` and any
+`duplicate_findings[]`.
 
-| Trigger | Action |
-|---------|--------|
-| Manuscript type = MA, systematic review, or a senior co-author review is expected | Load `references/section_guides/step7_1_classical_qc.md` → run the 7 grep checks together (§ symbol, AI Disclosure paragraph, heading style, eligibility numbered list, Funding placeholder, PROSPERO chronology, em-dash overuse) |
-| Verify all at once with a deterministic lint | `python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_classical_style.py" --manuscript manuscript/manuscript.md --strict` — `SECTION_SYMBOL`/`INBODY_AI_DISCLOSURE` (Major) + `ELIGIBILITY_PROSE`/`DECIMAL_INCONSISTENCY`/`EM_DASH_OVERUSE` (Minor). The machine-checkable subset of the same conventions as the 7-grep checklist. |
-| Global-rule cross-reference | `~/.claude/rules/manuscript-style-classical.md` (motivation for the 11 items) |
-| Pattern 19–21 body rewrite | `/humanize` (§, self-reference, AI Disclosure boilerplate) |
+**7.3a / 7.3b / 7.3c — Integrity audits.** Run all three between 7.3 and 7.4; each can HALT and
+route to 7.4a. **7.3a** numerical claims (text ↔ Table ↔ extraction CSV + primary-source check; a
+direction reversal or a p<0.05↔p≥0.05 crossing is a **P0 blocker**). **7.3b** estimand provenance
+(delegates to `/self-review` 2.5f; `PRIMARY_REASSIGNED`, `EVALUE_ARITHMETIC`, `EVALUE_NON_PRIMARY`
+= **P0**). **7.3c** reference adequacy (every named method cited — resolve via `/search-lit` →
+`/lit-sync` → `/verify-refs --strict`, **never fabricate**). See `phase7_integrity_audits.md`.
 
-**AI-disclosure meta-applicability (manuscript-style-classical §15):** if the manuscript
-contains an AI/LLM-use disclosure, that paragraph must itself satisfy the reporting items the
-manuscript critiques (FLAIR F1.6, TRIPOD-LLM, MI-CLEAR-LLM all require the tool **version**, the
-**access channel**, the **date range**, and the **responsible party**). Enforce all four tokens
-and zero unresolved placeholders:
+**7.4 — Self-Review + Fix Loop.** Call `/self-review --json --fix`: it reviews, applies
+`fixable_by_ai` edits, and re-reviews (≤2 iterations), stopping early on `PASS`. Log the score,
+verdict, iteration count, and residual issues. **Any surviving `severity: "fatal"` issue routes to
+7.4a — do not proceed to 7.5.**
 
-```bash
-DISC=$(grep -niE 'generative ai|large language model|\bLLM\b|assisted (the|with) (writing|drafting)|ChatGPT|Claude|Copilot|Gemini' manuscript/manuscript.md)
-# the disclosure paragraph must carry: version + channel + date + responsible party
-grep -iE 'version|[0-9]+\.[0-9x]+|GPT-[0-9]'   <<<"$DISC"   # version present
-grep -iE 'API|chat|web|Bedrock|Azure|interface' <<<"$DISC"   # access channel present
-grep -E '20[0-9]{2}'                            <<<"$DISC"   # date / date range present
-grep -iE 'by [A-Z]\.[A-Z]\.|reviewed by|deployed by|the authors' <<<"$DISC" # responsible party
-# zero placeholders
-grep -nE '\[(version|date|tool|model|channel)\]|TODO|XXXX|TBD' manuscript/manuscript.md  # must be empty
-```
+**7.4a — Audit Recovery Branch.** Some findings are structural, not prose: the data, protocol, or
+analysis script is wrong, and polishing on top yields a clean manuscript on a broken foundation.
+**Inline text fixes are forbidden** — recovery means re-extraction, re-analysis, or
+re-registration. Halt 7.5–7.6, log the branch, invoke the routed skill, re-enter at **7.3**.
+Loop budget: one cycle. Routing: `references/section_guides/step7_4a_audit_recovery.md`.
 
-Any missing token (or a surviving `[version]`/`TODO`/`XXXX` placeholder) is a HALT: the paper
-cannot critique a framework's AI-disclosure item while failing it itself. For a classical /
-senior-MA target the disclosure paragraph is not placed in the body at all — branch it to the
-title page (manuscript-style-classical §7 forbids the in-body AI-disclosure paragraph).
+**7.5 — Generate Deliverables.** `manuscript/manuscript.md`, `manuscript/title_page.md`,
+`qc/reporting_checklist.md`, `qc/self_review.md`, `qc/_pipeline_log.md`. **Do not hand-number
+author affiliations** — build and verify with `scripts/build_title_page_affiliations.py --check
+title_page.md --strict` (a Nature Portfolio / npj technical-check item).
 
-#### Step 7.2: Reporting Guideline Check
+**7.6 — DOCX Build.** Embed figures from `analysis/figures/_figure_manifest.md`, then render.
+Prefer `/manage-refs` (pandoc + citeproc + journal CSL) for any submission with >5 references, and
+**never hand-type a References list**.
 
-Call `/check-reporting` on `manuscript/manuscript.md`. Parse the output:
-- If the report includes a JSON summary block (Part D), extract MISSING items.
-- For each MISSING item where `fixable_by_ai` is true (e.g., missing ethics statement, missing data availability statement, missing sample size justification), insert the suggested text at the indicated location in `manuscript/manuscript.md`.
-- Do NOT attempt to fix items requiring external information (IRB numbers, registration numbers, protocol details only the author knows).
-- Log all auto-inserted text to `qc/_pipeline_log.md`.
-
-#### Step 7.3: Citation Verification
-
-**7.3.1 — Placeholder gate (v1.1.1 Phase 1A.4).** Before running `/verify-refs`,
-confirm that no `[@NEW:topic]` placeholders remain:
-
-```bash
-grep -nE '\[@NEW:[^]]+\]' manuscript/index.qmd manuscript/manuscript.md 2>/dev/null
-```
-
-If any match is returned, HARD STOP. Report the unresolved placeholders to the
-user and loop back: owner runs `/search-lit` → `/lit-sync` to import entries,
-collaborators flag via owner. Do NOT proceed to 7.3.2 until the grep is clean.
-
-**7.3.2 — Audit.** Call `/verify-refs` on the current manuscript. Per v1.2.0
-contract, its sole output is `qc/reference_audit.json` (no longer writes
-`references/*`). Parse that file: if `submission_safe: false`, stop the pipeline
-and surface the `FABRICATED` / `MISMATCH` records AND any `duplicate_findings[]`
-entries (duplicate PMID/DOI; cite renumbering required) to the user. If
-`/verify-refs` is unavailable, fall back to `/search-lit --verify-only` and flag
-any unverified references with `[UNVERIFIED]` markers.
-
-#### Steps 7.3a / 7.3b / 7.3c: Integrity audits (numerical / estimand / reference-adequacy)
-
-After Step 7.3 and before Step 7.4, run three integrity audits. Each can HALT and route to **Step 7.4a (Audit Recovery Branch)**. **Full procedures (triggers, blocker policy, the delegated checker commands, and the `qc/_pipeline_log.md` log formats) are in `${CLAUDE_SKILL_DIR}/references/phase7_integrity_audits.md` — load it when this step runs.**
-
-- **7.3a Numerical Claim Audit** (mandatory for MA / pooled estimates / comparative arms / revisions / reporting-quality-checklist synthesis): 3-way match text ↔ Table ↔ extraction CSV, primary-source back-check, analysis-script literal audit, and recompute reporting-quality headline numbers from matrix cells (denominator = Σ non-NA). A direction reversal or a p<0.05↔p≥0.05 crossing is a **P0 blocker**; composes with `/self-review` Phase 2.5a.
-- **7.3b Estimand Provenance & Promised-Analysis Audit** (any pre-registered/protocol primary, E-value, or named analyses): delegate to `/self-review` Phase 2.5f — `PRIMARY_REASSIGNED` / `ESTIMAND_DRIFT` / `EVALUE_ARITHMETIC` / `EVALUE_NON_PRIMARY` are **P0 blockers**; grep that Methods-promised analyses appear in Results; run `check_artifact_coverage.py --strict` for the disk-present-but-unreported reverse scan.
-- **7.3c Reference Adequacy Gate** (every named statistical method / reporting guideline must carry a citation): run `check_reference_adequacy.py` (no `--strict`; write-paper decides from the JSON); a `methods_zero_citations` / `methods_named_method_uncited` finding is a reference-acquisition blocker resolved only via `/search-lit` → `/lit-sync` → `/verify-refs --strict` (never fabricate); composes with `/self-review` Phase 2.5c-2.
-
-#### Step 7.4: Self-Review + Fix Loop
-
-Call `/self-review --json --fix` on the current `manuscript/manuscript.md`.
-
-This delegates the entire fix loop to the self-review skill, which:
-1. Runs systematic review (Phase 2) and generates a JSON report (Phase 3c).
-2. If `verdict` is `"REVISE"`: filters `fixable_by_ai` issues, applies text edits to `manuscript.md`, and re-reviews — up to 2 fix-and-re-review iterations.
-3. If `verdict` is `"PASS"` after any iteration: stops early.
-4. Returns the final JSON report with updated scores.
-
-**High-stakes manual pass (optional):** this autonomous loop deliberately uses the single-pass review — a multi-agent panel is *not* auto-applied in the pipeline (it spawns several reviewer agents plus an editor, multiplying token cost). For a top-tier or otherwise high-stakes manuscript, run `/self-review --panel` once manually as a final pre-submission pass (it diagnoses and prioritizes but does not auto-fix, so triage its findings yourself).
-
-After `/self-review --json --fix` completes:
-- Parse the final JSON output block.
-- Log the final `overall_score`, `verdict`, fix iteration count, and any remaining issues to `qc/_pipeline_log.md`.
-- If any `severity: "fatal"` issue remains: **route to Step 7.4a (Audit Recovery Branch)** — do NOT proceed to Step 7.5.
-- If no fatal issue remains: proceed to Step 7.5.
-
-#### Step 7.4a: Audit Recovery Branch
-
-**Purpose:** the linear polish flow assumes remaining issues are prose-level, but some
-self-review findings are structural — underlying data, protocol application, or analysis
-script is wrong, not prose. Continuing through Step 7.5 – 7.6 in that case produces a
-polished manuscript built on a broken foundation. This step makes the recovery loop
-explicit.
-
-**Trigger (any one from Step 7.4 JSON):** fatal issue in category `accuracy`,
-`data_fidelity`, `protocol_mismatch`, or `numerical_claim`; unresolved Step 7.3a primary-
-source disagreement; `[VERIFY-CSV]` tag persisting after two fix iterations; registered
-protocol ↔ delivered analysis inconsistency; reviewer-consensus ↔ locked-dataset
-disagreement. Inline text fixes are forbidden — recovery requires re-extraction,
-re-analysis, or re-registration.
-
-**Routing table:**
-
-| Symptom | Route to |
-|---|---|
-| MA pooled/forest/subgroup/funnel numbers disagree with source | `/meta-analysis` Phase 10 |
-| MA protocol ↔ analysis mismatch (eligibility, outcome, subgroup) | `/meta-analysis` Phase 10 + registry amendment |
-| Primary-study numerical claim disagrees with source Table/Figure | `/meta-analysis` Phase 6b, then return |
-| Non-MA extraction error affecting Table 1 / primary endpoint | Return to Phase 2, re-enter Phase 3 – 7 for affected sections |
-| Non-MA protocol amendment needed | HALT — human decision |
-
-**Sequence**: (1) halt Steps 7.5 – 7.6; (2) log the branch decision to
-`qc/_pipeline_log.md`; (3) invoke the routed skill with the specific findings; (4) on
-re-entry, resume at Step 7.3 (Citation Verification) — not Step 7.1, because recovery
-may have introduced new citations — and carry any change summary to Phase 8+;
-(5) loop budget is one cycle — a second cycle should trigger a root-cause review of
-Phase 2 / 6 / 6b rather than another recovery.
-
-**Autonomous mode.** In `--autonomous`, the orchestrator may auto-invoke the routed
-recovery skill. If the recovery requires human decision (protocol amendment, eligibility
-re-scope), the run stops and flags `RECOVERY_HALT_HUMAN_DECISION` in the log.
-
-**Load-on-demand procedural detail** (full trigger list, log-block template, per-route
-re-entry checklist, autonomous-mode edge cases):
-`${CLAUDE_SKILL_DIR}/references/section_guides/step7_4a_audit_recovery.md`.
-
-#### Step 7.5: Generate Deliverables
-
-Log the self-review fix loop results to `qc/_pipeline_log.md`:
-```
-## Self-Review Fix Loop (Phase 7.4)
-- Initial score: {score_before} → Final score: {score_after}
-- Fix iterations: {N}/2
-- Fixed issues: {count}
-- Remaining issues (human review needed): {count}
-- Final verdict: {PASS|REVISE}
-```
-
-Generate the following files:
-- `manuscript/manuscript.md`: Complete manuscript (with LLM disclosure in Methods and Acknowledgments if enabled)
-- `manuscript/title_page.md`: Title page with author info, word count, key points if required. **Number the author affiliations by first appearance** (affiliation 1 = the first author's first affiliation; each new affiliation gets the next integer as the author list is read left to right; each ends with city + country) — required by Nature Portfolio / npj technical checks. Do not hand-number; generate and verify with `scripts/build_title_page_affiliations.py` (`--authors authors.yaml` to build, `--check title_page.md --strict` to verify). See `references/section_guides/title_abstract.md` § "Title Page — Author & Affiliation Order".
-- `qc/reporting_checklist.md`: Filled reporting guideline checklist from Step 7.2
-- `qc/self_review.md`: Final self-review report from Step 7.4
-- `qc/_pipeline_log.md`: Pipeline execution log
-
-#### Step 7.6: DOCX Build
-
-Build the final submission-ready documents from the assembled components:
-
-1. **Input files**: `manuscript/manuscript.md`, `analysis/figures/_figure_manifest.md`, `analysis/tables/*.csv`
-2. **Figure embedding**: Parse `analysis/figures/_figure_manifest.md`. For each figure entry, verify the file exists at the specified path. Replace markdown image references `![Figure N. ...](path)` with the actual image path.
-3. **Table embedding**: For each `analysis/tables/*.csv` file referenced in the manuscript, the pandoc conversion will handle table formatting.
-4. **Pandoc conversion** (primary):
-   ```bash
-   pandoc manuscript/manuscript.md -o manuscript/manuscript_final.docx -V mainfont="Times New Roman" -V fontsize=12pt
-   pandoc manuscript/manuscript.md -o manuscript/manuscript_final.pdf --pdf-engine=xelatex -V geometry:margin=1in -V fontsize=11pt -V mainfont="Times New Roman"
-   ```
-   Ensure all figure image references use relative paths so figures render in both formats.
-
-   **With pandoc citeproc + journal CSL** (when manuscript uses `[@bibkey]` citations and a `.bib` is available — preferred for any submission with > 5 references; mandatory when reviewers have asked for "automatically generated reference list"):
-
-   The validation + render scripts live in `/manage-refs` (split out 2026-05-01). Either invoke `/manage-refs` directly (recommended), or call the scripts manually:
-   ```bash
-   MR="${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs"
-
-   # 1. Validate keys vs .bib first (fail fast on UNDEFINED keys; [@NEW:topic] placeholders pass through)
-   python "$MR/scripts/check_citation_keys.py" \
-     manuscript/manuscript.md manuscript/_src/refs.bib
-
-   # 2. Render with journal CSL (see manage-refs/citation_styles/ for bundled CSLs)
-   "$MR/scripts/render_pandoc.sh" \
-     -j european-radiology \
-     -i manuscript/manuscript.md \
-     -b manuscript/_src/refs.bib \
-     -o manuscript/manuscript_final.docx
-   ```
-   Bundled CSLs: `european-radiology`, `radiology`, `american-journal-of-roentgenology`,
-   `cardiovascular-and-interventional-radiology`, `korean-journal-of-radiology`,
-   `vancouver`, `vancouver-superscript`. Use `radiology` for RYAI; use `vancouver` for JVIR
-   (no dedicated CSL). On rejection cascade (e.g., ER → JVIR → CVIR), re-render with
-   different `-j` — references reformat in seconds. Never hand-type the References list.
-
-   **Decision: pandoc vs Zotero Word plugin (CWYW)** — `/manage-refs` documents the hybrid 3-phase strategy (Phase 1 pandoc draft → Phase 2 transition → Phase 3 Zotero CWYW for circulation/revision/submission). Use Workflow B (CWYW) once co-authors collaborate live in Word; use Workflow A (pandoc) for single-author lockdown, journal-cascade rejection re-formatting, or when the plugin is unavailable. See
-   `~/.claude/rules/manuscript-references.md` and `skills/manage-refs/SKILL.md`.
-5. **Fallback** (if pandoc is unavailable): Generate the DOCX using python-docx:
-   - Parse `manuscript/manuscript.md` sections (`##` → Heading 2, `###` → Heading 3, `**bold**` → bold runs)
-   - Insert figures as inline images at their markdown reference locations
-   - Insert tables as formatted Word tables from CSV sources
-   - Apply Times New Roman 12pt, double spacing, 1-inch margins, page numbers
-   - Save as `manuscript/manuscript_final.docx`
-6. **Verify output**: Confirm `manuscript/manuscript_final.docx` exists and is non-empty. Report file size.
-
-#### Step 7.6a: Cross-Reference QC (Manuscript ↔ rendered DOCX)
-
-Catches the failure mode where in-text Table/Figure citations resolve to the
-wrong rendered caption. Internal consistency (Phase 2.5 of `/self-review`)
-does NOT catch this because both the body prose and the build script can echo
-their own divergent SSOTs cleanly. Precedent: an STROBE cohort manuscript revision —
-body cited "Supplementary Table S4 (a sensitivity-analysis)" but the rendered DOCX S4
-was a diagnostics table; S1, S6, S7 mismatched and S8, S9 were cited but absent from
-the DOCX entirely.
-
-**Run after Step 7.6 DOCX build and before Step 7.7 final gate:**
+**7.6a — Cross-Reference QC.** After the build, before the final gate:
 
 ```bash
-MR="${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs"
-python3 "$MR/scripts/check_xref.py" \
-  --md manuscript/manuscript.md \
-  --docx manuscript/manuscript_final.docx \
-  --out qc/xref_audit.json \
-  --strict
+python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs/scripts/check_xref.py" \
+  --md manuscript/manuscript.md --docx manuscript/manuscript_final.docx \
+  --out qc/xref_audit.json --strict
 ```
 
-The script extracts (a) every `(Supplementary )?(Table|Figure)\s+(S?\d+[A-Z]?)`
-in-text citation, (b) caption definitions from `## Tables` / `## Figures` /
-`## Figure Legends` / `## Supplementary {Tables,Figures}` sections in the body,
-and (c) caption paragraphs in the rendered DOCX (via python-docx). It then
-emits a 3-way matrix to `qc/xref_audit.json`:
+Catches in-text citations resolving to the **wrong rendered caption** — body prose and build
+script each echo their own divergent SSOT, so no internal-consistency check sees it. Any
+`MISSING_DOCX`/`MISSING_BODY`/`MISMATCH` → `submission_safe: false`, exit 1, **HALT**. The body
+caption is the SSOT — fix the build pipeline, never the reverse.
 
-| Status | Meaning | Severity |
+**7.7 — Final Gate.** Autonomous: log completion; report word count, figure count, self-review
+score, reporting-compliance %, FATAL flags. Interactive: present summary, await confirmation.
+
+| File | Read it when | Cost if read blindly |
 |---|---|---|
-| `OK` | cited + body caption + DOCX caption all present and caption text agrees (Jaccard ≥ 0.40) | — |
-| `MISSING_DOCX` | cited but no caption with that label in the rendered DOCX | **P0 blocker** |
-| `MISSING_BODY` | cited but no caption definition in the markdown body sections (build SSOT drift) | **P0 blocker** |
-| `MISMATCH` | label exists in both body and DOCX but caption text disagrees | **P0 blocker** |
-| `UNCITED` | caption defined or rendered but never cited in main text | warn |
-| `NOT_CITED_NO_BODY` | label appears only in DOCX (rare; legacy artifact) | warn |
-
-**Submission gate:** if any `MISSING_DOCX` / `MISSING_BODY` / `MISMATCH` row is
-present, `submission_safe: false` and the script exits 1 under `--strict`.
-HALT pipeline. Do NOT proceed to Step 7.7. Route fixes by symptom:
-
-- `MISSING_BODY` → add caption definition under `## Tables` / `## Figures` in
-  `manuscript.md`, then re-run Step 7.6 + 7.6a. If the build script
-  (`build_manuscript_docx.py` or equivalent) carries its own hardcoded caption
-  list, that is the IMPROVEMENT_QUEUE #2 SSOT-unification issue — flag it.
-- `MISSING_DOCX` → either drop the citation (the table/figure was retired) or
-  re-add the table/figure to the build pipeline, then rebuild DOCX.
-- `MISMATCH` → reconcile body vs build script. Body caption is the SSOT;
-  update the build pipeline to match, never the reverse.
-
-Log the run to `qc/_pipeline_log.md`:
-```
-## Cross-Reference QC (Phase 7.6a)
-- in-text citations: {N}
-- unique labels: {N}
-- OK: {N} | MISSING_DOCX: {N} | MISSING_BODY: {N} | MISMATCH: {N} | UNCITED: {N}
-- submission_safe: {true|false}
-- audit: qc/xref_audit.json
-```
-
-If `python-docx` is unavailable, the script falls back to a body-only audit
-(citations vs body captions) with a warning. Install with `pip install python-docx`.
-
-#### Step 7.7: Final Gate
-
-- **Autonomous mode**: Log completion to `qc/_pipeline_log.md`. Report summary: word count, figure count, self-review score, reporting compliance percentage, any FATAL flags.
-- **Interactive mode**: Present the full summary to the user and await confirmation.
+| `references/phase7_polish_detail.md` | you reach the build steps (7.5–7.6a), a HALT fires, or the manuscript has an AI-disclosure paragraph | ~7,300 tokens — a run that stops at a 7.3 blocker never builds a DOCX |
+| `references/phase7_integrity_audits.md` | running 7.3a / 7.3b / 7.3c | ~3,000 tokens |
+| `references/section_guides/step7_4a_audit_recovery.md` | 7.4 left a fatal finding | ~1,700 tokens; most runs never branch |
 
 ---
-
 ### Phase 8+ (Optional): Cover Letter Generation
 
 Triggered when the user requests "generate cover letter" or after `/find-journal` recommendation.
@@ -981,7 +734,7 @@ Severity levels: **ENFORCED** = pipeline halts on failure (cannot proceed to nex
 | 7.5 | Humanize density (`/humanize`) | ADVISORY | AI patterns > 2.0 / 1000 words | Sweep + flag remaining; user reviews |
 | 7.5a | AIO checklist (`/academic-aio --aio`) | OPT-IN | user supplies `--aio` flag | PASS/PARTIAL/FAIL report; never auto-applies |
 | 7.6 | DOCX build (delegate `/manage-refs scripts/render_pandoc.sh`) | ENFORCED | render exits non-zero | Halt; report stderr to user |
-| 7.6a | Cross-reference QC (delegate `/manage-refs scripts/check_xref.py --strict`) | ENFORCED — submission gate | MISSING_DOCX / MISSING_BODY / MISMATCH > 0 | Halt; route fixes per `references/check_xref_symptoms.md` |
+| 7.6a | Cross-reference QC (delegate `/manage-refs scripts/check_xref.py --strict`) | ENFORCED — submission gate | MISSING_DOCX / MISSING_BODY / MISMATCH > 0 | Halt; route fixes per `references/phase7_polish_detail.md` |
 | 7.7 | Final submission gate | ENFORCED | any of 7.0–7.6a above failed | Refuse to mark `submission_safe: true` |
 | 8+ | Cover letter generation | OPT-IN | user invokes `--cover-letter` | Renders against journal profile |
 

--- a/skills/write-paper/references/phase0_init_detail.md
+++ b/skills/write-paper/references/phase0_init_detail.md
@@ -1,0 +1,139 @@
+# Phase 0 — Init: paper-type modes and gate detail
+
+Load-on-demand companion to `/write-paper` Phase 0. SKILL.md keeps the required
+inputs, the flags, the reporting-guideline selection, the backbone full-text gate, and
+the five citekey hard rules — everything the agent needs *before* it knows the ask.
+
+This file carries what only becomes relevant *after* the paper type is known:
+**Case Report Mode** and **Case Series Mode** (their word/reference-limit overrides,
+outline rewrites, and default figure sets), the backbone-article ranking and proposal
+behaviour, and the rationale behind the citekey gate.
+
+Read the mode block that matches the declared paper type. Do not read the others —
+a manuscript has one paper type.
+
+Gather essential information from the user before any writing begins.
+
+**Required inputs:**
+1. **Title** (working title is fine)
+2. **Paper type**: original article, AI validation, case report, case series, meta-analysis, technical note, animal study, NHIS cohort, cross-national
+3. **Target journal**: load profile from `${CLAUDE_SKILL_DIR}/references/journal_profiles/`
+4. **Research question / hypothesis**
+5. **Available data**: what datasets, tables, analyses already exist
+
+**Optional flags:**
+- `--no-llm-disclosure`: Skip LLM writing assistance disclosure. Default is ON (disclosure included). See [LLM Disclosure](#llm-writing-disclosure) section below.
+- `--autonomous`: Run the full pipeline without user gates. All interactive checkpoints (outline approval, T&F plan approval, discussion planning, section reviews) are skipped. The pipeline executes Phases 0-7 sequentially without pausing. Default is OFF (all gates active). Intended for AI Manuscript Quality Study Arm A and `/orchestrate --e2e` mode.
+
+**Actions:**
+1. Load the journal profile. If no profile exists, ask the user for: word limits, abstract format, citation style, figure/table limits, special requirements.
+2. Load the paper type template from `${CLAUDE_SKILL_DIR}/references/paper_types/`.
+3. Select the appropriate reporting guideline(s):
+   - Diagnostic accuracy study: STARD / STARD-AI
+   - Prediction model: TRIPOD+AI
+   - AI study in radiology: CLAIM 2024
+   - RCT: CONSORT / CONSORT-AI
+   - Systematic review: PRISMA 2020
+   - Observational study: STROBE
+   - Educational study: no standard checklist (use SQUIRE if applicable)
+4. **AI/LLM design-stage reporting map**: for AI validation, LLM/MLLM, NLP extraction, or report-generation papers, map each required AI-reporting item to a manuscript section before drafting. At minimum record model/version/access date, input fields, prompt or fine-tuning protocol, same-backbone zero-shot/few-shot baseline if an adaptation claim is made, test-data independence/contamination assessment, repeatability/stochasticity handling, and the Methods subsection where each will appear. If any item cannot be placed, halt for design clarification rather than burying it as a Phase 7 limitation.
+5. Create or confirm the project scaffold directory.
+6. Check for `--no-llm-disclosure` flag. If absent, LLM disclosure is ON by default.
+   Check for `--autonomous` flag. If present, record autonomous mode as ON.
+   Record both flag states for use in Phase 1-7 gate logic.
+
+#### Case Report Mode
+
+When paper type is "case report":
+1. Load `${CLAUDE_SKILL_DIR}/references/paper_types/case_report.md` (CARE structure).
+2. Load `${CLAUDE_SKILL_DIR}/references/exemplar_case_report.md` for the narrative flow,
+   150-word structured abstract anatomy, and case-report failure modes.
+2b. If the case is **imaging-led** (diagnostic radiology, nuclear medicine, or interventional
+    radiology — the contribution is the image or an image-guided procedure), also load
+    `${CLAUDE_SKILL_DIR}/references/exemplar_case_report_radiology.md` for per-modality
+    technique→findings→impression discipline, structured-reporting lexicons (BI-RADS/LI-RADS/
+    PI-RADS/TI-RADS/Lung-RADS/O-RADS), quantitative anchors with method/threshold honesty,
+    multimodality discordance, the IR procedure/complication subtype, incidental-finding reporting,
+    and DICOM de-identification / real alt text / device-vendor COI.
+3. Override word limits: total 1000-1500 words (excl. abstract, references, legends).
+4. Override abstract limit: 150 words, structured (Introduction, Case Presentation, Conclusion).
+5. Override reference limit: 15 references maximum.
+6. Apply CARE 2013 reporting guideline (mandatory; see `/check-reporting` `CARE.md`).
+7. Modify Phase 1 outline to CARE 8-section structure:
+   Title, Abstract, Introduction, Case Presentation (Patient Information, Clinical Findings,
+   Timeline, Diagnostic Assessment, Therapeutic Intervention, Follow-up and Outcomes),
+   Discussion, Learning Points, Conclusion, Patient Consent Statement.
+8. In Phase 2, default figures:
+   - Figure 1: Key imaging findings (annotated, typically 3-6 panels)
+   - Figure 2: Clinical timeline (if complex course)
+   - Table 1: Laboratory and clinical data at presentation
+9. In Phase 5 (Discussion), call `/search-lit` with query: `"[condition]" AND "case report"[Publication Type]`.
+   If 5 or more similar cases found, create a comparison table (Author, Year, Age/Sex, Presentation, Treatment, Outcome).
+   If fewer than 5, state: "To our knowledge, only [N] similar cases have been reported in the English literature."
+10. Skip Phase 5a Discussion Planning Gate — case reports are shorter; proceed directly to drafting.
+11. For extended case reports with literature review, user can specify `--extended` to raise
+    the word limit to 2000-3000 words and add a structured review section.
+
+#### Case Series Mode
+
+When paper type is "case series" (n≥2 patients reported together):
+1. Load `${CLAUDE_SKILL_DIR}/references/paper_types/case_series.md` — a case series is a
+   **methods-light mini-cohort**, not a stack of single case reports.
+2. Also load `${CLAUDE_SKILL_DIR}/references/exemplar_case_report.md` for per-case narrative
+   discipline (each vignette still follows the CARE moves).
+3. Typical word count: 1500–3000 words (scales with patient count).
+4. Apply CARE adapted for multiple patients; for ≥5 surgical cases consider PROCESS/SCARE.
+5. Modify Phase 1 outline to: Title → Abstract (structured) → Introduction → **Methods**
+   (design, setting, case identification, eligibility as a numbered list, protocol, assessment
+   process) → **Results** (mandatory all-cases summary table + consistent per-case vignettes,
+   grouped by subtype where a taxonomy exists) → Discussion (cross-case synthesis +
+   cohort-level limitations) → Conclusions → Ethics/Consent.
+6. In Phase 2, default a **summary Table 1 enumerating every case** (one row per patient) plus
+   representative figures labeled to each case number.
+7. In Discussion, enforce the case-series discipline: state selection/ascertainment and the
+   screened pool size; **report counts, not rates** (a referral/database series is not a
+   denominator of all disease); cohort-level limitations are mandatory and specific.
+
+7. **Identify a backbone article (auto-proposal first, ask only as fallback)**:
+   a. **Scan first** — if `manuscript/_src/refs.bib` exists, scan it for entries matching the current paper's study design (Phase 0 paper_type), imaging modality, and target journal (or comparable tier). Prefer entries whose Zotero record has a PDF attachment (full text locally available).
+   b. **Rank candidates** by: PDF available locally (+2), recency within 5 years (+1), same target journal (+2), same study design + modality (+2).
+   c. **Behavior**:
+      - **One strong candidate (score ≥ 5)** — propose it proactively: *"I found a likely backbone article: [citation]. Full text appears available. I will use it as the structural backbone unless you prefer another."* Proceed once user confirms or stays silent for one turn.
+      - **Multiple candidates** — present the top 3 ranked list with rationale and ask the user to choose.
+      - **No refs.bib, or no candidates** — ask the user to provide a published study (legacy behavior).
+   d. Record the chosen citekey in `project.yaml::backbone_article` so Methods, Tables, and Figures phases reuse it without re-asking.
+   e. **Full-text readiness gate (MANDATORY before any drafting).** A backbone whose full text is not extracted is a backbone in name only — the draft would follow an abstract. After recording the citekey, confirm its full text is retrieved and converted to Markdown, then gate on it:
+      ```bash
+      python3 ${CLAUDE_SKILL_DIR}/scripts/gate_backbone_fulltext.py \
+        --project project.yaml --refs manuscript/_src/refs.bib \
+        --fulltext-dir pdfs/ --strict
+      ```
+      `BACKBONE_FULLTEXT_MISSING` / `BACKBONE_FULLTEXT_THIN` means stop and retrieve it first — `/lit-sync` Phase 2.7 (open-access + Zotero "Find Available PDF") then `/fulltext-retrieval` `pdf_to_md.py` to convert the PDF to Markdown. Do **not** begin Methods drafting until this gate passes (addresses issues #4 and #8: the backbone is *used*, not merely *detected*). If the article is genuinely unavailable in full text, record that limitation explicitly and get user confirmation before proceeding on the abstract.
+8. Summarize the setup to the user and confirm before proceeding.
+
+**Output:** Setup summary with journal constraints, paper type, reporting guideline, backbone article, directory path, and LLM disclosure status (ON/OFF).
+
+#### Phase 0 Gate: Citekey-only references
+
+Before any section drafting begins, this skill enforces citekey-only entry into
+the manuscript. LLM-generated reference strings in prose are a primary source of
+citation fabrication.
+
+**Hard rules (v1.1.1 Phase 1A.4)**:
+
+1. **Every in-text citation MUST be `[@citekey]`**, where `citekey` exists in `manuscript/_src/refs.bib`. Pandoc/Quarto-style only. No "(Smith et al., 2024)" free text.
+2. **For a citation the user intends to add but has not yet imported to Zotero**, use the placeholder form `[@NEW:short-topic]` (e.g., `[@NEW:chest-xray-llm]`, `[@NEW:radbench-1]`). The topic slug is kebab-case, ≤30 characters, and must be unique within the manuscript.
+3. **Never** fabricate a citekey that "looks real" (e.g., `[@Smith_2024_AI]`) when the entry is not in `refs.bib`. The `[@NEW:...]` form is the only allowed placeholder.
+4. Before Phase 7 (Polish), ALL `[@NEW:...]` placeholders must be resolved:
+   - Owner runs `/search-lit` → `/lit-sync` to import verified entries into Zotero; Better BibTeX auto-export refreshes `refs.bib`; owner replaces `[@NEW:topic]` with the real citekey.
+   - Collaborators notify the owner (per `docs/zotero_policy.md`).
+5. Phase 7 pre-submission check: `grep -E '\[@NEW:[^]]+\]|\[N\]|\[N–N\]' manuscript/index.qmd` must return zero matches before `/sync-submission` is allowed to freeze a journal package. The bare numeric markers `[N]` / `[N–N]` are the failure mode where a manuscript is drafted outside this pipeline (no `refs.bib`) and method-load-bearing citations are left as unresolved placeholders; block them the same way as `[@NEW:...]`.
+
+**Why this matters**: PRISMA citation fabrication in MA projects and reference hallucination in solo manuscripts both traced back to LLM-generated citation strings inlined during drafting. Forcing the citekey discipline at Phase 0 redirects that failure mode into a visible placeholder the submission gate can block.
+
+**If refs.bib is absent (new project)**:
+- Create an empty `manuscript/_src/refs.bib` placeholder with a comment: `% refs.bib managed by /lit-sync via Zotero Better BibTeX. Do not hand-edit.`
+- Record in `SSOT.yaml` `reference_manager.required_for: project_owner` per Zotero policy.
+- Proceed; all early citations will be `[@NEW:...]` placeholders until the first `/lit-sync` run.
+
+---

--- a/skills/write-paper/references/phase7_polish_detail.md
+++ b/skills/write-paper/references/phase7_polish_detail.md
@@ -1,0 +1,283 @@
+# Phase 7 — Polish: step detail
+
+Load-on-demand companion to `/write-paper` Phase 7. SKILL.md keeps the strict step
+sequence (7.1 → 7.7), the command that runs at each step, and every HALT condition;
+this file carries the detail behind them — the AI-disclosure four-token grep, the
+Step 7.4a recovery routing table, the DOCX/citeproc build options and bundled CSL
+list, and the Step 7.6a cross-reference status matrix with its per-symptom fix routes.
+
+Read it when you reach the build steps (7.5 → 7.6a), when a HALT fires, or when the
+manuscript carries an AI/LLM-use disclosure paragraph.
+
+Two deeper references are cited from here and from SKILL.md:
+`references/phase7_integrity_audits.md` (Steps 7.3a/7.3b/7.3c) and
+`references/section_guides/step7_4a_audit_recovery.md` (the full recovery procedure).
+
+Final quality pass before submission.
+
+**Actions (strict sequential execution — each step MUST complete before the next begins):**
+
+#### Step 7.1: AI Pattern Scan
+
+Scan for and remove AI writing patterns (see AI Pattern Avoidance below). Edit `manuscript/manuscript.md` in place.
+
+**Classical-style QC (for senior MA reviewers) — load on demand:**
+
+| Trigger | Action |
+|---------|--------|
+| Manuscript type = MA, systematic review, or a senior co-author review is expected | Load `references/section_guides/step7_1_classical_qc.md` → run the 7 grep checks together (§ symbol, AI Disclosure paragraph, heading style, eligibility numbered list, Funding placeholder, PROSPERO chronology, em-dash overuse) |
+| Verify all at once with a deterministic lint | `python3 "${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/self-review/scripts/check_classical_style.py" --manuscript manuscript/manuscript.md --strict` — `SECTION_SYMBOL`/`INBODY_AI_DISCLOSURE` (Major) + `ELIGIBILITY_PROSE`/`DECIMAL_INCONSISTENCY`/`EM_DASH_OVERUSE` (Minor). The machine-checkable subset of the same conventions as the 7-grep checklist. |
+| Global-rule cross-reference | `~/.claude/rules/manuscript-style-classical.md` (motivation for the 11 items) |
+| Pattern 19–21 body rewrite | `/humanize` (§, self-reference, AI Disclosure boilerplate) |
+
+**AI-disclosure meta-applicability (manuscript-style-classical §15):** if the manuscript
+contains an AI/LLM-use disclosure, that paragraph must itself satisfy the reporting items the
+manuscript critiques (FLAIR F1.6, TRIPOD-LLM, MI-CLEAR-LLM all require the tool **version**, the
+**access channel**, the **date range**, and the **responsible party**). Enforce all four tokens
+and zero unresolved placeholders:
+
+```bash
+DISC=$(grep -niE 'generative ai|large language model|\bLLM\b|assisted (the|with) (writing|drafting)|ChatGPT|Claude|Copilot|Gemini' manuscript/manuscript.md)
+# the disclosure paragraph must carry: version + channel + date + responsible party
+grep -iE 'version|[0-9]+\.[0-9x]+|GPT-[0-9]'   <<<"$DISC"   # version present
+grep -iE 'API|chat|web|Bedrock|Azure|interface' <<<"$DISC"   # access channel present
+grep -E '20[0-9]{2}'                            <<<"$DISC"   # date / date range present
+grep -iE 'by [A-Z]\.[A-Z]\.|reviewed by|deployed by|the authors' <<<"$DISC" # responsible party
+# zero placeholders
+grep -nE '\[(version|date|tool|model|channel)\]|TODO|XXXX|TBD' manuscript/manuscript.md  # must be empty
+```
+
+Any missing token (or a surviving `[version]`/`TODO`/`XXXX` placeholder) is a HALT: the paper
+cannot critique a framework's AI-disclosure item while failing it itself. For a classical /
+senior-MA target the disclosure paragraph is not placed in the body at all — branch it to the
+title page (manuscript-style-classical §7 forbids the in-body AI-disclosure paragraph).
+
+#### Step 7.2: Reporting Guideline Check
+
+Call `/check-reporting` on `manuscript/manuscript.md`. Parse the output:
+- If the report includes a JSON summary block (Part D), extract MISSING items.
+- For each MISSING item where `fixable_by_ai` is true (e.g., missing ethics statement, missing data availability statement, missing sample size justification), insert the suggested text at the indicated location in `manuscript/manuscript.md`.
+- Do NOT attempt to fix items requiring external information (IRB numbers, registration numbers, protocol details only the author knows).
+- Log all auto-inserted text to `qc/_pipeline_log.md`.
+
+#### Step 7.3: Citation Verification
+
+**7.3.1 — Placeholder gate (v1.1.1 Phase 1A.4).** Before running `/verify-refs`,
+confirm that no `[@NEW:topic]` placeholders remain:
+
+```bash
+grep -nE '\[@NEW:[^]]+\]' manuscript/index.qmd manuscript/manuscript.md 2>/dev/null
+```
+
+If any match is returned, HARD STOP. Report the unresolved placeholders to the
+user and loop back: owner runs `/search-lit` → `/lit-sync` to import entries,
+collaborators flag via owner. Do NOT proceed to 7.3.2 until the grep is clean.
+
+**7.3.2 — Audit.** Call `/verify-refs` on the current manuscript. Per v1.2.0
+contract, its sole output is `qc/reference_audit.json` (no longer writes
+`references/*`). Parse that file: if `submission_safe: false`, stop the pipeline
+and surface the `FABRICATED` / `MISMATCH` records AND any `duplicate_findings[]`
+entries (duplicate PMID/DOI; cite renumbering required) to the user. If
+`/verify-refs` is unavailable, fall back to `/search-lit --verify-only` and flag
+any unverified references with `[UNVERIFIED]` markers.
+
+#### Steps 7.3a / 7.3b / 7.3c: Integrity audits (numerical / estimand / reference-adequacy)
+
+After Step 7.3 and before Step 7.4, run three integrity audits. Each can HALT and route to **Step 7.4a (Audit Recovery Branch)**. **Full procedures (triggers, blocker policy, the delegated checker commands, and the `qc/_pipeline_log.md` log formats) are in `${CLAUDE_SKILL_DIR}/references/phase7_integrity_audits.md` — load it when this step runs.**
+
+- **7.3a Numerical Claim Audit** (mandatory for MA / pooled estimates / comparative arms / revisions / reporting-quality-checklist synthesis): 3-way match text ↔ Table ↔ extraction CSV, primary-source back-check, analysis-script literal audit, and recompute reporting-quality headline numbers from matrix cells (denominator = Σ non-NA). A direction reversal or a p<0.05↔p≥0.05 crossing is a **P0 blocker**; composes with `/self-review` Phase 2.5a.
+- **7.3b Estimand Provenance & Promised-Analysis Audit** (any pre-registered/protocol primary, E-value, or named analyses): delegate to `/self-review` Phase 2.5f — `PRIMARY_REASSIGNED` / `ESTIMAND_DRIFT` / `EVALUE_ARITHMETIC` / `EVALUE_NON_PRIMARY` are **P0 blockers**; grep that Methods-promised analyses appear in Results; run `check_artifact_coverage.py --strict` for the disk-present-but-unreported reverse scan.
+- **7.3c Reference Adequacy Gate** (every named statistical method / reporting guideline must carry a citation): run `check_reference_adequacy.py` (no `--strict`; write-paper decides from the JSON); a `methods_zero_citations` / `methods_named_method_uncited` finding is a reference-acquisition blocker resolved only via `/search-lit` → `/lit-sync` → `/verify-refs --strict` (never fabricate); composes with `/self-review` Phase 2.5c-2.
+
+#### Step 7.4: Self-Review + Fix Loop
+
+Call `/self-review --json --fix` on the current `manuscript/manuscript.md`.
+
+This delegates the entire fix loop to the self-review skill, which:
+1. Runs systematic review (Phase 2) and generates a JSON report (Phase 3c).
+2. If `verdict` is `"REVISE"`: filters `fixable_by_ai` issues, applies text edits to `manuscript.md`, and re-reviews — up to 2 fix-and-re-review iterations.
+3. If `verdict` is `"PASS"` after any iteration: stops early.
+4. Returns the final JSON report with updated scores.
+
+**High-stakes manual pass (optional):** this autonomous loop deliberately uses the single-pass review — a multi-agent panel is *not* auto-applied in the pipeline (it spawns several reviewer agents plus an editor, multiplying token cost). For a top-tier or otherwise high-stakes manuscript, run `/self-review --panel` once manually as a final pre-submission pass (it diagnoses and prioritizes but does not auto-fix, so triage its findings yourself).
+
+After `/self-review --json --fix` completes:
+- Parse the final JSON output block.
+- Log the final `overall_score`, `verdict`, fix iteration count, and any remaining issues to `qc/_pipeline_log.md`.
+- If any `severity: "fatal"` issue remains: **route to Step 7.4a (Audit Recovery Branch)** — do NOT proceed to Step 7.5.
+- If no fatal issue remains: proceed to Step 7.5.
+
+#### Step 7.4a: Audit Recovery Branch
+
+**Purpose:** the linear polish flow assumes remaining issues are prose-level, but some
+self-review findings are structural — underlying data, protocol application, or analysis
+script is wrong, not prose. Continuing through Step 7.5 – 7.6 in that case produces a
+polished manuscript built on a broken foundation. This step makes the recovery loop
+explicit.
+
+**Trigger (any one from Step 7.4 JSON):** fatal issue in category `accuracy`,
+`data_fidelity`, `protocol_mismatch`, or `numerical_claim`; unresolved Step 7.3a primary-
+source disagreement; `[VERIFY-CSV]` tag persisting after two fix iterations; registered
+protocol ↔ delivered analysis inconsistency; reviewer-consensus ↔ locked-dataset
+disagreement. Inline text fixes are forbidden — recovery requires re-extraction,
+re-analysis, or re-registration.
+
+**Routing table:**
+
+| Symptom | Route to |
+|---|---|
+| MA pooled/forest/subgroup/funnel numbers disagree with source | `/meta-analysis` Phase 10 |
+| MA protocol ↔ analysis mismatch (eligibility, outcome, subgroup) | `/meta-analysis` Phase 10 + registry amendment |
+| Primary-study numerical claim disagrees with source Table/Figure | `/meta-analysis` Phase 6b, then return |
+| Non-MA extraction error affecting Table 1 / primary endpoint | Return to Phase 2, re-enter Phase 3 – 7 for affected sections |
+| Non-MA protocol amendment needed | HALT — human decision |
+
+**Sequence**: (1) halt Steps 7.5 – 7.6; (2) log the branch decision to
+`qc/_pipeline_log.md`; (3) invoke the routed skill with the specific findings; (4) on
+re-entry, resume at Step 7.3 (Citation Verification) — not Step 7.1, because recovery
+may have introduced new citations — and carry any change summary to Phase 8+;
+(5) loop budget is one cycle — a second cycle should trigger a root-cause review of
+Phase 2 / 6 / 6b rather than another recovery.
+
+**Autonomous mode.** In `--autonomous`, the orchestrator may auto-invoke the routed
+recovery skill. If the recovery requires human decision (protocol amendment, eligibility
+re-scope), the run stops and flags `RECOVERY_HALT_HUMAN_DECISION` in the log.
+
+**Load-on-demand procedural detail** (full trigger list, log-block template, per-route
+re-entry checklist, autonomous-mode edge cases):
+`${CLAUDE_SKILL_DIR}/references/section_guides/step7_4a_audit_recovery.md`.
+
+#### Step 7.5: Generate Deliverables
+
+Log the self-review fix loop results to `qc/_pipeline_log.md`:
+```
+## Self-Review Fix Loop (Phase 7.4)
+- Initial score: {score_before} → Final score: {score_after}
+- Fix iterations: {N}/2
+- Fixed issues: {count}
+- Remaining issues (human review needed): {count}
+- Final verdict: {PASS|REVISE}
+```
+
+Generate the following files:
+- `manuscript/manuscript.md`: Complete manuscript (with LLM disclosure in Methods and Acknowledgments if enabled)
+- `manuscript/title_page.md`: Title page with author info, word count, key points if required. **Number the author affiliations by first appearance** (affiliation 1 = the first author's first affiliation; each new affiliation gets the next integer as the author list is read left to right; each ends with city + country) — required by Nature Portfolio / npj technical checks. Do not hand-number; generate and verify with `scripts/build_title_page_affiliations.py` (`--authors authors.yaml` to build, `--check title_page.md --strict` to verify). See `references/section_guides/title_abstract.md` § "Title Page — Author & Affiliation Order".
+- `qc/reporting_checklist.md`: Filled reporting guideline checklist from Step 7.2
+- `qc/self_review.md`: Final self-review report from Step 7.4
+- `qc/_pipeline_log.md`: Pipeline execution log
+
+#### Step 7.6: DOCX Build
+
+Build the final submission-ready documents from the assembled components:
+
+1. **Input files**: `manuscript/manuscript.md`, `analysis/figures/_figure_manifest.md`, `analysis/tables/*.csv`
+2. **Figure embedding**: Parse `analysis/figures/_figure_manifest.md`. For each figure entry, verify the file exists at the specified path. Replace markdown image references `![Figure N. ...](path)` with the actual image path.
+3. **Table embedding**: For each `analysis/tables/*.csv` file referenced in the manuscript, the pandoc conversion will handle table formatting.
+4. **Pandoc conversion** (primary):
+   ```bash
+   pandoc manuscript/manuscript.md -o manuscript/manuscript_final.docx -V mainfont="Times New Roman" -V fontsize=12pt
+   pandoc manuscript/manuscript.md -o manuscript/manuscript_final.pdf --pdf-engine=xelatex -V geometry:margin=1in -V fontsize=11pt -V mainfont="Times New Roman"
+   ```
+   Ensure all figure image references use relative paths so figures render in both formats.
+
+   **With pandoc citeproc + journal CSL** (when manuscript uses `[@bibkey]` citations and a `.bib` is available — preferred for any submission with > 5 references; mandatory when reviewers have asked for "automatically generated reference list"):
+
+   The validation + render scripts live in `/manage-refs` (split out 2026-05-01). Either invoke `/manage-refs` directly (recommended), or call the scripts manually:
+   ```bash
+   MR="${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs"
+
+   # 1. Validate keys vs .bib first (fail fast on UNDEFINED keys; [@NEW:topic] placeholders pass through)
+   python "$MR/scripts/check_citation_keys.py" \
+     manuscript/manuscript.md manuscript/_src/refs.bib
+
+   # 2. Render with journal CSL (see manage-refs/citation_styles/ for bundled CSLs)
+   "$MR/scripts/render_pandoc.sh" \
+     -j european-radiology \
+     -i manuscript/manuscript.md \
+     -b manuscript/_src/refs.bib \
+     -o manuscript/manuscript_final.docx
+   ```
+   Bundled CSLs: `european-radiology`, `radiology`, `american-journal-of-roentgenology`,
+   `cardiovascular-and-interventional-radiology`, `korean-journal-of-radiology`,
+   `vancouver`, `vancouver-superscript`. Use `radiology` for RYAI; use `vancouver` for JVIR
+   (no dedicated CSL). On rejection cascade (e.g., ER → JVIR → CVIR), re-render with
+   different `-j` — references reformat in seconds. Never hand-type the References list.
+
+   **Decision: pandoc vs Zotero Word plugin (CWYW)** — `/manage-refs` documents the hybrid 3-phase strategy (Phase 1 pandoc draft → Phase 2 transition → Phase 3 Zotero CWYW for circulation/revision/submission). Use Workflow B (CWYW) once co-authors collaborate live in Word; use Workflow A (pandoc) for single-author lockdown, journal-cascade rejection re-formatting, or when the plugin is unavailable. See
+   `~/.claude/rules/manuscript-references.md` and `skills/manage-refs/SKILL.md`.
+5. **Fallback** (if pandoc is unavailable): Generate the DOCX using python-docx:
+   - Parse `manuscript/manuscript.md` sections (`##` → Heading 2, `###` → Heading 3, `**bold**` → bold runs)
+   - Insert figures as inline images at their markdown reference locations
+   - Insert tables as formatted Word tables from CSV sources
+   - Apply Times New Roman 12pt, double spacing, 1-inch margins, page numbers
+   - Save as `manuscript/manuscript_final.docx`
+6. **Verify output**: Confirm `manuscript/manuscript_final.docx` exists and is non-empty. Report file size.
+
+#### Step 7.6a: Cross-Reference QC (Manuscript ↔ rendered DOCX)
+
+Catches the failure mode where in-text Table/Figure citations resolve to the
+wrong rendered caption. Internal consistency (Phase 2.5 of `/self-review`)
+does NOT catch this because both the body prose and the build script can echo
+their own divergent SSOTs cleanly. Precedent: an STROBE cohort manuscript revision —
+body cited "Supplementary Table S4 (a sensitivity-analysis)" but the rendered DOCX S4
+was a diagnostics table; S1, S6, S7 mismatched and S8, S9 were cited but absent from
+the DOCX entirely.
+
+**Run after Step 7.6 DOCX build and before Step 7.7 final gate:**
+
+```bash
+MR="${MEDSCI_SKILLS_ROOT:-$HOME/workspace/medsci-skills}/skills/manage-refs"
+python3 "$MR/scripts/check_xref.py" \
+  --md manuscript/manuscript.md \
+  --docx manuscript/manuscript_final.docx \
+  --out qc/xref_audit.json \
+  --strict
+```
+
+The script extracts (a) every `(Supplementary )?(Table|Figure)\s+(S?\d+[A-Z]?)`
+in-text citation, (b) caption definitions from `## Tables` / `## Figures` /
+`## Figure Legends` / `## Supplementary {Tables,Figures}` sections in the body,
+and (c) caption paragraphs in the rendered DOCX (via python-docx). It then
+emits a 3-way matrix to `qc/xref_audit.json`:
+
+| Status | Meaning | Severity |
+|---|---|---|
+| `OK` | cited + body caption + DOCX caption all present and caption text agrees (Jaccard ≥ 0.40) | — |
+| `MISSING_DOCX` | cited but no caption with that label in the rendered DOCX | **P0 blocker** |
+| `MISSING_BODY` | cited but no caption definition in the markdown body sections (build SSOT drift) | **P0 blocker** |
+| `MISMATCH` | label exists in both body and DOCX but caption text disagrees | **P0 blocker** |
+| `UNCITED` | caption defined or rendered but never cited in main text | warn |
+| `NOT_CITED_NO_BODY` | label appears only in DOCX (rare; legacy artifact) | warn |
+
+**Submission gate:** if any `MISSING_DOCX` / `MISSING_BODY` / `MISMATCH` row is
+present, `submission_safe: false` and the script exits 1 under `--strict`.
+HALT pipeline. Do NOT proceed to Step 7.7. Route fixes by symptom:
+
+- `MISSING_BODY` → add caption definition under `## Tables` / `## Figures` in
+  `manuscript.md`, then re-run Step 7.6 + 7.6a. If the build script
+  (`build_manuscript_docx.py` or equivalent) carries its own hardcoded caption
+  list, that is the IMPROVEMENT_QUEUE #2 SSOT-unification issue — flag it.
+- `MISSING_DOCX` → either drop the citation (the table/figure was retired) or
+  re-add the table/figure to the build pipeline, then rebuild DOCX.
+- `MISMATCH` → reconcile body vs build script. Body caption is the SSOT;
+  update the build pipeline to match, never the reverse.
+
+Log the run to `qc/_pipeline_log.md`:
+```
+## Cross-Reference QC (Phase 7.6a)
+- in-text citations: {N}
+- unique labels: {N}
+- OK: {N} | MISSING_DOCX: {N} | MISSING_BODY: {N} | MISMATCH: {N} | UNCITED: {N}
+- submission_safe: {true|false}
+- audit: qc/xref_audit.json
+```
+
+If `python-docx` is unavailable, the script falls back to a body-only audit
+(citations vs body captions) with a warning. Install with `pip install python-docx`.
+
+#### Step 7.7: Final Gate
+
+- **Autonomous mode**: Log completion to `qc/_pipeline_log.md`. Report summary: word count, figure count, self-review score, reporting compliance percentage, any FATAL flags.
+- **Interactive mode**: Present the full summary to the user and await confirmation.
+
+---

--- a/tests/fixtures/phase_budget/skills/self-review/SKILL.md
+++ b/tests/fixtures/phase_budget/skills/self-review/SKILL.md
@@ -1,0 +1,214 @@
+# Frozen fixture — the REAL defect (self-review Phase 2 as it shipped at a36c79e).
+# 209-line body, loaded in full on every /self-review invocation. Do not "fix" this file:
+# it exists so tests/test_phase_budget.sh can prove the gate still fails on the real thing.
+
+### Phase 2: Systematic Check
+
+Run the manuscript through each applicable category below. For each item, assess whether
+a reviewer would raise it as a Major or Minor comment.
+
+Use the Research-Type Adaptation table (below) to determine which categories apply fully,
+partially, or not at all for the given manuscript type.
+
+#### A. Study Design & Data Integrity
+
+| Check | What to look for |
+|-------|-----------------|
+| Patient-level splitting | Are train/val/test splits at the patient level? Is this explicitly stated? |
+| Leakage risk | Any postoperative variable used in a preoperative model? Cohort-wide preprocessing before split? |
+| Input-text contamination | For NLP/LLM extraction tasks, does any supplied report text (clinical history, indication, impression, prior diagnosis, referral text) already contain the target label? If yes, mark as Major unless the input was masked or a no-leaky-field sensitivity analysis is reported. |
+| Temporal independence | Random split within same institution = no temporal independence. Acknowledged? |
+| Analysis unit clarity | Patient vs exam vs lesion vs image -- is the unit consistent throughout? |
+| Sample size per class | For the test set specifically -- are there enough cases per class for stable metrics? |
+
+#### B. Reference Standard & Ground Truth
+
+| Check | What to look for |
+|-------|-----------------|
+| Definition specificity | Is the reference standard precisely defined? (e.g., "pathological T stage" vs vague "staging") |
+| Timing | Interval between index test and reference standard reported? |
+| Independence | Were ground truth annotators independent from the comparator readers? |
+| Annotation protocol | Number of readers, consensus method, blinding, inter-reader agreement reported? |
+
+#### C. Validation & Statistical Reporting
+
+| Check | What to look for |
+|-------|-----------------|
+| Confidence intervals | All primary metrics have 95% CIs? |
+| Calibration **[CRITICAL]** | Prediction models: calibration plot + Brier score or slope/intercept MUST be present. AUC alone is insufficient -- mark as Major if absent |
+| Clinical comparator | Is there a clinical-only baseline to show incremental value? |
+| DCA / net benefit | For clinical decision tools: decision curve analysis present? |
+| Fine-tuning baseline | For LLM/NLP fine-tuning, LoRA, prompt-engineering, or multi-agent claims, is there a same-backbone zero-shot or few-shot comparator on the same input, schema, and test split? |
+| Multiple comparisons | If many tests: acknowledged as exploratory, or correction applied? |
+| Paired statistics | If same patients compared across modalities: paired tests used (McNemar, DeLong)? |
+| Effect-size meaningfulness | Scored separately from significance: is each primary effect (OR, HR, beta, Cohen's d, correlation) translated to a real-world unit shift and compared to a minimal clinically important difference? Is significance driven by magnitude rather than sample size? |
+| Power-aware null interpretation | Scored separately from significance, for any **non-significant primary result** (p > 0.05, 95% CI crossing the null): is the analysis powered to *exclude* a clinically meaningful effect? An underpowered null is "not yet established," not "no effect" -- if the upper CI bound still includes a meaningful effect size, a flat "X was not associated with Y" claim overreads the data. Look for reported observed power or a minimum detectable effect that justifies a negative conclusion, and watch for **bilateral over-correction** (a prior "independently associated" overclaim swinging to an equally unsupported "not associated" claim during revision). Undocumented null = Minor; a null that drives a clinical recommendation or a headline negative conclusion without power/CI-compatibility justification = Major. |
+| Equivalence-margin discipline | A claim that two groups/methods are "equivalent," "non-inferior," "indistinguishable," or show "no difference" requires a **pre-stated margin** — a TOST procedure, or the CI compared against a declared MCID. Grep `indistinguishable\|equivalent\|non-inferior\|no difference` and check for an adjacent `margin\|TOST\|MCID\|non-inferiority`; a margin-free equivalence claim is a Major (it converts a failure to reject into positive evidence of no effect). |
+| Interaction-anchor discipline | When synergy / interaction / effect-modification **is** the research question, the null must be anchored to the **interaction parameter** (a likelihood-ratio test of the interaction term, or the interaction OR/HR on one consistent scale), not to a main-effect OR whose upper CI is then read as "no synergy." Grep `synergy\|interaction\|joint effect\|effect modification`; if present, confirm Results carries an `OR_int\|β_int\|LRT\|p_interaction` term. A synergy conclusion resting on a main-effect estimate is a model mis-specification (Major), even when each main effect is individually correct. |
+| Difference-in-significance discipline | A between-group claim that an association is "more X / stronger / more pronounced in group A than group B" must rest on a **formal interaction test**, not on group A being significant (p < 0.05) while group B is not (p = NS). The difference between "significant" and "non-significant" is **not** itself significant. Grep `more (clearly\|strongly\|pronounced)\|stronger in\|(only\|chiefly) in (men\|women\|older\|younger\|the [A-Za-z]+ subgroup)` near two stratum-specific estimates with discordant p-values; if no interaction term (`p_interaction\|OR_int\|LRT`) is reported for that contrast, flag it (difference-in-significance fallacy). A subgroup-difference conclusion built this way is a Major; the fix is to report the interaction test or soften to "associations were observed in group A; the interaction was not formally tested." |
+
+#### D. Clinical Framing & Importance
+
+| Check | What to look for |
+|-------|-----------------|
+| Intended use | Is the clinical decision point clearly stated? (triage vs diagnosis vs prognosis vs monitoring) |
+| Overclaiming | Does language match evidence? ("will improve" -> "may potentially"; "superior" with overlapping CIs?) |
+| Terminology precision | Key terms defined? (e.g., "perioperative" = when exactly?) |
+| Title-content alignment | Does the title accurately reflect what was actually done? |
+| Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |
+| Substantive novelty differentiation | For AI/LLM extraction papers, does the Introduction name 2-3 close prior papers/systems and state the concrete delta (new task, dataset, workflow, method, validation, or clinical decision point), rather than merely saying the method is novel? |
+| Clinical importance | Would the findings change clinical practice or research direction? Is this articulated? |
+| Decision impact | Does the manuscript state what decision, workflow step, or downstream action would change if the model is correct? A text-only phenotype that does not alter triage, treatment, surveillance, enrichment, or research operations has weak clinical utility even if accuracy is high. |
+| Added value / actionability | Scored separately from novelty: does the finding add value over a measure already in routine use, or is it "real but redundant" (restates a standard test)? At the typical effect size, would a clinician act on it for an individual? |
+| Endpoint↔conclusion scope **[CRITICAL]** | Does the conclusion's *action* exceed what the design or endpoint supports? A cross-sectional / single-visit study cannot license a prognostic or surveillance claim (rescreen interval, disease progression); a binary surrogate endpoint (present/absent, >0) is risk stratification, not a care directive (defer/withhold/initiate therapy). Both are documented anti-patterns. |
+
+Run the deterministic scope gate:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_scope_coherence.py" \
+  --manuscript manuscript.md --out qc/scope_coherence.json --strict
+```
+
+`CROSS_SECTIONAL_PROGNOSTIC` and `SURROGATE_CARE_DIRECTIVE` are Anticipated Major Comments (category: D. Clinical Framing). `CROSS_SECTIONAL_YIELD_LANGUAGE` is an Anticipated **Minor** Comment — a cross-sectional / prevalence design using incidence-flavored screening vocabulary ("yield", "detection rate", "number-needed-to-screen/image", "rescreen interval") without defining "yield" once as cross-sectional report-positive prevalence. The gate is conservative — it fires only when a design/endpoint signal and a conclusion-region action verb (or the yield lexicon) co-occur.
+
+#### E. Reproducibility
+
+| Check | What to look for |
+|-------|-----------------|
+| Preprocessing details | All steps listed in order? Normalization, augmentation, resampling specified? |
+| Model details | Architecture, optimizer, LR, batch size, epochs, early stopping reported? |
+| Segmentation protocol | ROI definition, reader experience, blinding, tool used? |
+| Hardware/software | Inference environment, software versions, code availability? |
+| Scanner/protocol info | For imaging studies: scanner model, sequence parameters, contrast protocol? |
+| Data/code availability | Is a data availability statement included? Code shared or reason for not sharing stated? |
+
+#### F. Reporting Completeness
+
+| Check | What to look for |
+|-------|-----------------|
+| Abstract-body consistency | Numbers in Abstract match Tables/Results? |
+| Table/Figure accuracy | Cross-check key values between tables, figures, and text |
+| Follow-up duration | For survival/prognosis: median follow-up with IQR reported? |
+| Ethics | All participating institutions' IRB approval documented? Patient consent described? |
+| Missing data | Handling of incomplete cases described? |
+| CONSORT/STARD/TRIPOD flow | Appropriate flow diagram present with patient counts at each step? |
+| Body word count vs journal cap | Is the body within the target journal's word limit? A revise loop monotonically adds words and silently breaches the cap. Run `/sync-submission` `scripts/check_wordcount_cap.py` (`--journal-profile` or `--limit`; the binding number is the rendered DOCX count). Over cap → Major; within 0.95× → Minor (a further pass will likely breach). |
+| Funding & COI | Funding sources and competing interests disclosed? |
+
+#### G. Reporting Guideline Compliance
+
+Match the manuscript type to the appropriate checklist and verify key items:
+
+| Manuscript type | Checklist | Critical items to verify |
+|----------------|-----------|------------------------|
+| Diagnostic accuracy | STARD / STARD-AI | Flow diagram, reference standard, spectrum |
+| Prediction model (non-AI) | TRIPOD 2015 | Model development vs validation, calibration, missing data |
+| Prediction model (AI/ML) | TRIPOD+AI 2024 | Model development vs validation, calibration, leakage, fairness |
+| AI / Radiomics | CLAIM 2024 / CLEAR | Feature selection transparency, external validation |
+| RCT | CONSORT / CONSORT-AI | Randomization, blinding, ITT |
+| Systematic review (interventions) | PRISMA 2020 | Search strategy, screening, risk of bias |
+| Meta-analysis (observational) | MOOSE + PRISMA 2020 | Confounding assessment, heterogeneity, publication bias |
+| Observational | STROBE | Confounding, selection bias, missing data |
+| Reliability / agreement | GRRAS | ICC model/type, rater description, measurement protocol |
+| Educational | SQUIRE 2.0 | Intervention description, outcome measures, context |
+| Case report | CARE | Timeline, diagnostic reasoning, informed consent |
+| Surgical | STROBE-Surgery | Surgeon experience, technique details, complications |
+
+For a full item-by-item audit, run `/check-reporting` on this manuscript. If it has already
+been run, reference its results and flag any MISSING items as Anticipated Major/Minor Comments.
+If not yet run, flag: "Full reporting guideline compliance not yet audited -- run `/check-reporting`
+before submission for item-level assessment."
+
+#### H. Circularity
+
+| Check | What to look for |
+|-------|-----------------|
+| Label-feature overlap | Is the prediction label derived from the same data source as any input features? (e.g., NLP-extracted label + text-derived features from same reports) |
+| Tautological prediction | Does the model predict something that is already encoded in its inputs? |
+| Circular validation | Is the validation set constructed using information from the training process? |
+
+#### I. Protocol Heterogeneity
+
+| Check | What to look for |
+|-------|-----------------|
+| Multi-site acquisition | If multi-site: are scanner models, protocols, and acquisition parameters reported per site? |
+| Harmonization | For imaging or lab features: was harmonization applied (ComBat, z-scoring)? If not, acknowledged? |
+| Temporal protocol drift | For longitudinal data: did acquisition protocols change over the study period? |
+
+#### J. Method Transparency
+
+| Check | What to look for |
+|-------|-----------------|
+| Model provenance | Is it clear where the model came from? (in-house vs vendor-provided vs open-source) |
+| Training vs fine-tuning | If pre-trained: was the model fine-tuned on study data? If vendor-provided: any access to training data composition? |
+| Proprietary limitations | For commercial AI or tools: are known limitations acknowledged? Can results be independently reproduced? |
+| Classical-style body conventions | Does the body carry an AI tell or a policy violation a senior reviewer flags on sight — a `§` symbol, an in-body AI-disclosure paragraph, eligibility criteria as prose, mixed OR/HR decimal places, or em-dash overuse? |
+
+Run the deterministic classical-style lint (these are all greps, so they belong in a gate, not eyeballing):
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_classical_style.py" \
+  --manuscript manuscript.md --out qc/classical_style.json --strict
+```
+
+`SECTION_SYMBOL` and `INBODY_AI_DISCLOSURE` are Major (the `§` count must be 0; the AI-disclosure paragraph belongs on the title page for a classical / senior-MA target, not the body). `ELIGIBILITY_PROSE`, `DECIMAL_INCONSISTENCY`, and `EM_DASH_OVERUSE` are Minor. This is the self-review-side mirror of `/write-paper` Step 7.1's classical QC (manuscript-style-classical §5/§6/§7/§8).
+
+#### K. Reviewer-team consistency (SR/MA-only; fabrication-grade)
+
+| Check | What to look for |
+|-------|-----------------|
+| DUAL vs SINGLE conjunction **[CRITICAL]** | Methods or PROSPERO claims dual independent reviewers AND Discussion/Limitations admits single primary reviewer + 20% sample (or "deferred to before submission")? Mark as **MAJOR**, fabrication-grade. |
+| LLM-as-reviewer **[CRITICAL]** | A per-study extraction JSON whose `reviewer`/`screener`/`extractor` field is an LLM (Claude, GPT-4, Gemini, "LLM")? An LLM is a tool, not an independent reviewer — listing it as one misrepresents the team. **Fatal**, regardless of the prose. |
+| Deferred mitigation | A future-tense mitigation promise — "a 20% sample **will be completed before submission**" — unmet at circulation? The future tense is the tell that the work is not done. **MAJOR**. |
+
+Run the deterministic check at Phase 2 entry (pass the extraction JSON — a file or
+a directory of per-study JSONs — so the prose↔JSON↔confession 3-way is covered):
+
+```bash
+python "${CLAUDE_SKILL_DIR}/scripts/check_reviewer_team_consistency.py" \
+    --manuscript manuscript.md \
+    --prospero prospero/record.md \
+    --extraction-json extraction/ \
+    --out _audit_self/reviewer_team_consistency.md
+```
+
+Exit 1 = MAJOR red flag. The JSON sidecar carries `dual_hits`, `single_hits`,
+`llm_reviewer_hits`, and `deferred_mitigation_hits`. Any of the DUAL+SINGLE
+conjunction, an LLM reviewer field, or a deferred mitigation trips it. Either of
+the dual/single claims alone is fine; the conjunction is read by reviewers as
+fabrication. Resolution path:
+1. Honest Methods/PROSPERO update (single-reviewer execution disclosed), OR
+2. Limitations confession rewritten if dual review was actually completed.
+
+#### L. Editorial impression & defensiveness (advisory; the counterweight)
+
+This is the **ceiling** category (see "Two Objectives" above) and the inverse of the floor
+gates: where A–K and the numerical gates ask "what is missing or wrong?" (and answer by
+**adding**), L asks "does the accurate manuscript read confidently, or has it over-defended?"
+(and answers by **subtracting**). Every L finding is **advisory (Minor / impression) and
+non-blocking** — it never converts to a Major and never blocks submission. The fixes are
+REMOVE / MOVE / TIGHTEN, not "add a caveat."
+
+| Check | What to look for | Action |
+|-------|-----------------|--------|
+| Hedge density | Defensive-caveat tokens stacking up per 1,000 narrative words — the prose hedges faster than it asserts. Keep the load-bearing caveats; cut the reflexive ones. | TIGHTEN |
+| Repeated caveat | The same caveat motif ("no deployable claim", "not generalizable", "hypothesis-generating") repeated across body + Abstract. Say it once, firmly. | TIGHTEN |
+| Audit minutiae in body | Provenance tokens (SHA / git commit / unit-test / post-lock timeline / manifest / seed=N / audit trail) in the Introduction / Results / Discussion narrative. Reproducibility detail belongs in a Methods statement or a supplement. | MOVE |
+| Limitations volume | A Limitations passage that enumerates a long list of discrete items reads as a rebuttal letter; consolidate related items. | TIGHTEN |
+| Abstract caveat load | The Abstract carries several caveat clauses, burying the headline result before a reader reaches it. Lead with the result; keep one or two essential qualifiers. | TIGHTEN |
+| Buried defense | A strong numeric robustness / sensitivity result sitting only in Limitations or the supplement, with no robustness mention in Results. Promote it into Results — it is *evidence for* the finding, not a caveat against it. (The inverse of the scope-coherence gate, which pushes a *weak* analysis out of Results.) | MOVE |
+
+Run the deterministic gate (Phase 2.5g) rather than eyeballing it — these are all counts and placements:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_editorial_impression.py" \
+  --manuscript manuscript.md --out qc/editorial_impression.json
+```
+
+`HEDGE_DENSITY`, `HEDGE_REPEAT`, `AUDIT_IN_BODY`, `LIMITATIONS_VOLUME`, `ABSTRACT_CAVEAT_LOAD`,
+and `BURIED_DEFENSE` are Anticipated **Minor** Comments (category: L. Editorial impression),
+each carrying a REMOVE / MOVE / TIGHTEN `action`. The gate never blocks (it has no Major and
+exits 0 even under `--strict`); thresholds are tunable (`--hedge-per-1k`, `--repeat-threshold`,
+`--limitations-max`, `--abstract-caveat-max`). It is conservative — each probe fires only on an
+explicit, locatable signal.
+

--- a/tests/test_phase_budget.sh
+++ b/tests/test_phase_budget.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_phase_budget.py.
+#
+# The point of this gate is that a SKILL.md is loaded IN FULL on every invocation, so an
+# over-budget phase is a bill the user pays whether or not the run ever reaches it. The test
+# therefore has to prove two things, and the second is the one that matters:
+#
+#   1. the gate is SILENT on the fixed tree (no false positives -> nobody switches it off), and
+#   2. the gate FAILS on the real defect restored (a 200-line phase). A test that only proves
+#      "passes on clean input" proves nothing: a gate that never fires passes that test too.
+#
+# It also pins the two properties that make the measurement honest:
+#   - fence-awareness: a `## heading` inside a code fence is NOT a section boundary, so a long
+#     phase cannot hide by embedding an output template that chops it in two;
+#   - EXEMPT: a listed section is tolerated, so a long section is a decision on the record.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DET="$ROOT/scripts/check_phase_budget.py"
+
+pass=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ---------------------------------------------------------------- 1. live repo is silent
+python3 "$DET" --strict >/dev/null 2>&1 \
+  || fail "the live repo must be within budget (run: python3 scripts/check_phase_budget.py)"
+pass=$((pass + 1))
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/skills/good" "$tmp/skills/bloated"
+
+# ------------------------------------------- NEGATIVE FIXTURE: good work the gate must not flag
+# A skill with a short phase and a proper trigger table. If the gate fires on this, it fires on
+# correct work, gets switched off, and takes the honest gates with it.
+{
+  echo "# Good Skill"
+  echo
+  echo "## Phase 1: Init"
+  echo
+  echo "Ask for the manuscript and its type."
+  echo
+  echo "| File | Read it when | Cost if read blindly |"
+  echo "|---|---|---|"
+  echo "| \`references/detail.md\` | you know the paper type | ~2,000 tokens |"
+} > "$tmp/skills/good/SKILL.md"
+
+python3 "$DET" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1 \
+  || fail "NEGATIVE fixture: the gate fired on a compliant SKILL.md"
+pass=$((pass + 1))
+
+# ------------------------- REGRESSION 1: the REAL defect, frozen. The gate must FAIL on it.
+# tests/fixtures/phase_budget/ holds self-review Phase 2 exactly as it shipped at a36c79e:
+# a 209-line body loaded in full on every /self-review invocation. This is the bug the gate
+# exists for, pinned so it stays regressed even after the live tree is fixed.
+REAL="$ROOT/tests/fixtures/phase_budget/skills"
+if python3 "$DET" --skills-dir "$REAL" --strict >/dev/null 2>&1; then
+  fail "REGRESSION: the real 209-line self-review Phase 2 did NOT fail the gate"
+fi
+python3 "$DET" --skills-dir "$REAL" --json 2>/dev/null | grep -q '"body_lines": 209' \
+  || fail "REGRESSION: the real defect was not measured at its true 209 lines"
+pass=$((pass + 1))
+
+# ---------------------------------------- REGRESSION 2: restore the defect shape, assert it FAILS
+# A phase 200 lines long, loaded in full on every invocation before the agent knows whether it
+# is relevant. A test that only proves "passes on clean input" would pass with the gate deleted.
+{
+  echo "# Bloated Skill"
+  echo
+  echo "## Phase 2: Systematic Check"
+  echo
+  for i in $(seq 1 200); do echo "- check item $i, which the agent may never need"; done
+} > "$tmp/skills/bloated/SKILL.md"
+
+if python3 "$DET" --skills-dir "$tmp/skills" --strict >/dev/null 2>&1; then
+  fail "REGRESSION: a 200-line phase did NOT fail the gate — the gate is not watching anything"
+fi
+pass=$((pass + 1))
+
+# the failure must NAME the offender and TEACH the fix, not just exit 1
+out="$(python3 "$DET" --skills-dir "$tmp/skills" 2>&1 || true)"
+grep -q "Phase 2: Systematic Check" <<<"$out" || fail "failure output does not name the over-budget section"
+grep -q "BEFORE it knows what the user wants" <<<"$out" || fail "failure output does not print the deciding question"
+grep -q "Read it when" <<<"$out" || fail "failure output does not print the trigger-table shape"
+pass=$((pass + 1))
+
+# ---------------------------------------------- FENCE-AWARENESS: the evasion the gate must resist
+# A `## heading` inside a code fence is an output template, not a section boundary. A fence-blind
+# parser would split this 200-line phase into two ~100-line halves and report BOTH as under a
+# 120-line budget -- i.e. a long phase could hide behind an embedded template. Assert it does not.
+mkdir -p "$tmp/fence/skills/sneaky"
+{
+  echo "# Sneaky Skill"
+  echo
+  echo "## Phase 9: Long"
+  echo
+  for i in $(seq 1 100); do echo "line $i"; done
+  echo '```'
+  echo "## Output Template (this is NOT a real heading)"
+  echo '```'
+  for i in $(seq 101 200); do echo "line $i"; done
+} > "$tmp/fence/skills/sneaky/SKILL.md"
+
+if python3 "$DET" --skills-dir "$tmp/fence/skills" --max-lines 120 --strict >/dev/null 2>&1; then
+  fail "FENCE: a 200-line phase hid behind a '## ...' inside a code fence (fence-blind parsing)"
+fi
+python3 "$DET" --skills-dir "$tmp/fence/skills" --max-lines 120 --json 2>/dev/null \
+  | grep -q '"section": "Phase 9: Long"' \
+  || fail "FENCE: the section was not measured as one whole body"
+pass=$((pass + 1))
+
+# --------------------------------------------------------------------- JSON shape is machine-readable
+python3 - "$DET" "$tmp/skills" <<'PY' || fail "--json did not emit a usable verdict"
+import json, subprocess, sys
+det, skills = sys.argv[1], sys.argv[2]
+r = subprocess.run([sys.executable, det, "--skills-dir", skills, "--json"],
+                   capture_output=True, text=True)
+d = json.loads(r.stdout)
+assert d["verdict"] == "PHASE_BUDGET_EXCEEDED", d["verdict"]
+assert d["budget"] == 80
+over = d["over_budget"]
+assert len(over) == 1, over
+assert over[0]["skill"] == "bloated", over[0]
+assert over[0]["body_lines"] >= 200, over[0]
+assert over[0]["over_by"] == over[0]["body_lines"] - 80, over[0]
+PY
+pass=$((pass + 1))
+
+echo "PASS: phase-budget gate — $pass checks."
+echo "  live repo silent - negative fixture silent - 200-line phase FAILS -"
+echo "  message teaches the fix - fence-hidden phase still caught - JSON verdict usable."


### PR DESCRIPTION
The rule *"any phase over 80 lines gets extracted to references/, leaving a trigger table"* had been true for months and was enforced nowhere. Fifteen sections violated it (a first, fence-blind measurement counted 12 — `## foo` inside a code fence is not a heading, and a fence-blind gate can be evaded by embedding one).

`check_phase_budget.py` measures each `##`/`###` section body (fence-aware) and fails any over the project's own 80-line threshold. All fifteen are split: control flow, gate invocations, and every HALT stay inline; only reference material moved, behind a `| File | Read it when | Cost if read blindly |` table. **Net −1,234 lines across 9 SKILL.md**, EXEMPT empty.

`validate_routing_assets.py` + `check_detector_reachability.py` both pass — i.e. no `references/` pointer dangles and no enforcement moved out of a SKILL.md. Self-test regresses the real 209-line Phase 2 and asserts the gate fails.

⚠️ The largest-surface change in this stack — worth eyeballing a couple of the split SKILL.md files before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)