### PR TITLE
fix(check-reporting): TRIPOD+AI checklist was TRIPOD 2015 + -AI items, not the 2024 statement (fixes #352)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -469,6 +469,9 @@ jobs:
       - name: Run check-reporting framework-naming gate test
         run: bash skills/check-reporting/tests/test_framework_naming.sh
 
+      - name: "Run check-reporting checklist-fidelity gate test (a checklist must match the official inventory, issue #352)"
+        run: bash skills/check-reporting/tests/test_checklist_fidelity.sh
+
       - name: Run check-reporting PRISMA-cascade test
         run: bash skills/check-reporting/tests/test_prisma_cascade.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The bundled TRIPOD+AI checklist was TRIPOD 2015 with `-AI` additions, not the official 2024
+  statement (issue #352, external report).** The file was labelled "TRIPOD+AI 2024" but carried the
+  TRIPOD 2015 section sequence, non-canonical identifiers (`1-AI`, `10-AI-a`, …), and had no Open
+  Science or Patient-and-Public-Involvement items. The official TRIPOD+AI 2024 (Collins et al., BMJ
+  2024;385:e078378) is a **rewrite**: 27 main items, 52 subitems, with Open science (18) and PPI (19)
+  as first-class items. `check-reporting`'s SKILL.md already *said* so ("a complete rewrite, not an
+  addendum"); the checklist file did not follow it. Rewritten faithfully from the published statement
+  (verified item-by-item against the source; applicability labels D/E/D;E preserved), with the
+  toolkit's own engineering-reproducibility prompts (architecture, training config, software/hardware,
+  reproducibility) moved to a clearly-labelled "MedSci supplemental checks — NOT official TRIPOD+AI
+  items" section.
+
+### Added
+
+- `skills/check-reporting/scripts/verify_checklist_fidelity.py` — the check that was missing. Nothing
+  compared a bundled checklist against the official item inventory of the guideline it claims to be:
+  `check_checklist_exists` verifies presence, `check_framework_naming` verifies naming, neither
+  verifies the *contents*. This gate is manifest-driven (item count, required sections, forbidden
+  non-canonical identifiers, source DOI) so it generalises to other checklists by adding an entry, not
+  code. It runs in CI via `test_checklist_fidelity.sh`, which regresses the exact #352 defect and
+  holds the gate silent on the corrected file. Not a counted detector (a CI fidelity regression, not a
+  per-manuscript check).
+
+
 ### Added
 
 - **`check_density_complaint` (detector 66 -> 67, `/revise`): "too dense" is the one comment you

--- a/docs/skills/check-reporting.md
+++ b/docs/skills/check-reporting.md
@@ -51,6 +51,7 @@
 - `check_framework_naming.py`
 - `check_prisma_figure.py`
 - `prisma_cascade_check.py`
+- `verify_checklist_fidelity.py`
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -68,8 +68,8 @@
     },
     {
       "path": "skills/MAINTENANCE.md",
-      "size": 6555,
-      "sha256": "cf39c8c6015c7573aa40fb97631bba26acddab6a2fcb09c8d2a2ec5f49fdbd3f"
+      "size": 7114,
+      "sha256": "76844f21d84ee2704896f7a141d80547ef30bc41be83b76b10df3321d8d1785f"
     },
     {
       "path": "skills/academic-aio/SKILL.md",
@@ -838,8 +838,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_AI.md",
-      "size": 9262,
-      "sha256": "a7a8750eeeac1a31ad16088be871dfd7193d186639278fe9c9a1f67c5b31e7f7"
+      "size": 13826,
+      "sha256": "0ec248b9846a06bf4e13890daaa1f61e69b7588b390d0612dcabefed78c42975"
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_LLM.md",
@@ -895,6 +895,11 @@
       "path": "skills/check-reporting/scripts/prisma_cascade_check.py",
       "size": 9382,
       "sha256": "fe4859261c2af0783c82f4e0fe49af2e4b9311c7ca2d9c6241dd134a2bc32a04"
+    },
+    {
+      "path": "skills/check-reporting/scripts/verify_checklist_fidelity.py",
+      "size": 5529,
+      "sha256": "3dd2018588f784d0ca7772d31102d88e52517ff7478dbd5a78213a6ef19a0dbc"
     },
     {
       "path": "skills/check-reporting/skill.yml",

--- a/scripts/check_script_reachability.py
+++ b/scripts/check_script_reachability.py
@@ -59,6 +59,7 @@ TEST_MARKERS = ("/tests/", "_challenge/", "/challenge/")
 MAINTAINER_TOOLS: dict[str, str] = {
     "make-figures/scripts/build_jacc_template.py": "skills/MAINTENANCE.md",
     "make-figures/scripts/extract_exemplar_from_pdf.py": "skills/MAINTENANCE.md",
+    "check-reporting/scripts/verify_checklist_fidelity.py": "skills/MAINTENANCE.md",
 }
 
 IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+([A-Za-z_][\w]*)", re.MULTILINE)

--- a/skills/MAINTENANCE.md
+++ b/skills/MAINTENANCE.md
@@ -51,6 +51,12 @@ code with permission, and the gate fails on it. Current run-once tools:
   Illustration PPTX template (`references/visual_abstract_templates/jacc_central_illustration.pptx`).
 - `skills/make-figures/scripts/extract_exemplar_from_pdf.py` — extracts a figure region from a
   PDF page to grow the make-figures Critic-Loop exemplar reference set.
+- `skills/check-reporting/scripts/verify_checklist_fidelity.py` — a CI-run fidelity regression: it
+  holds each bundled reporting checklist to the official instrument's item inventory (item count,
+  required sections, forbidden non-canonical identifiers, source DOI). It runs in CI via
+  `skills/check-reporting/tests/test_checklist_fidelity.sh`, not at skill invocation. Added after
+  issue #352 (the bundled TRIPOD+AI checklist was TRIPOD 2015 + `-AI` additions, and nothing checked
+  it against the official 27-item/52-subitem TRIPOD+AI 2024 statement).
 
 ## 3b. Every other script MUST be invoked by a SKILL.md
 

