### PR TITLE
feat(self-review): two field-backlog gates — prose partition sums, prospective-registration chronology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## [Unreleased]
 
-## [5.22.0] - 2026-07-21
+### Added
+
+- **`/self-review` — two deterministic gates promoted from the field-feedback backlog, both as
+  verdicts on detectors that already run (no new counted detector).**
+  - **`check_cohort_arithmetic` now reads a PROSE partition, not only tables/CSV** (`PARTITION_OVERLAP`).
+    A sentence that presents an exhaustive split of a stated total — "of the 289 cases, 37 (12.8%) …
+    185 (64.0%) … 103 (35.6%) …" — but whose counts do not sum to the total (325 ≠ 289) or whose
+    percentages do not sum to ~100% (112.4%) has mixed a non-exclusive component in among the
+    mutually exclusive categories: a "these don't add to N" reviewer flag that every section echoes
+    consistently. A **partition-cue gate** keeps it off legitimate overlapping-attribute prose —
+    comorbidity prevalence ("210 (72.7%) had hypertension, 140 (48.4%) had diabetes, …") is not a
+    partition and its counts legitimately sum above N; the test pins that precision case as a
+    must-stay-silent negative.
+  - **`check_claim_artifact` now checks registration chronology** (`REGISTRATION_CHRONOLOGY`, Major).
+    A "prospectively registered" claim is falsifiable against the manuscript's own dates: if the
+    registration date postdates search completion, the review was registered *retrospectively*. The
+    check is manuscript-internal (no external pre-registration artifact needed) and fires only when a
+    prospective claim co-occurs with a registry and both dates parse and registration > search-end —
+    the exact overclaim that recurred across two projects while the prose-only panel probe slipped on
+    the second. Reframe to "registered with" or correct the chronology.
 
 **Hotfix:** three bundled reporting checklists that shipped in v5.21.0 and earlier — TRIPOD+AI, CLEAR,
 and MI-CLEAR-LLM — mis-stated their official item structure, so `/check-reporting` audited manuscripts

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4128,8 +4128,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",
-      "size": 18515,
-      "sha256": "70d09ba741389e3116ee002941c823a127528e8b43e1a08a32ac90cb93e3386e"
+      "size": 22106,
+      "sha256": "890ba1834c86d864e40c4ad3c9afb7db6824ffb5f50c2b8896b2a9bbea611ab0"
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",
@@ -4138,8 +4138,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 23911,
-      "sha256": "85c998f19877d5b9a2cebe4245910a59178a6e247c4d4e07f017e40c584484d6"
+      "size": 28137,
+      "sha256": "6711adf4ad70c9d70b76f526a2c0177b08ff56c9c80efb85265ee873886eff3f"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",

--- a/skills/self-review/scripts/check_claim_artifact.py
+++ b/skills/self-review/scripts/check_claim_artifact.py
@@ -13,6 +13,11 @@ highest-value, deterministic instances:
   2. E-VALUE — is a reported E-value arithmetically consistent with its adjacent
      effect estimate, and is it attached to the *primary* estimate rather than a
      secondary/exploratory one quoted as if it bounded the headline claim?
