### PR TITLE
feat(self-review): flag the same subgroup rendered twice with divergent CIs (SUBGROUP_DUPLICATE_CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@
 
 ### Added
 
+- **`/self-review` `check_cohort_arithmetic` — `SUBGROUP_DUPLICATE_CI`: the same subgroup
+  rendered twice in one table with two different confidence intervals.** A results table listed
+  "MetS ≥3 criteria" (OR 4.95, 4.32–5.94) and "MetS-positive (binary)" (OR 4.95, 4.26–5.83) — the
+  identical subgroup (same n, same events) relabeled, each with its own independently-resampled
+  bootstrap interval; a biostatistics reviewer asks why one group has two CIs. The gate now flags,
+  within a single GFM table, two rows sharing the **same effect estimate and identical count columns
+  (n / events) but printing different CIs** (Minor). High precision by construction: it requires the
+  non-label integer cells to be identical, so two genuinely distinct subgroups with a coincidentally
+  equal point estimate do not fire, and a table with no count columns is left alone (the label column,
+  which is exactly what differs between the two rows, is excluded from the identity). Regression cases
+  in `test_cohort_arithmetic.sh` fail on the pre-verdict detector. Grounding: real-failure. Additive
+  verdict on an existing detector; detector count unchanged.
+
 - **`/self-review` `check_panel_diversity` — `--roster` + `PANEL_UNDERRETURN`: a panel whose
   reviewers spawn and return nothing is now a failure, not a silent success.** A `--panel` run spawns
   N reviewers; when some or all return no parseable review, the resulting `panel_reviews.json` is thin

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4198,8 +4198,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 30945,
-      "sha256": "50e09a18b0e404f8fab97091efaaa8e6263bb20a76a5058d5b989655c4c2da94"
+      "size": 34274,
+      "sha256": "f9c738b7676d9a10b073f123736d4e3cb43e49d91a3801476410ebb1d5fef3c0"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -57,7 +57,9 @@ INPUTS
 OUTPUT
   A reconciliation table (stdout) and, with --out, a JSON artifact:
     {manuscript, data, claims[{verdict, severity, detail, where}], summary}
-  verdicts RATE_BACKCALC / CASCADE_SUM / PARTITION_OVERLAP are Major candidates.
+  verdicts RATE_BACKCALC / CASCADE_SUM / PARTITION_OVERLAP are Major candidates;
+  FOLLOWUP_VS_CRITERION and SUBGROUP_DUPLICATE_CI (the same subgroup rendered twice in
+  one table with divergent confidence intervals) are Minor.
   Exit 1 (with --strict) when any Major-severity claim exists.
 
 Stdlib-only (csv / json / re / argparse). Exit codes: 0 clean (or report-only),
@@ -624,6 +626,66 @@ def load_csv(path: str) -> list[dict]:
         return [r for r in csv.DictReader(f)]
 
 
+# Effect estimate with a bracketed CI: "4.95 (4.32-5.94)" / "4.95 [4.32 to 5.94]".
+_EFFECT_CI_RE = re.compile(
+    r"(?P<pt>\d+(?:\.\d+)?)\s*[\(\[]\s*"
+    r"(?P<lo>\d+(?:\.\d+)?)\s*(?:[-–—]|to|,)\s*(?P<hi>\d+(?:\.\d+)?)\s*[\)\]]"
+)
+
+
+def check_duplicate_subgroup_ci(text: str) -> list[dict]:
+    """Within one GFM table, two rows that share the SAME effect estimate AND the same
+    identity counts (n / events) but print DIFFERENT confidence intervals are the same
+    subgroup rendered twice (relabeled) with independently-resampled uncertainty — a
+    reviewer asks why one group has two intervals. High precision by construction: it
+    requires the non-effect integer cells (n, events) to be IDENTICAL between the rows,
+    so two genuinely distinct subgroups with a coincidentally-equal point estimate do
+    not fire; a table with no count columns is left alone."""
+    claims: list[dict] = []
+    for tbl in _parse_md_tables(text):
+        if len(tbl) < 3:            # header + at least two body rows
+            continue
+        groups: dict = {}
+        for row in tbl[1:]:
+            eff = eff_idx = None
+            for ci, cell in enumerate(row):
+                m = _EFFECT_CI_RE.search(cell)
+                if m:
+                    eff, eff_idx = m, ci
+                    break
+            if eff is None:
+                continue
+            # Identity = the count columns (n / events), NOT the label (col 0, which is
+            # exactly what differs between the two relabeled rows) and NOT the effect+CI
+            # cell. _ints_in already drops decimals, so CI bounds / p-values / percents
+            # do not enter the identity.
+            ids: list[int] = []
+            for ci, cell in enumerate(row):
+                if ci not in (0, eff_idx):
+                    ids += _ints_in(cell)
+            if not ids:             # need n/events to confirm it is the same subgroup
+                continue
+            key = (eff.group("pt"), tuple(sorted(ids)))
+            label = (row[0] if row else "").strip()
+            groups.setdefault(key, []).append(((eff.group("lo"), eff.group("hi")), label))
+        for (pt, ids), members in groups.items():
+            cis = {ci for ci, _ in members}
+            if len(members) >= 2 and len(cis) >= 2:
+                labels = [lab for _, lab in members if lab]
+                intervals = "; ".join(f"{lo}–{hi}" for lo, hi in sorted(cis))
+                claims.append({
+                    "verdict": "SUBGROUP_DUPLICATE_CI",
+                    "severity": "Minor",
+                    "detail": (f"rows sharing estimate {pt} and identity counts {list(ids)} print "
+                               f"different confidence intervals ({intervals}); the same subgroup appears "
+                               f"rendered twice with divergent uncertainty — harmonize to one interval, "
+                               f"or footnote why the two differ"
+                               + (f" (rows: {', '.join(labels)})" if labels else "")),
+                    "where": (" / ".join(labels))[:120] or f"estimate {pt}",
+                })
+    return claims
+
+
 def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dict:
     p = Path(manuscript)
     if not p.is_file():
@@ -637,6 +699,7 @@ def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dic
     claims += check_partition_md(text)
     claims += check_partition_text(text)
     claims += check_followup_criterion(text)
+    claims += check_duplicate_subgroup_ci(text)
 
     if data:
         rows = load_csv(data)

--- a/skills/self-review/tests/fixtures/cohort_dup_ci.md
+++ b/skills/self-review/tests/fixtures/cohort_dup_ci.md
@@ -1,0 +1,9 @@
+## Results
+
+**Table 3. Subgroup associations with the outcome.**
+
+| Subgroup | n | Events | OR (95% CI) |
+|---|---|---|---|
+| MetS (>=3 criteria) | 969 | 209 | 4.95 (4.32-5.94) |
+| MetS-positive (binary) | 969 | 209 | 4.95 (4.26-5.83) |
+| Diabetes | 512 | 88 | 2.10 (1.60-2.75) |

--- a/skills/self-review/tests/fixtures/cohort_dup_ci_clean.md
+++ b/skills/self-review/tests/fixtures/cohort_dup_ci_clean.md
@@ -1,0 +1,9 @@
+## Results
+
+**Table 3. Subgroup associations with the outcome.**
+
+| Subgroup | n | Events | OR (95% CI) |
+|---|---|---|---|
+| Metabolic syndrome | 969 | 209 | 4.95 (4.32-5.94) |
+| Hypertension | 512 | 88 | 4.95 (3.80-6.45) |
+| Diabetes | 700 | 120 | 2.10 (1.60-2.75) |

--- a/skills/self-review/tests/test_cohort_arithmetic.sh
+++ b/skills/self-review/tests/test_cohort_arithmetic.sh
@@ -112,5 +112,20 @@ d=json.load(open('$OUT'))
 raise SystemExit(0 if not any(c['verdict']=='FOLLOWUP_VS_CRITERION' for c in d['claims']) else 1)
 "
 
+# (N) a subgroup rendered twice with divergent CIs: two rows share the SAME estimate AND
+#     identical n/events but print different confidence intervals (independent bootstraps)
+#     -> SUBGROUP_DUPLICATE_CI (Minor). Two DISTINCT subgroups with a coincidentally equal
+#     estimate but different n/events must NOT fire (the precision guard).
+DUPCI="$HERE/fixtures/cohort_dup_ci.md"
+DUPCICLEAN="$HERE/fixtures/cohort_dup_ci_clean.md"
+python3 "$SCRIPT" --manuscript "$DUPCI" --out "$OUT" --quiet >/dev/null 2>&1
+check "SUBGROUP_DUPLICATE_CI on same estimate+n+events with divergent CI" has_verdict SUBGROUP_DUPLICATE_CI
+python3 "$SCRIPT" --manuscript "$DUPCICLEAN" --out "$OUT" --quiet >/dev/null 2>&1
+check "no SUBGROUP_DUPLICATE_CI when n/events differ (distinct subgroups, same OR)" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='SUBGROUP_DUPLICATE_CI' for c in d['claims']) else 1)
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## The defect