--- a/skills/check-reporting/references/checklists/TRIPOD_AI.md
+++ b/skills/check-reporting/references/checklists/TRIPOD_AI.md
@@ -1,140 +1,150 @@
-# TRIPOD+AI Checklist
+# TRIPOD+AI 2024 Checklist
 
-**Transparent Reporting of a multivariable prediction model for Individual Prognosis Or Diagnosis -- AI Extension**
-Version: TRIPOD+AI 2024
-Source: https://www.tripod-statement.org
+**Transparent Reporting of a multivariable prediction model for Individual Prognosis Or Diagnosis — Artificial Intelligence extension**
+
+- **Version:** TRIPOD+AI 2024
+- **Citation:** Collins GS, Moons KGM, Dhiman P, et al. *TRIPOD+AI statement: updated guidance for reporting clinical prediction models that use regression or machine learning methods.* BMJ 2024;385:e078378.
+- **DOI:** 10.1136/bmj-2023-078378
+- **Source:** https://www.tripod-statement.org — official expanded checklist: https://www.tripod-statement.org/wp-content/uploads/2024/04/TRIPODAI-Supplement.pdf
+- **Licence:** CC BY 4.0. Item wording below is reproduced faithfully from the published statement with attribution.
+
+**TRIPOD+AI 2024 supersedes and replaces TRIPOD 2015.** It is not TRIPOD 2015 plus AI addenda — it is a
+complete rewrite, applicable to prediction-model studies using **either** regression **or** machine-learning
+methods. For any prediction-model study (regression or AI/ML), use this checklist; do **not** apply the 2015
+checklist alongside it.
+
+The checklist has **27 main items** and **52 checklist subitems**, in eight sections: Title (1), Abstract (2),
+Introduction (3–4), Methods (5–17), Open science (18), Patient and public involvement (19), Results (20–24),
+and Discussion (25–27).
+
+**Applicability column:** `D` = relevant only to model **development**; `E` = relevant only to model
+**evaluation**; `D;E` = applicable to **both**.
 
 ## Checklist Items
 
-Items marked with **(AI)** are specific to the AI extension. All other items are from TRIPOD 2015.
+### Title
 
-### Title and Abstract
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 1 | Title | D;E | Identify the study as developing or evaluating the performance of a multivariable prediction model, the target population, and the outcome to be predicted. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 1 | Title | Identify the study as developing and/or validating a multivariable prediction model, the target population, and the outcome to be predicted. |
-| 1-AI | Title (AI) | Identify that the prediction model uses AI/ML methods. |
-| 2 | Abstract | Provide a summary of objectives, study design, setting, participants, sample size, predictors, outcome, statistical analysis, results, and conclusions. |
+### Abstract
+
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 2 | Abstract | D;E | See the TRIPOD+AI for Abstracts checklist. |
 
 ### Introduction
 
