### PR TITLE
feat(self-review,sync-submission): figures-not-embedded + cover-letter title drift

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -508,6 +508,9 @@ jobs:
       - name: Run sync-submission scope-drift gate test
         run: bash skills/sync-submission/tests/test_scope_drift.sh
 
+      - name: Run sync-submission cover-letter title-drift gate test
+        run: bash skills/sync-submission/tests/test_cover_letter_title_drift.sh
+
       - name: Run sync-submission vN-docx assertion gate test
         run: bash skills/sync-submission/tests/test_vN_docx_assertion.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@
 
 ### Added
 
-- **`/self-review` — two deterministic gates promoted from the field-feedback backlog, both as
-  verdicts on detectors that already run (no new counted detector).**
+- **Two more field-backlog gates, again as verdicts on detectors that already run (no new counted
+  detector).**
+  - **`check_figure_citation` now flags a manuscript that has figure captions but no embedded image**
+    (`FIGURE_NOT_EMBEDDED`). A "complete" circulation manuscript can ship with every figure legend and
+    not one picture — author-invisible, because the prose reads finished. The check is conservative
+    (fires only when *zero* images are embedded, never a per-figure guess) and **advisory by default**
+    (a drafting manuscript legitimately keeps figures as separate files); `--require-embedded` — the
+    submission preflight — escalates it to Major, where captions-with-no-picture is the failure.
+  - **`cover_letter_drift_check` now checks the manuscript TITLE, not only the counts**
+    (`TITLE_DRIFT`). The §4 cover-letter gate already caught word/reference/table drift; a title that
+    differs across the manuscript frontmatter, the cover letter, and the project config (three live
+    titles at once) is a guaranteed desk/technical-check flag it did not see. The manuscript title
+    must appear verbatim in the cover letter and match an optional `--config` (`title`/`title_working`)
+    field.
   - **`check_cohort_arithmetic` now reads a PROSE partition, not only tables/CSV** (`PARTITION_OVERLAP`).
     A sentence that presents an exhaustive split of a stated total — "of the 289 cases, 37 (12.8%) …
     185 (64.0%) … 103 (35.6%) …" — but whose counts do not sum to the total (325 ≠ 289) or whose

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4198,8 +4198,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_figure_citation.py",
-      "size": 5339,
-      "sha256": "fe86c632bb14aaab14d787bc2ebf56079828949cff400b16c2fd5df897da1513"
+      "size": 8374,
+      "sha256": "5961b5f9b23264ce392ed9161a827b7cfcd337b3b58d3ee1287077786d5b004e"
     },
     {
       "path": "skills/self-review/scripts/check_nested_group_comparison.py",
@@ -4468,8 +4468,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/cover_letter_drift_check.py",
-      "size": 16001,
-      "sha256": "347c5b702fbe9375899795791a34e8a60e246253bafb53b15ebb59d51dd45e7d"
+      "size": 19379,
+      "sha256": "9a1ef365e6aae53582a87570ce7bde327ed9302a9834571f681b2972b87b2d5d"
     },
     {
       "path": "skills/sync-submission/scripts/cross_document_n_check.py",

--- a/skills/self-review/scripts/check_figure_citation.py
+++ b/skills/self-review/scripts/check_figure_citation.py
@@ -11,6 +11,15 @@ Verdict:
   FIGURE_ORPHAN (Minor)  a figure with a caption "Figure N." has no in-text
                          "Figure N" / "Fig. N" citation anywhere outside its caption.
   TABLE_ORPHAN  (Minor)  the same for a "Table N." caption.
+  FIGURE_NOT_EMBEDDED    the manuscript has figure captions but NO markdown image link
+        (Minor;          (`![...](...)`) anywhere, so every figure is captioned yet
+   Major w/ --require-   absent from the rendered output — the "complete" submission that
+   embedded)             ships with the legends and none of the pictures. Advisory by
+                         default (a drafting manuscript may keep figures as separate
+                         files); --require-embedded (the submission preflight) makes it
+                         Major. Conservative: fires only when ZERO images are embedded,
+                         never a per-figure guess, so it stays silent once any figure is
+                         embedded.
 
 Deterministic and caption-anchored: a line beginning "Figure N." / "Table N." (with
 optional **bold**) DECLARES float N; any "Figure N" / "Table N" mention on a
@@ -38,13 +47,17 @@ from pathlib import Path
 CAPTION_RE = re.compile(r"^\s*\*{0,2}\s*(?P<kind>Figure|Fig\.?|Table)\s+(?P<num>\d+)\s*[.:]", re.I)
 # Any in-text mention: Figure N / Fig N / Fig. N / Table N (+ "Figures 1 and 2" heads)
 MENTION_RE = re.compile(r"\b(?P<kind>Figures?|Figs?\.?|Tables?)\s+(?P<num>\d+)\b", re.I)
+# A markdown image embed: ![alt](path). Its presence is how a figure reaches the
+# rendered output; a manuscript with figure captions but zero image links ships
+# with every legend and no picture.
+IMG_LINK_RE = re.compile(r"!\[[^\]]*\]\([^)]+\)")
 
 
 def _kind(raw: str) -> str:
     return "Table" if raw.lower().startswith("tab") else "Figure"
 
 
-def check(text: str) -> list[dict]:
+def check(text: str, require_embedded: bool = False) -> list[dict]:
     lines = text.splitlines()
     declared: dict[tuple[str, int], int] = {}   # (kind, num) -> caption line index
     for i, line in enumerate(lines):
@@ -71,23 +84,46 @@ def check(text: str) -> list[dict]:
                        f"in the body; add an in-text '{kind} {num}' citation or remove the float"),
             "where": lines[cap_line].strip()[:120],
         })
