### PR TITLE
feat(meta-analysis): flag records that pass screening but never reach consensus

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2533,8 +2533,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 41311,
-      "sha256": "8b71f297fa222da87e91063d39b87ad777876c71985617a4897d291d8e5f0ab5"
+      "size": 40295,
+      "sha256": "647df27bae2875947c7c93c132254563d237a65afba65b2c6713dd715ea334af"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2608,8 +2608,8 @@
     },
     {
       "path": "skills/meta-analysis/references/phase3_screening_detail.md",
-      "size": 9132,
-      "sha256": "9fbd21fc09da3952f50aaa942e408262284951f98d6e4adb064b1e1df0244229"
+      "size": 11123,
+      "sha256": "c1d5f06b86b5913312b08944517f1a99ca873d2bc65b4b35799059605aa3bff7"
     },
     {
       "path": "skills/meta-analysis/references/phase4_extraction_detail.md",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2533,8 +2533,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 40001,
-      "sha256": "06cb68d854782c59835399089f41ab184fb8b00900546d0e6e6a44d3e7d9f0bb"
+      "size": 41311,
+      "sha256": "8b71f297fa222da87e91063d39b87ad777876c71985617a4897d291d8e5f0ab5"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2708,8 +2708,8 @@
     },
     {
       "path": "skills/meta-analysis/scripts/screening_reconcile.py",
-      "size": 6044,
-      "sha256": "5b41128726cfc9641cecfa35ef1845abb8548737e6ca7b741825dfdf62ce4040"
+      "size": 8016,
+      "sha256": "2aab4ab04b52ede252c1786bf9f7d291f26eb0f1f8d3d666ed950663296885df"
     },
     {
       "path": "skills/meta-analysis/skill.yml",

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -186,13 +186,30 @@ python "${CLAUDE_SKILL_DIR}/scripts/screening_reconcile.py" \
 ```
 
 Downstream stages consume `screening_consensus.json` for counts and ID sets; the Markdown consensus
-document remains the human explanation. Two hard rules:
+document remains the human explanation. Three hard rules:
 
 1. **List the narrative-only IDs explicitly.** The highest-yield red flag is a numeric claim ("10
    narrative-only studies") that does not match the enumerable set `(A ∪ C) \ B \ T`.
 2. **No "N → M" transition without ID receipts.** "k rose from 30 to 32 after FLAG consensus" must
    cite the added/removed IDs. A transition claim with no enumerable ID set is a **P0** and blocks
    the Phase 5 hand-off.
+3. **`STAGE_TRANSFER_LOSS` is a P0.** The script exits 1 when a record is *included at screening*
+   but **absent from the consensus artifact altogether** — neither included nor excluded, so no
+   adjudication was ever recorded. Restore those records to the consensus stage, or record an
+   explicit exclusion decision for each.
+
+   Why this needs its own verdict: consensus-*excluded* and consensus-*absent* both leave the id
+   out of set `B`, so both flow into `qualitative` and then into `narrative_only`. A
+   diagnostic-accuracy review legitimately has narrative-only studies (eligible, no extractable
+   2x2), so a lost record parked there is invisible — and the totals still reconcile, because they
+   were recomputed from the downstream artifact. The output therefore splits `narrative_only` into
+   `narrative_only_adjudicated` (a decision exists) and `narrative_only_unadjudicated` (none does);
+   only the first is a legitimate category.
+
+   Precedent: a review reached journal submission with 15 studies and was withdrawn when 5 eligible
+   studies were found **inside its own retrieved records**. One had passed both screening passes and
+   was never entered into the consensus stage. A pre-specified sensitivity analysis flipped from
+   P = 0.064 to P = 0.033 once the pool was corrected.
 
 The set algebra, the reconciliation-table template, and the precedent (a manuscript shipped 32/10/46
 where the ID sets said 24/2/54, with four artifacts echoing the same unreconciled prose total) are

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -193,23 +193,9 @@ document remains the human explanation. Three hard rules:
 2. **No "N → M" transition without ID receipts.** "k rose from 30 to 32 after FLAG consensus" must
    cite the added/removed IDs. A transition claim with no enumerable ID set is a **P0** and blocks
    the Phase 5 hand-off.
-3. **`STAGE_TRANSFER_LOSS` is a P0.** The script exits 1 when a record is *included at screening*
-   but **absent from the consensus artifact altogether** — neither included nor excluded, so no
-   adjudication was ever recorded. Restore those records to the consensus stage, or record an
-   explicit exclusion decision for each.
-
-   Why this needs its own verdict: consensus-*excluded* and consensus-*absent* both leave the id
-   out of set `B`, so both flow into `qualitative` and then into `narrative_only`. A
-   diagnostic-accuracy review legitimately has narrative-only studies (eligible, no extractable
-   2x2), so a lost record parked there is invisible — and the totals still reconcile, because they
-   were recomputed from the downstream artifact. The output therefore splits `narrative_only` into
-   `narrative_only_adjudicated` (a decision exists) and `narrative_only_unadjudicated` (none does);
-   only the first is a legitimate category.
-
-   Precedent: a review reached journal submission with 15 studies and was withdrawn when 5 eligible
-   studies were found **inside its own retrieved records**. One had passed both screening passes and
-   was never entered into the consensus stage. A pre-specified sensitivity analysis flipped from
-   P = 0.064 to P = 0.033 once the pool was corrected.
+3. **`STAGE_TRANSFER_LOSS` is a P0.** Exit 1 when a record is included at screening but **absent
+   from the consensus artifact altogether** — no adjudication was ever recorded. An exclusion is a
+   decision; silence is a gap. Never let it settle into narrative-only (why: reference file).
 
 The set algebra, the reconciliation-table template, and the precedent (a manuscript shipped 32/10/46
 where the ID sets said 24/2/54, with four artifacts echoing the same unreconciled prose total) are

--- a/skills/meta-analysis/references/phase3_screening_detail.md
+++ b/skills/meta-analysis/references/phase3_screening_detail.md
@@ -94,6 +94,36 @@ ID sets. The Markdown consensus document remains the human explanation.
 
 **Precedent incident (a PRISMA-DTA meta-analysis revision):** a late-revision manuscript shipped with k_qualitative = 32 / k_narrative-only = 10 / k_FT-excluded = 46. ID-set reconciliation (performed only after an adversarial audit at post-Stage 4 QC) revealed true counts 24/2/54. An early-draft prose total ("30 → 32 after FLAG consensus") had been carried forward without ever being reconciled against the screening TSV intersected with the consensus spreadsheet; four downstream artifacts echoed the same wrong total. This gate would have caught the drift at the Phase 5 hand-off.
 
+##### Why `STAGE_TRANSFER_LOSS` needs its own verdict
+
+The set algebra above reconciles *counts*. On its own it does not distinguish the two ways an id
+can be missing from set `B`:
+
+| Case | Meaning | Where it lands |
+|---|---|---|
+| consensus says **exclude** | a decision was made and recorded | out of `qualitative` — correct |
+| consensus **has no row at all** | the record fell out of the pipeline; nobody adjudicated it | into `qualitative`, then `narrative_only` — **wrong, and silent** |
+
+Both leave the id out of `B`, so both look identical to a count-based check. And because a
+diagnostic-accuracy review legitimately contains narrative-only studies (eligible, but no
+extractable 2×2), a lost record parked in that set is indistinguishable from a real one. The
+totals still reconcile — they were recomputed from the downstream artifact, which is exactly
+where the record is already absent.
+
+`screening_reconcile.py` therefore reports `stage_transfer_loss` (= `screening_include` −
+`consensus_ids`) as a blocking issue, and splits `narrative_only` into `_adjudicated` (a decision
+exists) and `_unadjudicated` (none does). Only the first is a legitimate category.
+
+**Precedent incident (a single-arm intervention review):** the review reached journal submission
+with 15 studies and was withdrawn by the authors when 5 eligible studies were found **inside its
+own retrieved records** — none were search failures. One had passed both title/abstract screening
+passes and was never entered into the consensus stage; three others sat under an exclusion code
+that contradicted the registered eligibility criteria (single-arm case series were eligible by
+protocol but were coded "not comparative"). A pre-specified sensitivity analysis flipped from
+P = 0.064 to P = 0.033 once the pool was corrected to 18 studies. Note the shape: every count in
+the submitted manuscript reconciled, because each had been recomputed from an artifact the lost
+studies had already dropped out of.
+
 #### 3f.5 Pool composition lock (MANDATORY at adjudication freeze)
 
 After Phase 3f reconciliation passes, freeze the pool composition into a

--- a/skills/meta-analysis/scripts/screening_reconcile.py
+++ b/skills/meta-analysis/scripts/screening_reconcile.py
@@ -115,8 +115,21 @@ def main() -> int:
     bivariate = table1_ids
     narrative_only = qualitative - bivariate
 
+    # A record that passed screening and was EXCLUDED at consensus carries a decision.
+    # A record that passed screening and is ABSENT from the consensus artifact carries
+    # none -- it fell out of the pipeline. Both leave `consensus_exclude` empty for that
+    # id, so without this split the second case flows into `qualitative` and then into
+    # `narrative_only`, where it is indistinguishable from a study legitimately lacking
+    # extractable data. That is how an eligible study is lost silently.
+    if args.consensus:
+        stage_transfer_loss = screening_include - consensus_ids
+    else:
+        stage_transfer_loss = set()
+    narrative_only_unadjudicated = narrative_only & stage_transfer_loss
+    narrative_only_adjudicated = narrative_only - stage_transfer_loss
+
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "sources": {
             "screening": str(screening_path),
             "consensus": args.consensus,
@@ -129,6 +142,9 @@ def main() -> int:
             "qualitative": sorted(qualitative, key=lambda x: (len(x), x)),
             "bivariate": sorted(bivariate, key=lambda x: (len(x), x)),
             "narrative_only": sorted(narrative_only, key=lambda x: (len(x), x)),
+            "narrative_only_adjudicated": sorted(narrative_only_adjudicated, key=lambda x: (len(x), x)),
+            "narrative_only_unadjudicated": sorted(narrative_only_unadjudicated, key=lambda x: (len(x), x)),
+            "stage_transfer_loss": sorted(stage_transfer_loss, key=lambda x: (len(x), x)),
         },
         "totals": {
             "k_screening_include": len(screening_include),
@@ -137,6 +153,9 @@ def main() -> int:
             "k_qualitative": len(qualitative),
             "k_bivariate": len(bivariate),
             "k_narrative_only": len(narrative_only),
+            "k_narrative_only_adjudicated": len(narrative_only_adjudicated),
+            "k_narrative_only_unadjudicated": len(narrative_only_unadjudicated),
+            "k_stage_transfer_loss": len(stage_transfer_loss),
         },
         "blocking_issues": [],
     }
@@ -146,6 +165,20 @@ def main() -> int:
             {
                 "code": "TABLE1_NOT_IN_QUALITATIVE",
                 "ids": sorted(bivariate - qualitative, key=lambda x: (len(x), x)),
+            }
+        )
+
+    if stage_transfer_loss:
+        payload["blocking_issues"].append(
+            {
+                "code": "STAGE_TRANSFER_LOSS",
+                "ids": sorted(stage_transfer_loss, key=lambda x: (len(x), x)),
+                "detail": (
+                    "Included at screening but absent from the consensus artifact -- neither "
+                    "included nor excluded, so no adjudication is recorded. Either restore these "
+                    "records to the consensus stage, or record an explicit exclusion decision for "
+                    "each. Do not leave them to flow into the narrative-only set."
+                ),
             }
         )
 

--- a/skills/meta-analysis/tests/test_screening_reconcile.sh
+++ b/skills/meta-analysis/tests/test_screening_reconcile.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression test for screening_reconcile.py STAGE_TRANSFER_LOSS.
+#
+# The positive fixture reproduces the defect this check exists to stop: a record that
+# passed title/abstract screening, was never entered into the consensus stage, and is
+# absent from Table 1. Before the check existed, that record flowed into `qualitative`
+# and then into `narrative_only` -- where it is indistinguishable from a study that is
+# legitimately narrative-only -- and the script exited 0.
+#
+# The negative fixture is the case that must NOT fire: a genuine narrative-only study
+# (adjudicated at consensus as an include, simply lacking extractable 2x2 data). A
+# diagnostic-accuracy review normally has one or two of these, so a check that flags
+# them is useless.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECONCILE="${SCRIPT_DIR}/../scripts/screening_reconcile.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------- positive
+# id 99: include at screening, absent from consensus entirely, absent from Table 1.
+printf 'id\tdecision\n1\tinclude\n2\tinclude\n99\tinclude\n3\texclude\n' > "$TMP/screening.tsv"
+printf 'id\tdecision\n1\tinclude\n2\tinclude\n3\texclude\n'             > "$TMP/consensus.tsv"
+printf 'id\n1\n2\n'                                                     > "$TMP/table1.csv"
+
+set +e
+python3 "$RECONCILE" --screening "$TMP/screening.tsv" --consensus "$TMP/consensus.tsv" \
+  --table1 "$TMP/table1.csv" --output "$TMP/pos.json" > /dev/null
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "positive fixture: expected exit 1, got $rc"
+
+python3 - "$TMP/pos.json" <<'PY' || fail "positive fixture: STAGE_TRANSFER_LOSS not reported for id 99"
+import json, sys
+d = json.load(open(sys.argv[1]))
+codes = {i["code"] for i in d["blocking_issues"]}
+assert "STAGE_TRANSFER_LOSS" in codes, codes
+ids = [i["ids"] for i in d["blocking_issues"] if i["code"] == "STAGE_TRANSFER_LOSS"][0]
+assert ids == ["1", "2", "99"][2:], ids
+assert d["totals"]["k_stage_transfer_loss"] == 1
+assert d["sets"]["narrative_only_unadjudicated"] == ["99"]
+assert d["sets"]["narrative_only_adjudicated"] == []
+PY
+
+# ---------------------------------------------------------------- negative
+# id 7: adjudicated as an include at consensus, but has no extractable 2x2 -> it is
+# legitimately narrative-only. Must not fire.
+printf 'id\tdecision\n1\tinclude\n2\tinclude\n7\tinclude\n3\texclude\n' > "$TMP/screening_n.tsv"
+printf 'id\tdecision\n1\tinclude\n2\tinclude\n7\tinclude\n3\texclude\n' > "$TMP/consensus_n.tsv"
+printf 'id\n1\n2\n'                                                     > "$TMP/table1_n.csv"
+
+set +e
+python3 "$RECONCILE" --screening "$TMP/screening_n.tsv" --consensus "$TMP/consensus_n.tsv" \
+  --table1 "$TMP/table1_n.csv" --output "$TMP/neg.json" > /dev/null
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "negative fixture: expected exit 0, got $rc (false positive)"
+
+python3 - "$TMP/neg.json" <<'PY' || fail "negative fixture: genuine narrative-only misclassified"
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["blocking_issues"] == [], d["blocking_issues"]
+assert d["totals"]["k_stage_transfer_loss"] == 0
+assert d["sets"]["narrative_only"] == ["7"]
+assert d["sets"]["narrative_only_adjudicated"] == ["7"]
+assert d["sets"]["narrative_only_unadjudicated"] == []
+PY
+
+# ------------------------------------------------- negative: no consensus supplied
+# With no consensus artifact there is nothing to reconcile against; the check must
+# stay silent rather than flag every screened include.
+set +e
+python3 "$RECONCILE" --screening "$TMP/screening.tsv" --output "$TMP/noc.json" > /dev/null
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "no-consensus fixture: expected exit 0, got $rc"
+python3 - "$TMP/noc.json" <<'PY' || fail "no-consensus fixture: fired without a consensus artifact"
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["totals"]["k_stage_transfer_loss"] == 0
+assert d["blocking_issues"] == []
+PY
+
+echo "PASS: test_screening_reconcile.sh (positive + 2 negatives)"


### PR DESCRIPTION
## The gap

`screening_reconcile.py` gated one direction only. `TABLE1_NOT_IN_QUALITATIVE` catches a study **entering** Table 1 from outside the pipeline. Nothing caught the opposite, and more damaging, case: a study that passed screening and then **fell out** of it.

Consensus-*excluded* and consensus-*absent* both leave an id out of set `B`, so both flow into `qualitative` and then into `narrative_only`. Because a diagnostic-accuracy review legitimately has narrative-only studies (eligible, no extractable 2×2), a lost record parked there is indistinguishable from a real one — and the totals still reconcile, because they were recomputed from the downstream artifact.

Demonstrated against the shipped script before the change — a record included at screening, absent from consensus, absent from Table 1:

```
k_narrative_only: 1
blocking_issues: []
EXIT=0
```

The study is gone and the gate is green.

The set needed for the check was already being computed and thrown away: `consensus_ids` was assigned at line 99 and never referenced.

## The change

- **`STAGE_TRANSFER_LOSS`** (P0, exit 1) — ids included at screening but **absent from the consensus artifact altogether**: neither included nor excluded, so no adjudication was ever recorded. An explicit exclusion decision is a decision; silence is a gap.
- **`narrative_only` split** into `narrative_only_adjudicated` / `narrative_only_unadjudicated`, so a legitimate narrative-only study is distinguishable from a lost one in the output itself.
- `schema_version` 1 → 2. Existing keys are unchanged and additive-only, so consumers reading `totals`/`sets` keep working.
- SKILL.md 3f gains a third hard rule explaining why this needs its own verdict.

## Test

`tests/test_screening_reconcile.sh` — the positive fixture reproduces the real defect rather than a synthetic positive, and **fails against the pre-fix script** (`FAIL: positive fixture: expected exit 1, got 0`). Two negatives guard precision: a genuine adjudicated narrative-only study, and the no-consensus-artifact case (nothing to reconcile against → must stay silent).

## Grounding

A systematic review reached journal submission with 15 studies and was withdrawn when 5 eligible studies were found **inside its own retrieved records** — none were search failures. One had passed both screening passes and was simply never entered into the consensus stage. A pre-specified sensitivity analysis flipped from P = 0.064 to P = 0.033 once the pool was corrected.

Four sibling reviews were then audited with the same set-comparison method; all four were clean, which is the negative evidence that this check is narrow rather than noisy.

## Checks

`gen_distribution_manifest --check`, `gen_skill_docs --check`, `gen_detectors_catalog_json --check`, `validate_catalog_consistency`, `validate_skills.sh`, and both `skills/meta-analysis/tests/*.sh` pass locally. No new `check_*` detector, so detector counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
