### PR TITLE
fix(ci): the workflow gate could not see a runless step — the failure that bit today's merges

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,9 @@ jobs:
       - name: "Workflow files parse (a broken one runs ZERO jobs and reports no checks)"
         run: python3 scripts/check_workflow_yaml.py --strict
 
+      - name: "Workflow-yaml gate self-test (a runless step and an unquoted ': ' must both fail)"
+        run: bash tests/test_workflow_yaml.sh
+
       - name: Run validate_skills.sh (PII + structure)
         run: bash scripts/validate_skills.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixed
 
+- **`check_workflow_yaml.py` could not see the failure that motivated it, one layer down.** It was
+  built (#333) after an unquoted `: ` broke `validate.yml` and GitHub ran zero jobs — a failure that
+  *disappears* instead of turning a PR red. On 2026-07-15, resolving a merge conflict by keeping both
+  sides of a hunk left a `- name:` step whose `run:` had been dropped. The file was valid YAML, this
+  gate passed, and GitHub again ran zero jobs ("This run likely failed because of a workflow file
+  issue"). The gate now asserts every step in every job has `run:` or `uses:`, and ships the
+  self-test #333 never wrote — regressing the runless step, the unquoted `: `, and a jobless file,
+  and staying silent on a `uses:`-only step and a properly quoted name.
+
+
+### Fixed
+
 - **`/revise` was handing the author a sentence to tell an editor, and recommending it for its
   effect rather than its truth.** Category 5 read: *"This analysis was reviewed in consultation with
   our biostatistician" adds credibility.* That is a claim about who looked at the work — a claim

--- a/scripts/check_workflow_yaml.py
+++ b/scripts/check_workflow_yaml.py
@@ -69,6 +69,35 @@ def problems() -> list[str]:
             continue
         if not isinstance(doc, dict) or not doc.get("jobs"):
             out.append(f"{f.relative_to(ROOT)}: parses, but declares no jobs.")
+            continue
+
+        # 3. A step that parses but has neither `run` nor `uses`. GitHub rejects this at the
+        #    workflow-LOADING stage — before any job starts — so it runs ZERO jobs and calls it
+        #    "This run likely failed because of a workflow file issue". That is the same
+        #    disappearing failure a parse error causes, one layer past what a YAML parse can see.
+        #
+        #    On 2026-07-15 a merge conflict was resolved by keeping both sides of a hunk, which left
+        #    a `- name:` line whose `run:` had landed on the other side and was dropped. The file
+        #    parsed. This gate — before this block — passed. GitHub ran nothing, and the branch
+        #    looked quiet rather than broken. The exact lesson that built this file recurred, because
+        #    the file only checked the trap it already knew.
+        for job_name, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for idx, step in enumerate(job.get("steps") or [], 1):
+                if not isinstance(step, dict):
+                    continue
+                if "run" not in step and "uses" not in step:
+                    label = step.get("name", f"step {idx}")
+                    out.append(
+                        f"{f.relative_to(ROOT)}: job '{job_name}' step {idx} ({label!r}) has neither "
+                        f"`run:` nor `uses:`.\n"
+                        f"      GitHub rejects this when it loads the workflow and runs ZERO jobs — "
+                        f"the same disappearing failure a parse error causes, which a YAML parse "
+                        f"cannot see because the file is valid YAML.\n"
+                        f"      Fix: give the step a `run:` command or a `uses:` action. A dropped "
+                        f"`run:` in a merge is the usual cause."
+                    )
     return out
 
 

--- a/tests/test_workflow_yaml.sh
+++ b/tests/test_workflow_yaml.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_workflow_yaml.py — the gate that keeps a broken workflow from
+# VANISHING instead of failing. It shipped in #333 with no self-test of its own, and on 2026-07-15
+# a defect walked straight past it: a merge left a `- name:` step whose `run:` had been dropped. The
+# file was valid YAML, the gate passed, and GitHub ran zero jobs while the branch looked quiet.
+#
+# So this test does not check that the gate passes. It rebuilds each disappearing-failure shape and
+# demands the gate FAIL — and holds it silent on a well-formed workflow, because a gate that fires on
+# good work gets switched off.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+G="$REPO_ROOT/scripts/check_workflow_yaml.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-56s exit=%s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-56s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# 1) the live repo is well-formed
+python3 "$G" --strict >/dev/null 2>&1
+ck "live repo: all workflows load and every step runs" 0 "$?"
+
+# The gate reads .github/workflows relative to its own parent, so point it at a fixture tree by
+# running a copy from there. Simplest: build a throwaway repo root with just the gate + a workflow.
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/scripts" "$FIX/.github/workflows"
+cp "$G" "$FIX/scripts/check_workflow_yaml.py"
+run_fixture() { python3 "$FIX/scripts/check_workflow_yaml.py" --strict >/dev/null 2>&1; }
+
+# 2) REGRESSION — the 2026-07-15 defect: a step with a name but no run/uses
+cat > "$FIX/.github/workflows/w.yml" <<'YML'
+name: t
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: has a name but its run was dropped in a merge
+      - name: fine
+        run: echo ok
+YML
+run_fixture
+ck "REGRESSION: a step with no run/uses (the merge-drop bug)" 1 "$?"
+
+# 3) REGRESSION — the original #333 trap: unquoted ': ' turns a scalar into a mapping
+cat > "$FIX/.github/workflows/w.yml" <<'YML'
+name: t
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run deck-budget (same deck: fits an oral, too dense for a keynote)
+        run: echo ok
+YML
+run_fixture
+ck "REGRESSION: unquoted ': ' in a step name (the #333 trap)" 1 "$?"
+
+# 4) REGRESSION — parses but declares no jobs
+cat > "$FIX/.github/workflows/w.yml" <<'YML'
+name: t
+on: [push]
+YML
+run_fixture
+ck "REGRESSION: valid YAML with no jobs" 1 "$?"
+
+# 5) NEGATIVE — a `uses:` step (no run) is legitimate and must stay silent
+cat > "$FIX/.github/workflows/w.yml" <<'YML'
+name: t
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: echo ok
+YML
+run_fixture
+ck "NEGATIVE: a uses-only step is not runless" 0 "$?"
+
+# 6) NEGATIVE — a properly quoted name with ': ' inside must stay silent
+cat > "$FIX/.github/workflows/w.yml" <<'YML'
+name: t
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run deck-budget (same deck: fits an oral)"
+        run: echo ok
+YML
+run_fixture
+ck "NEGATIVE: a quoted name containing ': ' is fine" 0 "$?"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
`check_workflow_yaml.py` was built (#333) after an unquoted `: ` broke `validate.yml` and GitHub ran **zero jobs** — a failure that *disappears* instead of turning a PR red.

Merging the six audit-sweep PRs today (#342–#347), resolving a `validate.yml` conflict by keeping both sides of a hunk dropped a `- name:` step's `run:` onto the discarded side. The file was valid YAML, this gate passed, and GitHub again ran zero jobs ("This run likely failed because of a workflow file issue"). It was caught only by the local CI mirror *after* the push — the gate itself was blind to it, because it only checked the one trap it already knew.

- The gate now asserts every step in every job has `run:` or `uses:` (a `uses:`-only step stays silent).
- `tests/test_workflow_yaml.sh` is the self-test #333 never wrote — regresses the runless step, the unquoted `: `, and a jobless file; silent on a uses-only step and a quoted name.

Repo-level script; no detector-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)