### PR TITLE
chore(release): v5.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [5.22.0] - 2026-07-21
+
+**Hotfix:** three bundled reporting checklists that shipped in v5.21.0 and earlier — TRIPOD+AI, CLEAR,
+and MI-CLEAR-LLM — mis-stated their official item structure, so `/check-reporting` audited manuscripts
+against a mislabeled instrument and could report a compliance result the author believed. The fixes are
+below; the release does not wait the usual 14 days because a wrong result is already in users' hands.
+
 ### Fixed
 
 - **Two more bundled checklists mis-stated their official structure — the same class as #352, found

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.21.0"
+version: "5.22.0"
 date-released: "2026-07-11"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.21.0",
+  "version": "5.22.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.21.0",
+  "version": "5.22.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Cuts **v5.22.0**, draining 8 days of merged work since v5.21.0 (2026-07-13).

## Why now (cadence exemption)

`check_release_cadence.py` requires ≥14 days between releases; this is day 8. It stands aside on a declared **hotfix**, and this one is genuine:

> **Hotfix:** three bundled reporting checklists shipped in v5.21.0 and earlier — TRIPOD+AI, CLEAR, MI-CLEAR-LLM — mis-stated their official item structure, so `/check-reporting` audited manuscripts against a mislabeled instrument and could report a compliance result the author believed.

That is a wrong result already in users' hands. The rest of the release rides along.

## What's in it (v5.21.0 → v5.22.0)

- **+6 detectors (61 → 67):** `/contribute` safety, slide-tells (#63), deck-budget (#64), review-request-types (#65), analysis-definitions (#66), density-complaint (#67).
- **+1 skill (55 → 56):** `/contribute` — the way back for clinician edits that die on one laptop.
- **Checklist fidelity:** TRIPOD+AI, CLEAR, MI-CLEAR-LLM rebuilt to their official structure + a manifest-driven fidelity gate that regresses each defect.
- **Installer hardening:** Python-floor check, Windows App-Execution-Alias trap, setup doctor, contributor-friendly manifest-drift message.
- Plus the media-license container fix, phase-budget, detector-crossfire, workflow-yaml, hardcoded-locale, and named-skills gates.

## Verification

- Version consistent across CITATION.cff / package.json / distribution_manifest.json (all 5.22.0).
- Cadence gate passes on the hotfix exemption; full CI mirror green locally (validator, generators `--check`, catalog consistency, reachability, workflow-yaml).

On merge, tag `v5.22.0` → `release.yml` publishes the GitHub release, both classroom ZIPs, and `medsci-skills@5.22.0` on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)