-| # | Item | Description |
-|---|------|-------------|
-| 3a | Background | Explain the medical context (including whether diagnostic or prognostic) and rationale for developing or validating the multivariable prediction model, including references to existing models. |
-| 3b | Objectives | Specify the objectives, including whether the study describes the development or validation of the model or both. |
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 3a | Background | D;E | Explain the healthcare context (including whether diagnostic or prognostic) and rationale for developing or evaluating the prediction model, including references to existing models. |
+| 3b | Background | D;E | Describe the target population and the intended purpose of the prediction model in the context of the care pathway, including its intended users (e.g., healthcare professionals, patients, public). |
+| 3c | Background | D;E | Describe any known health inequalities between sociodemographic groups. |
+| 4 | Objectives | D;E | Specify the study objectives, including whether the study describes the development or validation of a prediction model (or both). |
 
 ### Methods
 
-#### Source of Data
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 5a | Data | D;E | Describe the sources of data separately for the development and evaluation datasets (e.g., randomised trial, cohort, routine care or registry data), the rationale for using these data, and the representativeness of the data. |
+| 5b | Data | D;E | Specify the dates of the collected participant data, including start and end of participant accrual; and, if applicable, end of follow-up. |
+| 6a | Participants | D;E | Specify key elements of the study setting (e.g., primary care, secondary care, general population) including the number and location of centres. |
+| 6b | Participants | D;E | Describe the eligibility criteria for study participants. |
+| 6c | Participants | D;E | Give details of any treatments received, and how they were handled during model development or evaluation, if relevant. |
+| 7 | Data preparation | D;E | Describe any data pre-processing and quality checking, including whether this was similar across relevant sociodemographic groups. |
+| 8a | Outcome | D;E | Clearly define the outcome that is being predicted and the time horizon, including how and when assessed, the rationale for choosing this outcome, and whether the method of outcome assessment is consistent across sociodemographic groups. |
+| 8b | Outcome | D;E | If outcome assessment requires subjective interpretation, describe the qualifications and demographic characteristics of the outcome assessors. |
+| 8c | Outcome | D;E | Report any actions to blind assessment of the outcome to be predicted. |
+| 9a | Predictors | D | Describe the choice of initial predictors (e.g., literature, previous models, all available predictors) and any pre-selection of predictors before model building. |
+| 9b | Predictors | D;E | Clearly define all predictors, including how and when they were measured (and any actions to blind assessment of predictors for the outcome and other predictors). |
+| 9c | Predictors | D;E | If predictor measurement requires subjective interpretation, describe the qualifications and demographic characteristics of the predictor assessors. |
+| 10 | Sample size | D;E | Explain how the study size was arrived at (separately for development and evaluation), and justify that the study size was sufficient to answer the research question. Include details of any sample size calculation. |
+| 11 | Missing data | D;E | Describe how missing data were handled. Provide reasons for omitting any data. |
+| 12a | Analytical methods | D | Describe how the data were used (e.g., for development and evaluation of model performance) in the analysis, including whether the data were partitioned, considering any sample size requirements. |
+| 12b | Analytical methods | D | Depending on the type of model, describe how predictors were handled in the analyses (functional form, rescaling, transformation, or any standardisation). |
+| 12c | Analytical methods | D | Specify the type of model, rationale, all model building steps, including any hyperparameter tuning, and method for internal validation. |
+| 12d | Analytical methods | D;E | Describe if and how any heterogeneity in estimates of model parameter values and model performance was handled and quantified across clusters (e.g., hospitals, countries). See TRIPOD-Cluster for additional considerations. |
+| 12e | Analytical methods | D;E | Specify all measures and plots used (and their rationale) to evaluate model performance (e.g., discrimination, calibration, clinical utility) and, if relevant, to compare multiple models. |
+| 12f | Analytical methods | E | Describe any model updating (e.g., recalibration) arising from the model evaluation, either overall or for particular sociodemographic groups or settings. |
+| 12g | Analytical methods | E | For model evaluation, describe how the model predictions were calculated (e.g., formula, code, object, application programming interface). |
+| 13 | Class imbalance | D;E | If class imbalance methods were used, state why and how this was done, and any subsequent methods to recalibrate the model or the model predictions. |
+| 14 | Fairness | D;E | Describe any approaches that were used to address model fairness and their rationale. |
+| 15 | Model output | D | Specify the output of the prediction model (e.g., probabilities, classification). Provide details and rationale for any classification and how the thresholds were identified. |
+| 16 | Training versus evaluation | D;E | Identify any differences between the development and evaluation data in healthcare setting, eligibility criteria, outcome, and predictors. |
+| 17 | Ethical approval | D;E | Name the institutional research board or ethics committee that approved the study and describe the participant informed consent or the ethics committee waiver of informed consent. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 4a | Source of data | Describe the study design or source of data (e.g., randomized trial, cohort, or registry data), separately for the development and validation data sets, if applicable. |
-| 4b | Source of data | Specify the key study dates, including start of accrual; end of accrual; and, if applicable, end of follow-up. |
-| 4-AI | Source of data (AI) | Describe the source of all input data types (e.g., imaging modality, laboratory system, free text, structured data). |
+### Open science
 
