### PR TITLE
fix(self-review): recognise reader-study statistics vocabulary in check_panel_diversity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixed
 
+- **`/self-review` `check_panel_diversity` — a statistics-dedicated reviewer no longer
+  reads as a missing `statistics` axis.** `UNCOVERED_AXIS` (Major) fires when a research
+  type's expected axis has zero major findings assigned to it, and the family classifier's
+  `statistics` lexicon was meta-analysis-flavoured (heterogeneity, pooling, I², DeLong). A
+  reader/agreement study's statistical majors — inter-rater **kappa**, **bootstrap**
+  resampling, **permutation** tests, **Bonferroni**/FDR, **odds ratio**, **intraclass
+  correlation** — matched none of it, classified as `other`, and left the statistics axis
+  looking uncovered, so the gate raised an unfounded Major on a panel that in fact covered
+  statistics thoroughly. The lexicon now includes the type-agnostic statistical vocabulary
+  (effect measures, resampling, agreement, multiplicity siblings, common tests, Bayesian).
+  A regression case in `test_panel_diversity.sh` (a stats reviewer using only the
+  previously-unmatched vocabulary) **fails on the old lexicon and passes on the new** — the
+  fixture was twice decontaminated of terms the old lexicon already matched (a heading
+  "Multiplicity", a comment "confidence interval") that masked the defect. Grounding:
+  real-failure. Detector count unchanged.
+
 - **`/self-review` `check_figure_citation` — a multi-panel citation is no longer a false
   `FIGURE_ORPHAN`.** The in-text mention regex ended in `(?P<num>\d+)\b`, and there is no
   word boundary between "3" and "a", so `(Figure 3a)` / `(Figure 3b)` — the *only* way

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4423,8 +4423,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_panel_diversity.py",
-      "size": 15365,
-      "sha256": "320f18504847ed33b1cb0a2913579e532cfec8b82aa6af9cf6877d2f80e0b519"
+      "size": 16274,
+      "sha256": "6a2c964bbf8afd42ded4ccd6773d7a208b397bc3661cfabcdd58db8e47384640"
     },
     {
       "path": "skills/self-review/scripts/check_paren_spans.py",

--- a/skills/self-review/scripts/check_panel_diversity.py
+++ b/skills/self-review/scripts/check_panel_diversity.py
@@ -90,7 +90,19 @@ FAMILY_LEXICON: list[tuple[str, re.Pattern]] = [
         r"\bci\b|heterogeneit|\bi2\b|i\^?2|pooling|pooled|random[-\s]?effects|"
         r"multiplicit|multiple compar|\bp[-\s]?value|\bpower\b|sample size|"
         r"model specif|proportional hazard|missing data|imputation|competing risk|"
-        r"events per variable|overfitting|effect size|subdistribution", re.IGNORECASE)),
+        r"events per variable|overfitting|effect size|subdistribution|"
+        # Type-agnostic statistical vocabulary a reader / agreement study raises but the
+        # meta-analysis-flavoured list above missed — effect measures, resampling,
+        # inter-rater agreement, multiplicity siblings, common tests, Bayesian. Without
+        # these a statistics-dedicated reviewer's majors classified as "other" and the
+        # statistics axis looked uncovered (false UNCOVERED_AXIS Major).
+        r"odds ratio|hazard ratio|risk ratio|relative risk|rate ratio|"
+        r"bootstrap|permutation|jackknife|monte[-\s]?carlo|"
+        r"\bkappa\b|κ|inter[-\s]?rater|intraclass|\bicc\b|\bac1\b|concordance|"
+        r"bonferroni|false discovery|\bfdr\b|\bholm\b|family[-\s]?wise|"
+        r"wilcoxon|mann[-\s]?whitney|mcnemar|log[-\s]?rank|chi[-\s]?squared?|fisher'?s? exact|"
+        r"bayesian|credible interval|posterior distribution|standard deviation|standard error",
+        re.IGNORECASE)),
     ("clinical", re.compile(
         r"clinical|actionab|guideline|management|generali[sz]ab|applicab|"
         r"external validit|patient[-\s]?care|over(?:reach|claim)|"

--- a/skills/self-review/tests/fixtures/panel_stats_lens.json
+++ b/skills/self-review/tests/fixtures/panel_stats_lens.json
@@ -1,0 +1,31 @@
+{
+  "research_type": "sr_ma",
+  "reviewers": [
+    {
+      "reviewer_id": "R1",
+      "expertise_area": "Methodology (search/screening/PRISMA)",
+      "major": [
+        {"heading": "Search strategy incomplete", "comment": "No grey-literature database was searched and the PRISMA flow omits duplicate record removal.", "location": "Methods, Search"}
+      ],
+      "minor": []
+    },
+    {
+      "reviewer_id": "R2",
+      "expertise_area": "Clinical",
+      "major": [
+        {"heading": "Overreaching recommendation", "comment": "Clinical actionability is asserted but generalizability to community care is unsupported.", "location": "Discussion"}
+      ],
+      "minor": []
+    },
+    {
+      "reviewer_id": "R3",
+      "expertise_area": "Statistics (reader agreement)",
+      "major": [
+        {"heading": "Agreement statistic without resampling", "comment": "Inter-rater agreement is reported as Cohen's kappa; no bootstrap resampling of the readers was performed.", "location": "Results"},
+        {"heading": "Repeated testing not corrected", "comment": "A permutation test across twelve endpoints with no Bonferroni correction was applied to the readers.", "location": "Methods"},
+        {"heading": "Effect measure ignores clustering", "comment": "The odds ratio disregards the intraclass correlation (ICC) induced by repeated readers.", "location": "Results"}
+      ],
+      "minor": []
+    }
+  ]
+}

--- a/skills/self-review/tests/test_panel_diversity.sh
+++ b/skills/self-review/tests/test_panel_diversity.sh
@@ -12,6 +12,7 @@ SCRIPT="$HERE/../scripts/check_panel_diversity.py"
 GOOD="$HERE/fixtures/panel_good.json"
 MONO="$HERE/fixtures/panel_monoculture.json"
 COLLAPSE="$HERE/fixtures/panel_collapse.json"
+STATS="$HERE/fixtures/panel_stats_lens.json"
 OUT="$(mktemp -t paneldiv_XXXX).json"
 trap 'rm -f "$OUT"' EXIT
 
@@ -50,6 +51,15 @@ python3 "$SCRIPT" --panel "$COLLAPSE" --out "$OUT" --strict --quiet >/dev/null 2
 check "exit 0 (collapse is flag-only)" test "$?" -eq 0
 check "LENS_COLLAPSE detected" has_verdict LENS_COLLAPSE
 check "no UNCOVERED_AXIS without research type" no_verdict UNCOVERED_AXIS
+
+# (4) a statistics reviewer using reader-study / agreement vocabulary (kappa, bootstrap,
+#     permutation, odds ratio, ICC) must register as covering the 'statistics' axis, so an
+#     sr_ma panel spanning all three expected axes fires NO UNCOVERED_AXIS. Regression:
+#     before the statistics lexicon was broadened these classified as 'other' and the axis
+#     looked uncovered, producing a false Major.
+python3 "$SCRIPT" --panel "$STATS" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 (stats reviewer covers the statistics axis)" test "$?" -eq 0
+check "no UNCOVERED_AXIS when statistics is covered by reader-study vocabulary" no_verdict UNCOVERED_AXIS
 
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## The bug

`check_panel_diversity` raises `UNCOVERED_AXIS` (Major) when a research type's expected axis has **zero** major findings assigned to it. The family classifier's `statistics` lexicon was meta-analysis-flavoured — heterogeneity, pooling, I², DeLong, random-effects. A **reader / agreement study**'s statistical majors are a different vocabulary:

- inter-rater **kappa** / ICC
- **bootstrap** resampling, **permutation** tests
- **Bonferroni** / FDR
- **odds ratio** / hazard ratio / risk ratio

None of that matched, so those findings classified as `other`, the `statistics` axis looked uncovered, and the gate raised an **unfounded Major** on a panel that in fact covered statistics thoroughly. Grounding: real-failure (a methodology/resource manuscript run through the panel; a whole reviewer was the statistics lens and every one of their majors was statistical).

## The fix

Broaden the `statistics` lexicon with the type-agnostic statistical vocabulary (effect measures, resampling, inter-rater agreement, multiplicity siblings, common tests, Bayesian). Localized to the one `FAMILY_LEXICON` entry; classification order is unchanged.

(Proposal ① in the candidate — downgrading the Major to informational on a research-type *mismatch* — is not implementable here: the detector's input is the reviewer findings, not the manuscript, so it cannot re-classify the paper. The lexicon gap is the actual defect and the one that fires.)

## Verification — the regression FAILS on the old lexicon

Adds case (4) to `test_panel_diversity.sh` (CI-wired): a `sr_ma` panel that covers all three expected axes, whose statistics coverage uses **only** the previously-unmatched vocabulary → **no `UNCOVERED_AXIS`**.

Proven by swapping the original detector back in and confirming the full test reports `FAILURES: 2`, then `ALL PASS` with the fix. The fixture had to be decontaminated **twice** of terms the old lexicon already matched (a heading `"Multiplicity"`, a comment `"confidence interval"`/`"pooled"`) that were silently covering the axis and masking the defect — the green-that-means-nothing trap.

Full `validate.yml` mirror via `scripts/run_ci_mirror.sh`: **173/173 gates pass**. Detector count unchanged (75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)