### PR TITLE
feat(self-review): check_citation_order UNCITED_FLOAT — a display item with a legend but no in-text citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,20 @@
 
 ### Added
 
+- **`/self-review` `check_citation_order` — `UNCITED_FLOAT`: a display item with a legend but
+  no in-text citation.** The gate already checked that cited floats appear in ascending order; it
+  never checked that a float which *exists* is cited at all. A DIR-4084 galley proof shipped with
+  three supplements (PRISMA checklist, flow data, a 2×2 reconciliation) that carried full captions
+  but were never cited anywhere in the main text — editorial offices and reviewers reject uncited
+  tables/figures/supplements, and nothing flagged it. The detector now parses float definitions
+  (legend/caption lines: `**Supplementary Table S7.** …`, `Figure 2 | …`) out of the back matter —
+  excluding the reference list — and emits `UNCITED_FLOAT` (Minor) for any that the narrative body
+  never cites. A float cited only inside its own legend still counts as uncited. Scoped to the
+  back-matter headers the order scan already recognises (Figure Legends, Table Legends, Tables,
+  Supplementary), so a float defined only in a separate supplement file is out of scope (that needs
+  the supplement file as a second input). Count-neutral: a new verdict on an existing detector, not
+  a new detector.
+
 - **`/self-review` `check_cohort_arithmetic` — `NESTED_MODEL_NO_BASELINE`: nested discrimination
   models with no base-model row.** A table reported C-indices for several nested models that all
   embedded age + sex (CMB+age+sex = 0.667, MetS+age+sex = 0.671, …) but had **no age+sex-only baseline

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4198,8 +4198,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_citation_order.py",
-      "size": 11722,
-      "sha256": "4ee5aaba572b62e2ecaf2884fea0aebcd01ef28f66667cb91f78ecd249a6c0aa"
+      "size": 15088,
+      "sha256": "7170b62c585b45599b55b32efcffb3803bce24190f3e34ec18cf6e7be48b94f1"
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",

--- a/skills/self-review/scripts/check_citation_order.py
+++ b/skills/self-review/scripts/check_citation_order.py
@@ -27,6 +27,10 @@ Verdicts:
                           S4, S9, S16, S12, …). Technical-check-fatal.
   CITATION_GAP  (Minor)   a series' cited numbers are not contiguous from 1
                           (a possible missing / mis-numbered float). Report-only.
+  UNCITED_FLOAT (Minor)   a float that HAS a legend/caption in the back matter is never
+                          cited anywhere in the narrative body — a display item the reader
+                          is never pointed to (uncited supplements/tables/figures are a
+                          recurrent reviewer/technical-check rejection). Report-only.
   DANGLING_SECTION_XREF   an in-text "Section N" / "Section N.M" reference has no
         (Major)           matching numbered heading — the common case being a
                           journal that typesets UNNUMBERED headings, where every
@@ -83,6 +87,20 @@ SERIES_LABEL = {
     ("table", True): "Supplementary Table",
     ("figure", True): "Supplementary Figure",
 }
+
+# A float DEFINITION (legend / caption line) in the back matter — line-start, optional
+# bold, the kind word, the number, then a caption delimiter (`.`/`:`/`|`). This is a
+# definition, not a citation: "Table 3. Baseline characteristics" (legend) vs "Table 3
+# shows…" (citation). Series is keyed by the number's S-prefix, exactly as the body-
+# citation scan keys it, so a defined float and its in-text citation land in the same
+# series and never produce a spurious mismatch.
+FLOAT_DEF_RE = re.compile(
+    r"(?im)^\s{0,3}\**\s*(?:Supplementary\s+|Suppl\.?\s+|Online\s+|e-?)?"
+    r"(Table|Figure)\s+(S?\d+)\s*[.:|]")
+# The references/bibliography list is back matter too but is not a source of float
+# definitions; truncate the definition scan there so a "Fig. 3" inside a citation string
+# cannot be read as a legend.
+REF_HEADER_RE = re.compile(r"(?im)^#{1,6}\s*\**\s*(references|bibliography)\b")
 
 # In-text reference to a numbered section ("as reported in Section 3.4"). Many
 # medical journals typeset UNNUMBERED headings (house style), so a "Section N"