-#### Participants
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 18a | Funding | D;E | Give the source of funding and the role of the funders for the present study. |
+| 18b | Conflicts of interest | D;E | Declare any conflicts of interest and financial disclosures for all authors. |
+| 18c | Protocol | D;E | Indicate where the study protocol can be accessed or state that a protocol was not prepared. |
+| 18d | Registration | D;E | Provide registration information for the study, including register name and registration number, or state that the study was not registered. |
+| 18e | Data sharing | D;E | Provide details of the availability of the study data. |
+| 18f | Code sharing | D;E | Provide details of the availability of the analytical code. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 5a | Participants | Specify key elements of the study setting (e.g., primary care, secondary care, general population) including number and location of centres. |
-| 5b | Participants | Describe eligibility criteria for participants. |
-| 5c | Participants | Give details of treatments received, if relevant. |
+### Patient and public involvement
 
-#### Outcome
-
-| # | Item | Description |
-|---|------|-------------|
-| 6a | Outcome | Clearly define the outcome that is predicted by the prediction model, including how and when assessed. |
-| 6b | Outcome | Report any actions to blind assessment of the outcome to be predicted. |
-
-#### Predictors
-
-| # | Item | Description |
-|---|------|-------------|
-| 7a | Predictors | Clearly define all predictors used in developing or validating the multivariable prediction model, including how and when they were measured. |
-| 7b | Predictors | Report any actions to blind assessment of predictors for the outcome and other predictors. |
-| 7-AI | Predictors (AI) | Describe data preprocessing steps: normalization, augmentation, feature extraction, handling of missing inputs, and any dimensionality reduction. |
-
-#### Sample Size
-
-| # | Item | Description |
-|---|------|-------------|
-| 8 | Sample size | Explain how the study size was arrived at. |
-| 8-AI | Sample size (AI) | Report the effective sample size relative to model complexity (e.g., events per variable, events per parameter). |
-
-#### Missing Data
-
-| # | Item | Description |
-|---|------|-------------|
-| 9 | Missing data | Describe how missing data were handled (e.g., complete-case analysis, single imputation, multiple imputation) with details of any imputation method. |
-
-#### Statistical Analysis Methods
-
-| # | Item | Description |
-|---|------|-------------|
-| 10a | Model development | Describe how predictors were handled in the analyses. |
-| 10b | Model development | Specify type of model, all model-building procedures (including any predictor selection), and method for internal validation. |
-| 10c | Validation | For validation, describe how the predictions were calculated. |
-| 10d | Model performance | Specify all measures used to assess model performance and, if relevant, to compare multiple models. |
-| 10e | Model updating | Describe any model updating (e.g., recalibration) arising from the validation, if done. |
-| 10-AI-a | Model architecture (AI) | Describe the model architecture in sufficient detail for replication (e.g., network type, number of layers, activation functions, loss function). |
-| 10-AI-b | Training procedure (AI) | Describe the training procedure: optimizer, learning rate (schedule), batch size, number of epochs, early stopping criteria, regularization methods. |
-| 10-AI-c | Software and hardware (AI) | Report software libraries (with version numbers), programming language, and hardware used (especially GPU type for deep learning). |
-| 10-AI-d | Reproducibility (AI) | Report measures taken to ensure reproducibility (random seeds, data splits, code availability). |
-
-#### Risk Groups
-
-| # | Item | Description |
-|---|------|-------------|
-| 11 | Risk groups | Provide details on how risk groups were created, if done. |
-
-#### Development vs. Validation
-
-| # | Item | Description |
-|---|------|-------------|
-| 12 | Development vs. validation | For validation, identify any differences from the development data in setting, eligibility criteria, outcome, and predictors. |
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 19 | Patient and public involvement | D;E | Provide details of any patient and public involvement during the design, conduct, reporting, interpretation, or dissemination of the study or state no involvement. |
 
 ### Results
 
