### PR TITLE
fix(skills): four sentences that described a package other than the one we ship

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: "Run phase-budget self-test (the real 209-line phase must still fail the gate)"
         run: bash tests/test_phase_budget.sh
+      - name: "Run check_named_skills_exist.py (a skill may not send you to a skill that does not exist)"
+        run: python3 scripts/check_named_skills_exist.py --strict
 
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,33 @@
   not committing it — the gate's first draft flagged the one file that had already got this right,
   which is exactly how a gate dies. `tests/test_hardcoded_locale.sh` regresses both forms of the
   defect and holds the gate silent on all three kinds of legitimate use.
+- **`/meta-analysis` told every user to run two skills that exist only on the maintainer's laptop.**
+  Phase 9: *"Co-author circulation | `/gws` + `/handoff`"*. Neither is in this package; both live in
+  `~/.claude/skills`. Anyone who installed from npm and reached Phase 9 was handed an instruction
+  they could not follow — and a glimpse of a private toolchain. `/lit-sync` did the same with
+  `/obsidian-paper-vault`.
+- **`/lit-sync` announced a gate that has never existed.** It said twice that `/verify-refs` treats
+  `refs_bib_refreshed: false` as an unverified snapshot and that downstream skills *block* on it.
+  `verify_refs.py` has never contained that string. The sentence describing the gate was the only
+  thing standing between a stale `refs.bib` and a manuscript. It also routed users to `/render` — a
+  skill that does not exist and never has.
+- **`/find-journal` ran 71 lines of dead code on every invocation.** Phase 3.6 globs
+  `TODO_*_profiles.md`; those files were deleted in the privacy commit (#39). The glob has matched
+  nothing since, so the step is loaded into context, evaluated, and skipped, every single time.
+  474 -> 404 lines.
+- **`/find-journal`'s description told every session something false about itself.** *"No cached
+  IF/APC data — users verify current metrics at journal sites."* Twenty-eight of the seventy-three
+  shipped profiles cache an APC (`APC ~$3,690`, `APC $4,160`, `APC US$2,000`), thirteen cache an
+  impact factor. The description is loaded into **every** session, used or not. It now says what is
+  true: those figures are point-in-time and may be stale.
+
+### Added
+
+- `scripts/check_named_skills_exist.py` — the sibling `validate_routing_assets.py` never had. That
+  gate refuses to let a SKILL.md point at a `references/` file that is not there; this one refuses to
+  let it point at a *skill* that is not there. Tokens that only look like invocations (an Embase
+  `/exp`, a path fragment) are exempted **with their reason written down**, so the exemption is a
+  decision rather than a hole.
 
 
 ### Fixed

--- a/docs/skills/find-journal.md
+++ b/docs/skills/find-journal.md
@@ -2,7 +2,7 @@
 
 # find-journal
 
-> Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
+> Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. Impact-factor and APC figures in a profile are point-in-time and may be stale — verify current metrics at the journal site. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 
 **Invoke:** `/find-journal` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1323,8 +1323,8 @@
     },
     {
       "path": "skills/find-journal/SKILL.md",
-      "size": 22072,
-      "sha256": "45074f6499896700bff0eb20bd91c4076b143bcd39521d56559239edaa8b24d8"
+      "size": 18598,
+      "sha256": "fe4188fc24ecaecf1af22ad8a889525746fa6a98b0e03726e5c27ea7ef0b5f54"
     },
     {
       "path": "skills/find-journal/references/acceptance_signals_schema.md",
@@ -1848,8 +1848,8 @@
     },
     {
       "path": "skills/lit-sync/SKILL.md",
-      "size": 21126,
-      "sha256": "4ba2d2b6dd4704803c0922993401b837d4135ac1d655d6064229315537a8e818"
+      "size": 21152,
+      "sha256": "e44d0451bdb005c0f65635fa5c7731945a4bb922e1cd75d0218d3f4a24dd4140"
     },
     {
       "path": "skills/lit-sync/references/locale/ko/note_templates.md",
@@ -2528,8 +2528,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 40107,
-      "sha256": "946a0fb14b629488cb62c0d43300308ff574a3ec4c832e6bfbd6c038c1e502aa"
+      "size": 40001,
+      "sha256": "06cb68d854782c59835399089f41ab184fb8b00900546d0e6e6a44d3e7d9f0bb"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",

--- a/scripts/check_named_skills_exist.py
+++ b/scripts/check_named_skills_exist.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""A skill may not send its user to a skill that does not exist.
+
+`validate_routing_assets.py` already refuses to let a SKILL.md point at a `references/` file that
+is not there. This is its sibling, and it exists because the same failure was happening one level up,
+where nothing was looking.
+
+`/meta-analysis` carried this row:
+
+    | Co-author circulation (Phase 9) | `/gws` + `/handoff` | Thread-reply send, deadline task registration |
+
+`/gws` and `/handoff` are the maintainer's **local** skills. They are in `~/.claude/skills`. They
+have never been in this package. So every person who installed medsci-skills from npm and reached
+Phase 9 of a meta-analysis was told to run two commands that do not exist on their machine — and the
+instruction quietly advertised a private toolchain besides. `/lit-sync` did the same with
+`/obsidian-paper-vault`.
+
+None of this was a hard problem. Nothing was checking.
+
+And the failure mode generalises past skills: `/lit-sync` also announced that `/verify-refs` blocks
+downstream work on a `refs_bib_refreshed: false` flag. `verify_refs.py` has never contained that
+string. The sentence describing the gate was the only thing standing between a stale `refs.bib` and
+a manuscript — which is the whole disease this audit is about:
+
+    A rule that ships as prose is a rule the model reads and disobeys.
+
+Usage:
+    check_named_skills_exist.py [--strict] [--root PATH]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# A skill invocation as it is written in these files: `/name`, in backticks or parentheses.
+NAMED = re.compile(r"[`(]/([a-z][a-z0-9-]{2,})(?=[`)\s,.;])")
+FENCE = re.compile(r"```.*?```", re.DOTALL)
+
+# Slash-tokens that are not skill invocations. Each is a decision someone wrote down, not a shrug —
+# the regex over-collects, and an allowlist that explains itself is better than a regex nobody can read.
+NOT_A_SKILL = {
+    "exp": "Emtree explosion operator in an Embase query (`/exp`)",
+    "plain": "the tail of `.md`/plain, describing input formats",
+    "submission": "a path fragment, `submission/{journal}/...`",
+    "unit-of-analysis": "a bolded phrase in prose, not an invocation",
+    "tmp": "a filesystem path",
+    "usr": "a filesystem path",
+    "home": "a filesystem path",
+    "dev": "a filesystem path",
+    "opt": "a filesystem path",
+    "var": "a filesystem path",
+    "etc": "a filesystem path",
+    "bin": "a filesystem path",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--root", type=Path, default=ROOT)
+    a = ap.parse_args()
+
+    skills_dir = a.root / "skills"
+    shipped = {d.name for d in skills_dir.iterdir() if (d / "SKILL.md").is_file()}
+
+    bad: list[tuple[str, int, str, str]] = []
+    for md in sorted(skills_dir.glob("*/SKILL.md")):
+        text = FENCE.sub(lambda m: "\n" * m.group(0).count("\n"), md.read_text(encoding="utf-8", errors="ignore"))
+        for i, line in enumerate(text.splitlines(), 1):
+            for m in NAMED.finditer(line):
+                name = m.group(1)
+                if name in shipped or name in NOT_A_SKILL:
+                    continue
+                bad.append((md.parts[-2], i, name, line.strip()[:96]))
+
+    if not bad:
+        print(f"OK: every skill named by a SKILL.md is one of the {len(shipped)} this package ships.")
+        return 0
+
+    print(f"SKILL_DOES_NOT_EXIST: {len(bad)} reference(s) to a skill this package does not ship.\n")
+    for skill, line, name, text in bad:
+        print(f"  skills/{skill}/SKILL.md:{line}  ->  /{name}")
+        print(f"      {text}")
+    print(
+        "\nA user who installs this package from npm has exactly the skills in `skills/`. They do not\n"
+        "have whatever is in the maintainer's `~/.claude/skills`. Telling them to run one is an\n"
+        "instruction they cannot follow, and it advertises a private toolchain besides.\n"
+        "\nEither ship the skill, name one that exists, or cut the sentence.\n"
+        "If the token is not a skill invocation at all — an Embase `/exp`, a path fragment — add it to\n"
+        "NOT_A_SKILL in this script WITH THE REASON, so that the exemption is a decision rather than\n"
+        "a hole.\n"
+    )
+    return 1 if a.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/find-journal/SKILL.md
+++ b/skills/find-journal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-journal
-description: Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. No cached IF/APC data — users verify current metrics at journal sites. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
+description: Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. Impact-factor and APC figures in a profile are point-in-time and may be stale — verify current metrics at the journal site. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 triggers: find journal, recommend journal, where to submit, which journal, journal selection, target journal, journal match
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
@@ -228,76 +228,6 @@ for the output:
 This enriches the recommendation output without loading all write-paper profiles.
 If no write-paper profile exists, use the compact profile data only.
 
-### 3.6 Profile Coverage Advisory
-
-Before emitting the final output, scan the skill directory for profile-gap TODO files and
-decide whether to append a Coverage Advisory block.
-
-**What this step protects against.** The recommendation list is bounded by what the public
-and private libraries contain. If a high-value journal is simply missing from both tiers,
-the ranking silently substitutes an adjacent journal and the user never learns that
-a better-fitting target exists. The Coverage Advisory surfaces known gaps and directs the
-user to `/add-journal` (or manual PDF + verification) to close them.
-
-**Procedure.**
-
-1. **Locate TODO files.** Glob `${CLAUDE_SKILL_DIR}/TODO_*_profiles.md`. These are
-   maintainer-curated gap files, one per field (e.g., `TODO_neurointervention_profiles.md`,
-   future: `TODO_pediatric_*`, `TODO_endocrinology_*`). The file must contain a
-   `## Field Keywords` section — files without this section are ignored.
-
-2. **Match against manuscript themes.** For each TODO file, read the Field Keywords
-   block. If any keyword (case-insensitive, word-boundary match) appears in the
-   manuscript's abstract or in the themes extracted in Phase 2, mark the TODO as
-   relevant.
-
-3. **Parse the gap list.** From each relevant TODO, extract the journal entries under
-   headings matching `## 추가 필요` / `## Missing` / `## Pending` — they are the still-missing
-   journals. Exclude any entry already marked completed (lines containing ✅ or
-   "추가 완료 / Completed"). Also skip journals listed under `## Private` (waiting on
-   private→public promotion).
-
-4. **Emit the advisory.** If at least one TODO is relevant and at least one journal
-   in it is still missing, append a Coverage Advisory block immediately below the
-   top-5 recommendation list and above the Mandatory Disclaimer. If no TODO is
-   relevant, skip this block entirely — no false alarms.
-
-**Output format (when emitted).**
-
-```
----
-### ⚠️ Profile Coverage Advisory — {field name}
-
-Your manuscript matches keywords for the **{field name}** field, and the public profile
-library has known gaps here. The following journals may be strong-fit candidates that did
-not appear in the top-5 only because they are not yet in the library:
-
-- **{Journal 1}** ({Publisher}) — {1-line reason from TODO entry}
-- **{Journal 2}** ({Publisher}) — {1-line reason from TODO entry}
-- ...
-
-To add any of them to the public library:
-
-1. Open the journal's author-guidelines page and save it as PDF (or paste the text).
-2. Invoke `/add-journal` with the PDF — it transcribes the Identity / Scope / Article
-   Types / AI policy fields directly from the source and verifies the ISSN against
-   `portal.issn.org`, per `skills/find-journal/POLICY.md`.
-3. After the new profile lands in `references/journal_profiles/`, re-run `/find-journal`
-   to see the updated ranking.
-
-TODO source: `skills/find-journal/{TODO filename}`
----
-```
-
-**Guardrails.**
-
-- Do not fabricate journals, publishers, or rationale. Copy the TODO entry verbatim (or
-  paraphrase minimally from the same line).
-- Do not promote a still-private profile into the advisory — private profiles are by
-  definition not production-ready.
-- Keep the advisory concise (≤10 missing journals per field). If a TODO file lists more,
-  show the first 10 in priority order and add a "... and {N} more in the TODO file" line.
-- The advisory is informational. It does not change the top-5 ranking or its scores.
 
 ---
 
@@ -330,7 +260,7 @@ After all 5 recommendations, add a brief comparison note (2-3 sentences) highlig
 the key tradeoffs between the top choices (e.g., scope breadth vs. specialty depth,
 tier vs. acceptance feasibility).
 
-Then add the two blocks below, then (if Phase 3.6 produced one) the Coverage Advisory,
+Then add the two blocks below,
 then the Mandatory Disclaimer.
 
 ### Acceptance-Readiness Summary

--- a/skills/lit-sync/SKILL.md
+++ b/skills/lit-sync/SKILL.md
@@ -46,7 +46,7 @@ Per `docs/artifact_contract.md`, `/lit-sync` is the **sole writer** of:
 
 | Artifact | Writer | Readers |
 |---|---|---|
-| `manuscript/_src/refs.bib` | `/lit-sync` (via Better BibTeX auto-export trigger) | `/write-paper`, `/verify-refs`, `/render` |
+| `manuscript/_src/refs.bib` | `/lit-sync` (via Better BibTeX auto-export trigger) | `/write-paper`, `/verify-refs`, `/manage-refs` |
 | `references/zotero_collection.json` | `/lit-sync` | `/verify-refs`, `/sync-submission` |
 
 Direct hand edits to `refs.bib` are drift — revert on sight.
@@ -192,7 +192,7 @@ Before entering the 10s polling loop in Step 2.5.2, verify both preconditions. I
 
    > Phase 2.5 skipped: target snapshot `<path>` not found. Configure BBT auto-export with "On Change" to the SSOT path, then re-run.
 
-In either early-exit, set `refs_bib_refreshed: false` + `reason: "precondition:<which>"` in the Step 2.5.3 JSON and return control to the caller. `/verify-refs` treats `refs_bib_refreshed: false` as an unverified snapshot — downstream skills (`/write-paper`, `/render`) block until the precondition is resolved.
+In either early-exit, set `refs_bib_refreshed: false` + `reason: "precondition:<which>"` in the Step 2.5.3 JSON and return control to the caller. Record it and tell the user; nothing downstream enforces it. `verify_refs.py` has never read this flag, and the sentence that said it did was the only thing standing between a stale `refs.bib` and a manuscript.
 
 Rationale (2026-04-24 Phase 1B-b dry-run): on a machine with BBT installed but no auto-export registered, the original Step 2.5.2 polled for 10s then emitted a generic "mtime unchanged" WARN that did not point at the actual cause. Findings: `~/.local/cache/phase1b_b_dryrun/findings.md`.
 
@@ -221,7 +221,7 @@ Append to the JSON written in Step 2.3:
 }
 ```
 
-If refresh failed, set `refs_bib_refreshed: false` and include `reason`. `/verify-refs` uses this flag to decide whether the snapshot is trustworthy.
+If refresh failed, set `refs_bib_refreshed: false` and include `reason`. The flag records whether the export ran. It is a note to the reader, not a gate.
 
 ---
 
@@ -246,7 +246,7 @@ python3 "$ENGINE" <worklist> -o pdfs/ -e <contact-email> --report pdfs/retrieval
 
 `<worklist>` is the DOI/PMID(/Title) list — the Phase-1 `.bib` DOIs, the worklist supplied
 in the standalone mode below, or the project collection's DOIs. Output: `pdfs/*.pdf` for
-`/meta-analysis`, `/obsidian-paper-vault`, and `pdf_to_md.py`, plus
+`/meta-analysis` and `pdf_to_md.py`, plus
 `pdfs/retrieval_report.json` (per-DOI `status`/`source`/`title_match`).
 
 ### Route B — in-library PDFs (Zotero-native, higher yield, proxy-aware)

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -596,7 +596,6 @@ When the number of included studies is small (< 10):
 | Need reporting check | `/check-reporting` | PRISMA-DTA / PRISMA 2020 compliance (includes Step 4c registration / amendment timing) |
 | Need manuscript writing | `/write-paper` | Full IMRAD manuscript generation |
 | Need self-review | `/self-review` | Pre-submission quality check |
-| Co-author circulation (Phase 9) | `/gws` + `/handoff` | Thread-reply send, deadline task registration |
 | Self-audit recovery entrypoint (Phase 10) | `/write-paper` Step 7.4a | Recovery branch for polish pipelines that surface structural audit failures |
 | `/sync-submission` SR-MA gate | `/sync-submission` | Before submission, verify supplementary package matches all 8 files in `templates/supplementary_8file_checklist.md` (PRISMA, PROSPERO, search strategy, exclusion list, extraction table, per-study x per-domain RoB, subgroup forests, sensitivity / publication bias). AI Disclosure presence check (cross-link `/peer-review` Phase 2A P8). Cite-list duplicate check via `/verify-refs` Gate 5 (duplicate PMID/DOI). |
 


### PR DESCRIPTION
Each is the same disease: a claim written in prose that nothing executed, so it drifted and stayed wrong.

- **`/meta-analysis` told every user to run `/gws` and `/handoff`** — the maintainer's LOCAL skills, never in this package. Anyone who installed from npm and reached Phase 9 got two commands that do not exist on their machine. `/lit-sync` did the same with `/obsidian-paper-vault`.
- **`/lit-sync` announced a gate that never existed** — that `/verify-refs` blocks downstream work on a `refs_bib_refreshed: false` flag. `verify_refs.py` has never contained that string. It also routed users to `/render`, a skill that does not exist.
- **`/find-journal` ran 71 lines of dead code every invocation** — Phase 3.6 globs `TODO_*_profiles.md`, deleted in the privacy commit (#39). 474 → 404 lines.
- **`/find-journal`'s description told every session something false** — *"No cached IF/APC data"* while 28 of 73 profiles cache an APC.

Gate: `check_named_skills_exist.py`, the sibling `validate_routing_assets.py` never had. That one refuses a dangling `references/` pointer; this one refuses a reference to a skill that is not shipped. Fires 5× on main. Non-invocation tokens (an Embase `/exp`, a path fragment) are exempted with their reason written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)