### PR TITLE
feat(self-review,write-paper): four field-backlog verdicts (additive, no count bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ### Added
 
+- **Four more field-backlog verdicts on detectors that already run (no new counted detector).**
+  - **`check_cohort_arithmetic` — `FOLLOWUP_VS_CRITERION` (Minor).** A reported "median follow-up was
+    102 days" against a reference standard requiring "size stability for ≥24 months" reads as if benign
+    classification had 102 days to work with. Usually the 102 days is the index-visit interval and the
+    total observation window (median 442 days) was simply never stated. Fires when the shortest reported
+    follow-up is below the longest duration criterion in the outcome definition **and** no
+    total-observation window is separately labelled (that label suppresses it).
+  - **`check_figure_citation` — `FIGURE_ATTR_STALE` (Major) + `AUTHOR_CONTRIB_FIGURE_REF` (Minor).** An
+    Author-Contributions / CRediT line attributing "prepared Figure 4" when only Figures 1–3 exist is a
+    stale attribution from a figure renumber/merge. Scoped strictly to the author-contributions section
+    (never Results, where "Figure N" is a normal citation); the advisory flags figure-numbered
+    attribution as drift-prone (use the CRediT "Visualization" role).
+  - **`check_scope_coherence` — `UNIVERSAL_NEGATIVE_UNSCOPED` (Minor).** A "no published system…",
+    "first study to quantify…", "has not been measured" claim in the Abstract/Introduction/Discussion
+    with no named discipline-scope qualifier. A single-database search supports "no *clinical* paper does
+    X", never "nobody does X". Suppressed by a discipline frame ("…in the radiology literature"); a bare
+    "to our knowledge" does not suppress, because that is the failure.
+  - **`check_placeholders` — `placeholder_strength_claim` (warn).** A strength assertion
+    (near-unanimous / all / every / none / always) on a line that also carries an unresolved `[VERIFY]`
+    marker — the claim written at the strength the author *hopes* the pending data has. The marker text
+    is stripped before the strength check, so a word inside the marker does not trip it; hedged marked
+    lines stay silent.
+
 - **Two more field-backlog gates, both additive verdicts (no new counted detector).**
   - **`check_citation_order` now resolves in-text `Section N` cross-references** (`DANGLING_SECTION_XREF`).
     Many medical journals typeset **unnumbered** headings, so a "as reported in Section 3.4" written

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4138,8 +4138,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 28137,
-      "sha256": "6711adf4ad70c9d70b76f526a2c0177b08ff56c9c80efb85265ee873886eff3f"
+      "size": 30945,
+      "sha256": "50e09a18b0e404f8fab97091efaaa8e6263bb20a76a5058d5b989655c4c2da94"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",
@@ -4233,8 +4233,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_figure_citation.py",
-      "size": 8374,
-      "sha256": "5961b5f9b23264ce392ed9161a827b7cfcd337b3b58d3ee1287077786d5b004e"
+      "size": 10635,
+      "sha256": "087ee531a5d1b8e2ebd2630d1c5180dfbacfec46299d262100ad19f0ba4fa32c"
     },
     {
       "path": "skills/self-review/scripts/check_nested_group_comparison.py",
@@ -4373,8 +4373,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_scope_coherence.py",
-      "size": 13030,
-      "sha256": "e0316f9d3e57ef47de00d6c082486c7520e2960fed6d3270069cc3e30de1c490"
+      "size": 17273,
+      "sha256": "9508c6f84f1971fea99500aba9bf9bf3d7045dba14e8a2d67053f32e4e0b06f8"
     },
     {
       "path": "skills/self-review/scripts/check_supplement_hygiene.py",
@@ -5133,8 +5133,8 @@
     },
     {
       "path": "skills/write-paper/scripts/check_placeholders.py",
-      "size": 7475,
-      "sha256": "2a7c9fe8caa000ab0c7bfffb6b09b4dd2508dcc3b374e2650d18c42ff52e7420"
+      "size": 8998,
+      "sha256": "eb781cf4dbd7246bfd15c76ee09454df024770b8c9633f11e837d92489a36121"
     },
     {
       "path": "skills/write-paper/scripts/gate_backbone_fulltext.py",

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -486,6 +486,57 @@ def check_partition_text(text: str) -> list[dict]:
     return claims
 
 
+# --- Check: FOLLOWUP_VS_CRITERION ------------------------------------------
+# A reported "median follow-up was 102 days" against a reference standard that
+# requires "size stability for >=24 months" reads, to a reviewer, as if the
+# benign classification had 102 days to work with. Usually the 102 days is the
+# index-visit interval and the total observation window (median 442 days) is
+# simply never stated. Pure arithmetic: if the shortest reported follow-up is
+# below the longest duration threshold the outcome/reference standard requires,
+# and no total-observation window is labelled, ask which quantity is reported.
+_DUR_UNIT_DAYS = {"day": 1.0, "week": 7.0, "month": 30.44, "year": 365.25}
+_FOLLOWUP_RE = re.compile(
+    r"(?:median|mean)\s+follow[-\s]?up[^.]{0,40}?(\d[\d,]*(?:\.\d+)?)\s*(day|week|month|year)s?", re.I)
+_CRITERION_CUE = re.compile(
+    r"stabilit|stable|reference standard|benign if|confirmed by|criterion|classified as|"
+    r"resolution over|no growth for|unchanged for|followed for", re.I)
+_CRITERION_DUR_RE = re.compile(
+    r"(?:>=|≥|at least|minimum of|for|over)\s*(\d+)\s*(day|week|month|year)s?", re.I)
+_TOTAL_WINDOW_RE = re.compile(
+    r"total observation|observation period|overall follow[-\s]?up|maximum follow[-\s]?up|"
+    r"observed for a (?:median|maximum) of|total follow[-\s]?up", re.I)
+
+
+def check_followup_criterion(text: str) -> list[dict]:
+    fu = [(_num(v) or 0) * _DUR_UNIT_DAYS[u.lower()]
+          for v, u in _FOLLOWUP_RE.findall(text)]
+    fu = [d for d in fu if d > 0]
+    if not fu:
+        return []
+    # criterion thresholds: a duration inside a reference-standard/outcome cue window
+    crit = []
+    for m in _CRITERION_DUR_RE.finditer(text):
+        win = text[max(0, m.start() - 120):m.end() + 40]
+        if _CRITERION_CUE.search(win):
+            crit.append(int(m.group(1)) * _DUR_UNIT_DAYS[m.group(2).lower()])
+    if not crit:
+        return []
+    min_fu, max_crit = min(fu), max(crit)
+    if min_fu >= max_crit:
+        return []
+    if _TOTAL_WINDOW_RE.search(text):
+        return []  # a distinctly-labelled total-observation window is already reported
+    return [{
+        "verdict": "FOLLOWUP_VS_CRITERION",
+        "severity": "Minor",
+        "detail": (f"the shortest reported follow-up ({min_fu / 30.44:.1f} months / {min_fu:.0f} days) "
+                   f"is below a {max_crit / 30.44:.0f}-month duration criterion in the outcome/reference "
+                   f"standard, and no total-observation window is reported — state whether the reported "
+                   f"follow-up is the index-visit interval or the total observation, and give the latter"),
+        "where": (_FOLLOWUP_RE.search(text).group(0)[:120] if _FOLLOWUP_RE.search(text) else "follow-up"),
+    }]
+
+
 # --- Check 4: ANALYSIS_UNIT_UNDISCLOSED ------------------------------------
 # Health-screening / EMR / registry cohorts routinely have repeat attendees, so a
 # record count is not a subject count. When the data carry a subject ID and
@@ -585,6 +636,7 @@ def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dic
     claims += check_cascade_text(text)
     claims += check_partition_md(text)
     claims += check_partition_text(text)
+    claims += check_followup_criterion(text)
 
     if data:
         rows = load_csv(data)

--- a/skills/self-review/scripts/check_figure_citation.py
+++ b/skills/self-review/scripts/check_figure_citation.py
@@ -51,6 +51,10 @@ MENTION_RE = re.compile(r"\b(?P<kind>Figures?|Figs?\.?|Tables?)\s+(?P<num>\d+)\b
 # rendered output; a manuscript with figure captions but zero image links ships
 # with every legend and no picture.
 IMG_LINK_RE = re.compile(r"!\[[^\]]*\]\([^)]+\)")
+# The author-contributions / CRediT heading.
+CREDIT_HEADING_RE = re.compile(
+    r"^#{1,6}\s*\*{0,2}\s*(?:Authors?[’'\s]*\s*[Cc]ontributions?|CRediT[^\n]*)\*{0,2}\s*:?\s*$",
+    re.MULTILINE)
 
 
 def _kind(raw: str) -> str:
@@ -106,6 +110,40 @@ def check(text: str, require_embedded: bool = False) -> list[dict]:
                            f"separate file before submission"),
                 "where": lines[cap_line].strip()[:120],
             })