-| # | Item | Description |
-|---|------|-------------|
-| 13a | Participants | Describe the flow of participants through the study, including the number of participants with and without the outcome and, if applicable, a summary of the follow-up time. A diagram may be helpful. |
-| 13b | Participants | Describe the characteristics of the participants (basic demographics, clinical features, available predictors), including the number of participants with missing data for predictors and outcome. |
-| 13c | Participants | For validation, show a comparison with the development data of the distribution of important variables (demographics, predictors, and outcome). |
-| 14a | Model development | Specify the number of participants and outcome events in each analysis. |
-| 14b | Model development | If done, report the unadjusted association between each candidate predictor and outcome. |
-| 15a | Model specification | Present the full prediction model to allow predictions for individuals (i.e., all regression coefficients, and model intercept or baseline survival at a given time point). |
-| 15b | Model specification | Explain how to use the prediction model. |
-| 15-AI | Model specification (AI) | If the full model cannot be presented as coefficients: report model availability (e.g., open-source repository, API, executable), and describe the input/output specification. |
-| 16 | Model performance | Report performance measures (with CIs) for the prediction model. Report discrimination (e.g., C-statistic/AUC) and calibration (e.g., calibration plot, Hosmer-Lemeshow, calibration slope and intercept). |
-| 16-AI | Fairness assessment (AI) | Report model performance stratified by relevant demographic subgroups (age, sex, ethnicity) if data are available. |
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 20a | Participants | D;E | Describe the flow of participants through the study, including the number of participants with and without the outcome and, if applicable, a summary of the follow-up time. A diagram may be helpful. |
+| 20b | Participants | D;E | Report the characteristics overall and, where applicable, for each data source or setting, including the key dates, key predictors (including demographics), treatments received, sample size, number of outcome events, follow-up time, and amount of missing data. A table may be helpful. Report any differences across key demographic groups. |
+| 20c | Participants | E | For model evaluation, show a comparison with the development data of the distribution of important predictors (demographics, predictors, and outcome). |
+| 21 | Model development | D;E | Specify the number of participants and outcome events in each analysis (e.g., for model development, hyperparameter tuning, model evaluation). |
+| 22 | Model specification | D | Provide details of the full prediction model (e.g., formula, code, object, application programming interface) to allow predictions in new individuals and to enable third party evaluation and implementation, including any restrictions to access or reuse (e.g., freely available, proprietary). |
+| 23a | Model performance | D;E | Report model performance estimates with confidence intervals, including for any key subgroups (e.g., sociodemographic). Consider plots to aid presentation. |
+| 23b | Model performance | D;E | If examined, report results of any heterogeneity in model performance across clusters. See TRIPOD-Cluster for additional details. |
+| 24 | Model updating | E | Report the results from any model updating, including the updated model and subsequent performance. |
 
 ### Discussion
 
-| # | Item | Description |
-|---|------|-------------|
-| 18 | Limitations | Discuss any limitations of the study (such as nonrepresentative sample, few events per predictor, missing data). |
-| 19a | Interpretation | For validation, discuss the results with reference to performance in the development data, and any other validation data. |
-| 19b | Interpretation | Give an overall interpretation of the results, considering objectives, limitations, results from similar studies, and other relevant evidence. |
-| 19-AI | Interpretation (AI) | Discuss potential sources of bias in the AI model: data bias, label noise, distribution shift between development and deployment settings. |
-| 20 | Implications | Discuss the potential clinical use of the model and implications for future research. |
-
-### Other Information
-
-| # | Item | Description |
-|---|------|-------------|
-| 21 | Supplementary information | Provide information about the availability of supplementary resources, such as study protocol, Web calculator, and data sets. |
-| 21-AI | Code and model availability (AI) | State whether the trained model and/or source code are publicly available, and provide the repository URL or access instructions. |
-| 22 | Funding | Give the source of funding and the role of the funders for the present study. |
+| Item | Topic | D/E | Checklist item |
+|---|---|---|---|
+| 25 | Interpretation | D;E | Give an overall interpretation of the main results, including issues of fairness in the context of the objectives and previous studies. |
+| 26 | Limitations | D;E | Discuss any limitations of the study (such as a non-representative sample, sample size, overfitting, missing data) and their effects on any biases, statistical uncertainty, and generalisability. |
+| 27a | Usability of the model in the context of current care | D | Describe how poor quality or unavailable input data (e.g., predictor values) should be assessed and handled when implementing the prediction model. |
+| 27b | Usability of the model in the context of current care | D | Specify whether users will be required to interact in the handling of the input data or use of the model, and what level of expertise is required of users. |
+| 27c | Usability of the model in the context of current care | D;E | Discuss any next steps for future research, with a specific view to applicability and generalisability of the model. |
 
 ---
 
-## Notes for Assessors
+## MedSci supplemental checks — NOT official TRIPOD+AI items
 
