### PR TITLE
fix(self-review): read panel-suffixed figure citations so multi-panel figures aren't false orphans

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -468,6 +468,9 @@ jobs:
       - name: Run self-review DTA-denominator challenge (sens/spec vs reference-standard)
         run: bash skills/self-review/scripts/check_dta_denominators_challenge/verify.sh
 
+      - name: "Run self-review figure-citation panel-suffix challenge (Figure 3a cites Figure 3 -> no orphan; uncited -> orphan)"
+        run: bash skills/self-review/scripts/check_figure_citation_challenge/verify.sh
+
       - name: Run self-review paired-difference-estimator challenge (median parity / degenerate CI)
         run: bash skills/self-review/scripts/check_paired_difference_estimator_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/self-review` `check_figure_citation` — a multi-panel citation is no longer a false
+  `FIGURE_ORPHAN`.** The in-text mention regex ended in `(?P<num>\d+)\b`, and there is no
+  word boundary between "3" and "a", so `(Figure 3a)` / `(Figure 3b)` — the *only* way
+  multi-panel figures are ever cited — matched nothing. Figure 3 then looked uncited and
+  `FIGURE_ORPHAN` fired on essentially every manuscript with a multi-panel figure. The
+  citation regex now allows an optional single-letter panel suffix (`Figure 3a` cites
+  Figure 3); the caption anchor (`Figure 3.` names the whole float) is unchanged, so the
+  caption↔citation correspondence the gate relies on is preserved, and a genuinely
+  uncited figure still fires. Ships a regression challenge card that **fails on the old
+  regex and passes on the new** (a decontaminated fixture — the first attempt hid the bug
+  because the image alt-text contained "figure 1"). Grounding: real-failure (co-author
+  review of a multi-panel manuscript). Detector count unchanged.
+
 ### Added
 
 - **`/sync-submission` — `check_portal_field_residue` (detector 72 → 73): markdown that pastes into

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -43,6 +43,7 @@
 - `bash scripts/check_paired_difference_estimator_challenge/verify.sh  # median parity / degenerate CI / unnamed estimator`
 - `bash scripts/check_effect_stability_challenge/verify.sh  # CI upper/lower ratio > 10x + events-per-variable < 10`
 - `bash scripts/check_incorporation_bias_challenge/verify.sh  # trajectory reference standard + trajectory predictor`
+- `bash scripts/check_figure_citation_challenge/verify.sh  # panel-suffixed citation (Figure 3a) regression + real orphan`
 - `feed R0-numbered output into /revise`
 
 **Evidence** — `demo`
@@ -75,6 +76,7 @@
 - `check_effect_stability_challenge/` (6 files)
 - `check_emphasis_density.py`
 - `check_figure_citation.py`