+
+    # FIGURE_NOT_EMBEDDED: captioned figures but no image link anywhere in the file.
+    # Conservative on purpose (only the zero-embed case, never a per-figure guess) so
+    # it stays silent whenever any figure is embedded. Tables are inline markdown, not
+    # embedded images, so they are exempt.
+    figures = sorted((n, ln) for (k, n), ln in declared.items() if k == "Figure")
+    if figures and not IMG_LINK_RE.search(text):
+        # Advisory by default: a markdown manuscript with figures kept as separate
+        # attachment files legitimately embeds no image. --require-embedded (the
+        # submission preflight) escalates to Major, where captions-with-no-picture
+        # is the "complete package that ships with the legends and none of the
+        # figures" failure.
+        sev = "Major" if require_embedded else "Minor"
+        for num, cap_line in figures:
+            claims.append({
+                "verdict": "FIGURE_NOT_EMBEDDED",
+                "severity": sev,
+                "detail": (f"Figure {num} is captioned (line {cap_line + 1}) but no image is embedded "
+                           f"anywhere in the manuscript; confirm the figure is embedded or attached as a "
+                           f"separate file before submission"),
+                "where": lines[cap_line].strip()[:120],
+            })
     return claims
 
 
-def analyze(manuscript: str) -> dict:
+def analyze(manuscript: str, require_embedded: bool = False) -> dict:
     p = Path(manuscript)
     if not p.is_file():
         sys.stderr.write(f"ERROR: manuscript not found: {manuscript}\n")
         sys.exit(2)
-    claims = check(p.read_text(encoding="utf-8"))
+    claims = check(p.read_text(encoding="utf-8"), require_embedded=require_embedded)
+    n_major = sum(1 for c in claims if c["severity"] == "Major")
     return {
         "manuscript": str(p),
         "claims": claims,
         "summary": {
             "n_claims": len(claims),
-            "n_major": 0,
-            "n_flag": len(claims),
-            "verdict": "REVIEW" if claims else "OK",
+            "n_major": n_major,
+            "n_flag": len(claims) - n_major,
+            "verdict": "MAJOR_CANDIDATE" if n_major else ("REVIEW" if claims else "OK"),
         },
     }
 
@@ -107,11 +143,14 @@ def main() -> int:
     ap.add_argument("--manuscript", required=True, help="manuscript markdown/text")
     ap.add_argument("--out", help="write JSON artifact to this path")
     ap.add_argument("--strict", action="store_true",
-                    help="exit 1 if any Major (none — this gate is Minor-only)")
+                    help="exit 1 if any Major (a captioned figure with no embedded image under --require-embedded)")
+    ap.add_argument("--require-embedded", action="store_true",
+                    help="submission context: escalate FIGURE_NOT_EMBEDDED to Major (figures must be "
+                         "embedded in the manuscript, not kept as separate files)")
     ap.add_argument("--quiet", action="store_true", help="suppress stdout table")
     args = ap.parse_args()
 
-    result = analyze(args.manuscript)
+    result = analyze(args.manuscript, require_embedded=args.require_embedded)
 
     if not args.quiet:
         print("=" * 44)
@@ -119,8 +158,13 @@ def main() -> int:
         print("=" * 44)
         print(render(result))
         print()