@@ -155,12 +173,59 @@ def _first_appearance(text: str):
     return order
 
 
+def _defined_floats(text: str) -> set[tuple[str, int]]:
+    """{(series_label, number)} for every float DEFINED by a legend/caption line in the
+    back matter (references excluded). Keyed the same way as a body citation."""
+    m = REF_HEADER_RE.search(text)
+    legends = text[: m.start()] if m else text
+    out: set[tuple[str, int]] = set()
+    for dm in FLOAT_DEF_RE.finditer(legends):
+        kind = "table" if dm.group(1).lower() == "table" else "figure"
+        supp = dm.group(2)[0].lower() == "s"
+        num = int(dm.group(2).lstrip("Ss"))
+        out.add((SERIES_LABEL[(kind, supp)], num))
+    return out
+
+
+def _cited_floats(body: str) -> set[tuple[str, int]]:
+    """{(series_label, number)} cited at least once in the narrative body."""
+    return {(label, n) for label, nums in _first_appearance(body).items() for n in nums}
+
+
+def _check_uncited_floats(clean: str) -> list[dict]:
+    """A float DEFINED by a legend/caption but never cited in the narrative body is a
+    display item the reader is never pointed to — editorial offices and reviewers reject
+    uncited tables/figures/supplements (DIR-4084: three supplements shipped uncited)."""
+    m = BACK_MATTER_RE.search(clean)
+    if not m:
+        return []  # no legends/back matter -> nothing is "defined" to check against
+    body_only = clean[: m.start()]
+    defined = _defined_floats(clean[m.start():])
+    if not defined:
+        return []
+    cited = _cited_floats(body_only)
+    claims = []
+    for label, num in sorted(defined - cited):
+        prefix = "S" if label.startswith("Supplementary") else ""
+        claims.append({
+            "verdict": "UNCITED_FLOAT",
+            "severity": "Minor",
+            "detail": (f"{label} {prefix}{num} has a legend/caption but is never cited in the "
+                       f"main text — cite it at least once or remove it (editorial offices and "
+                       f"reviewers flag display items the narrative never points to)"),
+            "where": f"{label} {prefix}{num}",
+        })
+    return claims
+
+
 def check(text: str, include_back_matter: bool) -> list[dict]:
     claims = []
     # Strip any leading YAML front matter first: a `status:`/changelog block that narrates a
     # display-item renumber ("old Table 1 -> Supplementary Table S2") is not a body citation.
-    body = _body(strip_frontmatter(text), include_back_matter)
+    clean = strip_frontmatter(text)
+    body = _body(clean, include_back_matter)
     claims += _check_section_xref(body)
+    claims += _check_uncited_floats(clean)
     order = _first_appearance(body)
     for label in ("Table", "Figure", "Supplementary Table", "Supplementary Figure"):
         seq = order.get(label)

--- a/skills/self-review/tests/fixtures/citation_order_uncited.md
+++ b/skills/self-review/tests/fixtures/citation_order_uncited.md
@@ -1,0 +1,24 @@
+# Methods
+
+Baseline characteristics are in Table 1 and the cohort flow in Figure 1. The
+pre-specified sensitivity analyses are in Supplementary Table S1.
+
+# Results
+
+The primary endpoint is summarized in Table 1, and the subgroup breakdown is in
+Supplementary Table S1.
+
+# Figure Legends
+
+**Figure 1.** Study flow diagram.
+
+# Table Legends
+
+**Table 1.** Baseline characteristics of the analytic cohort.
+
+# Supplementary Material
+
+**Supplementary Table S1.** Pre-specified sensitivity analyses.
+
+**Supplementary Figure S1.** Additional subgroup forest plot — defined here with a
+full caption but never cited anywhere in the Methods or Results.

--- a/skills/self-review/tests/test_citation_order.sh
+++ b/skills/self-review/tests/test_citation_order.sh
@@ -31,6 +31,12 @@ import json
 d=json.load(open('$OUT'))
 assert d['summary']['n_major']==0, d['summary']
 "; }
