### PR TITLE
chore(skills): remove two dead prose blocks (subtractive audit, −35 lines/invocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Two dead prose blocks removed from SKILL.md (−35 lines loaded every invocation).** From a
+  subtractive audit that sorted every normative sentence in 30 skills into enforced / judgment /
+  scriptable / decoration: 71 rules are enforced by a script, 269 legitimately direct the model's
+  judgment, and the "decoration" pile — sentences nothing catches, that ship no defective artifact —
+  turned out, on line-by-line re-verification, to be far smaller than a first pass claimed. Almost
+  everything a first agent flagged was defended and kept ("when in doubt, keep"). Only what could be
+  deleted with certainty is cut here:
+  - `lit-sync`: a dated dry-run rationale whose only referent was `~/.local/cache/phase1b_b_dryrun/`,
+    a machine-local path dead for every installed copy.
+  - `present-paper`: a 28-line `<details>` block self-labelled "The original list, for reference" —
+    the superseded prior version of the Step 0a load guidance, every file it named still pointed to
+    by the current A/B/C + on-demand table above it (verified: no orphaned reference).
+
+
 ### Fixed
 
 - **`check_workflow_yaml.py` could not see the failure that motivated it, one layer down.** It was

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1848,8 +1848,8 @@
     },
     {
       "path": "skills/lit-sync/SKILL.md",
-      "size": 21152,
-      "sha256": "e44d0451bdb005c0f65635fa5c7731945a4bb922e1cd75d0218d3f4a24dd4140"
+      "size": 20859,
+      "sha256": "75c62c4d1064466a16555c17cfcccae1902da536a7a1e2635234108adf533fa8"
     },
     {
       "path": "skills/lit-sync/references/locale/ko/note_templates.md",
@@ -3428,8 +3428,8 @@
     },
     {
       "path": "skills/present-paper/SKILL.md",
-      "size": 41029,
-      "sha256": "9f9f7635053748e8174d23e78bd1e6661ab2acca87889a773282a01dde6edb55"
+      "size": 39097,
+      "sha256": "da139de9b1633bc789b8f3e59f72aa315186192351fccfdbcfcb3f99405db993"
     },
     {
       "path": "skills/present-paper/references/ai_slide_tells.md",

--- a/skills/lit-sync/SKILL.md
+++ b/skills/lit-sync/SKILL.md
@@ -194,8 +194,6 @@ Before entering the 10s polling loop in Step 2.5.2, verify both preconditions. I
 
 In either early-exit, set `refs_bib_refreshed: false` + `reason: "precondition:<which>"` in the Step 2.5.3 JSON and return control to the caller. Record it and tell the user; nothing downstream enforces it. `verify_refs.py` has never read this flag, and the sentence that said it did was the only thing standing between a stale `refs.bib` and a manuscript.
 
-Rationale (2026-04-24 Phase 1B-b dry-run): on a machine with BBT installed but no auto-export registered, the original Step 2.5.2 polled for 10s then emitted a generic "mtime unchanged" WARN that did not point at the actual cause. Findings: `~/.local/cache/phase1b_b_dryrun/findings.md`.
-
 ### Step 2.5.2: Verify refresh
 
 After Phase 2 adds items:
@@ -325,11 +323,7 @@ tags:
 
 ## Key points (in my own words)
 
-
-
 ## My thoughts
-
-
 
 ## Related notes
 - [[Research Hub]]

--- a/skills/present-paper/SKILL.md
+++ b/skills/present-paper/SKILL.md
@@ -75,35 +75,6 @@ animation discipline) plus the G1–G10 self-check the Phase 3.5 critic scores a
 | `references/slide_visual_styles/CATALOG.md` → one style file | Q2 has chosen a style | ~2,300 tokens per style |
 | `references/slide_design_principles.md` | you are stuck on *why* a slide is not landing — Reynolds / Duarte / Knaflic / Tufte, the theory under the rules in **C** | ~2,600 tokens of theory you mostly already applied |
 
-<details>
-<summary>The original list, for reference</summary>
-
-1. **`references/slide_design_principles.md`** — Reynolds (Presentation Zen) +
-   Duarte (Slide:ology Glance Test™) + Knaflic (Storytelling with Data preattentive
-   attributes) + Tufte (Cognitive Style of PowerPoint). The design *theory*. **Read this
-   first** — it shifts the outline from "what content fits" to "what should the audience
-   remember 10 seconds after each slide."
-2. **`references/presentation_design_guidelines.md`** — the *operational* companion to
-   #1: concrete, enforceable rules (assertion headlines, 24-pt floor, 30–35% negative
-   space, ≤3 colors, colorblind-safe palettes, redraw-don't-screenshot, animation
-   discipline) plus a G1–G10 self-check the Phase 3.5 critic scores against. Read with #1.
-3. **`references/medical_presentation_templates.md`** — Section structure, slide counts,
-   and design seeds for the 5 contexts: journal club, grand rounds, conference talk,
-   lecture, and academic lecture multi-paper survey. Pick the matching template after
-   Phase 0 inputs are collected, then customize.
-4. **`references/slide_visual_styles/CATALOG.md`** — the menu of visual styles (palette +
-   typography + layout-grid + slide-type recipes) callable from any of the 5 context
-   templates. Available: **Nature/Lancet** (`nature_lancet.md`, default for medical
-   academic decks), **Clinical Blue** (`clinical_blue.md`, grand rounds/CME, CVD-safe),
-   **Editorial Mono** (`editorial_mono.md`, single-message keynote), **Dark Modern**
-   (`dark_modern.md`, AI/tech talks), and **Institutional Brand** (`institutional_brand.md`,
-   fill a venue's branded template). Nature/Lancet has a dedicated builder
-   (`templates/build_pptx_nature_lancet.py`); the others swap design tokens into the
-   generic builder (`references/generate_pptx_templates.py`). PDF figures →
-   `scripts/extract_pdf_figures.py`.
-
-</details>
-
 These mirror the entry-point pattern used in
 `make-figures/references/design_principles.md` (Step 1 "Specify"). Both skills share
 the same Reynolds / Knaflic / Tufte foundations — slide-level (this skill) and


### PR DESCRIPTION
First small batch from the §1 subtractive audit — sorting every normative sentence in 30 skills into **enforced** (a script fires: 71), **judgment** (legitimately prose: 269), **scriptable** (an unenforced artifact constraint — handled in #346/#347), and **decoration** (nothing catches it, no defective artifact).

The decoration pile looked large. Re-verifying line-by-line against the live files (the first pass mis-numbered lines), almost all of it was **defended and kept** — a rule that constrains the artifact is not decoration even when unenforced, and a repeated safety guard is deliberate. **When in doubt, keep.** What survived as a certain cut:

- **`lit-sync`**: a dated dry-run rationale whose only referent was `~/.local/cache/phase1b_b_dryrun/` — dead for every installed copy.
- **`present-paper`**: a 28-line `<details>` block self-labelled *"The original list, for reference"* — the superseded prior Step 0a guidance; every file it named is still referenced by the current A/B/C + on-demand table (`validate_routing_assets` confirms no orphan).

−35 lines loaded on every invocation. No behaviour change. Full CI mirror green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)