+
+    # Author-contributions / CRediT figure-number attribution. A "prepared Figure 4"
+    # attribution silently breaks when figures are renumbered or merged; the canonical
+    # CRediT "Visualization" role carries no numbers and is drift-proof. Scanned ONLY
+    # inside the author-contributions/CRediT section (never Results/Discussion, where
+    # "Figure N" is a normal citation).
+    cm = CREDIT_HEADING_RE.search(text)
+    if cm:
+        start = cm.end()
+        nxt = re.search(r"^#{1,6}\s", text[start:], re.MULTILINE)
+        region = text[start: start + nxt.start()] if nxt else text[start:]
+        declared_fignums = {n for (k, n) in declared if k == "Figure"}
+        fig_tokens = [int(m.group("num")) for m in MENTION_RE.finditer(region)
+                      if _kind(m.group("kind")) == "Figure"]
+        if fig_tokens:
+            claims.append({
+                "verdict": "AUTHOR_CONTRIB_FIGURE_REF",
+                "severity": "Minor",
+                "detail": ("the author-contributions/CRediT section attributes work by figure number "
+                           "(e.g. 'prepared Figure N'); this attribution breaks on any figure renumber or "
+                           "merge — use the CRediT 'Visualization' role, which carries no figure numbers"),
+                "where": "author contributions",
+            })
+            for num in sorted(set(fig_tokens)):
+                if num not in declared_fignums:
+                    claims.append({
+                        "verdict": "FIGURE_ATTR_STALE",
+                        "severity": "Major",
+                        "detail": (f"the author-contributions/CRediT section attributes Figure {num}, but no "
+                                   f"Figure {num} is declared in the manuscript — a stale attribution left by a "
+                                   f"figure renumber/merge (declared figures: "
+                                   f"{', '.join(str(n) for n in sorted(declared_fignums)) or 'none'})"),
+                        "where": "author contributions",
+                    })
     return claims
 
 

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -15,6 +15,10 @@ conclusion action verb co-occur, and both are documented anti-patterns
                               dichotomized) drives a patient-care directive (defer,
                               withhold, initiate/discontinue therapy, statin). A
                               risk-stratification marker is not a management trigger.