+count_uncited() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+n=sum(1 for c in d['claims'] if c['verdict']=='UNCITED_FLOAT')
+assert n==$1, f'expected $1 UNCITED_FLOAT, got {n}'
+"; }
 
 [[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
 
@@ -72,6 +78,24 @@ python3 "$SCRIPT" --manuscript "$FM" --out "$OUT" --strict --quiet >/dev/null 2>
 check "exit 0 with an out-of-order renumber in YAML front matter (body clean)" test "$?" -eq 0
 check "no CITATION_ORDER from a front-matter changelog" count_order 0
 check "no Major from a front-matter changelog" no_falsepos
+
+# (6) A float DEFINED by a legend/caption but never cited in the narrative body ->
+#     UNCITED_FLOAT (Minor). The fixture cites Table 1, Figure 1 and Supplementary Table
+#     S1 (all defined and cited), and defines Supplementary Figure S1 with a full caption
+#     that no sentence ever cites.
+UNC="$HERE/fixtures/citation_order_uncited.md"
+python3 "$SCRIPT" --manuscript "$UNC" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 (UNCITED_FLOAT is Minor, not Major)" test "$?" -eq 0
+check "one UNCITED_FLOAT for the defined-but-uncited float" count_uncited 1
+check "the uncited claim names Supplementary Figure S1" python3 -c "
+import json
+d=json.load(open('$OUT'))
+u=[c for c in d['claims'] if c['verdict']=='UNCITED_FLOAT']
+assert u and u[0]['where']=='Supplementary Figure S1', [c['where'] for c in u]
+"
+# (7) the clean fixture defines nothing uncited -> no UNCITED_FLOAT (no over-fire).
+python3 "$SCRIPT" --manuscript "$GOOD" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "no UNCITED_FLOAT on the clean manuscript (no over-fire)" count_uncited 0
 
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## What

`check_citation_order` already verified that *cited* floats appear in ascending order. It
never checked that a float which **exists** is cited at all. On the DIR-4084 galley proof
(Galenos typeset), three supplements — a PRISMA checklist, flow data, and a 2×2
reconciliation — carried full captions but were **never cited anywhere in the main text**.
Editorial offices and reviewers reject uncited tables/figures/supplements, and no
deterministic gate flagged it.

## Fix — new `UNCITED_FLOAT` verdict (Minor)

The detector now parses float **definitions** — legend/caption lines in the back matter
(`**Supplementary Table S7.** …`, `Figure 2 | …`) — and emits `UNCITED_FLOAT` for any that
the narrative body never cites.

- Definitions are read from the back-matter legend sections the order scan already
  recognises (Figure Legends, Table Legends, Tables, Supplementary); the reference list is
  truncated out so a `Fig. 3` inside a citation string is never read as a legend.
- Series is keyed by the number's `S`-prefix, exactly as the body-citation scan keys it, so
  a defined float and its in-text citation land in the same series — no spurious mismatch.
- A float cited only inside **its own legend** still counts as uncited (the "cited" set is
  computed from the narrative body only, before the back matter).
- Verified against the real DIR-4084 shape: an uncited `Supplementary Table S7` (PRISMA
  checklist) is flagged; a fully-cited manuscript is silent.

## Scope

Manuscript-self-contained: a float defined **only in a separate supplement file** (no
in-manuscript legend) is out of scope — that needs the supplement file as a second input,
a larger `check_galley_declarations` build the candidate also proposes. This catches the
common in-manuscript case (author writes a supplementary legend, forgets to cite it).

## Count-neutral

A new **verdict** on an existing detector, not a new detector — 76 detectors unchanged, no
catalog SSOT change (verified: verdict strings are not separately registered). Regenerated
the distribution manifest (modified script's content hash).

## Tests (green-means-nothing verified)

`test_citation_order.sh` cases (6)+(7): a fixture that cites Table 1 / Figure 1 / Supp
Table S1 (all defined) and defines Supp Figure S1 with a caption no sentence cites →
exactly one `UNCITED_FLOAT` naming `Supplementary Figure S1`, Minor (exit 0); the clean
fixture does not over-fire. Both new assertions **failed on the stashed pre-fix detector**
(the verdict cannot exist there). All 5 existing fixtures were re-run — none newly fires
`UNCITED_FLOAT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
