### PR TITLE
chore(governance): add CODEOWNERS and open a drive-by path in the PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,49 @@
+# CODEOWNERS — routes review according to the decision rule in MAINTAINERS.md.
+#
+# What this does: GitHub auto-requests review from the owner of any path a PR touches.
+# What it does NOT do: GitHub never requests review from a PR's own author, so this
+# file is inert on maintainer-authored PRs. Its purpose is to route EXTERNAL
+# contributions — journal profiles, checklists, locale packs, skills — to the
+# Clinical Lead without anyone having to remember to.
+#
+# The roles, the decision rule, and the permission ramp live in MAINTAINERS.md; this
+# file only routes. The two blocks below follow the seam that document already draws:
+# clinical/research validity stays with the founder, while the technical surface is
+# explicitly shareable. Today both point to the same person. When a Technical
+# Maintainer is onboarded, they are added to the SECOND block only — the first block
+# is the one that must not be delegated.
+
+# ---------------------------------------------------------------------------
+# Default
+# ---------------------------------------------------------------------------
+*                                               @Yoojin-nam
+
+# ---------------------------------------------------------------------------
+# Clinical / research validity — Clinical Lead sign-off (MAINTAINERS.md)
+# Scope, official-skill decisions, medical or research claims, reporting-checklist
+# fidelity, and benchmark interpretation. Not delegable.
+# ---------------------------------------------------------------------------
+/skills/                                        @Yoojin-nam
+/skills/check-reporting/references/checklists/  @Yoojin-nam
+/skills/find-journal/references/                @Yoojin-nam
+/skills/write-paper/references/                 @Yoojin-nam
+/evaluation/                                    @Yoojin-nam
+/demo/                                          @Yoojin-nam
+/paper.md                                       @Yoojin-nam
+/paper.bib                                      @Yoojin-nam
+/MEDSCI_AUDIT.md                                @Yoojin-nam
+/MAINTAINERS.md                                 @Yoojin-nam
+/ROADMAP.md                                     @Yoojin-nam
+/README.md                                      @Yoojin-nam
+/CITATION.cff                                   @Yoojin-nam
+
+# ---------------------------------------------------------------------------
+# Technical surface — shareable (MAINTAINERS.md: Technical Maintainer)
+# CI, packaging, installers, release automation, repo validators. A future
+# co-maintainer is added here first, per the permission ramp in
+# docs/maintainer_workflow.md.
+# ---------------------------------------------------------------------------
+/scripts/                                       @Yoojin-nam
+/installers/                                    @Yoojin-nam
+/.github/                                       @Yoojin-nam
+/package.json                                   @Yoojin-nam

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
 <!--
 Thanks for contributing to MedSci Skills. Keep PRs small and reviewable.
 See CONTRIBUTING.md for the full workflow and PII/publication hygiene rules.
+
+ADDING ONE FILE? (a journal profile, a CSL style, a reporting checklist, a
+de-identification locale pack, a figure exemplar, a README translation)
+Tick the first box under "Type of change" and stop. The rest of this template is
+for larger changes. CI runs for you and a maintainer handles the bookkeeping
+(catalog counts, changelog) in review — see CONTRIBUTING.md.
 -->
 
 ## Summary
@@ -9,6 +15,7 @@ See CONTRIBUTING.md for the full workflow and PII/publication hygiene rules.
 
 ## Type of change
 
+- [ ] **One-file contribution** (journal profile, CSL, checklist, locale pack, figure exemplar, translation, typo) — **stop here.** A maintainer handles the bookkeeping below.
 - [ ] New skill
 - [ ] Fix or improvement to an existing skill
 - [ ] Deterministic script / validator
@@ -16,6 +23,13 @@ See CONTRIBUTING.md for the full workflow and PII/publication hygiene rules.
 - [ ] Other (describe above)
 
 ## Validators
+
+<!--
+CI runs every gate for you. To run them locally, `python3 scripts/run_ci_mirror.py`
+executes the whole `validate` job in order — it parses the workflow, so it cannot
+drift from CI. A red CI on a first contribution is normal and is NOT yours to fix
+alone: say so in the PR and a maintainer will pick it up.
+-->
 
 - [ ] `bash scripts/validate_skills.sh`
 - [ ] `python3 scripts/validate_skill_contracts.py`


### PR DESCRIPTION
Follow-up to #390, from the same external review (its finding #3: bus factor and independent review).

## What the review got right, and what it did not

The review read this as a governance-documentation gap. It is not: `MAINTAINERS.md`, `ROADMAP.md`, `docs/maintainer_workflow.md`, and CONTRIBUTING's medical-claim gate all already exist and are specific. **The gap is reality, not documentation** — both roles are the same person, and no file changes that. This PR does not pretend otherwise; it wires the policy that already exists into GitHub, which is the part that *was* missing.

## 1. `.github/CODEOWNERS` (new)

`MAINTAINERS.md` draws a seam: clinical/research validity stays with the founder, the technical surface is explicitly shareable via a permission ramp. Nothing wired that seam into GitHub. The file follows it exactly — two blocks, both pointing at the same person today:

- **Clinical / research validity** (`skills/`, checklists, journal profiles, `evaluation/`, `paper.md`, `README.md`, `CITATION.cff`, `MEDSCI_AUDIT.md`) — not delegable.
- **Technical surface** (`scripts/`, `installers/`, `.github/`, `package.json`) — where a future Technical Maintainer is added *first*, per the ramp.

Value: external PRs (#330, #351, and the good-first-issues) now auto-request review instead of waiting to be noticed; and onboarding help later is a handle change in the second block only.

**Stated limitation, written into the file:** GitHub never requests review from a PR's own author, so this is **inert on maintainer-authored PRs**. It routes external contributions; it does not create independent review of my own work. Only a second person does that.

## 2. PR template — a light path for one-file contributions

The template already covered the important things (Clinical-Lead gate for medical claims, catalog-count SSOT, PII hygiene), so it is **left intact**. What it lacked was the tiering CONTRIBUTING promises:

> the heavier Pull Request Checklist … apply to maintainers and larger PRs — not to a one-file drive-by contribution.

The template nonetheless presented ~14 checkboxes with no escape hatch — contradicting that welcome for exactly the contributors the good-first-issues target (journal profiles, CSL styles, locale packs, figure exemplars). Added:

- a **"One-file contribution — stop here"** option as the first type-of-change box, plus the same note in the header comment;
- a pointer to `scripts/run_ci_mirror.py` (parses the workflow, so it cannot drift from CI);
- CONTRIBUTING's existing reassurance that **a red CI on a first contribution is not the contributor's to fix alone**.

## Verification

- Full CI mirror (`run_ci_mirror.py`, all 182 `validate`-job gates) → **182/182 green**.
- CODEOWNERS owner handle verified to resolve and hold write access before committing (a bad handle makes CODEOWNERS silently inert). GitHub's own CODEOWNERS-errors API will be checked on this PR.
- No CHANGELOG entry: contributor-facing repo infrastructure, not user-visible, ships in no release payload — consistent with the release-cadence rule that docs/CI/chore-only work is not a release.