### PR TITLE
fix(self-review): strip YAML front matter before check_citation_order + check_aphorism_density scan (npj live-submission false positives)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -517,6 +517,9 @@ jobs:
       - name: Run self-review float citation-order gate test
         run: bash skills/self-review/tests/test_citation_order.sh
 
+      - name: Run self-review aphorism-density gate test
+        run: bash skills/self-review/tests/test_aphorism_density.sh
+
       - name: Run self-review claim-artifact (estimand provenance) gate test
         run: bash skills/self-review/tests/test_claim_artifact.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixed
 
+- **`/self-review` — two `--manuscript` detectors read a manuscript's YAML front matter as
+  body prose and fired on it.** A pandoc manuscript keeps its `status:`, changelog and build
+  notes in the leading `---`-fenced block; the shared line-filter idiom (`#`, `|`, `>`, `!`,
+  list markers, code fences) matches none of those, so the front matter was scanned as text.
+  On a live npj Digital Medicine submission this made **`check_citation_order`** report
+  `Tables cited 1, 3, 2` — the sequence came entirely from a `status:` block narrating a
+  display-item renumber ("old Table 1 → Supplementary Table S2", "old Table 3 → Box 1") while
+  the body cited every float in order — and made **`check_aphorism_density`** list
+  `THIS FILE IS THE SSOT` and `Build: python3 build/build_npj.py` among the manuscript's "very
+  short declaratives". Both now strip the leading front matter first, via a shared private
+  helper (`skills/self-review/scripts/_frontmatter.py`, same fence semantics as
+  sync-submission's `_yaml_frontmatter.py`; a lone `---` in the body is never mistaken for
+  front matter). Regression fixtures narrate an out-of-order renumber (and pack short negative
+  definitions) in the front matter over a clean body — both cases fired before the fix.
+  `check_aphorism_density`, shipped without a wired CI test, now has one.
+
 - **The classroom ZIP shipped no licence text at all, and GitHub could not detect our
   licence.** Two defects with one root cause. `LICENSE` was MIT followed by an appended
   third-party index, so GitHub's detector fell back to `NOASSERTION` / "Other" — the repo

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -59,6 +59,7 @@
 
 **Scripts** (`skills/self-review/scripts/`):
 