+  UNIVERSAL_NEGATIVE_UNSCOPED  a 'nobody / first to / has not been' novelty claim
+                          in a claim region with no named discipline-scope qualifier
+                          (Minor): a single-database search cannot support a universal
+                          negative. Narrow the claim or widen the search.
   CROSS_SECTIONAL_YIELD_LANGUAGE  a cross-sectional / prevalence design uses
                               incidence/prospective-flavored vocabulary — "yield",
                               "detection rate", "number-needed-to-screen/image",
@@ -32,7 +36,8 @@ INPUTS
 OUTPUT
   A reconciliation table (stdout) and, with --out, a JSON artifact:
     {manuscript, claims[{verdict, severity, detail, where}], summary}
-  Both verdicts are Major. Exit 1 (with --strict) when any Major claim exists.
+  CROSS_SECTIONAL_PROGNOSTIC and SURROGATE_CARE_DIRECTIVE are Major; UNIVERSAL_NEGATIVE_
+  UNSCOPED and CROSS_SECTIONAL_YIELD_LANGUAGE are Minor. Exit 1 (with --strict) on any Major.
 
 Stdlib-only (json / re / argparse / pathlib). Exit codes: 0 clean (or report-only),
 1 Major claim(s) found (with --strict), 2 input/usage error.
@@ -148,9 +153,77 @@ def conclusion_region(text: str) -> str:
     return "\n".join(spans)
 
 
