### PR TITLE
docs(evaluation): pre-register the 80-detector refresh; fix a family table that summed to 72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+- **A pre-registered protocol for the evaluation refresh that covers all 80 detectors.**
+  `evaluation/REFRESH_PROTOCOL.md` — written before any run, because an analysis plan chosen
+  after seeing results is a re-designation, not a derivation, and the toolkit enforces exactly
+  that discipline on its users. It splits the question into three arms with different evidentiary
+  standing and refuses to blend them: **Arm A** extends the seeded-defect design to every
+  detector, per *verdict* rather than per detector, and adds the **hard negative** (a near-miss
+  that must stay silent) that E1 never had — the class where the recent `/verify-refs` precision
+  bugs actually lived. **Arm B** measures what the evidence base has nothing on and what actually
+  decides adoption: **alert burden on clean manuscripts**, with applicability gating so a
+  genre-gated detector's silence is not counted as a true negative, and a pre-specified budget
+  (0 Major, median ≤ 3 Minor). **Arm C** is the real-use precision ledger, permanently
+  out-of-band. Two constraints are recorded up front rather than discovered later: an injection
+  benchmark **cannot report precision or sensitivity** (fault injection has no defined defect
+  prevalence — E1's own rationale, carried forward), and Arm B **should not be run to completion
+  while the only adjudicator is the person who wrote the detectors**, since an author judging his
+  own gate inherits the blind spot that produced it. Stages 0–2 are solo-completable; Stage 3 is
+  explicitly gated on recruiting an external adjudicator.
+
 - **Perspective structural gate — a Perspective drafted like an original article, caught before a
   co-author does.** `/self-review` gains `check_perspective_structure` (genre-gated to
   `article_type: Perspective`): it flags IMRAD section headings ("Introduction / Methods / Results /
@@ -157,6 +175,22 @@
   78.
 
 ### Fixed
+
+- **The MedSci-Audit family table enumerated 72 detectors under a sentence claiming 80.** The
+  registry's own per-family rows had gone stale by eight: style/review 18 → **24**,
+  confounding/scope/estimand 6 → **7**, data preparation 14 → **15** (`check_aphorism_density`,
+  `check_baseline_drift`, `check_perspective_structure`, `check_rewrite_fidelity`,
+  `check_rhetorical_density`, `check_sentence_variety`, `check_analysis_definitions`,
+  `check_dataset_profile` were missing rows). The total *was* gated — "The 80 detectors fall
+  into six audit families" is a watched claim — but **nothing checked that the rows beneath it
+  summed to it**, so the flagship audit document contradicted itself in public. Found while
+  scoping the family-stratified benchmark, where a stale family size would have misallocated the
+  sampling budget. `validate_catalog_consistency` gains **Layer 4**: every family row is asserted
+  against `metadata/detectors_catalog.json` — declared count against the family's true size, and
+  listed names against its true membership — so a detector added without a row now fails CI
+  instead of silently unbalancing the registry. The column header is renamed `Examples` →
+  `Detectors`, because the rows are the complete enumeration and the gate now enforces that.
+  Regression-tested both ways (count drift and membership drift each FAIL).
 
 - **Drifted public-facing catalog claims corrected, and the consistency gate widened to the phrasings
   that slipped past it.** An external review found several current-state counts stale against the

--- a/MEDSCI_AUDIT.md
+++ b/MEDSCI_AUDIT.md
@@ -17,14 +17,20 @@ The authoritative, machine-readable list is **[`metadata/detectors_catalog.json`
 
 The 80 detectors fall into six audit families:
 
-| Family | Count | Examples |
+The per-family rows below are the **complete** enumeration, not a sample, and are CI-gated
+against `metadata/detectors_catalog.json` (`validate_catalog_consistency.py`): each row's count
+must equal that family's size in the catalog, and the names listed must be exactly that family's
+members. The gate exists because the total and the rows drifted apart once — the sentence above
+said 80 while these rows enumerated 72.
+
+| Family | Count | Detectors |
 |--------|------:|----------|
 | Numerical, cohort & pool arithmetic | 11 | `check_cohort_arithmetic`, `check_effect_stability`, `check_table_percentages`, `check_reported_p_from_counts`, `check_dta_denominators`, `check_paired_difference_estimator`, `check_pool_consistency`, `check_artifact_coverage`, `check_rounded_delta`, `detect_copy_divergence`, `derive_figure_legend_counts` |
 | Citation & reference integrity | 8 | `verify_refs`, `check_citation_keys`, `check_xref`, `check_csl_render`, `check_reference_adequacy`, `check_placeholders`, `check_reference_duplication`, `check_bib_title_markup` |
-| Style & review-process integrity | 18 | `check_classical_style`, `check_generated_code`, `check_panel_diversity`, `check_reviewer_team_consistency`, `check_paren_spans`, `check_training_hygiene`, `check_editorial_impression`, `check_emphasis_density`, `check_response_claims`, `check_pdf_injection`, `check_marked_manuscript`, `check_self_improvement_claims`, `check_slide_tells`, `check_deck_budget`, `check_density_complaint`, `check_review_request_types`, `check_review_length`, `check_review_boxes` |
-| Confounding, scope & estimand contracts | 6 | `check_scope_coherence`, `check_incorporation_bias`, `check_confounding_completeness`, `check_nested_group_comparison`, `check_claim_artifact`, `check_null_calibration` |
+| Style & review-process integrity | 24 | `check_classical_style`, `check_generated_code`, `check_panel_diversity`, `check_reviewer_team_consistency`, `check_paren_spans`, `check_training_hygiene`, `check_editorial_impression`, `check_emphasis_density`, `check_response_claims`, `check_pdf_injection`, `check_marked_manuscript`, `check_self_improvement_claims`, `check_slide_tells`, `check_deck_budget`, `check_density_complaint`, `check_review_request_types`, `check_review_length`, `check_review_boxes`, `check_aphorism_density`, `check_baseline_drift`, `check_perspective_structure`, `check_rewrite_fidelity`, `check_rhetorical_density`, `check_sentence_variety` |
+| Confounding, scope & estimand contracts | 7 | `check_scope_coherence`, `check_incorporation_bias`, `check_confounding_completeness`, `check_nested_group_comparison`, `check_claim_artifact`, `check_null_calibration`, `check_analysis_definitions` |
 | Reporting compliance | 15 | `check_framework_naming`, `check_checklist_exists`, `check_checklist_version`, `check_prisma_figure`, `check_figure_citation`, `check_wordcount_cap`, `check_disclosure_availability`, `check_summary_box`, `check_supplement_hygiene`, `check_citation_order`, `check_model_card_complete`, `check_mllm_eval_completeness`, `check_explainability_report`, `check_uncertainty_reporting`, `check_exclusion_code_validity` |
-| Data preparation & validation | 14 | `check_structural_zero`, `check_reverse_coding`, `check_asset_anonymization`, `check_cross_artifact_stale`, `check_checklist_dump_leak`, `check_binning_consistency`, `check_cv_leakage`, `check_split_leakage`, `check_metric_reporting`, `check_preprocessing_leakage`, `check_radiomics_ml`, `check_separation`, `check_contribution_safety`, `check_portal_field_residue` |
+| Data preparation & validation | 15 | `check_structural_zero`, `check_reverse_coding`, `check_asset_anonymization`, `check_cross_artifact_stale`, `check_checklist_dump_leak`, `check_binning_consistency`, `check_cv_leakage`, `check_split_leakage`, `check_metric_reporting`, `check_preprocessing_leakage`, `check_radiomics_ml`, `check_separation`, `check_contribution_safety`, `check_portal_field_residue`, `check_dataset_profile` |
 
 ## The artifact contract
 
@@ -51,7 +57,7 @@ The suite's evaluation evidence and its current size are **two separate facts** 
 
 - **Current detector catalog: 80** (the enumerated list in `metadata/detectors_catalog.json`).
 - **Canonical evaluation runs are v3.8-era and validate the then-current subset.** The seeded-defect benchmark (**E1**) is built on **19 `DefectSpec` rows / 17 deterministic injectors** ([`evaluation/h1_seeded_defects/DEFECT_RATIONALE.md`](evaluation/h1_seeded_defects/DEFECT_RATIONALE.md)), and the coverage inventory (**E7**) is **n=21** ([`evaluation/runs/canonical/E7/limitations.md`](evaluation/runs/canonical/E7/limitations.md)). Both predate the A1–A4 detectors that brought the catalog to 24. The frozen canonical runs under [`evaluation/runs/canonical/`](evaluation/runs/canonical/) are pinned to the published methods artifacts and are intentionally left unchanged.
-- **Detectors added since v3.8 are covered by their own per-skill CI tests** (e.g. `skills/sync-submission/tests/test_asset_anonymization.sh`, `skills/check-reporting/tests/test_checklist_version.sh`, `skills/write-paper/tests/test_placeholders.sh`), run on every push via [`.github/workflows/validate.yml`](.github/workflows/validate.yml) — not by a re-run of the frozen E1/E7. A refresh of E1/E7 to cover all 80 detectors is a separate evaluation effort and is **not** part of this registry.
+- **Detectors added since v3.8 are covered by their own per-skill CI tests** (e.g. `skills/sync-submission/tests/test_asset_anonymization.sh`, `skills/check-reporting/tests/test_checklist_version.sh`, `skills/write-paper/tests/test_placeholders.sh`), run on every push via [`.github/workflows/validate.yml`](.github/workflows/validate.yml) — not by a re-run of the frozen E1/E7. A refresh of E1/E7 to cover all 80 detectors is a separate evaluation effort and is **not** part of this registry — it is pre-registered as a protocol in [`evaluation/REFRESH_PROTOCOL.md`](evaluation/REFRESH_PROTOCOL.md), which also states why an injection benchmark cannot report precision, and why its clean-manuscript arm should not be run to completion without an external adjudicator.
 
 For the broader evaluation harness (E1–E9: seeded-defects, LLM baseline, cost/time, fresh-clone reproducibility, audit-trail completeness, portability, inventory, drift, self-review convergence), see [`evaluation/`](evaluation/).
 

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -27,6 +27,20 @@ scope here by design.
 | E8 | `h6_inventory_drift/run_e8_drift.py` | Public-metadata drift is caught by the catalog validator | exact |
 | E9 | `h7_selfreview_convergence/` | Whether the self-review loop reduces its own actionable findings (internal QC convergence) | non-deterministic — **ships, NOT_RUN by default** |
 
+## Coverage status, and the planned refresh
+
+The harnesses above are **v3.8-era**: E1 rests on 19 `DefectSpec` rows / 17 offline injectors and
+E7 is n=21, while the current catalog is **80 detectors**. Detectors added since are covered by
+per-detector CI challenge cards — regression tripwires, not a benchmark.
+
+[`REFRESH_PROTOCOL.md`](REFRESH_PROTOCOL.md) pre-registers the refresh that closes that gap:
+family-stratified coverage of all 80 detectors with hard negatives (Arm A), an alert-burden
+measurement on clean manuscripts (Arm B), and an out-of-band real-use precision ledger (Arm C).
+It is a protocol only — **no results exist yet** — and it records two constraints up front: an
+injection benchmark cannot report precision (there is no defined defect prevalence), and the
+clean-manuscript arm should not be run to completion while the only available adjudicator is the
+person who wrote the detectors.
+
 ## Running
 
 ```bash

--- a/evaluation/REFRESH_PROTOCOL.md
+++ b/evaluation/REFRESH_PROTOCOL.md
@@ -1,0 +1,207 @@
+# Evaluation refresh protocol — covering all 80 detectors
+
+**Status: pre-registered protocol. No results exist yet.** Every number below is a target, a
+budget, or a stopping rule fixed *before* any run. This document is written first on purpose:
+the toolkit's own `estimand-provenance` discipline says an analysis plan chosen after seeing
+results is a re-designation, not a derivation, and an evaluation of that discipline should not
+violate it.
+
+## 1. Why a refresh
+
+The suite's size and its evaluation evidence are two separate facts, reported at different
+versions (see [`MEDSCI_AUDIT.md`](../MEDSCI_AUDIT.md) § Evidence):
+
+- **Current catalog: 80 detectors** across six families.
+- **Canonical evaluation is v3.8-era.** The seeded-defect benchmark (**E1**) rests on 19
+  `DefectSpec` rows / 17 offline injectors; the coverage inventory (**E7**) is n=21. Both
+  predate most of the current catalog.
+- Detectors added since are covered by **per-detector CI challenge cards**, which are
+  *regression* tests, not a benchmark: they answer "does this still fire?" on every push, not
+  "how does the suite behave, as a suite, at a pinned version?"
+
+So the honest current claim is: an architecture-level benchmark on a then-current subset, plus
+component-level regression on everything since. What is missing is a **system-level measurement
+of the present suite**. That gap is the single largest remaining weakness in the evidence base,
+and it is the one a methods reviewer will name first.
+
+**Non-goal.** This does not replace or re-run the frozen canonical runs under
+[`runs/canonical/`](runs/canonical/). Those are pinned to the published methods artifacts and
+stay unchanged. This is a new, separately-versioned measurement.
+
+## 2. What the existing design already gets right (and must be carried forward)
+
+E1's [`DEFECT_RATIONALE.md`](h1_seeded_defects/DEFECT_RATIONALE.md) makes a methodological
+commitment that is easy to lose in a "bigger benchmark" and must not be:
+
+> Because fault injection has **no defined defect prevalence**, the benchmark reports **recall
+> and the clean false-positive rate, not precision or sensitivity** — it is a *triggering*
+> check, not a population estimate.
+
+That is correct and binding. Injecting a defect and seeing the detector fire tells you the
+detector triggers; it tells you nothing about how often that defect occurs in real manuscripts,
+so no precision, PPV, or sensitivity can be computed from injection alone. **A refresh that
+reports "sensitivity and specificity" from an injection corpus would be reporting numbers its
+design cannot support.** The protocol therefore splits the question into three arms with
+different evidentiary standing, and never blends their metrics into one headline.
+
+Carried forward unchanged from E1: one defect at a time; deterministic injection (first match in
+document order, no RNG); exactly one judged detector per injected copy, so attribution is
+unambiguous; and every run reproducible from a pinned manifest.
+
+## 3. Three arms
+
+| Arm | Question | Corpus | Yields | Does **not** yield |
+|-----|----------|--------|--------|--------------------|
+| **A — E1-R** | Does each detector fire on the defect it exists to catch, and stay silent on a near-miss? | Synthetic injected + hard negatives | Per-detector **recall**, **clean-FP**, **hard-negative pass rate** | Precision, PPV, prevalence |
+| **B — E10** | How noisy is the suite on a *clean* manuscript? | Clean realistic manuscripts | **Alert burden** per manuscript, per-detector share of alerts, adjudicated FP rate | Recall |
+| **C — ledger** | On real manuscripts, what fraction of fires are worth acting on? | Real use, out-of-band | Aggregate per-detector **precision** with n | Recall; anything publishable at row level |
+
+Arm B is the one that decides adoption. A detector suite with perfect recall that fires forty
+times on a clean paper is unusable, and no amount of Arm A evidence fixes that. It is also the
+arm the current evidence base has nothing on.
+
+### Arm A — per-detector triggering (E1-R)
+
+**Unit of analysis:** a `(detector, verdict)` pair, not a detector. A detector that emits three
+distinct verdicts is three units; a verdict with no positive fixture is untested regardless of
+how well its siblings do.
+
+**Coverage requirement.** Every one of the 80 detectors carries:
+1. **≥1 positive fixture per emitted verdict** — the defect is injected, that specific verdict
+   must fire.
+2. **≥1 hard negative** — a *near-miss* that a naive implementation would flag but that is
+   correct, and on which the detector must stay silent. A blank file is not a hard negative.
+3. **A clean-baseline run** — the un-injected input, on which the verdict must not fire.
+
+Hard negatives are the addition over E1. They are where precision bugs actually live: the
+`/verify-refs` defects that motivated recent releases (a Unicode hyphen in a surname read as a
+fabricated author; a brace-protected surname read as a corporate author) were both near-miss
+failures, not missing-recall failures.
+
+**Family stratification.** The catalog is unbalanced by design — style/review 24, reporting
+compliance 15, data preparation 15, numerical/cohort 11, confounding/scope/estimand 7,
+citation/reference 8. Reporting is **per family and per detector**; no single pooled recall
+figure is reported as the headline, because pooling lets a large easy family mask a small hard
+one.
+
+**Metrics.** Per `(detector, verdict)`: recall ∈ {0,1} (deterministic — the ground truth is the
+injection); clean-FP ∈ {0,1}; hard-negative pass ∈ {0,1}. Aggregated per family as counts, not
+percentages, when n < 20.
+
+**No adjudication needed.** Ground truth is the injection itself. This is Arm A's strength and
+the reason it is the cheap arm.
+
+### Arm B — alert burden on clean manuscripts (E10)
+
+**Corpus.** Manuscripts that are believed defect-free and are *realistic* — full IMRAD length,
+real tables, real reference lists. Two sources, both licence-checked and synthetic-or-public
+only (see § 5): purpose-built synthetic manuscripts spanning the study designs the suite
+targets, and open-access published articles whose licence permits redistribution.
+
+**Applicability gating is mandatory.** Many detectors are genre-gated (a Perspective-structure
+check must not be scored against an RCT; a slide-deck check must not be scored against a
+manuscript). Each corpus item declares which detectors are *applicable*; a non-applicable
+detector that stays silent is not a true negative and is excluded from that item's denominator.
+Failing to do this would manufacture a flattering burden figure.
+
+**Metrics.** Alerts per manuscript (median, IQR, max) split by severity; the fraction of clean
+manuscripts with ≥1 Major alert; each detector's share of total alerts (the "top offender"
+ranking); and the adjudicated false-positive rate among fires.
+
+**Pre-specified burden budget.** A clean manuscript should draw **0 Major alerts** and a median
+of **≤ 3 Minor** alerts. A detector responsible for more than **20 %** of all alerts across the
+clean corpus is flagged for review regardless of its Arm A recall. These thresholds are fixed
+now so that a disappointing result cannot be re-described as acceptable later.
+
+**Adjudication — and the honest constraint.** "Clean" is an assumption, not a fact: an alert on
+a supposedly clean manuscript may be a true positive the corpus builder missed. Every alert is
+therefore adjudicated as *true defect* / *false positive* / *ambiguous* by **two independent
+adjudicators**, disagreements resolved by a third, with agreement (Cohen's κ) reported.
+
+**This is the binding constraint on the whole protocol, and it is not a tooling problem.** The
+project currently has one maintainer, who is also the detector author. Self-adjudication of
+one's own detectors is exactly the self-confirming loop the architecture exists to avoid — an
+author judging whether his own gate was right inherits the blind spot that produced it. Arm B
+therefore **cannot be completed credibly without at least one external adjudicator**, and this
+protocol should not be run to completion until one is recruited (see
+[`MAINTAINERS.md`](../MAINTAINERS.md) § Clinical Reviewers, an already-defined role that is
+currently unfilled). Running Arm B solo and reporting the numbers would be a worse outcome than
+not running it.
+
+### Arm C — real-manuscript disposition ledger (out-of-band)
+
+The only source of genuine precision on real inputs is what happened when a detector fired on a
+real manuscript and a human decided whether to act. Those labels accumulate during ordinary use
+as `real` / `spurious` / `unsure` dispositions.
+
+**This arm lives outside this repository and always will.** Real manuscripts carry
+unpublished-work, collaborator, and institutional detail; the raw ledger is never committed,
+mirrored, or included in a release payload. Only **aggregate per-detector precision with its n**
+is publishable, and only once n is large enough that a single project cannot be re-identified
+from the pattern. Arm C is reported as supporting evidence, never as the headline, because its
+sampling frame is "manuscripts this author happened to work on."
+
+## 4. Bootstrapping from what already exists
+
+Arm A does not start from zero. Every detector already ships a CI challenge card with a positive
+case and a negative control. The first work item is therefore an **inventory, not an authoring
+sprint**:
+
+- **Stage 0 — inventory.** For each of the 80 detectors, mechanically determine: verdicts
+  emitted; positive fixtures present; whether the existing negative control is a *hard* negative
+  or merely an empty/trivial input. Output: a per-detector gap table. Largely automatable from
+  the existing challenge-card wiring and `metadata/detectors_catalog.json`.
+- **Stage 1 — fill gaps.** Author only the missing positives and hard negatives found in Stage 0.
+- **Stage 2 — run Arm A** at a pinned version; emit the manifest in § 6.
+- **Stage 3 — build the clean corpus and run Arm B.** Gated on an external adjudicator (§ 3).
+- **Stage 4 — report** per family, with Arm C aggregates as supporting evidence.
+
+Stages 0–2 are solo-completable. Stage 3 is not. Publishing Stages 0–2 alone is a legitimate
+partial result provided it is described as triggering coverage and not as accuracy.
+
+## 5. Corpus provenance and the synthetic-only firewall
+
+- **No patient data, ever** — no PHI, no clinical vignettes derived from real encounters.
+- **No private manuscript content** — no unpublished collaborator work, no manuscript IDs, no
+  institution-identifying context. This is the same firewall the repo's PII gates enforce; the
+  benchmark corpus is not an exception to it.
+- **Public articles** are included only where the licence permits redistribution, recorded per
+  item with source URL, licence, and retrieval date.
+- **Synthetic manuscripts** record their generator and the design they represent.
+- Every corpus item is content-hashed; the corpus is versioned as a unit.
+
+## 6. Pinning, manifest, and what invalidates a run
+
+A run is meaningless without knowing what was measured. Each run emits
+`runs/<UTC-date>_<arm>/manifest.json` recording: repo commit SHA; `detector_count` and the
+per-family id lists from `metadata/detectors_catalog.json`; Python version and OS; corpus
+version and per-item hashes; and the protocol version (this file's commit).
+
+A run is **invalidated** — not amended — by any change to the detector catalog or the corpus.
+Adding a detector does not retroactively join a completed run; it schedules the next one. This
+is deliberate: a benchmark that silently absorbs new detectors reports a number that no single
+version of the software ever produced.
+
+## 7. Pre-specified consequences
+
+Fixed now, so the analysis is not shopped afterwards:
+
+| Finding | Consequence |
+|---|---|
+| Recall = 0 on a detector's own injected defect | Bug. Fix before the next release. |
+| Fires on its hard negative | Precision bug. Fix, or downgrade `maturity` to `experimental`. |
+| > 20 % share of clean-corpus alerts | Review for over-firing; tighten or gate by genre. |
+| Zero fires across the clean corpus **and** no real-world dispositions | Prune candidate — a gate nobody has ever seen fire is unverified surface, not coverage. |
+| A verdict with no positive fixture after Stage 1 | Not reported as covered. Absence is stated, not implied. |
+
+The last row is the one that keeps the report honest: **coverage claims are made per verdict,
+and anything untested is named as untested.**
+
+## 8. Relationship to CI
+
+Challenge cards and this benchmark answer different questions and neither replaces the other.
+Challenge cards run on every push and protect against regression; they are a *tripwire*. This
+protocol runs at a pinned version and measures the suite as a system; it is a *measurement*.
+Where Stage 1 authors a new hard negative, that fixture is wired into CI as well — so the
+benchmark's investment compounds into the regression suite rather than sitting in a one-off
+evaluation directory.

--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -7,7 +7,7 @@ said "22 guidelines" while orchestrate said "15"; more recently every doc said
 "33 reporting guidelines" while only 32 are enumerated and vendored). This makes
 the counts a single source of truth and fails CI on drift.
 
-Three layers:
+Four layers:
   1. Recompute every count from disk (the real ground truth).
   2. Assert metadata/catalog_counts.json matches disk — the SSOT cannot lie.
      Exception: the journal-profile counts (``AUTO_DERIVED_KEYS``) are recomputed
@@ -27,6 +27,11 @@ Three layers:
      prose never trips it, and comparison/marketing lines about *other* repos
      ("400-900 skills", "869 skills") are never touched. Dated version notes (2- or
      3-component, e.g. **v5.20.1**) are skipped for every current-claim scan.
+  4. Assert the MEDSCI_AUDIT per-family detector table against the generated
+     metadata/detectors_catalog.json — each row's count against that family's true
+     size, and its listed names against that family's true membership. Layer 3 already
+     watched the "The N detectors fall into six audit families" total; nothing watched
+     the rows under it, and they drifted to 72 against a total of 80.
 
 Exit 0 when everything agrees; non-zero on any drift. Stdlib-only.
 """
@@ -147,6 +152,49 @@ NUM_WORDS = {w: i for i, w in enumerate(
     ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
      "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
      "sixteen", "seventeen", "eighteen", "nineteen", "twenty"])}
+
+# The MEDSCI_AUDIT family table is a hand-maintained mirror of the auto-generated
+# metadata/detectors_catalog.json. It drifted: the prose said "The 80 detectors fall
+# into six audit families" — gated by DETECTOR_CLAIM_PATTERNS above — while the rows
+# beneath it enumerated only 72. The total was watched; the rows were not. Layer 4
+# asserts every row against the catalog's own per-family id list, so a detector added
+# without a family-table row fails here instead of silently unbalancing the registry.
+FAMILY_TABLE_FILE = "MEDSCI_AUDIT.md"
+DETECTORS_CATALOG = "metadata/detectors_catalog.json"
+
+
+def family_table_failures() -> list[str]:
+    """Return one message per MEDSCI_AUDIT family row that disagrees with the catalog.
+
+    Checks each row's declared count against the family's true size and its listed
+    names against the family's true membership (the rows are the complete enumeration,
+    not a sample). Rows whose label is not a catalog family label are ignored, so the
+    other tables in the file are never parsed as family rows.
+    """
+    out: list[str] = []
+    cat, doc = ROOT / DETECTORS_CATALOG, ROOT / FAMILY_TABLE_FILE
+    if not cat.exists() or not doc.exists():
+        return out
+    families = json.loads(cat.read_text(encoding="utf-8")).get("families", [])
+    truth = {f["label"]: set(f["ids"]) for f in families}
+    row_re = re.compile(r"^\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*(.+?)\s*\|\s*$", re.M)
+    seen: set[str] = set()
+    for m in row_re.finditer(doc.read_text(encoding="utf-8")):
+        label, count, cells = m.group(1).strip(), int(m.group(2)), m.group(3)
+        if label not in truth:
+            continue  # not a family row
+        seen.add(label)
+        listed, real = set(re.findall(r"`([A-Za-z0-9_]+)`", cells)), truth[label]
+        if count != len(real):
+            out.append(f"{FAMILY_TABLE_FILE} family '{label}': count {count}, catalog has {len(real)}")
+        if missing := sorted(real - listed):
+            out.append(f"{FAMILY_TABLE_FILE} family '{label}': row omits {', '.join(missing)}")
+        if extra := sorted(listed - real):
+            out.append(f"{FAMILY_TABLE_FILE} family '{label}': row lists non-member(s) {', '.join(extra)}")
+    for label in truth:
+        if label not in seen:
+            out.append(f"{FAMILY_TABLE_FILE}: no family row for '{label}'")
+    return out
 
 
 def doc_claims() -> list[tuple[str, int, int, str]]:
@@ -283,6 +331,11 @@ def main() -> int:
         if claimed != expected:
             print(f"\nFAIL: {rel} {ctx}: claims {claimed}, expected {expected}", file=sys.stderr)
             failures += 1
+
+    # Layer 4 — the MEDSCI_AUDIT family table must match the generated catalog.
+    for msg in family_table_failures():
+        print(f"\nFAIL: {msg}", file=sys.stderr)
+        failures += 1
 
     if failures:
         print(f"\nCATALOG_COUNT_DRIFT: {failures} mismatch(es).", file=sys.stderr)


### PR DESCRIPTION
Third and last item from the external review (#390, #391 were the first two). Its finding #2 — *"현재 80개 detector 전체에 대한 통합 평가가 없다"* — is the largest remaining weakness in the evidence base, and the review was right.

Two things here; the second was found while scoping the first.

## 1. `evaluation/REFRESH_PROTOCOL.md` — a pre-registered protocol

**No results exist yet, and the document says so in its first line.** It is written *before* any run on purpose: an analysis plan chosen after seeing results is a re-designation rather than a derivation, and this toolkit enforces exactly that discipline on its users (`estimand-provenance`). Pre-registering our own benchmark is the consistent thing to do.

**Three arms, deliberately not blended into one headline:**

| Arm | Question | Yields | Does **not** yield |
|---|---|---|---|
| **A** (E1-R) | Does each detector fire on its defect, and stay silent on a near-miss? | per-detector recall, clean-FP, hard-negative pass | precision, prevalence |
| **B** (E10) | How noisy is the suite on a **clean** manuscript? | alert burden, per-detector alert share, adjudicated FP rate | recall |
| **C** | On real manuscripts, what fraction of fires are worth acting on? | aggregate precision with n | anything at row level |

Design points worth flagging:

- **Arm A is scored per *verdict*, not per detector.** A detector emitting three verdicts is three units; a verdict with no positive fixture is untested no matter how well its siblings do.
- **Hard negatives are the addition over E1** — a near-miss that a naive implementation would flag but that is correct. That is where precision bugs actually live: the two recent `/verify-refs` defects (a Unicode hyphen read as a fabricated author; a brace-protected surname read as a corporate author) were both near-miss failures, not missing recall.
- **Arm B is the one that decides adoption** and the evidence base has nothing on it. A suite with perfect recall that fires forty times on a clean paper is unusable. Budget fixed in advance: **0 Major, median ≤ 3 Minor**; any detector >20% of clean-corpus alerts is flagged regardless of its recall.
- **Applicability gating is mandatory in Arm B** — a genre-gated detector that stays silent on a manuscript it does not apply to is *not* a true negative. Skipping this would manufacture a flattering burden number.

**Two constraints recorded up front rather than discovered later:**

1. **An injection benchmark cannot report precision or sensitivity.** Fault injection has no defined defect prevalence — this is E1's own stated position and it is carried forward, not quietly dropped because the review asked for "sensitivity, specificity". A refresh reporting those from an injection corpus would be reporting numbers its design cannot support.
2. **Arm B should not be run to completion while the only adjudicator is the person who wrote the detectors.** An author judging whether his own gate was right inherits the blind spot that produced it. Stages 0–2 are solo-completable; **Stage 3 is explicitly gated on recruiting an external adjudicator** (the `Clinical Reviewers` role in `MAINTAINERS.md`, currently unfilled). Running it solo and publishing the numbers would be worse than not running it — which is also why review finding #2 and finding #3 (bus factor) turn out to be the same problem.

Also pre-specified so results cannot be shopped afterwards: what invalidates a run (any catalog or corpus change — a completed run does not retroactively absorb a new detector), and the consequence table (recall 0 → bug; fires on hard negative → precision bug or `maturity: experimental`; never fires anywhere → prune candidate).

## 2. The family table summed to 72 under a sentence claiming 80

`MEDSCI_AUDIT.md`'s per-family rows were stale by eight detectors:

| Family | Was | Now |
|---|---:|---:|
| Style & review-process integrity | 18 | **24** |
| Confounding, scope & estimand contracts | 6 | **7** |
| Data preparation & validation | 14 | **15** |
| **Sum** | **72** | **80** |

Missing: `check_aphorism_density`, `check_baseline_drift`, `check_perspective_structure`, `check_rewrite_fidelity`, `check_rhetorical_density`, `check_sentence_variety`, `check_analysis_definitions`, `check_dataset_profile`.

The **total** was gated ("The 80 detectors fall into six audit families" is a watched claim), but **nothing checked that the rows beneath it summed to it** — so the flagship audit registry contradicted itself in public. It surfaced because family-stratified sampling needs true family sizes, and a stale one would have misallocated the benchmark budget.

`validate_catalog_consistency` gains **Layer 4**: each family row asserted against `metadata/detectors_catalog.json` — declared count vs the family's true size, listed names vs its true membership. A detector added without a family row now fails CI. Column header renamed `Examples` → `Detectors`, since the rows are the complete enumeration and the gate enforces that.

## Verification

- New gate regression-tested both ways: count drift → `count 18, catalog has 24`; membership drift → `row omits check_dataset_profile`. Clean state passes.
- Full CI mirror (`run_ci_mirror.py`, all 182 `validate`-job gates) → **182/182 green**.
- No skill / detector / guideline count change.