### PR TITLE
fix(skills): a rule /publish-skill wrote down, that nothing executed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -147,6 +147,12 @@ jobs:
       - name: Run check_locale_inventory.py self-test
         run: bash tests/test_locale_inventory.sh
 
+      - name: "Run check_hardcoded_locale.py (no skill picks its user's language)"
+        run: python3 scripts/check_hardcoded_locale.py --strict
+
+      - name: Run hardcoded-locale gate self-test (the rule /publish-skill already wrote down)
+        run: bash tests/test_hardcoded_locale.sh
+
       - name: Run self-review panel-mode structural + PII test
         run: bash skills/self-review/tests/test_panel_mode.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 ### Fixed
 
+- **`/revise` was handing the author a sentence to tell an editor, and recommending it for its
+  effect rather than its truth.** Category 5 read: *"This analysis was reviewed in consultation with
+  our biostatistician" adds credibility.* That is a claim about who looked at the work — a claim
+  about the world — offered as a rhetorical move, in a toolkit whose whole thesis is that you do not
+  write down what you have not verified. Removed. If a statistician was in fact consulted, say so.
+- **Two skills told every user of an international toolkit what language they speak.**
+  `/humanize` opened with *"Communicate with the user in Korean"*; `/polish-language` with
+  *"Conversation with the user may be in Korean."* This package ships on npm and is starred from
+  countries its maintainer has never visited. Both now say what `/publish-skill` already said:
+  **in their preferred language.**
+
+  The rule was not missing. It was written down — **in `/publish-skill`, the skill whose job is to
+  scrub a personal skill before it goes public**, which lists "Language hardcoding" among the defects
+  to remove and prints the replacement. It was a sentence, and nothing executed it, and so the
+  repository shipped two violations of its own rule for months.
+
+  *A rule that ships as prose is a rule the model reads and disobeys. The difference between the
+  rules that held and the one that did not was not importance. It was executability.*
+
+### Added
+
+- `scripts/check_hardcoded_locale.py` — that sentence, executed. A SKILL.md may name a language as
+  the **subject** of the work ("manuscript edits are in English"); it may not choose which language
+  to address the **user** in. Naming the defect in order to teach it (as `/publish-skill` does) is
+  not committing it — the gate's first draft flagged the one file that had already got this right,
+  which is exactly how a gate dies. `tests/test_hardcoded_locale.sh` regresses both forms of the
+  defect and holds the gate silent on all three kinds of legitimate use.
+
+
+### Fixed
+
 - **`/self-review` `check_analysis_definitions` was reading layout, not defect** (detector #66,
   shipped hours earlier in #340). Two bugs, both caught on the *second* real manuscript:
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1823,8 +1823,8 @@
     },
     {
       "path": "skills/humanize/SKILL.md",
-      "size": 14240,
-      "sha256": "f179598c74b1ab0b3d6639fdd26b8cafa33713a9ebe9374aad5d31571340d836"
+      "size": 14232,
+      "sha256": "49ce02c245e7a816b795b85a402aefb8d655da020b9b0624a25a151a513451ab"
     },
     {
       "path": "skills/humanize/references/ai_patterns.md",
@@ -3343,8 +3343,8 @@
     },
     {
       "path": "skills/polish-language/SKILL.md",
-      "size": 6578,
-      "sha256": "16cc5dd91c4614e3306d766c8f3810a52a50f8a6bc2192483cb7d8f144843dd6"
+      "size": 6585,
+      "sha256": "5d68e807703817b5771f0b3f05beafe71eb34c0e68b2df4b74b995e871a1c679"
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/expected/report.txt",
@@ -3768,8 +3768,8 @@
     },
     {
       "path": "skills/revise/SKILL.md",
-      "size": 29984,
-      "sha256": "79e12a5bd02f16665a5b3bdef582167e081a9b7ba3c722de3e0438d488c5ae5e"
+      "size": 30049,
+      "sha256": "66e9660254fe44af90173a288c7e17017888015d50a4c1800dcc9199294a9ee9"
     },
     {
       "path": "skills/revise/references/r2r_voice.md",

--- a/scripts/check_hardcoded_locale.py
+++ b/scripts/check_hardcoded_locale.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""No skill gets to decide what language its user speaks.
+
+This toolkit is downloaded from npm, installed from a classroom ZIP, and starred by people in
+countries its maintainer has never been to. And two of its skills opened by telling the model:
+
+    skills/humanize/SKILL.md:17         "Communicate with the user in Korean."
+    skills/polish-language/SKILL.md:20  "Conversation with the user may be in Korean."
+
+Every user of `/humanize`, anywhere, was being addressed in a language chosen for them by a file
+they never read. The correct sentence was already in the repo — `/publish-skill` says
+*"Communicate with the user in their preferred language"* — so this was not a hard problem anyone
+had failed to solve. It was a rule nobody was checking.
+
+And here is the part worth sitting with. `/publish-skill`, the skill whose entire job is to scrub a
+personal skill before it goes public, **lists this exact defect**:
+
+    6. **Language hardcoding** ("in Korean", "한국어로", "in Japanese", "in Chinese")
+
+The rule existed. It was written down. It was written down *in the skill responsible for enforcing
+it*. And the repository shipped two violations of it for months, because the rule was a **sentence**
+and nothing executed it.
+
+    A rule that ships as prose is a rule the model reads and disobeys.
+    The difference between the rules that held and the one that did not was not importance.
+    It was executability.
+
+So this is that sentence, executed.
+
+What is allowed: naming a language as the *subject* of the work — "manuscript edits are in English",
+"medical terminology stays in English", the locale inventory, a translated `_ko` reference file. The
+defect is narrow and specific: **instructing the model which human language to address the USER in.**
+
+Usage:
+    check_hardcoded_locale.py [--strict] [--root PATH]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# "talk to the user" + a named language. Both halves are required: a skill may certainly say that
+# the MANUSCRIPT is in English. It may not say which language the PERSON gets.
+ADDRESSING_USER = r"(communicat\w*|convers\w*|speak\w*|respond\w*|repl\w*|talk\w*|address\w*|answer\w*|interact\w*|report\w*)"
+NAMED_LANGUAGE = (r"(korean|한국어|japanese|일본어|chinese|중국어|mandarin|spanish|french|german|"
+                  r"portuguese|italian|russian|arabic|hindi|vietnamese|thai)")
+
+# The whole sentence, so that "in their preferred language" is visibly a different thing.
+HARDCODE = re.compile(
+    rf"\b{ADDRESSING_USER}\b[^.\n]{{0,60}}?\b(?:with|to|the)?\s*(?:the\s+)?user[^.\n]{{0,40}}?\bin\s+{NAMED_LANGUAGE}\b",
+    re.IGNORECASE,
+)
+# ...and the terser form, "- Communicate in Korean."
+HARDCODE_TERSE = re.compile(
+    rf"^\s*[-*]?\s*{ADDRESSING_USER}\b[^.\n]{{0,30}}?\bin\s+{NAMED_LANGUAGE}\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# A skill may quote the defect in order to TEACH it. `/publish-skill` does exactly that — it lists
+# "Language hardcoding" among the things to scrub, and it prints the replacement:
+#
+#     - Replace: `"in Korean"` / `"한국어로"` → `"in the user's preferred language"`
+#
+# The first draft of this gate fired on that line. It flagged the one file in the repository that
+# had already got this right, for the crime of saying so. A gate that fires on good work gets
+# switched off, and it takes the honest gates with it.
+#
+# So: a line that names the defect alongside its cure is naming it, not committing it. The tell is
+# that the correct form appears on the same line.
+TEACHING = re.compile(
+    r"(language hardcoding|do not hardcode|never hardcode|scrub|PII audit|forbidden"
+    r"|preferred language|user's language|→|->|Replace:|instead of)",
+    re.IGNORECASE,
+)
+
+FENCE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def offences(md: Path) -> list[tuple[int, str]]:
+    text = FENCE.sub(lambda m: "\n" * m.group(0).count("\n"), md.read_text(encoding="utf-8", errors="ignore"))
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if not (HARDCODE.search(line) or HARDCODE_TERSE.search(line)):
+            continue
+        if TEACHING.search(line):
+            continue                       # this line is naming the defect, not committing it
+        out.append((i, line.strip()))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--root", type=Path, default=ROOT)
+    a = ap.parse_args()
+
+    skills = sorted((a.root / "skills").glob("*/SKILL.md"))
+    bad: list[tuple[Path, int, str]] = []
+    for md in skills:
+        for line, text in offences(md):
+            bad.append((md, line, text))
+
+    if not bad:
+        print(f"OK: none of the {len(skills)} skills picks a human language for its user.")
+        return 0
+
+    print(f"HARDCODED_LOCALE: {len(bad)} skill line(s) choose the user's language for them.\n")
+    for md, line, text in bad:
+        print(f"  {md.relative_to(a.root)}:{line}")
+        print(f"      {text}")
+    print(
+        "\nThis toolkit ships on npm and is used by people the maintainer has never met. A skill does\n"
+        "not get to decide what language they speak.\n"
+        "\nThe sentence that works is already in the repo — /publish-skill uses it:\n"
+        "\n    - Communicate with the user in their preferred language.\n"
+        "\nNaming a language as the SUBJECT of the work is fine and stays fine: \"manuscript edits are\n"
+        "in English\", \"medical terminology stays in English\". The defect is narrow — telling the model\n"
+        "which language to address the PERSON in.\n"
+    )
+    return 1 if a.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -14,9 +14,9 @@ wrote it, while preserving every technical claim, number, and citation.
 
 ## Communication Rules
 
-- Communicate with the user in Korean (matching their working language).
+- Communicate with the user in their preferred language.
 - All manuscript edits are in English.
-- Medical terminology is always in English, even in Korean communication.
+- Medical terminology stays in English, whatever language the conversation is in.
 
 ## Reference Files
 

--- a/skills/polish-language/SKILL.md
+++ b/skills/polish-language/SKILL.md
@@ -17,7 +17,7 @@ register while never touching facts.
 ## Communication Rules
 
 - Manuscript content and edits in English.
-- Conversation with the user may be in Korean.
+- Converse with the user in their preferred language.
 - Report issues first; only edit after the user approves (see gates below).
 
 ## Scope boundary (what this skill is, and is not)

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -274,10 +274,10 @@ not an attack. **Never ignore these requests** — reviewer engagement is a posi
 ### Category 5: Statistical Method Challenge
 
 Reviewer questions or requests changes to statistical methods.
-**Response**: Consult a biostatistician if unfamiliar → provide a reasoned justification
-for your method choice with references → if the reviewer's suggestion is valid, perform
-both analyses and show results are consistent. "This analysis was reviewed in consultation
-with our biostatistician" adds credibility.
+**Response**: Provide a reasoned justification for the method with references. If the reviewer's
+suggestion is valid, run both analyses and show the results are consistent. If a statistician was
+in fact consulted, say so; do not write that sentence because it *sounds* credible — a claim about
+who reviewed the work is a claim about the world, and this letter goes to an editor.
 
 ### Mapping to MAJ/MIN/REB
 

--- a/tests/test_hardcoded_locale.sh
+++ b/tests/test_hardcoded_locale.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_hardcoded_locale.py — no skill gets to pick its user's language.
+#
+# The rule this gate enforces was not missing. It was written down, in prose, inside the very skill
+# whose job is to enforce it: /publish-skill lists "Language hardcoding" among the defects to scrub
+# before a skill goes public, and prints the replacement sentence. And for months the package shipped
+# /humanize saying "Communicate with the user in Korean" to every person on earth who invoked it.
+#
+# That is the whole thesis in one file: the difference between the rules that held and the one that
+# did not was not importance. It was executability.
+#
+# So this test does not check that the gate passes. It rebuilds the defect and demands the gate FAIL —
+# and, just as hard, it demands the gate stay SILENT on the file that already had it right. A gate
+# that punishes good work gets switched off, and takes the honest gates with it.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+G="$REPO_ROOT/scripts/check_hardcoded_locale.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+mk() { mkdir -p "$FIX/skills/$1"; cat > "$FIX/skills/$1/SKILL.md"; }
+
+# 1) the live repo: nobody picks the user's language
+python3 "$G" --strict >/dev/null 2>&1
+ck "live repo: no skill chooses its user's language" 0 "$?"
+
+# 2) REGRESSION — the defect exactly as it shipped
+mk regressed <<'EOF'
+# Regressed skill
+## Communication Rules
+- Communicate with the user in Korean (matching their working language).
+- All manuscript edits are in English.
+EOF
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "REGRESSION: 'communicate with the user in Korean'" 1 "$?"
+
+# ...and it must be the LINE that is named, not merely the file
+python3 "$G" --root "$FIX" 2>&1 | grep -q "skills/regressed/SKILL.md:3" \
+  && ck "the offending line is named, with its number" 0 0 \
+  || ck "the offending line is named, with its number" 0 1
+
+# 3) the softer form, which is the same defect wearing a hedge
+rm -rf "$FIX/skills/regressed"
+mk hedged <<'EOF'
+# Hedged skill
+- Conversation with the user may be in Korean.
+EOF
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "REGRESSION: 'conversation with the user may be in Korean'" 1 "$?"
+
+# 4) NEGATIVE — the correct sentence, which is already in the repo
+rm -rf "$FIX/skills/hedged"
+mk correct <<'EOF'
+# Correct skill
+## Communication Rules
+- Communicate with the user in their preferred language.
+- All manuscript edits are in English.
+- Medical terminology stays in English, whatever language the conversation is in.
+EOF
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "NEGATIVE: 'in their preferred language' is silent" 0 "$?"
+
+# 5) NEGATIVE — a language named as the SUBJECT of the work is not the defect
+rm -rf "$FIX/skills/correct"
+mk subject <<'EOF'
+# Subject skill
+- The manuscript is written in English.
+- Translate the abstract into Japanese for the society submission.
+- Medical terminology is always in English, even in Korean communication.
+EOF
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "NEGATIVE: a language as the work's subject is not the defect" 0 "$?"
+
+# 6) NEGATIVE — the file that already knew must not be punished for saying so.
+#    /publish-skill names the defect AND prints its cure on the same line. The first draft of this
+#    gate flagged it. That is how a gate dies.
+rm -rf "$FIX/skills/subject"
+mk teaching <<'EOF'
+# Teaching skill
+### PII scrub
+6. **Language hardcoding** ("in Korean", "in Japanese", "in Chinese")
+- Replace: `"in Korean"` / `"Korean language"` -> `"in the user's preferred language"`
+EOF
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "NEGATIVE: naming the defect + its cure is teaching, not doing" 0 "$?"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
`/publish-skill` exists to scrub a personal skill before it goes public. Its defect list includes *"Language hardcoding (\"in Korean\", …)"* with the replacement printed. And for months the package shipped `/humanize` opening with **"Communicate with the user in Korean"**, and `/polish-language` with *"Conversation with the user may be in Korean."*

The rule was not missing. It was a **sentence**, and nothing executed it. The two Korean gates that exist look for Hangul *characters*; an English sentence choosing the user's language was never in scope.

- Both skills now say what `/publish-skill` already said: **in their preferred language.**
- `check_hardcoded_locale.py` executes that sentence. A skill may name a language as the *subject* of the work ("manuscript edits are in English"); it may not pick the language its *user* is addressed in. Naming the defect to teach it (as `/publish-skill` does) is not committing it — the gate's first draft flagged the one file that already got this right, which is how a gate dies.
- Also removed a fabrication template from `/revise`: *"This analysis was reviewed in consultation with our biostatistician" adds credibility.* A claim about who reviewed the work, recommended for its effect, in a toolkit built on not writing down what you have not verified. It went to editors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)