-        n = result["summary"]["n_flag"]
-        print(f"{'REVIEW: ' + str(n) + ' orphan float(s).' if n else 'OK: every captioned float is cited in the body.'}")
+        s = result["summary"]
+        if s["n_major"]:
+            print(f"MAJOR: {s['n_major']} figure(s) captioned but not embedded; {s['n_flag']} orphan float(s).")
+        elif s["n_flag"]:
+            print(f"REVIEW: {s['n_flag']} orphan float(s).")
+        else:
+            print("OK: every captioned float is cited and embedded.")
 
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)

--- a/skills/self-review/tests/fixtures/figcite_embedded.md
+++ b/skills/self-review/tests/fixtures/figcite_embedded.md
@@ -1,0 +1,13 @@
+# Display items
+
+**Figure 1.** Study flow diagram.
+
+![Figure 1](figures/fig1.png)
+
+**Figure 2.** ROC curves for the primary model.
+
+![Figure 2](figures/fig2.png)
+
+## Results
+
+As shown in Figure 1, 289 patients were included. Discrimination is in Figure 2.

--- a/skills/self-review/tests/fixtures/figcite_not_embedded.md
+++ b/skills/self-review/tests/fixtures/figcite_not_embedded.md
@@ -1,0 +1,9 @@
+# Display items
+
+**Figure 1.** Study flow diagram.
+
+**Figure 2.** ROC curves for the primary model.
+
+## Results
+
+As shown in Figure 1, 289 patients were included. Discrimination is in Figure 2.

--- a/skills/self-review/tests/fixtures/figure_clean.md
+++ b/skills/self-review/tests/fixtures/figure_clean.md
@@ -4,7 +4,12 @@ the primary and secondary results respectively.
 
 ## Figure Legends
 **Figure 1.** Study flow diagram.
+
+![Figure 1](figures/fig1.png)
+
 **Figure 3.** Forest plot of subgroup effects.
+
+![Figure 3](figures/fig3.png)
 
 ## Tables
 **Table 1.** Baseline characteristics.

--- a/skills/self-review/tests/test_figure_citation.sh
+++ b/skills/self-review/tests/test_figure_citation.sh
@@ -30,10 +30,26 @@ orphans={(c['verdict'], c['detail'].split(' has')[0]) for c in d['claims']}
 assert ('FIGURE_ORPHAN','Figure 1') not in orphans and ('TABLE_ORPHAN','Table 1') not in orphans
 "
 python3 "$SCRIPT" --manuscript "$CLEAN" --out "$OUT" --quiet >/dev/null 2>&1
-check "no orphans when every float is cited" python3 -c "
+check "no orphans/embed flags when every float is cited AND embedded" python3 -c "
 import json
 d=json.load(open('$OUT'))
 assert not d['claims'], d['claims']
 "
+
+# FIGURE_NOT_EMBEDDED: captions present, cited, but no image link anywhere.
+NE="$HERE/fixtures/figcite_not_embedded.md"
+python3 "$SCRIPT" --manuscript "$NE" --out "$OUT" --quiet >/dev/null 2>&1
+check "FIGURE_NOT_EMBEDDED when no image is embedded" has_verdict FIGURE_NOT_EMBEDDED
+# advisory (Minor) by default -> exit 0 even under --strict
+python3 "$SCRIPT" --manuscript "$NE" --strict --quiet >/dev/null 2>&1
+check "advisory Minor by default (exit 0 under --strict)" test "$?" -eq 0
+# submission context: --require-embedded escalates to Major -> exit 1 under --strict
+python3 "$SCRIPT" --manuscript "$NE" --require-embedded --strict --quiet >/dev/null 2>&1
+check "Major under --require-embedded (exit 1 under --strict)" test "$?" -eq 1
+# a manuscript that embeds its figures stays silent
+EMB="$HERE/fixtures/figcite_embedded.md"
+python3 "$SCRIPT" --manuscript "$EMB" --require-embedded --strict --quiet >/dev/null 2>&1
+check "silent when figures are embedded (even --require-embedded)" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/sync-submission/scripts/cover_letter_drift_check.py
+++ b/skills/sync-submission/scripts/cover_letter_drift_check.py
@@ -4,9 +4,12 @@ cover_letter_drift_check.py — Phase 4 cover-letter free-text drift gate.
 
 Compares the numeric claims embedded in a cover letter (body word count,
 abstract word count, reference count, table/figure count, reporting-guideline
-status) against the manuscript artifacts that should be their source of truth.
-Emits a drift report when the cover letter has gone stale relative to the
-manuscript.
+status) — and the manuscript TITLE — against the artifacts that should be their
+source of truth. Emits a drift report when the cover letter (or the project
+config) has gone stale relative to the manuscript. The title check requires the
+manuscript title to appear verbatim in the cover letter and to match an optional
+`--config` (SSOT.yaml/project.yaml) `title`/`title_working` field — three live
+titles at once is a guaranteed desk/technical-check flag.
 
 Why this gate exists
 ====================