-- TRIPOD applies to both development and validation studies. Some items (e.g., 10c, 13c, 19a) are specific to validation studies; mark as N/A for development-only studies.
-- The AI extension items are mandatory for any study using machine learning or deep learning methods.
-- Item 15a (full model specification) is often not feasible for deep learning models; in that case, item 15-AI (model availability) becomes critical.
-- Item 16 must include BOTH discrimination and calibration. A study reporting only AUC without calibration assessment is PARTIAL on this item.
-- Item 16-AI (fairness) is increasingly expected but may be marked N/A if the study population lacks demographic diversity data, with a note explaining this limitation.
-- For studies that are both diagnostic accuracy and prediction model studies, consider cross-referencing with STARD as well.
+The following are **not** TRIPOD+AI checklist items. They are engineering-reproducibility prompts this
+toolkit adds because they matter for an AI/ML model to be rebuildable, and they extend (do not replace) the
+official items noted. Assess them **only as supplements**; never report them as canonical TRIPOD+AI item
+numbers, and never let them substitute for an official item.
+
+| Supplemental check | Extends official item | What to look for |
+|---|---|---|
+| Model architecture | 12c | Network type, depth, layers, activation and loss functions — enough detail to rebuild the model. |
+| Training configuration | 12c | Optimizer, learning-rate schedule, batch size, epochs, early-stopping criterion, regularisation. |
+| Software and hardware | 18f, 22 | Libraries with version numbers, language, and the compute used (e.g., GPU type for deep learning). |
+| Reproducibility | 18e, 18f | Random seeds, the exact data split, and whether code + weights are available to reproduce results. |
+
+Official item **14 (Fairness)**, **18f (Code sharing)**, **22 (Model specification / API)**, and
+**7 (Data preparation)** already cover fairness, code/model availability, and preprocessing — assess those
+under their official items, not as extras here.
+
+## Notes for assessors
+
+- **Applicability.** Mark items labelled `D` (development-only) or `E` (evaluation-only) as N/A when they do
+  not apply to the study design; `D;E` items apply to both.
+- **Open science (18a–18f) and PPI (19) are official, mandatory items** — a compliance report that skips them
+  is incomplete. Data sharing (18e) and code sharing (18f) are where an AI/ML study's reproducibility is
+  assessed.
+- **Performance (23a) with confidence intervals is required**, including for key subgroups; heterogeneity
+  across clusters (23b) when examined. A study reporting a point estimate without a CI is PARTIAL on 23a.
+- **Fairness is an official item (14)** and is reported across demographic groups in 20b and 23a — not an
+  optional AI add-on.
+- Do **not** apply TRIPOD 2015 alongside this checklist; TRIPOD+AI 2024 supersedes it for both regression and
+  AI/ML prediction models.
+- For a study that is both a diagnostic-accuracy study and a prediction-model study, cross-reference STARD.

