### PR TITLE
feat(self-review): flag a gradient-across-strata claim with no interaction test (GRADIENT_WITHOUT_INTERACTION)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@
 
 ### Added
 
+- **`/self-review` `check_scope_coherence` — `GRADIENT_WITHOUT_INTERACTION`: a "gradient across
+  strata" claim with no interaction test.** An age×CMB "gradient" was claimed via joint
+  stratification (primary table + heatmap + Central Illustration) with no interaction term or LRT
+  anywhere; re-analysis showed the interaction was non-significant (LRT P=0.67) — the narrative was
+  difference-in-significance across strata, not a tested interaction. Because the manuscript used
+  "gradient" rather than "synergy/interaction", the existing token trigger never fired. The gate now
+  flags a cross-strata directional claim ("shortest in the high-risk tertile", "monotonically across
+  the age strata", "more pronounced in") that carries a stratification context but reports no
+  interaction test (interaction term / LRT / p-interaction / effect modification) anywhere (Minor).
+  Precision-guarded against the FP-heavy word "gradient": a physical "pressure gradient across the
+  stenosis", an MRI "gradient echo", a claim over an "arm" rather than a stratum, a Methods-only
+  mention, and any interaction-tested claim all stay clean. Regression cases in
+  `test_scope_coherence.sh` fail on the pre-verdict detector. Grounding: real-failure. Additive
+  verdict on an existing detector; detector count unchanged.
+
 - **`/self-review` `check_cohort_arithmetic` — `SUBGROUP_DUPLICATE_CI`: the same subgroup
   rendered twice in one table with two different confidence intervals.** A results table listed
   "MetS ≥3 criteria" (OR 4.95, 4.32–5.94) and "MetS-positive (binary)" (OR 4.95, 4.26–5.83) — the

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4488,8 +4488,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_scope_coherence.py",
-      "size": 17273,
-      "sha256": "9508c6f84f1971fea99500aba9bf9bf3d7045dba14e8a2d67053f32e4e0b06f8"
+      "size": 21565,
+      "sha256": "8832be5b380f340cb34f3228fd1e16632245ac97661ca0fb5955120a7bc9507e"
     },
     {
       "path": "skills/self-review/scripts/check_supplement_hygiene.py",

--- a/skills/self-review/scripts/check_scope_coherence.py
+++ b/skills/self-review/scripts/check_scope_coherence.py
@@ -26,6 +26,15 @@ conclusion action verb co-occur, and both are documented anti-patterns
                               prevalence design these read as longitudinal screening
                               performance. Minor unless "yield" is defined once as
                               cross-sectional report-positive prevalence.
+  GRADIENT_WITHOUT_INTERACTION  a cross-strata directional claim ("shortest in the
+                              high-risk tertile", "monotonically across the age strata")
+                              stated as a finding, with a stratification context nearby,
+                              but NO interaction test (interaction term / LRT / p-
+                              interaction / effect modification) reported anywhere. A
+                              difference in significance across strata is not a tested
+                              interaction. Minor. Precision-guarded: a physical "pressure
+                              gradient" or "gradient echo" and an interaction-tested claim
+                              do not fire.
 
 The gate is conservative: it fires only when both a signal and a conclusion-region
 verb are present, to keep false positives low on a widely-used skill.
@@ -37,7 +46,8 @@ OUTPUT
   A reconciliation table (stdout) and, with --out, a JSON artifact:
     {manuscript, claims[{verdict, severity, detail, where}], summary}
   CROSS_SECTIONAL_PROGNOSTIC and SURROGATE_CARE_DIRECTIVE are Major; UNIVERSAL_NEGATIVE_
-  UNSCOPED and CROSS_SECTIONAL_YIELD_LANGUAGE are Minor. Exit 1 (with --strict) on any Major.
+  UNSCOPED, CROSS_SECTIONAL_YIELD_LANGUAGE and GRADIENT_WITHOUT_INTERACTION are Minor.
+  Exit 1 (with --strict) on any Major.
 
 Stdlib-only (json / re / argparse / pathlib). Exit codes: 0 clean (or report-only),
 1 Major claim(s) found (with --strict), 2 input/usage error.
@@ -185,6 +195,43 @@ SCOPE_QUALIFIER_RE = re.compile(
     re.IGNORECASE)
 
 
+# A cross-strata DIRECTIONAL claim: the estimate trends / differs across the levels of a
+# subgroup. Anchored to distinctive phrases so a physical "pressure gradient across the
+# stenosis" or an MRI "gradient echo" does not match (bare "gradient" is never enough).
+GRADIENT_CLAIM_RE = re.compile(
+    r"more pronounced (?:in|among|for)\b"
+    r"|(?:short|long|high|low|great|small|strong|weak)(?:est|er) (?:in|among|for)\b"
+    r"|monotonic(?:ally)?\b"
+    r"|step[-\s]?wise (?:increase|decrease|rise|decline|shorten|across|with)"
+    r"|gradient (?:across|among|by|over|with (?:higher|increasing|worsening))"
+    r"|dose[-\s]?response (?:relationship|gradient|pattern)?\s*(?:across|with|by)"
+    r"|(?:increas|decreas|shorten|worsen)(?:ed|ing) (?:monotonically|step[-\s]?wise|progressively)",
+    re.IGNORECASE)
+
+# A stratification CONTEXT (the LEVELS of a subgroup) — required in the same window so
+# the directional language is about subgroup strata, not a physical or temporal trend.
+STRATA_CONTEXT_RE = re.compile(
+    r"tertile|quartile|quintile|decile|stratum|strata|stratified|subgroup"
+    r"|categor(?:y|ies)|\bband\b|joint(?:ly)?[-\s]?(?:strat|classif)|cross[-\s]?classif"
+    r"|(?:age|risk|score|bmi|dose)[-\s]?(?:group|categor|band|tier)",
+    re.IGNORECASE)
+
+# Evidence an interaction WAS actually tested (any hit anywhere -> suppress the flag).
+INTERACTION_TEST_RE = re.compile(
+    r"interaction (?:term|test|p[-\s]?value|effect|coefficient)"
+    r"|p[-_\s]?interaction|p[-_\s]?int\b|effect modification"
+    r"|test(?:ed|ing)? for interaction|multiplicative interaction|product term"
+    r"|likelihood[-\s]?ratio test|\bLRT\b|(?:OR|HR|RR|beta|β)[-_]?int\b",
+    re.IGNORECASE)
+
+# Claim regions where a cross-strata directional statement is a substantive claim
+# (not the Methods description of a stratified analysis).
+CLAIM_REGION_HEADINGS = re.compile(
+    r"^#{1,4}\s*\*{0,2}\s*(?:abstract|results?|discussion|interpretation|conclusions?"
+    r"|key results?|principal findings?)\b",
+    re.IGNORECASE | re.MULTILINE)
+
+
 def _region(text: str, heading_re) -> str:
     spans = []
     all_headings = [m.start() for m in re.finditer(r"^#{1,4}\s", text, re.MULTILINE)]
@@ -267,6 +314,29 @@ def check(text: str) -> list[dict]:
                            f"performance"),
                 "where": text[max(0, ym.start() - 40):ym.end() + 40].strip()[:160],
             })