+  3. REGISTRATION CHRONOLOGY — a "prospectively registered" claim is falsifiable
+     against the manuscript's own dates: if the registration date postdates search
+     completion, the review was registered retrospectively. Manuscript-internal
+     (needs no external prereg artifact); include supplement text in --manuscript
+     to catch an overclaim that survives only in the supplement.
 
 Figure/flow-count reconciliation, Methods-promised-analysis completeness, and
 imputation-input integrity are separate subchecks (see /make-figures and
@@ -320,7 +325,71 @@ def check_code_labels(manuscript: str, scripts_dir: str | None) -> list[dict]:
     return claims
 
 
-MAJOR = {"PRIMARY_REASSIGNED", "EVALUE_ARITHMETIC"}
+# --- Check: REGISTRATION_CHRONOLOGY ----------------------------------------
+# A "prospectively registered" claim is falsifiable against the manuscript's own
+# dates: if the registration date postdates search completion, the review was
+# registered *retrospectively*, and a reviewer flags the overclaim on sight. This
+# is manuscript-internal (no external prereg artifact needed) -- both dates and the
+# claim live in the text (body or supplement). Fires only when a prospective claim
+# co-occurs with a registry AND both dates parse AND registration > search-end.
+_MONTHS = ("January|February|March|April|May|June|July|August|September|October|"
+           "November|December")
+_MONTH_NUM = {m.lower(): i + 1 for i, m in enumerate(_MONTHS.split("|"))}
+_DATE = (rf"\d{{4}}-\d{{2}}-\d{{2}}|\d{{1,2}}\s+(?:{_MONTHS})\s+\d{{4}}|"
+         rf"(?:{_MONTHS})\s+\d{{1,2}},?\s+\d{{4}}")
+_PROSPECTIVE_RE = re.compile(r"\bprospectiv\w*\b", re.I)
+_REGISTRY_RE = re.compile(r"\b(?:PROSPERO|CRD42\d{9}|OSF|ClinicalTrials|NCT\d{6,})\b", re.I)
+_REG_DATE_RE = re.compile(
+    rf"(?:registered|registration|PROSPERO|CRD42\d{{9}}|OSF)[^.]*?\bon\b\s+({_DATE})"
+    rf"|(?:registered|registration)[^.]{{0,60}}?({_DATE})", re.I)
+_SEARCH_END_RE = re.compile(
+    rf"search\w*[^.]*?\b(?:to|through|up to|until|inception to)\b\s+({_DATE})"
+    rf"|search\w*[^.]{{0,80}}?({_DATE})", re.I)
+
+
+def _parse_date(s: str) -> tuple[int, int, int] | None:
+    s = s.strip()
+    m = re.fullmatch(r"(\d{4})-(\d{2})-(\d{2})", s)
+    if m:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    m = re.fullmatch(rf"(\d{{1,2}})\s+({_MONTHS})\s+(\d{{4}})", s, re.I)
+    if m:
+        return (int(m.group(3)), _MONTH_NUM[m.group(2).lower()], int(m.group(1)))
+    m = re.fullmatch(rf"({_MONTHS})\s+(\d{{1,2}}),?\s+(\d{{4}})", s, re.I)
+    if m:
+        return (int(m.group(3)), _MONTH_NUM[m.group(1).lower()], int(m.group(2)))
+    return None
+
+
+def _first_group(m) -> str | None:
+    return next((g for g in m.groups() if g), None) if m else None
+
+
+def check_registration_chronology(manuscript: str) -> list[dict]:
+    claims: list[dict] = []
+    if not (_PROSPECTIVE_RE.search(manuscript) and _REGISTRY_RE.search(manuscript)):
+        return claims
+    reg_s = _first_group(_REG_DATE_RE.search(manuscript))
+    srch_s = _first_group(_SEARCH_END_RE.search(manuscript))
+    if not reg_s or not srch_s:
+        return claims
+    reg, srch = _parse_date(reg_s), _parse_date(srch_s)
+    if not reg or not srch or reg <= srch:
+        return claims
+    claims.append({
+        "claim_id": "registration-chronology",
+        "type": "registration",
+        "prose_value": f"registered {reg_s.strip()}",
+        "artifact_source": f"search completed {srch_s.strip()} (manuscript)",
+        "verdict": "REGISTRATION_CHRONOLOGY",
+        "detail": (f"a prospective-registration claim, but registration ({reg_s.strip()}) postdates "
+                   f"search completion ({srch_s.strip()}) — the review was registered "
+                   f"retrospectively; reframe as \"registered with\" or correct the chronology"),
+    })
+    return claims
+
+
+MAJOR = {"PRIMARY_REASSIGNED", "EVALUE_ARITHMETIC", "REGISTRATION_CHRONOLOGY"}
 
 
 def main() -> int:
@@ -353,7 +422,8 @@ def main() -> int:
             sys.stderr.write(f"WARN: prereg not found: {args.prereg} (estimand provenance limited)\n")
 
     claims = (check_estimand(manuscript, prereg, prereg_raw) + check_evalue(manuscript)
-              + check_code_labels(manuscript, args.scripts))
+              + check_code_labels(manuscript, args.scripts)
+              + check_registration_chronology(manuscript))
     n_major = sum(1 for c in claims if c["verdict"] in MAJOR)
     n_flag = sum(1 for c in claims if c["verdict"] not in MAJOR and c["verdict"] != "OK")
 

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -21,7 +21,16 @@ section echoes the same wrong number:
                        total and sum(stratum events) == total events. A tier split
                        whose denominators sum above the unique cohort double-counts
                        subjects; a table where every stratum n equals the grand
