### PR TITLE
feat(self-review): flag nested discrimination models with no base-model row (NESTED_MODEL_NO_BASELINE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@
 
 ### Added
 
+- **`/self-review` `check_cohort_arithmetic` — `NESTED_MODEL_NO_BASELINE`: nested discrimination
+  models with no base-model row.** A table reported C-indices for several nested models that all
+  embedded age + sex (CMB+age+sex = 0.667, MetS+age+sex = 0.671, …) but had **no age+sex-only baseline
+  row** — the section was even titled "(age + sex baseline)". "CMB comparable to MetS" was
+  uninterpretable because the shared age + sex could account for the discrimination; re-analysis put
+  C(age+sex) = 0.648 and the incremental ΔC at only 0.019/0.023. The gate now flags a table with a
+  discrimination column (C-index / AUC) where two or more additive ("X + Y") models share a common
+  covariate set but no row reports those common covariates alone and no incremental ΔC is stated
+  (Minor). Deterministic and header-gated: it only considers tables with a discrimination column and
+  `+`-additive model labels, drops non-covariate words from the label, and stays silent when the
+  base-model row or a ΔC is present. Regression cases in `test_cohort_arithmetic.sh` fail on the
+  pre-verdict detector. Grounding: real-failure. Additive verdict on an existing detector; detector
+  count unchanged.
+
 - **`/self-review` `check_scope_coherence` — `GRADIENT_WITHOUT_INTERACTION`: a "gradient across
   strata" claim with no interaction test.** An age×CMB "gradient" was claimed via joint
   stratification (primary table + heatmap + Central Illustration) with no interaction term or LRT

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4208,8 +4208,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 34274,
-      "sha256": "f9c738b7676d9a10b073f123736d4e3cb43e49d91a3801476410ebb1d5fef3c0"
+      "size": 37883,
+      "sha256": "ef239b1896f1b17f3b0d75b7d45ef2d3e285d96320a357c31aced06f823cf38b"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -58,8 +58,9 @@ OUTPUT
   A reconciliation table (stdout) and, with --out, a JSON artifact:
     {manuscript, data, claims[{verdict, severity, detail, where}], summary}
   verdicts RATE_BACKCALC / CASCADE_SUM / PARTITION_OVERLAP are Major candidates;
-  FOLLOWUP_VS_CRITERION and SUBGROUP_DUPLICATE_CI (the same subgroup rendered twice in
-  one table with divergent confidence intervals) are Minor.
+  FOLLOWUP_VS_CRITERION, SUBGROUP_DUPLICATE_CI (the same subgroup rendered twice in one
+  table with divergent confidence intervals) and NESTED_MODEL_NO_BASELINE (nested
+  discrimination models sharing a covariate set with no base-model row / ΔC) are Minor.
   Exit 1 (with --strict) when any Major-severity claim exists.
 
 Stdlib-only (csv / json / re / argparse). Exit codes: 0 clean (or report-only),
@@ -686,6 +687,78 @@ def check_duplicate_subgroup_ci(text: str) -> list[dict]:
     return claims
 
 
+_CINDEX_HDR = ("c-index", "c index", "cindex", "c-statistic", "c statistic", "concordance",
+               "auc", "auroc", "harrell", "discrimination", "c (95")
+_MODEL_HDR = ("model", "covariate", "predictor", "variables", "adjustment")
+# tokens that appear in a model label but are NOT covariates
+_COVAR_STOP = {"model", "models", "only", "vs", "versus", "plus", "the", "and", "reference",
+               "baseline", "base", "full", "final", "adjusted", "unadjusted", "alone",
+               "with", "index"}
+_CI_VAL_RE = re.compile(r"\b0\.[5-9]\d")
+
+
+def _covar_set(label: str) -> frozenset:
+    """'CMB + age + sex' -> {'cmb','age','sex'} (additive split on '+', notes and
+    non-covariate words dropped)."""
+    label = re.sub(r"\(.*?\)", " ", label)
+    out = set()
+    for tok in re.split(r"\s*\+\s*", label):
+        t = re.sub(r"[^a-z0-9]", "", tok.lower())
+        if t and len(t) >= 2 and t not in _COVAR_STOP:
+            out.add(t)
+    return frozenset(out)
+
+
+def check_nested_model_baseline(text: str) -> list[dict]:
+    """A table of nested prediction models reports a discrimination statistic (C-index /
+    AUC) for two or more models that all embed a common covariate set (e.g. every model
+    is 'X + age + sex'), but there is no BASE-model row (the common covariates alone) and
+    no incremental deltaC — so the shared covariates could account for the discrimination,
+    and 'model A comparable to model B' is uninterpretable. Deterministic and header-gated:
+    only tables with a discrimination column and additive ('X + Y') model labels are
+    considered, so an ordinary results table does not fire."""
+    claims: list[dict] = []
+    for tbl in _parse_md_tables(text):
+        if len(tbl) < 3:
+            continue
+        header = tbl[0]
+        ci_idx = _pick(header, _CINDEX_HDR)
+        if ci_idx is None:
+            continue
+        model_idx = _pick(header, _MODEL_HDR)
+        if model_idx is None:
+            model_idx = 0
+        additive: list[tuple[str, frozenset]] = []
+        ci_row_sets: set = set()
+        for row in tbl[1:]:
+            if ci_idx >= len(row) or not _CI_VAL_RE.search(row[ci_idx]):
+                continue
+            label = row[model_idx] if model_idx < len(row) else (row[0] if row else "")
+            cset = _covar_set(label)
+            ci_row_sets.add(cset)
+            if "+" in label:
+                additive.append((label, cset))
+        if len(additive) < 2:
+            continue
+        common = frozenset.intersection(*(s for _, s in additive))
+        if not common or common in ci_row_sets:
+            continue
+        if re.search(r"(?:Δ|delta[-\s]?)\s?(?:c\b|auc)|incremental (?:c[-\s]?index|auc|discrimination)",
+                     text, re.IGNORECASE):
+            continue
+        claims.append({
+            "verdict": "NESTED_MODEL_NO_BASELINE",
+            "severity": "Minor",
+            "detail": (f"{len(additive)} nested models report a discrimination statistic and all embed "
+                       f"the covariates {sorted(common)}, but no base-model row (those covariates alone) "
+                       f"and no incremental ΔC is reported; the shared covariates could account for the "
+                       f"discrimination — add the base-model C-index and the ΔC so the incremental value "
+                       f"is interpretable"),
+            "where": ("; ".join(lab for lab, _ in additive[:3]))[:120],
+        })
+    return claims
+
+
 def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dict:
     p = Path(manuscript)
     if not p.is_file():
@@ -700,6 +773,7 @@ def analyze(manuscript: str, data: str | None, id_col: str | None = None) -> dic
     claims += check_partition_text(text)
     claims += check_followup_criterion(text)
     claims += check_duplicate_subgroup_ci(text)
+    claims += check_nested_model_baseline(text)
 
     if data:
         rows = load_csv(data)

--- a/skills/self-review/tests/fixtures/cohort_nested_models.md
+++ b/skills/self-review/tests/fixtures/cohort_nested_models.md
@@ -1,0 +1,9 @@
+## Results
+
+**Table 3. Discrimination of nested prediction models.**
+
+| Model | C-index (95% CI) |
+|---|---|
+| CMB + age + sex | 0.667 (0.62-0.71) |
+| MetS + age + sex | 0.671 (0.63-0.72) |
+| CMB + MetS + age + sex | 0.673 (0.63-0.72) |

--- a/skills/self-review/tests/fixtures/cohort_nested_models_base.md
+++ b/skills/self-review/tests/fixtures/cohort_nested_models_base.md
@@ -1,0 +1,9 @@
+## Results
+
+**Table 3. Discrimination of nested prediction models.**
+
+| Model | C-index (95% CI) |
+|---|---|
+| Age + sex | 0.648 (0.60-0.69) |
+| CMB + age + sex | 0.667 (0.62-0.71) |
+| MetS + age + sex | 0.671 (0.63-0.72) |

--- a/skills/self-review/tests/test_cohort_arithmetic.sh
+++ b/skills/self-review/tests/test_cohort_arithmetic.sh
@@ -127,5 +127,19 @@ d=json.load(open('$OUT'))
 raise SystemExit(0 if not any(c['verdict']=='SUBGROUP_DUPLICATE_CI' for c in d['claims']) else 1)
 "
 
+# (N) nested prediction models all embedding a common covariate set (age + sex) report a
+#     C-index but there is no base-model (age+sex-only) row and no incremental deltaC ->
+#     NESTED_MODEL_NO_BASELINE (Minor). Adding the base-model row must suppress it.
+NEST="$HERE/fixtures/cohort_nested_models.md"
+NESTBASE="$HERE/fixtures/cohort_nested_models_base.md"
+python3 "$SCRIPT" --manuscript "$NEST" --out "$OUT" --quiet >/dev/null 2>&1
+check "NESTED_MODEL_NO_BASELINE when nested models share covariates with no base row" has_verdict NESTED_MODEL_NO_BASELINE
+python3 "$SCRIPT" --manuscript "$NESTBASE" --out "$OUT" --quiet >/dev/null 2>&1
+check "no NESTED_MODEL_NO_BASELINE when the base-model (age+sex) row is present" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='NESTED_MODEL_NO_BASELINE' for c in d['claims']) else 1)
+"
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## The defect