+
+    # GRADIENT_WITHOUT_INTERACTION — a cross-strata directional claim ("shortest in the
+    # high-risk tertile", "monotonically across the age strata") stated as a finding, with
+    # a stratification context nearby, but NO interaction test reported anywhere. A
+    # difference in significance across strata is not a tested interaction; the
+    # joint-stratification framing escapes the synergy/interaction token trigger.
+    if not INTERACTION_TEST_RE.search(text):
+        claim_region = _region(text, CLAIM_REGION_HEADINGS)
+        for gm in GRADIENT_CLAIM_RE.finditer(claim_region):
+            window = claim_region[max(0, gm.start() - 160):gm.end() + 160]
+            if not STRATA_CONTEXT_RE.search(window):
+                continue
+            claims.append({
+                "verdict": "GRADIENT_WITHOUT_INTERACTION",
+                "severity": "Minor",
+                "detail": (f"a cross-strata directional claim ('{gm.group(0).strip()}') is made across "
+                           f"subgroup levels, but no interaction test (interaction term / LRT / "
+                           f"p-interaction / effect modification) is reported anywhere; a difference in "
+                           f"significance across strata is not a tested interaction — report the "
+                           f"interaction test, or reframe as descriptive stratified estimates"),
+                "where": window.replace("\n", " ").strip()[:160],
+            })
+            break
 
     return claims
 