@@ -274,6 +277,76 @@ def extract_claims(cover_letter_path: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Title / running-head drift
+# ---------------------------------------------------------------------------
+
+
+def _norm_title(s: str) -> str:
+    """Lowercase, collapse whitespace, strip surrounding quotes and a trailing period."""
+    s = s.strip().strip("\"'“”‘’").strip()
+    s = re.sub(r"\s+", " ", s).strip()
+    return s.rstrip(".").lower()
+
+
+def _title_from_yaml_key(text: str, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        m = re.search(rf"^{key}:\s*(.+?)\s*$", text, re.MULTILINE)
+        if m:
+            return m.group(1).strip().strip("\"'")
+    return ""
+
+
+def extract_manuscript_title(manuscript_path: Path) -> str:
+    lines = manuscript_path.read_text(encoding="utf-8").splitlines()
+    yaml_lines, body_lines = split_yaml_front_matter(lines)
+    t = _title_from_yaml_key("\n".join(yaml_lines), ("title",))
+    if t:
+        return t
+    for ln in body_lines:  # fallback: first H1
+        hm = re.match(r"^#\s+(.+)", ln.strip())
+        if hm:
+            return hm.group(1).strip()
+    return ""
+
+
+def extract_config_title(config_path: Path) -> str:
+    text = config_path.read_text(encoding="utf-8")
+    return _title_from_yaml_key(text, ("title_working", "title"))
+
+
+def evaluate_title_drift(manuscript_path: Path, cover_letter_path: Path,
+                         config_path: Optional[Path]) -> list[dict]:
+    """The manuscript title must appear verbatim in the cover letter and match the
+    project config. A title that differs across these sidecars is a guaranteed
+    desk/technical-check flag (the running head and portal metadata are next)."""
+    drifts: list[dict] = []
+    ms_title = extract_manuscript_title(manuscript_path)
+    if not ms_title:
+        return drifts
+    needle = _norm_title(ms_title)
+    haystack = _norm_title(cover_letter_path.read_text(encoding="utf-8"))
+    if needle not in haystack:
+        drifts.append({
+            "field": "title",
+            "truth": ms_title,
+            "cover_letter_claim": "(manuscript title not found verbatim in cover letter)",
+            "severity": "MAJOR",
+            "note": "the cover letter does not state the manuscript title verbatim — a desk-check mismatch",
+        })
+    if config_path is not None and config_path.exists():
+        cfg_title = extract_config_title(config_path)
+        if cfg_title and _norm_title(cfg_title) != needle:
+            drifts.append({
+                "field": "title(config)",
+                "truth": ms_title,
+                "cover_letter_claim": cfg_title,
+                "severity": "MAJOR",
+                "note": "the project config title disagrees with the manuscript title",
+            })
+    return drifts
+
+
+# ---------------------------------------------------------------------------
 # Drift evaluation
 # ---------------------------------------------------------------------------
 
@@ -377,6 +450,9 @@ def main() -> int:
     p.add_argument("--refs", type=Path, default=None,
                    help="refs.bib path. Used for reference count truth. "
                         "If absent, falls back to counting unique [@key] in manuscript.")
+    p.add_argument("--config", type=Path, default=None,
+                   help="Optional project config (SSOT.yaml / project.yaml) with a `title`/"
+                        "`title_working` field to cross-check against the manuscript title.")
     p.add_argument("--out", type=Path, default=Path("qc/cover_letter_drift.json"))
     p.add_argument("--body-tolerance-pct", type=float, default=DEFAULT_BODY_TOLERANCE_PCT,
                    help="Allowed slack on body word count (percent). Default %(default)s.")
@@ -409,6 +485,7 @@ def main() -> int:
         body_tolerance_pct=args.body_tolerance_pct,
         abstract_tolerance=args.abstract_tolerance,
     )
+    drifts += evaluate_title_drift(args.manuscript, args.cover_letter, args.config)
 
     report = {
         "submission_safe": len(drifts) == 0,

--- a/skills/sync-submission/tests/test_cover_letter_title_drift.sh
+++ b/skills/sync-submission/tests/test_cover_letter_title_drift.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression for cover_letter_drift_check.py TITLE_DRIFT (Phase 4 cover-letter gate).
+# A manuscript title must appear verbatim in the cover letter and match the project
+# config; three different live titles at once is a guaranteed desk-check flag.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/cover_letter_drift_check.py"
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+OUT="$T/o.json"
+fail=0
+check() { local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+  else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi; }
+has_field() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert any(x['field']=='$1' for x in d['drifts']), '$1 not in drifts'
+"; }
+no_drift() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert d['submission_safe'] and not d['drifts'], d['drifts']
+"; }
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+cat > "$T/manuscript.md" <<'MD'
+---
+title: Adjunctive ablation halves local recurrence
+---
+## Introduction
+Body text citing Table 1 and Figure 1.
+MD
+
+# POSITIVE: cover letter states a DRIFTED title + config carries a THIRD title.
+cat > "$T/cover_bad.md" <<'MD'
+Dear Editor, we submit our manuscript entitled "Adjunctive ablation reduces local recurrence".
+MD
+cat > "$T/ssot_bad.yaml" <<'MD'
+title_working: Adjunctive thermal ablation and recurrence
+MD
+python3 "$SCRIPT" --manuscript "$T/manuscript.md" --cover-letter "$T/cover_bad.md" \
+    --config "$T/ssot_bad.yaml" --out "$OUT" >/dev/null 2>&1
+check "exit 2 on title drift" test "$?" -eq 2
+check "TITLE_DRIFT (cover letter) reported"  has_field title
+check "TITLE_DRIFT (config) reported"        has_field "title(config)"
+
+# NEGATIVE: cover letter states the title verbatim, config matches -> silent.
+cat > "$T/cover_ok.md" <<'MD'
+Dear Editor, we submit our manuscript entitled "Adjunctive ablation halves local recurrence".
+MD
+cat > "$T/ssot_ok.yaml" <<'MD'
+title_working: Adjunctive ablation halves local recurrence
+MD
+python3 "$SCRIPT" --manuscript "$T/manuscript.md" --cover-letter "$T/cover_ok.md" \
+    --config "$T/ssot_ok.yaml" --out "$OUT" >/dev/null 2>&1
+check "exit 0 when title agrees everywhere" test "$?" -eq 0
+check "no drifts when title agrees"         no_drift
+
+# NEGATIVE: no --config given, title verbatim in cover letter -> silent (no config FP).
+python3 "$SCRIPT" --manuscript "$T/manuscript.md" --cover-letter "$T/cover_ok.md" \
+    --out "$OUT" >/dev/null 2>&1
+check "exit 0 without --config when cover letter carries the title" test "$?" -eq 0
+
+echo "test_cover_letter_title_drift: $((6-fail)) passed, $fail failed"
+[[ "$fail" -eq 0 ]] || exit 1


### PR DESCRIPTION
Batch 2 of the `review-harvest` promotion. Both are **verdicts on detectors that already run** — no new counted detector, count stays **67**. Selected by an 8-agent vetting pass (4 BUILD, 4 demand-gate DEFER for single-project / no-host-script).

## `check_figure_citation` — `FIGURE_NOT_EMBEDDED`

A "complete" circulation manuscript can ship with every figure caption present and **no embedded image at all** (the CHEST-class failure) — author-invisible, because the prose reads finished.

- **Conservative**: fires only when *zero* images are embedded (never a per-figure guess), so it stays silent the moment any figure is embedded.
- **Advisory by default**: a drafting manuscript legitimately keeps figures as separate files, so defaulting to Major would fire on good work (the "gate fires on good work → gets switched off" trap). `--require-embedded` — the submission preflight — escalates to Major.
- The existing clean fixture now embeds its figures (the correct complete state).

## `cover_letter_drift_check` — `TITLE_DRIFT`

The §4 cover-letter gate caught word / reference / table drift but **not the title**. Three different live titles at once (manuscript frontmatter, cover letter, project config) is a guaranteed desk/technical-check flag. The manuscript title must appear verbatim in the cover letter and match an optional `--config` (`title`/`title_working`) field.

## Verification

Positive + negative fixtures for both. `test_cover_letter_title_drift.sh` added and CI-wired; `test_figure_citation.sh` extended (advisory-default + `--require-embedded` + embedded-silent cases); existing preflight/figure tests still green. Full CI mirror green locally (validator, workflow-yaml, catalog consistency 67 unchanged, generators `--check`, reachability, envelopes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)