A results table listed two rows for what turned out to be the **identical subgroup**, relabeled:

| Subgroup | n | Events | OR (95% CI) |
|---|---|---|---|
| MetS ≥3 criteria | 969 | 209 | 4.95 (4.32–5.94) |
| MetS-positive (binary) | 969 | 209 | 4.95 (4.26–5.83) |

Same n, same events, same point estimate — but two different bootstrap CIs from independent resampling. A biostatistics reviewer asks why one group has two intervals. No arithmetic gate sees it (each row is individually valid). Grounding: real-failure.

## The verdict (additive on `check_cohort_arithmetic` — count unchanged, 76)

`SUBGROUP_DUPLICATE_CI` (Minor) fires when, within one GFM table, two rows share the **same effect estimate and identical count columns (n / events)** but print **different confidence intervals**.

**High precision by construction:**
- The identity requires the non-label integer cells (n, events) to be **identical** → two genuinely distinct subgroups with a coincidentally equal point estimate do **not** fire (verified: same OR 4.95, different n/events → clean).
- The **label column (col 0) is excluded** from the identity — it is exactly what differs between the two relabeled rows (this was the bug in the first draft: `≥3` in a label leaked a `3` into the identity).
- `_ints_in` drops decimals, so CI bounds / p-values / percentages never enter the identity.
- A table with **no count columns** is left alone (silent).
- Same estimate + same n/events + **same** CI (a plain duplicate) does not fire — this verdict is specifically about *divergent* uncertainty.

## Verification

Two regression cases in `test_cohort_arithmetic.sh` (CI-wired): the divergent-CI duplicate fires; the distinct-subgroups-same-OR trap is clean. Proven by running the test on the pre-verdict detector → **FAILURES: 1**, then `ALL PASS` with the fix. Full `validate.yml` mirror via `scripts/run_ci_mirror.sh`: **173/173 gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)