### PR TITLE
feat(make-figures): STROBE flow diagram asserts its own exclusion cascade closes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -336,6 +336,9 @@ jobs:
       - name: Run make-figures pptx Mac-compatibility validator test
         run: python3 skills/make-figures/tests/test_pptx_mac_compat.py
 
+      - name: Run make-figures STROBE cascade-closure test
+        run: bash skills/make-figures/tests/test_strobe_cascade.sh
+
       - name: Run clean-data structural-zero test
         run: bash skills/clean-data/tests/test_structural_zero.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- **`/make-figures` — STROBE flow diagrams now assert their own exclusion cascade closes.** The
+  numbers a reviewer actually sees live as text in the figure, generated from a YAML config,
+  and can drift from the prose the manuscript gates check. A real cohort figure once read
+  "500 excluded → N = 9,470" while the enrolled box said 10,000, so 10,000 − 500 = 9,500, not
+  9,470 — a second exclusion, present in the legend, had been dropped from the figure, and it
+  survived a full round of peer review because figure-image numbers are text-grep blind. `build_strobe_template.py` now checks
+  that every declared exclusion link balances (`A − Σ(exclusions after A) == next box`): it warns
+  loudly on any imbalance and, with `--strict-cascade`, refuses to build. The check is a private
+  helper (`scripts/_strobe_cascade.py`) runnable standalone without python-pptx, so it travels
+  with the config. Low false-positive by construction — a link is checked only when an exclusion
+  is actually declared after it (a branching Analysis leaf with no exclusion between siblings is
+  never treated as a cascade step) and a box with no `n = …` count is skipped, not guessed.
+  Count-neutral: a build-time validation, not a new detector.
+
 - **`/profile-imaging` — the step that sets the research direction had no skill.** The model
   lane could design a preprocessing pipeline (`preprocess-imaging`), prove a split disjoint
   (`model-validation`) and pick metrics (`model-evaluation`), but nothing established *what the

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -53,6 +53,7 @@
 
 **Scripts** (`skills/make-figures/scripts/`):
 
+- `_strobe_cascade.py`
 - `build_jacc_template.py`
 - `build_prisma2020_template.py`
 - `build_strobe_template.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1908,8 +1908,8 @@
     },
     {
       "path": "skills/make-figures/SKILL.md",
-      "size": 46155,
-      "sha256": "2a567bfe908a813acc02b2e9b9ba5500de23702b2088d915329483651630f5dd"
+      "size": 46740,
+      "sha256": "37708a13b21368040891f2250cfece89ab5ef0c1dd21b68a78710c1a1cbf2557"
     },
     {
       "path": "skills/make-figures/references/critic_rubrics/data_plot.md",
@@ -2207,6 +2207,11 @@
       "sha256": "9c151944b960fba4342dbfcae4004c529227598ab50ce0e80f7bbb5f3343f754"
     },
     {
+      "path": "skills/make-figures/scripts/_strobe_cascade.py",
+      "size": 4913,
+      "sha256": "f655ec7080a6f00eb9cd54c1afda58bad74cd6f0a6473a112f21198fa65e6aa0"
+    },
+    {
       "path": "skills/make-figures/scripts/build_jacc_template.py",
       "size": 2941,
       "sha256": "6374b2e3ab159fba629597b12cc1cb0e52a8171bbf4cad33f757e580a7208e66"
@@ -2218,8 +2223,8 @@
     },
     {
       "path": "skills/make-figures/scripts/build_strobe_template.py",
-      "size": 13928,
-      "sha256": "04e267e1b4f10d38544944d2a06b9976f17b567d6530c57a0c661386fcce65c6"
+      "size": 14638,
+      "sha256": "518c73195494b4e3eb28bf5255cb646e3a21d28663c261646038c3523052386b"
     },
     {
       "path": "skills/make-figures/scripts/critic_figure.py",

--- a/skills/make-figures/SKILL.md
+++ b/skills/make-figures/SKILL.md
@@ -560,6 +560,14 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/build_strobe_template.py \
     --out    figures/figure1_strobe.pptx
 ```
 
+The builder checks that the exclusion cascade closes — the count in a spine box, minus the
+exclusions declared after it, must equal the next spine box (`A - Σ(exclusions after A) ==
+B`), for every link that declares an exclusion. It warns loudly on any imbalance and, with
+`--strict-cascade`, refuses to build. This catches the figure-image arithmetic drift that
+text-grep and prose gates miss (a dropped exclusion leaving the figure short of the analytic
+N). Run `scripts/_strobe_cascade.py --config figure1_strobe.yaml --strict` to check a config
+without rebuilding the diagram.
+
 For STROBE the canonical KJR/Radiology/BMJ submission flow is:
 
 1. Render the vector submission file via the auto-fitting Graphviz path:

--- a/skills/make-figures/scripts/_strobe_cascade.py
+++ b/skills/make-figures/scripts/_strobe_cascade.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""STROBE participant-flow cascade closure check for a build_strobe_template.py config.
+
+A STROBE flow diagram's exclusion cascade must balance: the count in a spine box, minus the
+exclusions declared after it, must equal the count in the next spine box. A real cohort
+figure once read "500 excluded -> N = 9,470" while the enrolled box said 10,000, so
+10,000 - 500 = 9,500, not 9,470 — a second exclusion, present in the legend, had been
+dropped from the figure. It survived a full round of peer review and was found only by
+rendering the submission PDF to an image and reading it by eye, because figure-image numbers
+are text-grep blind.
+
+`check_cohort_arithmetic.py` already asserts this closure in manuscript prose, GFM tables and
+committed CSVs. The number that a reviewer actually sees, though, lives as text in the flow
+diagram, generated here from a structured YAML — so the diagram can drift from the prose.
+This makes the figure carry its own assertion.
+
+Low false-positive by construction: a spine link is checked ONLY when at least one exclusion
+is declared after that box (the author is asserting "A minus these gives B"), and only when
+every count involved is extractable. A branching Analysis leaf (two boxes sharing a parent,
+no exclusion between them) is never treated as a cascade step. A box with no "n = …" count is
+skipped, not guessed.
+
+Reused by build_strobe_template.py (a loud warning during the build; fatal under
+--strict-cascade) and runnable standalone (`_strobe_cascade.py --config figure1.yaml
+--strict`) so the check travels without python-pptx.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# The box TOTAL is the first "n = X" / "N = X" in the box text — the parenthetical after the
+# label ("Enrolled (n = 10,000)", "Excluded (n = 500):"). Sub-bullet counts come after it.
+_COUNT_RE = re.compile(r"[nN]\s*=\s*([\d,]+)")
+
+
+def extract_count(text: str | None) -> int | None:
+    """First `n = X` in the box text as an int, or None when the box carries no count."""
+    if not text:
+        return None
+    m = _COUNT_RE.search(str(text))
+    return int(m.group(1).replace(",", "")) if m else None
+
+
+def check_cascade(cfg: dict) -> list[dict]:
+    """Return an imbalance finding for every declared exclusion link A -> B where
+    ``A.count - sum(exclusions after A) != B.count``."""
+    spine = cfg.get("spine") or []
+    exclusions = cfg.get("exclusions") or []
+    if len(spine) < 2:
+        return []
+
+    counts = {b.get("id"): extract_count(b.get("text")) for b in spine if isinstance(b, dict)}
+    excl_after: dict[str, list[int | None]] = {}
+    for e in exclusions:
+        if isinstance(e, dict) and e.get("after"):
+            excl_after.setdefault(e["after"], []).append(extract_count(e.get("text")))
+
+    findings: list[dict] = []
+    for i in range(len(spine) - 1):
+        a, b = spine[i], spine[i + 1]
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            continue
+        aid = a.get("id")
+        excls = excl_after.get(aid)
+        if not excls:                       # only a DECLARED exclusion link is a cascade step
+            continue
+        a_n, b_n = counts.get(aid), counts.get(b.get("id"))
+        if a_n is None or b_n is None or any(x is None for x in excls):
+            continue                        # never guess a missing count
+        got = a_n - sum(excls)
+        if got != b_n:
+            findings.append({
+                "after": aid,
+                "next": b.get("id"),
+                "detail": (f"STROBE cascade does not close after '{aid}': {a_n:,} - "
+                           f"{'+'.join(f'{x:,}' for x in excls)} = {got:,}, but the next box "
+                           f"'{b.get('id')}' says {b_n:,} (off by {b_n - got:+,})"),
+            })
+    return findings
+
+
+def _load(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml  # noqa: PLC0415
+        except ModuleNotFoundError:
+            sys.exit("PyYAML not installed; install it or pass a JSON config.")
+        return yaml.safe_load(text) or {}
+    import json  # noqa: PLC0415
+    return json.loads(text)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="STROBE flow cascade-closure check.")
+    ap.add_argument("--config", required=True, help="build_strobe_template.py YAML/JSON config")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if the cascade does not close")
+    a = ap.parse_args()
+    findings = check_cascade(_load(Path(a.config)))
+    if findings:
+        for f in findings:
+            print(f"CASCADE_IMBALANCE: {f['detail']}")
+    else:
+        print("OK: STROBE exclusion cascade closes at every declared link.")
+    return 1 if (findings and a.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/make-figures/scripts/build_strobe_template.py
+++ b/skills/make-figures/scripts/build_strobe_template.py
@@ -59,6 +59,8 @@ import json
 import sys
 from pathlib import Path
 
+from _strobe_cascade import check_cascade
+
 try:
     import yaml
     HAS_YAML = True
@@ -337,11 +339,23 @@ def main():
     p = argparse.ArgumentParser(description="Build an editable STROBE flow diagram .pptx from a YAML config.")
     p.add_argument("--config", required=True, type=Path, help="YAML/JSON STROBE config")
     p.add_argument("--out",    required=True, type=Path, help="Output .pptx path")
+    p.add_argument("--strict-cascade", action="store_true",
+                   help="refuse to build if the exclusion cascade does not close "
+                        "(A - sum(exclusions after A) != next box)")
     args = p.parse_args()
 
     cfg = load_config(args.config)
     if not isinstance(cfg, dict):
         sys.exit(f"Config root must be a mapping; got {type(cfg)}")
+
+    # The numbers a reviewer sees are in the figure, not the prose — assert the cascade closes
+    # before rendering. Warn loudly by default; refuse under --strict-cascade.
+    cascade = check_cascade(cfg)
+    for f in cascade:
+        sys.stderr.write(f"⚠️  {f['detail']}\n")
+    if cascade and args.strict_cascade:
+        sys.exit("STROBE cascade does not close; refusing to build (drop --strict-cascade "
+                 "to build anyway).")
 
     build(cfg, args.out)
     print(f"Wrote {args.out}")

--- a/skills/make-figures/tests/fixtures/strobe_cascade_balanced.yaml
+++ b/skills/make-figures/tests/fixtures/strobe_cascade_balanced.yaml
@@ -1,0 +1,7 @@
+# The same cascade, closing exactly: 10,000 - 500 = 9,500.
+title: "Figure 1. STROBE participant flow diagram"
+spine:
+  - {id: enrolled, text: "Participants enrolled (n = 10,000)"}
+  - {id: analyzed, text: "Included in the primary analysis (n = 9,500)"}
+exclusions:
+  - {after: enrolled, text: "Excluded (n = 500):\n- missing baseline covariate"}

--- a/skills/make-figures/tests/fixtures/strobe_cascade_branching.yaml
+++ b/skills/make-figures/tests/fixtures/strobe_cascade_branching.yaml
@@ -1,0 +1,10 @@
+# A branching Analysis leaf: primary and landmark share the eligible parent, with no
+# exclusion declared between them. The landmark subset (4,200) must NOT be read as an
+# unbalanced cascade step off the primary (5,000).
+title: "Figure 1. STROBE participant flow diagram"
+spine:
+  - {id: eligible, text: "Eligible cohort (n = 5,000)"}
+  - {id: primary,  text: "Primary Cox model (n = 5,000)"}
+  - {id: landmark, text: "Landmark subset analysis (n = 4,200)"}
+exclusions:
+  - {after: eligible, text: "Excluded (n = 0)"}

--- a/skills/make-figures/tests/fixtures/strobe_cascade_imbalanced.yaml
+++ b/skills/make-figures/tests/fixtures/strobe_cascade_imbalanced.yaml
@@ -1,0 +1,10 @@
+# Synthetic, PII-free. One exclusion box drops out of the arithmetic: enrolled 10,000 minus
+# the single declared exclusion 500 is 9,500, but the analysis box reads 9,470 — off by 30
+# (a second exclusion, present in the legend, was dropped from the figure). This is the
+# real-world class: a cascade that is short of the analytic N by one omitted exclusion.
+title: "Figure 1. STROBE participant flow diagram"
+spine:
+  - {id: enrolled, text: "Participants enrolled (n = 10,000)"}
+  - {id: analyzed, text: "Included in the primary analysis (N = 9,470)"}
+exclusions:
+  - {after: enrolled, text: "Excluded (n = 500):\n- missing baseline covariate"}

--- a/skills/make-figures/tests/test_strobe_cascade.sh
+++ b/skills/make-figures/tests/test_strobe_cascade.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression test for the STROBE flow cascade-closure check (make-figures).
+# Synthetic, PII-free YAML fixtures modelled on a real cohort-figure defect:
+#   imbalanced -> 10,000 - 500 = 9,500, but the analysis box says 9,470 (off by 30)
+#   balanced   -> the same cascade closing exactly (9,500)
+#   branching  -> a landmark-subset leaf with no exclusion between it and its parent, which
+#                 must NOT be read as an unbalanced cascade step (low-false-positive guard)
+# The helper (_strobe_cascade.py) is checked directly (no python-pptx needed); the
+# build_strobe_template.py --strict-cascade integration is checked only when pptx is present.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHK="$HERE/../scripts/_strobe_cascade.py"
+BUILD="$HERE/../scripts/build_strobe_template.py"
+FX="$HERE/fixtures"
+fail=0
+ck() { if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"; else printf '  FAIL  %s (want %s got %s)\n' "$1" "$2" "$3"; fail=$((fail+1)); fi; }
+
+[ -f "$CHK" ] || { echo "ENV-ERR: helper missing" >&2; exit 2; }
+
+# (1) imbalanced cascade -> exit 1 under --strict, and the message names the offending link.
+out="$(python3 "$CHK" --config "$FX/strobe_cascade_imbalanced.yaml" --strict 2>&1)"; rc=$?
+ck "imbalanced exits 1 under --strict" 1 "$rc"
+printf '%s\n' "$out" | grep -q 'CASCADE_IMBALANCE' && ck "imbalanced reports CASCADE_IMBALANCE" yes yes || ck "imbalanced reports CASCADE_IMBALANCE" yes no
+printf '%s\n' "$out" | grep -q "off by -30" && ck "imbalanced names the -30 offset" yes yes || ck "imbalanced names the -30 offset" yes no
+
+# (2) balanced cascade -> exit 0, no imbalance.
+python3 "$CHK" --config "$FX/strobe_cascade_balanced.yaml" --strict >/dev/null 2>&1; ck "balanced exits 0" 0 "$?"
+
+# (3) branching leaf -> exit 0 (the 4,200 subset is not a cascade step off the 5,000 parent).
+out3="$(python3 "$CHK" --config "$FX/strobe_cascade_branching.yaml" --strict 2>&1)"; ck "branching leaf exits 0 (no false positive)" 0 "$?"
+printf '%s\n' "$out3" | grep -q 'CASCADE_IMBALANCE' && { echo "  FAIL  branching leaf falsely flagged" >&2; fail=$((fail+1)); } || printf '  PASS  branching leaf not flagged\n'
+
+# (4) build integration (only if python-pptx is installed): --strict-cascade refuses the
+#     imbalanced config and builds the balanced one.
+if python3 -c "import pptx" 2>/dev/null; then
+  tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+  python3 "$BUILD" --config "$FX/strobe_cascade_imbalanced.yaml" --out "$tmp/x.pptx" --strict-cascade >/dev/null 2>&1
+  ck "build --strict-cascade refuses the imbalanced config" 1 "$?"
+  python3 "$BUILD" --config "$FX/strobe_cascade_balanced.yaml" --out "$tmp/ok.pptx" --strict-cascade >/dev/null 2>&1
+  ck "build --strict-cascade builds the balanced config" 0 "$?"
+  [ -f "$tmp/ok.pptx" ] && ck "balanced build wrote the pptx" yes yes || ck "balanced build wrote the pptx" yes no
+else
+  echo "  SKIP  build integration (python-pptx not installed)"
+fi
+
+echo "fail=$fail"; [ "$fail" -eq 0 ] && echo "ALL PASS" || echo "FAILURES: $fail"
+exit "$fail"


### PR DESCRIPTION
## What

A STROBE participant-flow diagram's exclusion cascade must balance: the count in a spine box,
minus the exclusions declared after it, must equal the next spine box. A real cohort figure once
read "500 excluded → N = 9,470" while the enrolled box said 10,000, so 10,000 − 500 = 9,500, not
9,470 — a second exclusion, present in the legend, had been dropped from the figure. It survived
a full round of peer review and was found only by rendering the submission PDF to an image and
reading it by eye, because **figure-image numbers are text-grep blind**.

`check_cohort_arithmetic` already asserts this closure in prose, GFM tables and CSVs — but the
number a reviewer sees is in the figure, generated from a YAML config, and can drift from the
prose.

## Fix — the figure carries its own assertion

`build_strobe_template.py` now checks that every **declared exclusion link** closes
(`A − Σ(exclusions after A) == next box`). It warns loudly on any imbalance and, with
`--strict-cascade`, refuses to build.

- The check is a private helper, `scripts/_strobe_cascade.py`, runnable standalone
  (`_strobe_cascade.py --config figure1.yaml --strict`) **without python-pptx**, so it travels
  with the config and can gate a draft before the diagram is rendered.
- **Low false-positive by construction:** a link is checked only when an exclusion is actually
  declared after that box; a branching Analysis leaf (two boxes sharing a parent, no exclusion
  between them) is never treated as a cascade step; a box with no `n = …` count is skipped, not
  guessed. The box total is the first `n = X` in the box text, so exclusion sub-bullet counts are
  not mistaken for it.
- The shipped exemplar config validates clean.

## Count-neutral

A build-time validation + a private (underscored, uncounted) helper — **not a new detector**.
Detector count and catalog SSOT unchanged.

## Tests

`tests/test_strobe_cascade.sh` (CI-wired), synthetic PII-free YAML fixtures: imbalanced → exit 1
+ names the −30 offset; balanced → exit 0; branching leaf → exit 0 (no false positive); and the
`build_strobe_template.py --strict-cascade` integration refuses the imbalanced config and builds
the balanced one (when python-pptx is present). Neutering `check_cascade` to return `[]` was
confirmed to make the test fail — it gates the behavior, not just its own scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