--- a/skills/check-reporting/scripts/verify_checklist_fidelity.py
+++ b/skills/check-reporting/scripts/verify_checklist_fidelity.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""A bundled checklist must match the official instrument it claims to be.
+
+Issue #352 (an external report, 2026-07-21): the file labelled "TRIPOD+AI 2024" was actually TRIPOD
+2015 with separately-numbered `-AI` additions — the older section sequence, non-canonical item
+identifiers (`1-AI`, `10-AI-a`, …), and no Open Science or Patient-and-Public-Involvement items. The
+official TRIPOD+AI 2024 (Collins et al., BMJ 2024;385:e078378) is a **rewrite**: 27 main items, 52
+subitems, with Open science (18) and PPI (19) as first-class items.
+
+Nothing caught it. `check_checklist_exists` verifies the file is *present*; `check_framework_naming`
+verifies it *names* its base instrument. Neither compares the file's item inventory against the
+official one — so a checklist could silently drift from the guideline it claims to reproduce, and an
+audit could report "TRIPOD+AI compliant" while checking a different, older instrument.
+
+This is that check. It is manifest-driven, so it generalises: each entry states the official
+inventory (item count, required sections, forbidden non-canonical identifiers, a source token) and
+this script holds the bundled file to it. Add a guideline by adding an EXPECTED entry, not code.
+
+Not named `check_*` on purpose — it is a fidelity regression, run in CI, not one of the manuscript
+integrity detectors in the published count.
+
+Usage:
+    verify_checklist_fidelity.py [--strict] [--root PATH]
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CHECKLISTS = "skills/check-reporting/references/checklists"
+
+# The official inventory each bundled checklist must reproduce. Sourced from the published statement,
+# not from the file being checked — that is the whole point.
+EXPECTED = {
+    "TRIPOD_AI.md": {
+        "official_section_start": "## Checklist Items",
+        "official_section_end": "## MedSci supplemental",   # supplemental checks are ours, exempt
+        "main_items": list(range(1, 28)),                    # 1..27
+        "subitem_rows": 52,
+        "required_headings": ["### Open science", "### Patient and public involvement"],
+        "forbidden_in_official": r"\b\d+-AI\b",              # non-canonical identifiers
+        "must_contain": ["10.1136/bmj-2023-078378", "supersedes and replaces TRIPOD 2015"],
+        "source": "Collins GS et al. BMJ 2024;385:e078378 (TRIPOD+AI 2024)",
+    },
+}
+
+
+def official_slice(text: str, spec: dict) -> str:
+    s = text.find(spec["official_section_start"])
+    e = text.find(spec["official_section_end"])
+    if s < 0:
+        return text
+    return text[s : e if e > s else len(text)]
+
+
+def check_one(path: Path, spec: dict) -> list[str]:
+    out: list[str] = []
+    if not path.is_file():
+        return [f"{path.name}: file missing"]
+    text = path.read_text(encoding="utf-8")
+    official = official_slice(text, spec)
+
+    # main item numbers present in the official section
+    nums = sorted({int(m) for m in re.findall(r"^\|\s*(\d+)[a-g]?\s*\|", official, re.MULTILINE)})
+    want = spec["main_items"]
+    if nums != want:
+        missing = [n for n in want if n not in nums]
+        extra = [n for n in nums if n not in want]
+        out.append(f"{path.name}: main items are {nums or '[]'} — "
+                   f"expected {want[0]}..{want[-1]}"
+                   + (f"; missing {missing}" if missing else "")
+                   + (f"; unexpected {extra}" if extra else ""))
+
+    rows = len(re.findall(r"^\|\s*\d+[a-g]?\s*\|", official, re.MULTILINE))
+    if rows != spec["subitem_rows"]:
+        out.append(f"{path.name}: {rows} checklist rows in the official section — expected "
+                   f"{spec['subitem_rows']} subitems ({spec['source']}).")
+
+    for h in spec["required_headings"]:
+        if h not in text:
+            out.append(f"{path.name}: missing required section '{h}' — it is an official item, not optional.")
+
+    bad = re.findall(spec["forbidden_in_official"], official)
+    if bad:
+        out.append(f"{path.name}: non-canonical identifier(s) in the official section: "
+                   f"{sorted(set(bad))} — the official checklist has no '<n>-AI' items; keep repo-specific "
+                   f"checks in the clearly-labelled supplemental section.")
+
+    for tok in spec["must_contain"]:
+        if tok not in text:
+            out.append(f"{path.name}: missing required marker {tok!r} (source DOI / version / framing).")
+
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--root", type=Path, default=ROOT)
+    a = ap.parse_args()
+
+    problems: list[str] = []
+    for name, spec in EXPECTED.items():
+        problems += check_one(a.root / CHECKLISTS / name, spec)
+
+    if not problems:
+        print(f"OK: {len(EXPECTED)} bundled checklist(s) match their official item inventory.")
+        return 0
+
+    print(f"CHECKLIST_FIDELITY: {len(problems)} discrepanc(ies) — a bundled checklist does not match "
+          f"the official instrument it claims to be.\n")
+    for p in problems:
+        print(f"  - {p}")
+    print(
+        "\nA checklist labelled with an official guideline's name must reproduce that guideline's item\n"
+        "inventory, or a compliance audit checks a different instrument than the one it reports.\n"
+    )
+    return 1 if a.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/check-reporting/tests/test_checklist_fidelity.sh
+++ b/skills/check-reporting/tests/test_checklist_fidelity.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Self-test for scripts/verify_checklist_fidelity.py — a bundled checklist must match the official
+# instrument it claims to be.
+#
+# Issue #352: the file labelled "TRIPOD+AI 2024" was actually TRIPOD 2015 + separately-numbered `-AI`
+# additions — wrong section sequence, non-canonical identifiers, no Open Science, no PPI. Nothing
+# caught it: check_checklist_exists only checks the file is present, check_framework_naming only
+# checks it names its base. So this gate regresses the exact defect from the issue and demands it
+# fail, and holds the gate silent on the corrected file.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+G="$REPO_ROOT/skills/check-reporting/scripts/verify_checklist_fidelity.py"
+
+pass=0; fail=0
+ck() { if [ "$2" = "$3" ]; then printf '  PASS  %-52s exit=%s\n' "$1" "$3"; pass=$((pass+1));
+       else printf '  FAIL  %-52s want=%s got=%s\n' "$1" "$2" "$3"; fail=$((fail+1)); fi; }
+
+# 1) the live repo's corrected TRIPOD+AI file passes
+python3 "$G" --strict >/dev/null 2>&1
+ck "live repo: TRIPOD+AI matches the official 27/52 inventory" 0 "$?"
+
+# 2) REGRESSION — point the gate at a fixture tree carrying the #352 defect (TRIPOD 2015 + -AI items,
+#    no Open Science / PPI, non-canonical identifiers, no DOI). It must fail.
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/skills/check-reporting/references/checklists"
+cat > "$FIX/skills/check-reporting/references/checklists/TRIPOD_AI.md" <<'MD'
+# TRIPOD+AI Checklist
+Version: TRIPOD+AI 2024
+
+## Checklist Items
+
+Items marked with **(AI)** are specific to the AI extension. All other items are from TRIPOD 2015.
+
+### Title and Abstract
+| # | Item | Description |
+|---|------|-------------|
+| 1 | Title | Identify the study. |
+| 1-AI | Title (AI) | Identify AI/ML methods. |
+| 2 | Abstract | Provide a summary. |
+
+### Methods
+| # | Item | Description |
+|---|------|-------------|
+| 10-AI-a | Model architecture (AI) | Describe the architecture. |
+
+### Discussion
+| # | Item | Description |
+|---|------|-------------|
+| 18 | Limitations | Discuss limitations. |
+| 20 | Implications | Discuss clinical use. |
+
+## MedSci supplemental
+MD
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "REGRESSION: the #352 defect (2015 + -AI, no 18/19) fails" 1 "$?"
+
+# ...and the message must name the specific defects, not just exit nonzero
+OUT="$(python3 "$G" --root "$FIX" 2>&1)"
+echo "$OUT" | grep -q "Open science"          && ck "names the missing Open science section" 0 0 || ck "names the missing Open science section" 0 1
+echo "$OUT" | grep -q "non-canonical"          && ck "names the non-canonical -AI identifiers" 0 0 || ck "names the non-canonical -AI identifiers" 0 1
+echo "$OUT" | grep -q "10.1136/bmj-2023-078378" && ck "names the missing source DOI marker"    0 0 || ck "names the missing source DOI marker"    0 1
+
+# 3) NEGATIVE — a corrected copy in the fixture tree passes (proves it is not always-fail)
+cp "$REPO_ROOT/skills/check-reporting/references/checklists/TRIPOD_AI.md" \
+   "$FIX/skills/check-reporting/references/checklists/TRIPOD_AI.md"
+python3 "$G" --root "$FIX" --strict >/dev/null 2>&1
+ck "NEGATIVE: the corrected file passes in a fixture tree too" 0 "$?"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Fixes #352 — thank you to @zhang8630 for a careful, well-sourced report.