-                       total is a stratum-total mis-entry.
+                       total is a stratum-total mis-entry. This also fires on an
+                       in-text PROSE enumeration presented as an exhaustive split
+                       of a stated total (>=3 "count (pct%)" categories with
+                       partition-cue language, e.g. "of the 289 cases, 37 (12.8%)
+                       ... 185 (64.0%) ... 103 (35.6%) ...") when the counts do not
+                       sum to the total or the percentages do not sum to ~100% --
+                       the sign that a non-exclusive component was mixed among the
+                       mutually exclusive categories. The partition-cue gate keeps
+                       it off legitimate overlapping-attribute prose (comorbidity
+                       prevalence).
   4. ANALYSIS_UNIT_   when --data carries a subject ID and records > unique
      UNDISCLOSED       subjects (health-screening / EMR / registry repeat
                        attendees), observations are non-independent -> anti-
@@ -408,6 +417,75 @@ def check_partition_csv(rows: list[dict]) -> list[dict]:
     return _partition_from_rows(label_of, n_of, ev_of, rows, source="--data partition")
 
 
+# Prose partition: an in-text enumeration presented as an exhaustive split of a
+# stated total. A sentence that decomposes N into >=3 "count (pct%)" categories
+# with partition-cue language, but whose counts do not sum to N (or whose
+# percentages do not sum to ~100), has mixed a non-exclusive component in among
+# mutually exclusive categories -- a "these don't add to N" reviewer flag. The
+# partition-cue gate is what keeps this off legitimate overlapping-attribute prose
+# ("210 (72.7%) had hypertension, 140 (48.4%) had diabetes, ..."): comorbidity
+# prevalence is not a partition, and its counts legitimately sum above N.
+_PART_CUE_RE = re.compile(
+    r"\b(?:decomposed|broke\s+down|broken\s+down|breakdown|comprised|"
+    r"consist(?:ed|ing)\s+of|partitioned|categori[sz]ed|classified|of\s+which|"
+    r"identified\s+(?:by|as|through)|attributable\s+to|ascertained\s+(?:by|through|via)|"
+    r"accounted\s+for|respectively)\b", re.I)
+_PART_TOTAL_RE = re.compile(
+    r"\b(?:among|of|the|these|totall?ing)\s+(?:the\s+)?([0-9][0-9,]{2,})\s+"
+    r"(?:incident\s+|total\s+|remaining\s+|eligible\s+|included\s+)?"
+    r"(?:cases|patients|subjects|participants|individuals|events|records|women|men|"
+    r"children|deaths|lesions|nodules|tumou?rs|samples|episodes|visits)\b", re.I)
+_PART_CAT_RE = re.compile(r"\b([0-9][0-9,]{0,})\s*\(\s*([0-9]+(?:\.[0-9]+)?)\s*%\s*\)")
+_SENT_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z(\"'])")
+# Bound the scan to a paragraph so an enumeration cannot accrue counts across a
+# blank line or a markdown header (a partition claim lives in one sentence).
+_BLOCK_SPLIT_RE = re.compile(r"\n\s*\n|\n#{1,6}\s")
+
+
+def _iter_partition_sentences(text: str):
+    for block in _BLOCK_SPLIT_RE.split(text):
+        for sent in _SENT_SPLIT_RE.split(block):
+            yield sent
+
+
+def check_partition_text(text: str) -> list[dict]:
+    claims = []
+    for sent in _iter_partition_sentences(text):
+        tm = _PART_TOTAL_RE.search(sent)
+        if not tm:
+            continue
+        cats = _PART_CAT_RE.findall(sent)
+        if len(cats) < 3:
+            continue
+        if not _PART_CUE_RE.search(sent):
+            continue  # cue gate: only an exhaustive-split claim, never overlapping attributes
+        total = _num(tm.group(1))
+        counts = [_num(c) for c, _ in cats]
+        if total is None or any(c is None for c in counts):
+            continue
+        sum_c = sum(counts)
+        sum_p = sum(float(p) for _, p in cats)
+        if abs(sum_c - total) >= 1:
+            claims.append({
+                "verdict": "PARTITION_OVERLAP",
+                "severity": "Major",
+                "detail": (f"enumerated counts sum to {int(sum_c):,} but the stated total is "
+                           f"{int(total):,} (difference {int(sum_c - total):+,}); a non-exclusive "
+                           f"component may be mixed among the mutually exclusive categories"),
+                "where": sent.strip()[:160],
+            })
+        elif not (99.0 <= sum_p <= 101.0):
+            claims.append({
+                "verdict": "PARTITION_OVERLAP",
+                "severity": "Major",
+                "detail": (f"category percentages sum to {sum_p:.1f}% (expected ~100%) for an "
+                           f"exhaustive split of {int(total):,}; a non-exclusive component may be "
+                           f"mixed among the mutually exclusive categories"),
+                "where": sent.strip()[:160],
+            })
+    return claims
+
+
 # --- Check 4: ANALYSIS_UNIT_UNDISCLOSED ------------------------------------
 # Health-screening / EMR / registry cohorts routinely have repeat attendees, so a
 # record count is not a subject count. When the data carry a subject ID and
@@ -506,6 +584,7 @@ def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dic
     claims += check_rate_text(text)
     claims += check_cascade_text(text)
     claims += check_partition_md(text)
+    claims += check_partition_text(text)
 
     if data:
         rows = load_csv(data)

--- a/skills/self-review/tests/fixtures/claim_registration_bad.md
+++ b/skills/self-review/tests/fixtures/claim_registration_bad.md
@@ -1,0 +1,7 @@
+# Registration chronology fixture (synthetic, PII-free) — FIRES
+
+## Methods
+
+We searched PubMed, Embase, and Cochrane from inception to 31 March 2026.
+
+The review was prospectively registered in PROSPERO (CRD42026123456) on 16 April 2026.

--- a/skills/self-review/tests/fixtures/claim_registration_clean.md
+++ b/skills/self-review/tests/fixtures/claim_registration_clean.md
@@ -1,0 +1,11 @@
+# Registration chronology negatives (synthetic, PII-free) — all SILENT
+
+## Negative 1 — genuinely prospective (registration precedes search-end)
+
+The review was prospectively registered in PROSPERO (CRD42026123456) on 1 February 2026.
+We searched PubMed, Embase, and Cochrane from inception to 31 March 2026.
+
+## Negative 2 — no prospective claim (registration postdates search, but the text does not claim "prospective")
+
+The review was registered with PROSPERO (CRD42026123456) on 16 April 2026.
+We searched the databases from inception to 31 March 2026.

--- a/skills/self-review/tests/fixtures/cohort_partition_prose.md
+++ b/skills/self-review/tests/fixtures/cohort_partition_prose.md
@@ -1,0 +1,9 @@
+# Prose partition fixture (synthetic, PII-free)
+
+## Positive — exhaustive split that does not reconcile (FIRES)
+
+Among the 289 incident cases, 37 (12.8%) were identified by isolated single
+glucose, 185 (64.0%) by the HbA1c threshold, and 103 (35.6%) by diagnosis,
+medication, or history. Here 185 is the non-exclusive HbA1c component sitting
+among two mutually exclusive categories, so the counts sum to 325 and the
+percentages to 112.4%.

--- a/skills/self-review/tests/fixtures/cohort_partition_prose_clean.md
+++ b/skills/self-review/tests/fixtures/cohort_partition_prose_clean.md
@@ -1,0 +1,19 @@
+# Prose partition negatives (synthetic, PII-free) — all must stay SILENT
+
+## Negative 1 — the same split, corrected: counts sum to N, percentages to 100
+
+Among the 289 incident cases, 37 (12.8%) were identified by isolated single
+glucose, 149 (51.6%) by the HbA1c threshold, and 103 (35.6%) by diagnosis,
+medication, or history.
+
+## Negative 2 — overlapping attributes, no percentages (a cross-tabulation, not a partition)
+
+Of the 289 patients, 210 had hypertension, 140 had diabetes, and 95 had
+dyslipidemia.
+
+## Negative 3 — overlapping attributes WITH percentages but no partition cue (the precision case)
+
+Of the 289 patients, 210 (72.7%) had hypertension, 140 (48.4%) had diabetes, and
+95 (32.9%) had dyslipidemia. These comorbidities are not mutually exclusive, so
+their counts legitimately sum above 289; the "had" verb carries no partition-cue
+language, so the gate stays silent.

--- a/skills/self-review/tests/test_claim_artifact.sh
+++ b/skills/self-review/tests/test_claim_artifact.sh
@@ -101,5 +101,17 @@ d=json.load(open('$OUT'))
 raise SystemExit(0 if not any(c['verdict']=='PRIMARY_LABEL_CODE_DRIFT' for c in d['claims']) else 1)
 "
 
+# Registration chronology (manuscript-internal, no --prereg needed): a
+# "prospectively registered" claim whose registration date (16 Apr 2026) postdates
+# search completion (31 Mar 2026) -> REGISTRATION_CHRONOLOGY (Major), exit 1.
+RB="$HERE/fixtures/claim_registration_bad.md"
+python3 "$SCRIPT" --manuscript "$RB" --out "$OUT" --strict >/dev/null 2>&1
+check "exit 1 on retrospective registration under a prospective claim" test "$?" -eq 1
+check "REGISTRATION_CHRONOLOGY detected" has_verdict REGISTRATION_CHRONOLOGY
+# Silent when registration precedes search-end, and when no "prospective" claim is made.
+RC="$HERE/fixtures/claim_registration_clean.md"
+python3 "$SCRIPT" --manuscript "$RC" --strict >/dev/null 2>&1
+check "exit 0 on genuinely-prospective + no-prospective-claim registrations" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_cohort_arithmetic.sh
+++ b/skills/self-review/tests/test_cohort_arithmetic.sh
@@ -82,5 +82,21 @@ assert not any(c['verdict']=='RATE_BACKCALC' for c in d['claims']), 'numerator m
 python3 "$SCRIPT" --manuscript "$RFP" --strict --quiet >/dev/null 2>&1
 check "exit 0 on correct-rate manuscript" test "$?" -eq 0
 
+# (8) PROSE partition: an in-text exhaustive split whose counts do not sum to the
+#     stated total (37 + 185 + 103 = 325 != 289, % = 112.4) -> PARTITION_OVERLAP,
+#     exit 1.
+PPROSE="$HERE/fixtures/cohort_partition_prose.md"
+python3 "$SCRIPT" --manuscript "$PPROSE" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 on prose partition that does not reconcile" test "$?" -eq 1
+check "PARTITION_OVERLAP from prose enumeration"          has_verdict PARTITION_OVERLAP
+
+# (9) PRECISION: the corrected split (37+149+103=289, %=100), a no-% cross-tab,
+#     and an overlapping-comorbidity enumeration WITH %s but no partition cue must
+#     all stay silent -> exit 0. The last is the case a naive count-sum check
+#     would false-fire on.
+PPCLEAN="$HERE/fixtures/cohort_partition_prose_clean.md"
+python3 "$SCRIPT" --manuscript "$PPCLEAN" --strict --quiet >/dev/null 2>&1
+check "exit 0 on corrected + cross-tab + cue-less overlapping prose" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
Two deterministic gates promoted from the `review-harvest` backlog, both as **verdicts on detectors that already run** — no new counted detector, count stays **67**.

Selected by an 8-agent vetting pass over a shortlist (each agent read the candidate, grepped the repo for existing coverage / re-arrival, and confirmed a synthetic fixture is feasible). Of the 8: 2 were already shipped (skipped), 2 were demand-gate deferred (single-project), 2 died on API errors (left for next batch), and these 2 survived as clean external-grounded builds.

## `check_cohort_arithmetic` — prose `PARTITION_OVERLAP`

The partition check was table/CSV-only. It now also reads an **in-text exhaustive split**: *"of the 289 cases, 37 (12.8%) … 185 (64.0%) … 103 (35.6%) …"* whose counts sum to **325 ≠ 289** (and % to 112.4) has mixed a non-exclusive component in among mutually exclusive categories — a "these don't add to N" reviewer flag that survives a prose pass because every section echoes the same numbers.

The precision risk is real: a naive count-sum check would false-fire on **comorbidity prevalence** (*"210 (72.7%) had hypertension, 140 (48.4%) had diabetes, …"* — overlapping attributes legitimately sum above N). A mandatory **partition-cue gate** suppresses that, and it's pinned as a must-stay-silent negative. The scan is bounded to a paragraph so counts can't accrue across a blank line or markdown header.

## `check_claim_artifact` — `REGISTRATION_CHRONOLOGY` (Major)

A *"prospectively registered"* claim is falsifiable against the manuscript's own dates: if registration postdates search completion, the review was registered **retrospectively**. Manuscript-internal (no external prereg artifact); fires only when a prospective claim co-occurs with a registry **and** both dates parse **and** registration > search-end. This overclaim recurred across two projects while the prose-only panel probe slipped on the second — the case for a deterministic gate.

## Verification

Both detector tests extended with positive + the precision negatives (`test_cohort_arithmetic.sh`, `test_claim_artifact.sh`, CI-wired). Full CI mirror green locally: validator, detector-envelopes (65/67 self-identify), catalog consistency (67 unchanged), generators `--check`, reachability, workflow-yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)