+# Claim regions where a novelty/neglect claim lives: Abstract, Introduction/
+# Background, Discussion, Conclusion.
+NOVELTY_REGION_HEADINGS = re.compile(
+    r"^#{1,4}\s*\*{0,2}(?:ABSTRACT|Abstract|INTRODUCTION|Introduction|BACKGROUND|Background|"
+    r"DISCUSSION|Discussion|CONCLUSIONS?|Conclusions?)\*{0,2}\s*:?\s*$",
+    re.IGNORECASE | re.MULTILINE)
+
+# A universal-negative / first-to novelty construction.
+UNIVERSAL_NEGATIVE_RE = re.compile(
+    r"\bno(?:body|-one| one)\b"
+    r"|\bnone of (?:the |these )?(?:\w+\s+){0,2}(?:studies|systems|works|methods|papers|reports)\b"
+    r"|\bno (?:\w+\s+){0,3}(?:published |existing |prior )?"
+    r"(?:system|study|work|method|approach|dataset|benchmark|paper|report|research)\b"
+    r"[^.\n]{0,50}?\b(?:measure|report|quantif|examine|assess|address|exist|investigate|describe|ask)"
+    r"|\bnever been (?:measured|examined|studied|reported|asked|quantified|assessed|investigated|addressed|explored)\b"
+    r"|\bhas not (?:yet )?been (?:measured|examined|studied|asked|quantified|assessed|investigated|addressed|explored)\b"
+    r"|\bfirst (?:study|work|report|paper)\b[^.\n]{0,50}?\b(?:to )?(?:measure|report|examine|quantif|assess|investigate|describe|characteri[sz]e)"
+    r"|\bwe are the first\b|\bthe first to (?:measure|report|examine|quantif|assess|investigate|describe|characteri[sz]e)"
+    r"|\bremains? (?:largely )?(?:unmeasured|unexamined|unexplored|unaddressed)\b|\bunexamined\b|\bunexplored\b",
+    re.IGNORECASE)
+
+# A named discipline/literature FRAME that legitimately scopes the negative. A bare
+# epistemic hedge ("to our knowledge") is NOT a frame and does not suppress.
+SCOPE_QUALIFIER_RE = re.compile(
+    r"\bclinical(?:ly)? (?:published|literature)\b"
+    r"|\bin (?:the )?(?:clinical|medical|radiolog\w+|surgical|nursing|imaging|oncolog\w+) (?:literature|domain|setting|field)\b"
+    r"|\bin radiology\b|\bin medicine\b|\bpeer-reviewed clinical\b"
+    r"|\b(?:within|among|across) (?:the )?(?:published )?\w+ (?:literature|studies)\b"
+    r"|\bto date in the \w+ literature\b",
+    re.IGNORECASE)
+
+
+def _region(text: str, heading_re) -> str:
+    spans = []
+    all_headings = [m.start() for m in re.finditer(r"^#{1,4}\s", text, re.MULTILINE)]
+    for m in heading_re.finditer(text):
+        s = m.end()
+        nxt = next((h for h in all_headings if h > s), len(text))
+        spans.append(text[s:nxt])
+    mt = re.search(r"^#{1,6}\s+(.+)$", text, re.MULTILINE)  # title
+    if mt:
+        spans.append(mt.group(1))
+    return "\n".join(spans) if spans else text
+
+
 def check(text: str) -> list[dict]:
     claims = []
     concl = conclusion_region(text)
+
+    # UNIVERSAL_NEGATIVE_UNSCOPED — a "nobody / first to / has not been" claim in a
+    # claim region with no named discipline-scope qualifier nearby. Minor: the fix is
+    # usually a one-word scope narrowing (or a wider, cross-discipline search).
+    region = _region(text, NOVELTY_REGION_HEADINGS)
+    seen: set[str] = set()
+    for m in UNIVERSAL_NEGATIVE_RE.finditer(region):
+        window = region[max(0, m.start() - 200):m.end() + 200]
+        if SCOPE_QUALIFIER_RE.search(window):
+            continue
+        key = re.sub(r"\s+", " ", m.group(0).lower())[:60]
+        if key in seen:
+            continue
+        seen.add(key)
+        claims.append({
+            "verdict": "UNIVERSAL_NEGATIVE_UNSCOPED",
+            "severity": "Minor",
+            "detail": (f"a universal-negative / first-to claim ('{m.group(0).strip()}') with no named "
+                       f"discipline-scope qualifier; a single-database search supports 'no *clinical* "
+                       f"paper does X', never 'nobody does X' — narrow the claim ('...in the clinical "
+                       f"literature') or widen the search to the venues where the subject lives"),
+            "where": region[max(0, m.start() - 30):m.end() + 40].replace("\n", " ").strip()[:160],
+        })
 
     if DESIGN_CROSS_SECTIONAL.search(text):
         # Fire only on a prognostic/surveillance token that is NOT inside a