The bundled `TRIPOD_AI.md` was labelled "TRIPOD+AI 2024" but reproduced the **TRIPOD 2015** section sequence plus separately-numbered `-AI` additions (`1-AI`, `10-AI-a`, …), with **no Open Science and no Patient-and-Public-Involvement items**. The official TRIPOD+AI 2024 (Collins et al., BMJ 2024;385:e078378) is a rewrite: **27 main items, 52 subitems**, with Open science (18) and PPI (19) as first-class items. The skill's own SKILL.md already said "a complete rewrite, not an addendum" — the checklist file just didn't follow it.

And nothing caught it: `check_checklist_exists` verifies presence, `check_framework_naming` verifies naming — neither compares the *item inventory* against the official guideline.

**This PR:**
- Rewrites `TRIPOD_AI.md` faithfully from the published statement — all 27 items / 52 subitems, correct sections, applicability labels (D/E/D;E) preserved, source DOI + version, supersedes-2015 framing. Verified **item-by-item against the source** (an adversarial pass confirmed no fabricated or missing items, labels all correct).
- Moves the repo's engineering-reproducibility prompts (architecture, training config, software/hardware, reproducibility) into a clearly-labelled **"MedSci supplemental checks — NOT official TRIPOD+AI items"** section — exactly as the reporter suggested — and notes where fairness / code-sharing / preprocessing are already covered by official items 14 / 18f / 22 / 7.
- Adds `verify_checklist_fidelity.py` (manifest-driven, generalises to other checklists) + a self-test that regresses the exact #352 defect and stays silent on the corrected file. Not a counted detector — a CI fidelity regression.

Full CI mirror green. No detector-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)