### PR TITLE
feat: add root SKILL.md for bundle-level skill discovery

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: medsci
+description: MedSci skills bundle — medical research workflow skills (study design, statistics, writing, reporting, peer review). See capabilities.yml for the master index and skills/ for individual skills.
+---
+
+# MedSci Skills Bundle
+
+This directory is a bundle of medical-research workflow skills, intended for use
+with [opencode](https://opencode.ai) agent skill discovery.
+
+## Structure
+
+- `capabilities.yml` — master capability index. **Start here** to find the right
+  skill for a given research phase.
+- `skills/<name>/SKILL.md` — individual skills, each loadable via the `skill`
+  tool. Examples: `design-study`, `analyze-stats`, `write-paper`,
+  `check-reporting`, `search-lit`, `meta-analysis`.
+- `scripts/` — supporting Python/Bash scripts invoked by the skills.
+
+## Usage
+
+Load a skill by name via the `skill` tool, e.g. `skill("write-paper")`. Each
+skill's `SKILL.md` describes its workflow and prerequisites. The
+`orchestrate` skill routes multi-step or ambiguous research goals to the
+appropriate skill(s) from this bundle.
+
+## Scope
+
+Covers the full medical-research lifecycle: literature search, study design,
+sample-size calculation, data cleaning, statistical analysis, manuscript
+writing, reporting-guideline compliance, figure generation, journal selection,
+peer review, and revision. Includes specialized tracks for medical-imaging AI
+(model scaffolding, validation, explainability, uncertainty quantification)
+and for clinical-radiomics / tabular ML.


### PR DESCRIPTION
## Summary

Adds a `SKILL.md` at the repository root so the bundle itself is discoverable as a single `medsci` skill entry point.

## Why

Skill-management tooling (e.g. [lazyskills](https://github.com/alvinunreal/lazyskills), and opencode-style skill discovery) expects a `SKILL.md` at the root of a skills directory to register the bundle. Currently this repo ships `capabilities.yml`, `skills/<name>/SKILL.md` for each sub-skill, and `scripts/`, but **no root `SKILL.md`** — so tooling that scans for a root `SKILL.md` does not register the bundle, and there is no top-level entry point describing the bundle as a whole.

This root `SKILL.md`:

- Registers the bundle under the name `medsci` (matches the directory consumers vendor it as).
- Points users to `capabilities.yml` as the master index and `skills/` for the individual loadable skills.
- Documents structure, usage, and scope in one place.

It is a thin index/landing page — it does not duplicate or override any sub-skill. Individual skills remain the loadable units via their own `skills/<name>/SKILL.md`.

## What changed

- **Added:** `SKILL.md` (root) — frontmatter (`name: medsci`) + structure/usage/scope sections.

## Validation

- `python3 scripts/gen_distribution_manifest.py` — manifest unchanged (root file is not a shipped artifact); `metadata/` not modified.
- `python3 scripts/gen_skill_docs.py --check` — `OK: docs/skills/ in sync (56 skill pages + index).`
- `python3 scripts/validate_capabilities.py --strict` — `OK: skill registry is consistent.`

## Notes

- Happy to adjust the `description` / scope wording to match maintainer preference.
- If a root `skill.yml` is preferred instead of (or alongside) `SKILL.md`, let me know and I'll adjust.