--- a/skills/self-review/tests/fixtures/cohort_followup_criterion.md
+++ b/skills/self-review/tests/fixtures/cohort_followup_criterion.md
@@ -1,0 +1,2 @@
+The median follow-up was 102 days. Nodules were classified benign if they
+demonstrated size stability for at least 24 months.

--- a/skills/self-review/tests/fixtures/cohort_followup_ok.md
+++ b/skills/self-review/tests/fixtures/cohort_followup_ok.md
@@ -1,0 +1,3 @@
+The median follow-up was 102 days. Nodules were classified benign if they
+demonstrated size stability for at least 24 months. The total observation period
+was a median of 442 days (maximum 2,016 days).

--- a/skills/self-review/tests/fixtures/figcite_credit_bad.md
+++ b/skills/self-review/tests/fixtures/figcite_credit_bad.md
@@ -1,0 +1,9 @@
+## Figures
+**Figure 1.** Flow. **Figure 2.** ROC. **Figure 3.** Calibration.
+![Figure 1](f1.png) ![Figure 2](f2.png) ![Figure 3](f3.png)
+
+## Results
+Figure 1, Figure 2, and Figure 3 show the results.
+
+## Author Contributions
+Y.N.: prepared Figure 4 and drafted the manuscript. H.S.O.: Figure 1b.

--- a/skills/self-review/tests/fixtures/figcite_credit_ok.md
+++ b/skills/self-review/tests/fixtures/figcite_credit_ok.md
@@ -1,0 +1,9 @@
+## Figures
+**Figure 1.** Flow. **Figure 2.** ROC.
+![Figure 1](f1.png) ![Figure 2](f2.png)
+
+## Results
+Figure 1 and Figure 2 show the results.
+
+## Author Contributions
+Y.N.: Conceptualization, Visualization, Writing – original draft. H.S.O.: Visualization.

--- a/skills/self-review/tests/fixtures/scope_universal_negative.md
+++ b/skills/self-review/tests/fixtures/scope_universal_negative.md
@@ -1,0 +1,3 @@
+## Introduction
+No published system measures inter-agent error independence, and this is the first
+study to quantify it.

--- a/skills/self-review/tests/fixtures/scope_universal_negative_ok.md
+++ b/skills/self-review/tests/fixtures/scope_universal_negative_ok.md
@@ -1,0 +1,3 @@
+## Introduction
+To our knowledge, no clinically published system measures inter-agent error
+independence in the radiology literature.

--- a/skills/self-review/tests/test_cohort_arithmetic.sh
+++ b/skills/self-review/tests/test_cohort_arithmetic.sh
@@ -98,5 +98,19 @@ PPCLEAN="$HERE/fixtures/cohort_partition_prose_clean.md"
 python3 "$SCRIPT" --manuscript "$PPCLEAN" --strict --quiet >/dev/null 2>&1
 check "exit 0 on corrected + cross-tab + cue-less overlapping prose" test "$?" -eq 0
 
+# (10) FOLLOWUP_VS_CRITERION: reported "median follow-up 102 days" against a ">= 24
+#      months stability" criterion with no total-observation window -> Minor flag.
+FUC="$HERE/fixtures/cohort_followup_criterion.md"
+python3 "$SCRIPT" --manuscript "$FUC" --out "$OUT" --quiet >/dev/null 2>&1
+check "FOLLOWUP_VS_CRITERION when follow-up < a criterion duration" has_verdict FOLLOWUP_VS_CRITERION
+# (11) silent once the total-observation window is distinctly reported.
+FUOK="$HERE/fixtures/cohort_followup_ok.md"
+python3 "$SCRIPT" --manuscript "$FUOK" --out "$OUT" --quiet >/dev/null 2>&1
+check "no FOLLOWUP_VS_CRITERION when total observation window is reported" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='FOLLOWUP_VS_CRITERION' for c in d['claims']) else 1)
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_figure_citation.sh
+++ b/skills/self-review/tests/test_figure_citation.sh
@@ -51,5 +51,16 @@ EMB="$HERE/fixtures/figcite_embedded.md"
 python3 "$SCRIPT" --manuscript "$EMB" --require-embedded --strict --quiet >/dev/null 2>&1
 check "silent when figures are embedded (even --require-embedded)" test "$?" -eq 0
 