+- `_frontmatter.py`
 - `check_analysis_definitions.py`
 - `check_analysis_definitions_challenge/` (6 files)
 - `check_aphorism_density.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4142,6 +4142,11 @@
       "sha256": "d78e98cc0eee08b56b13539c9a61836485a7357a2b4b53b6db7d6329d2443da8"
     },
     {
+      "path": "skills/self-review/scripts/_frontmatter.py",
+      "size": 2411,
+      "sha256": "129e1785593629dd63e2b4a264e8cadb034e41ed058cdfe784375e3f765cb5de"
+    },
+    {
       "path": "skills/self-review/scripts/check_analysis_definitions.py",
       "size": 13004,
       "sha256": "a2942e15652ac7b19444bd04153023818f3385e5bd881cbc94482ed5e6009538"
@@ -4178,8 +4183,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_aphorism_density.py",
-      "size": 9086,
-      "sha256": "a45486a74acd061ce951c24c59d32a629d11909017eb9e52816550f721b5dd92"
+      "size": 9219,
+      "sha256": "432ae0071a2f130b212978a6eea7c493494ea7e1a88169233e24e9d13c6a84bd"
     },
     {
       "path": "skills/self-review/scripts/check_artifact_coverage.py",
@@ -4193,8 +4198,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_citation_order.py",
-      "size": 11472,
-      "sha256": "e405065299cf1f5f46710cf0c3fb03228e7ce48aaa6b67c9289e1dc7dfb16055"
+      "size": 11722,
+      "sha256": "4ee5aaba572b62e2ecaf2884fea0aebcd01ef28f66667cb91f78ecd249a6c0aa"
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",

--- a/skills/self-review/scripts/_frontmatter.py
+++ b/skills/self-review/scripts/_frontmatter.py
@@ -1,0 +1,44 @@
+"""Strip a leading YAML front-matter block off a manuscript before prose analysis.
+
+Several `--manuscript` detectors in this skill roll their own body extractor that filters
+lines starting with `#`, `|`, `>`, `!`, list markers and code fences. A `---`-fenced YAML
+front-matter block matches none of those, so the `status:`, changelog and build-note lines
+that projects keep at the top of a pandoc manuscript were read as body prose. Two shipped
+detectors fired on it on a live submission: `check_citation_order` reported floats "cited out
+of order" from a `status:` block narrating a display-item renumber, and `check_aphorism_density`
+listed build notes among the manuscript's "very short declaratives".
+
+`strip_frontmatter` removes exactly the pandoc/YAML front-matter block: an opening `---` fence
+on the FIRST line and its matching closing `---` fence. If the first line is not a fence, or the
+block is never closed, the whole text is returned unchanged (a lone `---` in the body — a
+horizontal rule or a setext underline — is never mistaken for front matter). Same fence semantics
+as `sync-submission/scripts/_yaml_frontmatter.py`; kept independent because skills are
+self-contained and cross-skill imports are forbidden.
+
+Private helper (leading underscore) so the detector-catalog glob (`check_*` / `detect_*` /
+`derive_*` / `verify_refs`) never counts it. Consumers run with their own directory on
+sys.path[0] (invoked as `python3 .../scripts/<name>.py`), so a sibling `from _frontmatter import
+strip_frontmatter` resolves wherever the skill is installed or vendored.
+"""
+from __future__ import annotations
+
+import re
+
+_FENCE_RE = re.compile(r"^---\s*$")
+
+
+def strip_frontmatter(text: str) -> str:
+    """Return ``text`` with a leading ``---``-fenced YAML front-matter block removed.
+
+    Returns ``text`` unchanged when there is no opening fence on the first line or the
+    block is never closed. The trailing newline layout of the body is preserved so
+    character offsets after the front matter shift by a fixed amount only.
+    """
+    lines = text.splitlines(keepends=True)
+    if not lines or not _FENCE_RE.match(lines[0].rstrip("\r\n")):
+        return text
+    for i in range(1, len(lines)):
+        if _FENCE_RE.match(lines[i].rstrip("\r\n")):
+            return "".join(lines[i + 1:])
+    # Opening fence but no closing fence — not front matter; leave the text intact.
+    return text

--- a/skills/self-review/scripts/check_aphorism_density.py
+++ b/skills/self-review/scripts/check_aphorism_density.py
@@ -53,6 +53,8 @@ import statistics
 import sys
 from pathlib import Path
 
+from _frontmatter import strip_frontmatter
+
 FENCE_RE = re.compile(r"```.*?```", re.S)
 CITE_RE = re.compile(r"\[@[^\]]+\]|\[\d+(?:[,–-]\d+)*\]")
 INLINE_RE = re.compile(r"[*_`]")
@@ -79,6 +81,7 @@ MIN_SENTENCES = 40           # below this a rate is noise
 
 def body_text(md: str) -> str:
     """Body prose only: no headings, tables, block quotes, code, citations, markup."""
+    md = strip_frontmatter(md)   # a `status:`/build-note YAML block is not prose rhythm
     md = FENCE_RE.sub(" ", md)
     keep = []
     for line in md.splitlines():

--- a/skills/self-review/scripts/check_citation_order.py
+++ b/skills/self-review/scripts/check_citation_order.py
@@ -58,6 +58,8 @@ import re
 import sys
 from pathlib import Path
 
+from _frontmatter import strip_frontmatter
+
 # A back-matter / float-definition section header. Everything from the first such
 # header onward is excluded from the body citation-order scan (legends list floats
 # in order by construction; references are not citations).
@@ -155,7 +157,9 @@ def _first_appearance(text: str):
 
 def check(text: str, include_back_matter: bool) -> list[dict]:
     claims = []
-    body = _body(text, include_back_matter)
+    # Strip any leading YAML front matter first: a `status:`/changelog block that narrates a
+    # display-item renumber ("old Table 1 -> Supplementary Table S2") is not a body citation.
+    body = _body(strip_frontmatter(text), include_back_matter)
     claims += _check_section_xref(body)
     order = _first_appearance(body)
     for label in ("Table", "Figure", "Supplementary Table", "Supplementary Figure"):

--- a/skills/self-review/tests/fixtures/aphorism_frontmatter.md
+++ b/skills/self-review/tests/fixtures/aphorism_frontmatter.md
@@ -1,0 +1,19 @@
+---
+status: |
+  Authority is not cognition. Fluency is not understanding. Rigor is not caution. It shipped. We moved on.
+  THIS FILE IS THE SSOT (SSOT.yaml -> truth.manuscript_md)
+---
+
+# Discussion
+
+Our retrospective cohort enrolled one thousand two hundred consecutive adults across a
+single tertiary centre over roughly one decade of longitudinal clinical follow-up. The
+analysis adjusted for the pre-specified confounders that the study protocol had named
+before any outcome data were unblinded to the investigating team. We observed a modest
+association between the exposure of interest and the primary endpoint after accounting
+for the competing risk of death from unrelated causes. The confidence interval around
+that adjusted estimate remained wide enough that a clinically negligible effect could not
+be excluded on the available evidence. These findings should therefore be read as
+hypothesis-generating rather than as a basis for changing current management in routine
+practice. A larger multi-centre study with prospectively collected covariates would be
+required before any firmer conclusion about causality could reasonably be drawn.

--- a/skills/self-review/tests/fixtures/citation_order_frontmatter.md
+++ b/skills/self-review/tests/fixtures/citation_order_frontmatter.md
@@ -1,0 +1,30 @@
+---
+title: A cohort study of the thing
+status: |
+  Display-item renumber for the npj revision (narrative, not body):
+    old Table 1 -> Supplementary Table S2
+    old Table 3 -> Box 1
+    Table 2 and S3 REMOVED
+  Build: python3 build/build_npj.py (no arguments)
+  THIS FILE IS THE SSOT (SSOT.yaml -> truth.manuscript_md)
+---
+
+# Abstract
+
+We report a cohort study. The body contains no numbered main-text tables; every
+display item is a supplementary table or a figure, cited in ascending order.
+
+# Methods
+
+The design schematic is in Figure 1. Number-at-risk counts are in Supplementary
+Table S1.
+
+# Results
+
+Baseline characteristics are in Supplementary Table S2. The endpoint decomposition
+is in Figure 2. Both supplementary tables and both figures are cited in order.
+
+# Discussion
+
+The finding held across sensitivity analyses. All display items are cited in
+first-appearance order once the front-matter changelog is excluded.

--- a/skills/self-review/tests/test_aphorism_density.sh
+++ b/skills/self-review/tests/test_aphorism_density.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression test for the aphorism-density gate (P26 / §J — the sentence-rhythm AI tell).
+# Synthetic, PII-free fixtures. Three cases:
+#   (1) aphorism_dense.md  — the same argument written as epigrams -> APHORISM_DENSITY fires
+#   (2) aphorism_clean.md  — the same argument written as explanation -> no finding
+#   (3) aphorism_frontmatter.md — a `status:`/build-note YAML block full of short negative
+#       definitions, over a body of ordinary explanatory prose. The front matter must be
+#       stripped before the rhythm is measured; otherwise its lines are counted as body
+#       "very short declaratives" and the detector fires on the changelog. Body-only rate
+#       is 0/0, so the no-fire here is the fix, not the min-sentences floor (6 sentences).
+# Uses --min-sentences 6 so the small A/B fixtures clear the noise floor. Stdlib-only.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/check_aphorism_density.py"
+FX="$HERE/fixtures"
+OUT="$(mktemp -t aphorism_XXXX).json"
+trap 'rm -f "$OUT"' EXIT
+
+fail=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+run() { python3 "$SCRIPT" --manuscript "$1" --min-sentences 6 --out "$OUT" --quiet >/dev/null 2>&1; }
+fired()     { python3 -c "import json,sys; sys.exit(0 if json.load(open('$OUT'))['findings'] else 1)"; }
+not_fired() { python3 -c "import json,sys; sys.exit(0 if not json.load(open('$OUT'))['findings'] else 1)"; }
+
+[[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
+
+# (1) epigram-dense prose -> APHORISM_DENSITY
+run "$FX/aphorism_dense.md"
+check "epigram-dense fixture fires APHORISM_DENSITY" fired
+
+# (2) explanatory prose (same argument) -> silent
+run "$FX/aphorism_clean.md"
+check "explanatory fixture does not fire" not_fired
+
+# (3) YAML front-matter changelog must not be measured as body rhythm
+run "$FX/aphorism_frontmatter.md"
+check "front-matter build/status block does not fire (stripped before measuring)" not_fired
+check "no front-matter line is counted as a short declarative" python3 -c "
+import json
+d=json.load(open('$OUT'))
+lines=[s for f in d['findings'] for s in f.get('short_declaratives',[])]
+assert not any('SSOT' in s or 'is not' in s for s in lines), lines
+assert d['metrics']['sentences']==6, d['metrics']  # body-only sentence count
+"
+
+echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"

--- a/skills/self-review/tests/test_citation_order.sh
+++ b/skills/self-review/tests/test_citation_order.sh
@@ -63,5 +63,15 @@ d=json.load(open('$OUT'))
 assert not any(c['verdict']=='DANGLING_SECTION_XREF' for c in d['claims']), 'false positive'
 "
 
+# (5) YAML front matter narrating a display-item renumber ("old Table 1 -> Supplementary
+#     Table S2", "old Table 3 -> Box 1") must NOT be scanned as body citations — a
+#     `status:`/changelog block is not prose. Body cites Supplementary Tables and figures
+#     in ascending order and has no main-text tables.
+FM="$HERE/fixtures/citation_order_frontmatter.md"
+python3 "$SCRIPT" --manuscript "$FM" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 with an out-of-order renumber in YAML front matter (body clean)" test "$?" -eq 0
+check "no CITATION_ORDER from a front-matter changelog" count_order 0
+check "no Major from a front-matter changelog" no_falsepos
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## What

Two shipped `/self-review` `--manuscript` detectors read a manuscript's leading YAML
front matter as body prose and fired on it. On a live *npj Digital Medicine* submission:

- **`check_citation_order`** reported `Tables are cited out of numerical order — 1, 3, 2`.
  The sequence came entirely from a `status:` block narrating a display-item renumber
  (`old Table 1 -> Supplementary Table S2`, `old Table 3 -> Box 1`); the body cited every
  float in ascending order. Its recommended fix — "renumber by first-citation order" —
  would have corrupted a correct manuscript.
- **`check_aphorism_density`** listed `THIS FILE IS THE SSOT` and
  `Build: python3 build/build_npj.py` among the manuscript's "very short declaratives".

Root cause: the shared body-extraction idiom filters lines starting with `#`, `|`, `>`,
`!`, list markers and code fences. A `---`-fenced front-matter block matches none of those,
so the `status:`, changelog and build notes that pandoc manuscripts keep at the top were
scanned as prose. Second occurrence of the citation_order variant in one session.

## Fix

- New private helper `skills/self-review/scripts/_frontmatter.py` — `strip_frontmatter(text)`,
  same fence semantics as `sync-submission/scripts/_yaml_frontmatter.py` (opening `---` on
  line 1 + its matching close; a lone `---` in the body — horizontal rule / setext underline
  — is never mistaken for front matter; CRLF-safe). Leading underscore → not counted as a
  detector; reachable via import from the two detectors.
- `check_citation_order.check()` and `check_aphorism_density.body_text()` strip front matter
  before scanning.

## Tests (green-means-nothing verified)

- `test_citation_order.sh` case (5): front matter narrates an out-of-order renumber; body
  clean. **Fired 2× CITATION_ORDER on pre-fix HEAD** (confirmed by stashing the detector
  edits); passes post-fix.
- **New `test_aphorism_density.sh`** — this detector shipped in #371 with fixtures but **no
  wired CI test**; now wired. Cases: dense fires, clean silent, and a front-matter fixture
  packed with short negative definitions that **fired pre-fix**, listing its own build/status
  lines as short declaratives; silent post-fix.

## Count-neutral

No new detector; no catalog SSOT change (still 76 detectors). Regenerated `docs/skills/self-review.md`
(script list) + distribution manifest (`_frontmatter.py` ships). Full CI mirror predicted green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