--- a/skills/self-review/tests/fixtures/scope_gradient.md
+++ b/skills/self-review/tests/fixtures/scope_gradient.md
@@ -1,0 +1,7 @@
+# CAC warranty by joint age and calcium stratification
+
+## Results
+
+The time to a 25% CAC threshold was shortest in the high-risk tertile and shortened
+monotonically across the age strata, with the gradient most pronounced among the older
+participants.

--- a/skills/self-review/tests/fixtures/scope_gradient_tested.md
+++ b/skills/self-review/tests/fixtures/scope_gradient_tested.md
@@ -1,0 +1,6 @@
+# CAC warranty by joint age and calcium stratification
+
+## Results
+
+The time to a 25% CAC threshold shortened monotonically across the age strata; the
+age x calcium interaction was tested with a likelihood ratio test (p-interaction = 0.02).

--- a/skills/self-review/tests/test_scope_coherence.sh
+++ b/skills/self-review/tests/test_scope_coherence.sh
@@ -12,6 +12,8 @@ SCRIPT="$HERE/../scripts/check_scope_coherence.py"
 BAD="$HERE/fixtures/scope_bad.md"
 SURR="$HERE/fixtures/scope_surrogate.md"
 CLEAN="$HERE/fixtures/scope_clean.md"
+GRAD="$HERE/fixtures/scope_gradient.md"
+GRADTEST="$HERE/fixtures/scope_gradient_tested.md"
 OUT="$(mktemp -t scope_XXXX).json"
 trap 'rm -f "$OUT"' EXIT
 
@@ -109,6 +111,19 @@ check "no UNIVERSAL_NEGATIVE_UNSCOPED when a discipline-scope qualifier is prese
 import json
 d=json.load(open('$OUT'))
 raise SystemExit(0 if not any(c['verdict']=='UNIVERSAL_NEGATIVE_UNSCOPED' for c in d['claims']) else 1)
+"
+
+# (N) cross-strata directional claim ("shortest in the high-risk tertile", "monotonically
+#     across the age strata") with a stratification context but NO interaction test ->
+#     GRADIENT_WITHOUT_INTERACTION (Minor). The SAME claim with an interaction test reported
+#     (LRT / p-interaction) must NOT fire (the suppression guard).
+python3 "$SCRIPT" --manuscript "$GRAD" --out "$OUT" --quiet >/dev/null 2>&1
+check "GRADIENT_WITHOUT_INTERACTION on gradient-across-strata, no interaction test" has_verdict GRADIENT_WITHOUT_INTERACTION
+python3 "$SCRIPT" --manuscript "$GRADTEST" --out "$OUT" --quiet >/dev/null 2>&1
+check "no GRADIENT_WITHOUT_INTERACTION when the interaction is tested (LRT / p-interaction)" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='GRADIENT_WITHOUT_INTERACTION' for c in d['claims']) else 1)
 "
 
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"


### PR DESCRIPTION
## The defect

A directional claim across strata can be mistaken for a tested interaction. Wording such as "gradient" needs the same interaction-test review as "synergy" or "interaction".

## The verdict (additive on `check_scope_coherence` — count unchanged, 76)

`GRADIENT_WITHOUT_INTERACTION` (Minor) fires when a **cross-strata directional claim** — "shortest in the high-risk tertile", "monotonically across the age strata", "more pronounced in", "stepwise across" — is stated as a finding, carries a **stratification context** nearby, and **no interaction test** (interaction term / LRT / p-interaction / effect modification / product term) is reported anywhere.

## Precision (the reason this isn't just `grep gradient`)

"gradient" is FP-heavy in a medical corpus. Verified clean on:
- `pressure gradient across the stenosis` (physiology — no stratum context)
- `gradient echo` MRI sequence (not a directional-across-strata phrase)
- `greater in the treatment arm` (an *arm*, not a stratum)
- a Methods-only "stratified by tertile" mention (region-scoped to claim sections)
- the same gradient claim **with** an interaction LRT / p-interaction reported (suppression guard)

## Verification

Two regression cases in `test_scope_coherence.sh` (CI-wired): the untested gradient fires; the interaction-tested version is clean. Proven by running the test on the pre-verdict detector → **FAILURES: 1**, then `ALL PASS`. Full `validate.yml` mirror via `scripts/run_ci_mirror.sh`: **173/173 gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)