+# FIGURE_ATTR_STALE: Author Contributions attributes "Figure 4" but only 1-3 declared.
+CB="$HERE/fixtures/figcite_credit_bad.md"
+python3 "$SCRIPT" --manuscript "$CB" --out "$OUT" --quiet >/dev/null 2>&1
+check "FIGURE_ATTR_STALE on a CRediT attribution to a nonexistent figure" has_verdict FIGURE_ATTR_STALE
+python3 "$SCRIPT" --manuscript "$CB" --strict --quiet >/dev/null 2>&1
+check "stale figure attribution is Major (exit 1 under --strict)" test "$?" -eq 1
+# canonical CRediT roles (no figure numbers) -> silent
+CO="$HERE/fixtures/figcite_credit_ok.md"
+python3 "$SCRIPT" --manuscript "$CO" --strict --quiet >/dev/null 2>&1
+check "exit 0 when CRediT uses canonical roles (no figure numbers)" test "$?" -eq 0
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -97,5 +97,19 @@ assert not any(c['verdict']=='CROSS_SECTIONAL_PROGNOSTIC' for c in d['claims']),
 python3 "$SCRIPT" --manuscript "$APLIST" --strict --quiet >/dev/null 2>&1
 check "exit 0 on enumerated-defect list" test "$?" -eq 0
 
+# UNIVERSAL_NEGATIVE_UNSCOPED: a "no published system … first study to quantify"
+# claim with no named discipline-scope qualifier.
+UN="$HERE/fixtures/scope_universal_negative.md"
+python3 "$SCRIPT" --manuscript "$UN" --out "$OUT" --quiet >/dev/null 2>&1
+check "UNIVERSAL_NEGATIVE_UNSCOPED on an unscoped novelty claim" has_verdict UNIVERSAL_NEGATIVE_UNSCOPED
+# a discipline-scope qualifier ("clinically published … in the radiology literature") suppresses it
+UNOK="$HERE/fixtures/scope_universal_negative_ok.md"
+python3 "$SCRIPT" --manuscript "$UNOK" --out "$OUT" --quiet >/dev/null 2>&1
+check "no UNIVERSAL_NEGATIVE_UNSCOPED when a discipline-scope qualifier is present" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='UNIVERSAL_NEGATIVE_UNSCOPED' for c in d['claims']) else 1)
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/skills/write-paper/scripts/check_placeholders.py
+++ b/skills/write-paper/scripts/check_placeholders.py
@@ -73,6 +73,19 @@ BLOCKER_PATTERNS = [
     ("template_url", TEMPLATE_URL),
 ]
 
+# A placeholder marker whose value has not landed yet: [VERIFY…]/[CONFIRM…]/[TEAM…]/
+# [TBD…], or an in-prose "forthcoming / interim data / data not yet available".
+VERIFY_MARKER = re.compile(
+    r"\[(?:VERIFY|CONFIRM|TEAM|TBD|PENDING)\b[^\]]*\]"
+    r"|\b(?:forthcoming|interim data|data (?:are )?not yet available|pending (?:data|results))\b",
+    re.IGNORECASE)
+# A strength adjective/quantifier: a claim written at the strength the author HOPES
+# the not-yet-held data has. Checked only on a line that already carries a marker.
+STRENGTH_LEXICON = re.compile(
+    r"\b(?:near-unanim\w*|unanimous|near-universal|universal|all|every|none|consistently|"
+    r"invariably|overwhelming(?:ly)?|vast majority|uniformly|without exception|always|never)\b",
+    re.IGNORECASE)
+
 HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)\s*$")
 REFERENCES_TITLE_RE = re.compile(r"references|bibliography|works cited|reference list", re.IGNORECASE)
 FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