A table reported C-indices for several nested prediction models that **all embedded age + sex**:

| Model | C-index |
|---|---|
| CMB + age + sex | 0.667 |
| MetS + age + sex | 0.671 |
| CMB + MetS + age + sex | 0.673 |

— but **no age+sex-only baseline row** (the section was even titled "(age + sex baseline)"). "CMB comparable to MetS" was uninterpretable, because the shared age + sex could account for the discrimination. Re-analysis: C(age+sex) = 0.648; incremental ΔC only 0.019/0.023. Grounding: real-failure (panel).

## The verdict (additive on `check_cohort_arithmetic` — count unchanged, 76)

`NESTED_MODEL_NO_BASELINE` (Minor) fires when a table has a **discrimination column** (C-index / AUC) and **≥2 additive (`X + Y`) models share a common covariate set**, but no row reports those common covariates *alone* and no incremental ΔC is stated.

## Precision (deterministic, header-gated)

Verified clean on:
- a table **with** the base-model (`age + sex`) row present
- a table where an incremental **ΔC** is reported in prose
- models that share **no** covariate (no `+`)
- an ordinary OR table with **no discrimination column**

Non-covariate words (model, adjusted, baseline, …) are dropped from the label before intersecting, so the "common covariate set" is real.

## Verification

Two regression cases in `test_cohort_arithmetic.sh` (CI-wired): the missing-baseline table fires; adding the base row suppresses it. Proven by running the test on the pre-verdict detector → **FAILURES: 1**, then `ALL PASS`. Full `validate.yml` mirror via `scripts/run_ci_mirror.sh`: **173/173 gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)