+- `check_figure_citation_challenge/` (4 files)
 - `check_incorporation_bias.py`
 - `check_incorporation_bias_challenge/` (6 files)
 - `check_nested_group_comparison.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4278,8 +4278,28 @@
     },
     {
       "path": "skills/self-review/scripts/check_figure_citation.py",
-      "size": 10635,
-      "sha256": "087ee531a5d1b8e2ebd2630d1c5180dfbacfec46299d262100ad19f0ba4fa32c"
+      "size": 11137,
+      "sha256": "92847a5ca4faf32b94bceaf4369a6a9ca4c83a5aaa503606dd7b581c0770e093"
+    },
+    {
+      "path": "skills/self-review/scripts/check_figure_citation_challenge/fixture/panel_regression.md",
+      "size": 453,
+      "sha256": "109bc12356c32f5a450d73904e93821f6d9c13ecc273c70b4fe2bb779f3785bc"
+    },
+    {
+      "path": "skills/self-review/scripts/check_figure_citation_challenge/fixture/real_orphan.md",
+      "size": 329,
+      "sha256": "6eecd9632607f0d630de7ee0bd7cc8ede546477c536e529b20f0214699cdaeb1"
+    },
+    {
+      "path": "skills/self-review/scripts/check_figure_citation_challenge/problem.md",
+      "size": 1409,
+      "sha256": "d636aa1f488b0c1f794e935b96725c5f23e9f8897ca4eacca2eacaebe7bb7997"
+    },
+    {
+      "path": "skills/self-review/scripts/check_figure_citation_challenge/verify.sh",
+      "size": 1605,
+      "sha256": "227f668d5583bbe96e2281284bf42e99a6903daecbe40f53a3b459856cde6434"
     },
     {
       "path": "skills/self-review/scripts/check_incorporation_bias.py",
@@ -4498,8 +4518,8 @@
     },
     {
       "path": "skills/self-review/skill.yml",
-      "size": 3517,
-      "sha256": "bfde47be6ba4e4298f7ac99734f2427a9a329368db74bcbb5007d8cb3ce07ab5"
+      "size": 3642,
+      "sha256": "eb25be632ab8dfd5c7a77625f0bf562f8a84ea870584c170c44c008dd8d47d13"
     },
     {
       "path": "skills/setup-medsci/SKILL.md",

--- a/skills/self-review/scripts/check_figure_citation.py
+++ b/skills/self-review/scripts/check_figure_citation.py
@@ -45,8 +45,14 @@ from pathlib import Path
 
 # A caption/legend line: (optional **) Figure|Table N (.|:) ...
 CAPTION_RE = re.compile(r"^\s*\*{0,2}\s*(?P<kind>Figure|Fig\.?|Table)\s+(?P<num>\d+)\s*[.:]", re.I)
-# Any in-text mention: Figure N / Fig N / Fig. N / Table N (+ "Figures 1 and 2" heads)
-MENTION_RE = re.compile(r"\b(?P<kind>Figures?|Figs?\.?|Tables?)\s+(?P<num>\d+)\b", re.I)
+# Any in-text mention: Figure N / Fig N / Fig. N / Table N (+ "Figures 1 and 2" heads),
+# with an OPTIONAL single-letter panel suffix so "Figure 3a" / "(Figure 3b)" registers
+# as citing Figure 3 (multi-panel figures are cited only by panel, and without this the
+# num-then-\b never matched "3a"). Panels never appear in CAPTION_RE ("Figure 3." names
+# the whole float), so caption<->citation correspondence is preserved; the trailing \b
+# after the optional letter keeps "Figure 3rd" / "3mg" from matching (no boundary
+# between the letter and a following word char).
+MENTION_RE = re.compile(r"\b(?P<kind>Figures?|Figs?\.?|Tables?)\s+(?P<num>\d+)(?P<panel>[a-zA-Z])?\b", re.I)
 # A markdown image embed: ![alt](path). Its presence is how a figure reaches the
 # rendered output; a manuscript with figure captions but zero image links ships
 # with every legend and no picture.

--- a/skills/self-review/scripts/check_figure_citation_challenge/fixture/panel_regression.md
+++ b/skills/self-review/scripts/check_figure_citation_challenge/fixture/panel_regression.md
@@ -1,0 +1,15 @@
+# Multi-panel citation regression
+
+The lesion appears in (Figure 1a) and the control in (Figure 1b). Figure 2c shows the
+overlay, and Table 1 lists the cohort.
+
+![lesion and control panels](figures/fig1.png)
+![overlay panels](figures/fig2.png)
+
+## Figure legends
+
+**Figure 1.** Multi-panel figure: (a) lesion, (b) control.
+
+**Figure 2.** Overlay panels: (a) baseline, (b) follow-up, (c) difference.
+
+**Table 1.** Baseline characteristics of the cohort.

--- a/skills/self-review/scripts/check_figure_citation_challenge/fixture/real_orphan.md
+++ b/skills/self-review/scripts/check_figure_citation_challenge/fixture/real_orphan.md
@@ -1,0 +1,13 @@
+# Orphan detection still works
+
+We reference (Figure 1a) in the text; Table 1 summarizes the results.
+
+![panels of the primary lesion](figures/fig1.png)
+
+## Figure legends
+
+**Figure 1.** Panels (a) and (b).
+
+**Figure 2.** This figure has a caption but is never cited anywhere in the body.
+
+**Table 1.** Baseline characteristics.

--- a/skills/self-review/scripts/check_figure_citation_challenge/problem.md
+++ b/skills/self-review/scripts/check_figure_citation_challenge/problem.md
@@ -1,0 +1,28 @@
+# Challenge — figure-citation gate must read panel-suffixed citations
+
+## The defect this fixes
+
+Multi-panel figures are cited in the body only by panel — `(Figure 3a)`, `(Figure 3b)`
+— never as a bare "Figure 3". The orphan gate's mention regex ended in
+`(?P<num>\d+)\b`, and there is **no word boundary between "3" and "a"**, so "Figure 3a"
+matched nothing. Figure 3 therefore looked uncited and `FIGURE_ORPHAN` fired — a false
+positive on every manuscript that uses multi-panel figures.
+
+The fix allows an optional single-letter panel suffix in the *citation* regex only; the
+caption anchor (`Figure 3.` names the whole float) is unchanged, so the caption↔citation
+correspondence the gate depends on is preserved.
+
+## Fixtures
+
+- **`panel_regression.md`** (regression / negative): Figure 1 is cited only as
+  `(Figure 1a)` / `(Figure 1b)`, Figure 2 only as `Figure 2c`, the table is cited, and
+  both images are embedded. Post-fix this is **clean (zero claims)**; pre-fix Figures 1
+  and 2 both fired `FIGURE_ORPHAN`.
+- **`real_orphan.md`** (positive): Figure 1 is cited (`Figure 1a`) but Figure 2 has a
+  caption and is **never cited in any form** → `FIGURE_ORPHAN` for Figure 2 only. Proves
+  the fix did not blind the gate to genuine orphans.
+
+## Verify
+
+`bash verify.sh` — deterministic, network-free. Asserts the panel-cited manuscript is
+clean and the truly-uncited figure still fires.

--- a/skills/self-review/scripts/check_figure_citation_challenge/verify.sh
+++ b/skills/self-review/scripts/check_figure_citation_challenge/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the figure-citation panel-suffix regression.
+#   Regression: figures cited ONLY by panel (Figure 1a / 2c) must NOT be orphans -> clean.
+#   Positive:   a figure with a caption and no citation in any form -> FIGURE_ORPHAN.
+# No network. Exit 0 = both match expectations.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DET="$HERE/../check_figure_citation.py"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# --- Regression: panel-cited figures are NOT orphans, and nothing else fires ---
+python3 "$DET" --manuscript "$HERE/fixture/panel_regression.md" --quiet --out "$tmp/reg.json"
+n=$(python3 -c "import json;print(len(json.load(open('$tmp/reg.json'))['claims']))")
+if [ "$n" -ne 0 ]; then
+  echo "FAIL: panel-cited manuscript should be clean, got $n claim(s) (the false positive this fixes)" >&2
+  cat "$tmp/reg.json" >&2
+  exit 1
+fi
+
+# --- Positive: a genuinely uncited figure still fires; a panel-cited one does not ---
+python3 "$DET" --manuscript "$HERE/fixture/real_orphan.md" --quiet --out "$tmp/orph.json"
+python3 - "$tmp/orph.json" <<'PY'
+import json, sys
+orph = [c for c in json.load(open(sys.argv[1]))["claims"] if c["verdict"] == "FIGURE_ORPHAN"]
+assert any("Figure 2 " in c["detail"] for c in orph), "Figure 2 (never cited) should be FIGURE_ORPHAN"
+assert not any("Figure 1 " in c["detail"] for c in orph), "Figure 1 (cited via 1a) must NOT be an orphan"
+print("orphan detection intact: Figure 2 flagged, Figure 1 (panel-cited) not")
+PY
+
+echo "PASS: panel-cited figures are not orphans (regression); a truly uncited figure still fires."

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -63,5 +63,6 @@ validation_commands:
   - "bash scripts/check_paired_difference_estimator_challenge/verify.sh  # median parity / degenerate CI / unnamed estimator"
   - "bash scripts/check_effect_stability_challenge/verify.sh  # CI upper/lower ratio > 10x + events-per-variable < 10"
   - "bash scripts/check_incorporation_bias_challenge/verify.sh  # trajectory reference standard + trajectory predictor"
+  - "bash scripts/check_figure_citation_challenge/verify.sh  # panel-suffixed citation (Figure 3a) regression + real orphan"
   - "feed R0-numbered output into /revise"
 evidence_surface: demo


### PR DESCRIPTION
## The bug

`check_figure_citation`'s in-text mention regex ended in `(?P<num>\d+)\b`. There is **no word boundary between "3" and "a"**, so `(Figure 3a)` / `(Figure 3b)` — the *only* way a multi-panel figure is ever cited in running text — matched nothing. Figure 3 then looked uncited and `FIGURE_ORPHAN` fired. On any manuscript that uses multi-panel figures (common), this is a systematic false positive. Grounding: real-failure (co-author review of a multi-panel manuscript).

## The fix

One line: the **citation** regex now allows an optional single-letter panel suffix, so `Figure 3a` registers as citing Figure 3:

```
(?P<num>\d+)\b   →   (?P<num>\d+)(?P<panel>[a-zA-Z])?\b
```

The **caption** anchor (`Figure 3.` names the whole float) is deliberately unchanged, so the caption↔citation correspondence the gate depends on is preserved. The trailing `\b` after the optional letter keeps `Figure 3rd` / `3mg` from matching. A genuinely uncited figure still fires.

## Verification — the challenge FAILS on the old regex

Ships `check_figure_citation_challenge/` (wired into CI + `skill.yml`):
- **`panel_regression.md`** — figures cited only by panel (`Figure 1a`, `Figure 2c`) → **clean**; on the old regex both fired `FIGURE_ORPHAN`.
- **`real_orphan.md`** — a captioned figure never cited in any form → `FIGURE_ORPHAN` (detection intact).

The regression was validated by reverting the regex and confirming the card **fails** (2 false orphans), then passes with the fix. The first fixture attempt *hid* the bug because an image alt-text read `![figure 1 ...]` — a "figure 1" the buggy regex counted as a citation — so the alt-text was decontaminated. Detector count unchanged (73).

Full `validate.yml` mirror via `scripts/run_ci_mirror.sh`: **171/171 gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)