@@ -107,6 +120,20 @@ def scan(text: str) -> list[dict]:
                     "type": "bare_numeric_cite",
                     "line": lineno,
                     "text": m.group(0).strip()[:120],
+                    "severity": "warn",
+                })
+        # placeholder_strength_claim: a strength assertion on a line that also carries
+        # an unresolved [VERIFY]-family marker — the claim is written at the strength the
+        # author hopes the pending source has. Strip bracketed marker text first so a
+        # word INSIDE the marker ("[VERIFY: all figures]") does not trip it.
+        if VERIFY_MARKER.search(line):
+            prose = re.sub(r"\[[^\]]*\]", " ", line)
+            sm = STRENGTH_LEXICON.search(prose)
+            if sm:
+                findings.append({
+                    "type": "placeholder_strength_claim",
+                    "line": lineno,
+                    "text": sm.group(0).strip()[:120],
                     "severity": "warn",
                 })
     return findings

--- a/skills/write-paper/tests/test_placeholders.sh
+++ b/skills/write-paper/tests/test_placeholders.sh
@@ -98,6 +98,23 @@ run --manuscript "$WORK/warn.md" --quiet
 run --manuscript "$WORK/warn.md" --strict --quiet
 [ $? -eq 1 ] && ok "warn-only fails under --strict" || bad "warn-only should fail under --strict"
 
+# 4b. placeholder_strength_claim (warn): a strength assertion on a [VERIFY]-marked
+#     line; the hedged marked line and a bare code-fenced line stay silent.
+cat > "$WORK/strength.md" <<'EOF'
+# Results
+
+Faculty were near-unanimous that residents should read independently [VERIFY: numbers pending].
+
+Faculty reported concerns about premature reliance [VERIFY: exact figures pending].
+EOF
+run --manuscript "$WORK/strength.md" --out "$WORK/strength.json" --quiet
+python3 -c "
+import json,sys
+d=json.load(open('$WORK/strength.json'))
+t=[f['type'] for f in d['findings']]
+sys.exit(0 if t.count('placeholder_strength_claim')==1 else 1)
+" && ok "placeholder_strength_claim on the strength+marker line only" || bad "placeholder_strength_claim mis-detected"
+
 # 5. missing file -> exit 2
 run --manuscript "$WORK/nope.md" --quiet
 [ $? -eq 2 ] && ok "missing file exits 2" || bad "missing file should exit 2"


### PR DESCRIPTION
Batch 3 of the `review-harvest` promotion — **four verdicts on detectors that already run** (no new counted detector, count stays **68**). Selected by an 8-agent vetting pass (6 BUILD, 2 not-deterministic/single-project). The two *new* detectors from batch 3 (incorporation-bias, portal-residue) follow in separate PRs.

| Verdict | Detector | What it catches |
|---|---|---|
| `FOLLOWUP_VS_CRITERION` (Minor) | `check_cohort_arithmetic` | reported follow-up (102 d) shorter than the longest duration criterion in the outcome definition (≥24 mo), with no total-observation window labelled |
| `FIGURE_ATTR_STALE` (Major) + `AUTHOR_CONTRIB_FIGURE_REF` (Minor) | `check_figure_citation` | a CRediT/Author-Contributions attribution to a figure number that doesn't exist (stale after a figure reorg), scoped to that section only |
| `UNIVERSAL_NEGATIVE_UNSCOPED` (Minor) | `check_scope_coherence` | a "nobody / first to / has not been" novelty claim with no discipline-scope qualifier — a single-DB search can't support a universal negative |
| `placeholder_strength_claim` (warn) | `check_placeholders` | a strength assertion (near-unanimous / all / every / always) on a line carrying an unresolved `[VERIFY]` marker — the claim at the strength the author *hopes* the pending data has |

## Precision

Each ships the negatives that keep it quiet on good work: total-observation-window suppression; canonical CRediT roles (no figure numbers); a discipline-scope frame ("…in the radiology literature"); and hedged / no-marker / fenced lines for the placeholder check (with the marker text stripped before the strength scan so a word inside `[VERIFY: …]` doesn't trip it).

All four detector tests extended; full CI mirror green locally (validator, catalog consistency @ 68 unchanged, generators `--check`, reachability @ 134, envelopes @ 68, workflow-yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)