### PR TITLE
feat(self-review): check_citation_order audits the in-text reference series (+ range expansion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- **`check_citation_order` now audits the in-text reference series, not just numbered floats.**
+  The Vancouver rule that governs Tables and Figures governs a fifth series the gate never
+  saw: the bracketed reference numbers themselves (`[12]`, `[4–11]`). They must ascend by
+  first appearance (`REFERENCE_ORDER`, Major), be contiguous from 1 (`REFERENCE_GAP`, Minor),
+  and reach the reference-list length (`REFERENCE_COUNT_MISMATCH` — Major when a `[N]` overruns
+  the list and dangles, Minor when trailing entries are never cited). A citeproc `[@key]`
+  manuscript has no numbers to check and stays silent; a **hand-typed `[N]` manuscript** (the
+  Word/Zotero placeholder path) previously had no gate at all. Ranges are now **expanded**
+  (`[4–11]` → 4..11) before ordering and gap analysis — for the reference series *and* the
+  existing float series — so a number sitting inside a rendered range is no longer read as a
+  false gap (an endpoint-only reader reported spurious gaps `[10]`/`[37]` sitting inside
+  `4–11`/`36–38`). No new detector: the count stays **80**. Verified clean on the bracketed-
+  citation demo manuscript and four new fixtures (out-of-order, gap, the range-trap negative,
+  and a clean series). Grounded in a real submission cycle where a citeproc build masked a
+  hand-typed-`[N]` ordering fault. See the journal technical-check gate.
+
 - **A pre-registered protocol for the evaluation refresh that covers all 80 detectors.**
   `evaluation/REFRESH_PROTOCOL.md` — written before any run, because an analysis plan chosen
   after seeing results is a re-designation, not a derivation, and the toolkit enforces exactly

--- a/metadata/detectors_catalog.json
+++ b/metadata/detectors_catalog.json
@@ -202,7 +202,7 @@
       "skill": "self-review",
       "family": "reporting_compliance",
       "family_label": "Reporting compliance",
-      "description": "Float citation-ORDER gate (journal technical-check pass)."
+      "description": "Citation-ORDER gate — numbered floats and the in-text reference series (journal technical-check pass)."
     },
     {
       "id": "check_claim_artifact",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4013,8 +4013,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 87995,
-      "sha256": "6cb1011bf8894469793bd410ea7350961903d6fe097e90237c8ace16b0bb6246"
+      "size": 88030,
+      "sha256": "ab927f6a9702b4e988246fad965cab6025fcbd91f9378bf3e2002ba7dee9e6dd"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",
@@ -4198,8 +4198,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5f_claim_artifact.md",
-      "size": 11616,
-      "sha256": "f95dea63f14cfca4cf40c5e8c858b8c7a0679b1c54b6fcd65acc68424e770bac"
+      "size": 12382,
+      "sha256": "c4e83d109e67ca331de1c1f0ee514457426d2be6c6a4fbe56ed0be2a6fc45b25"
     },
     {
       "path": "skills/self-review/references/phases/phase2_systematic_check.md",
@@ -4323,8 +4323,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_citation_order.py",
-      "size": 15088,
-      "sha256": "7170b62c585b45599b55b32efcffb3803bce24190f3e34ec18cf6e7be48b94f1"
+      "size": 22760,
+      "sha256": "47c50a1ec4e2d64e33c90756b4c83a72721e5cff5e45c93a383549e48ba6e5b7"
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -655,7 +655,7 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/check_supplement_hygiene.py" \
   --supplement supplement.md --supplement tables.md --supplement captions.md \
   --manuscript manuscript.md --out qc/supplement_hygiene.json --strict
 
-# 4. float citation order — a desk-reject item the hygiene gate does not cover
+# 4. float AND in-text reference-number ([N]) citation order — a desk-reject item the hygiene gate does not cover
 python3 "${CLAUDE_SKILL_DIR}/scripts/check_citation_order.py" \
   --manuscript manuscript.md --out qc/citation_order.json --strict
 

--- a/skills/self-review/references/phases/phase2_5f_claim_artifact.md
+++ b/skills/self-review/references/phases/phase2_5f_claim_artifact.md
@@ -115,14 +115,17 @@ analysis completeness, and imputation-input integrity are separate subchecks (ru
    Anticipated Major Comments — a reader-facing slip in a supplement is as fatal at a
    technical check as one in the body.
 
-   **Float citation order (same technical-check pass).** Editorial offices "unsubmit"
-   manuscripts *before* peer review when numbered floats are not cited in ascending
-   order of first appearance — a fully deterministic desk-check item the hygiene gate
-   above does not cover (it lints xref *resolution*, not *order*). Run the citation-order
-   gate, which checks each series independently (main Tables, main Figures, Supplementary
-   Tables, Supplementary Figures), scanning only the narrative body (it auto-excludes the
-   Figure Legends / back-matter so an in-order legends block cannot mask an out-of-order
-   body):
+   **Citation order — floats AND the in-text reference series (same technical-check pass).**
+   Editorial offices "unsubmit" manuscripts *before* peer review when numbered floats are
+   not cited in ascending order of first appearance — a fully deterministic desk-check item
+   the hygiene gate above does not cover (it lints xref *resolution*, not *order*). Run the
+   citation-order gate, which checks each series independently (main Tables, main Figures,
+   Supplementary Tables, Supplementary Figures) **and the in-text reference-number series**
+   (`[12]`, `[4–11]`) — the Vancouver numbering a hand-typed `[N]` manuscript (the Word/Zotero
+   path) has no other gate for; a citeproc `[@key]` manuscript has no numbers to check and
+   stays silent. Ranges are expanded (`[4–11]`→4..11) so a number inside a rendered range is
+   never a false gap. It scans only the narrative body (auto-excluding the Figure Legends /
+   back-matter so an in-order legends block cannot mask an out-of-order body):
 
    ```bash
    python3 "${CLAUDE_SKILL_DIR}/scripts/check_citation_order.py" \
@@ -135,7 +138,11 @@ analysis completeness, and imputation-input integrity are separate subchecks (ru
    every cross-reference, expanding ranges like `S12–S15` by hand and leaving non-float
    sensitivity-spec labels such as `S1–S6` untouched) or by rephrasing away the early
    citation. `CITATION_GAP` (Minor) — cited numbers not contiguous from 1 (a possible
-   missing/mis-numbered float).
+   missing/mis-numbered float). `REFERENCE_ORDER` (Major) — in-text reference numbers cited
+   out of order (e.g. `[12]` before `[5]`); the Vancouver list is mis-numbered. `REFERENCE_GAP`
+   (Minor) — a reference number never cited. `REFERENCE_COUNT_MISMATCH` — the highest cited
+   `[N]` overruns the reference-list length (dangling, **Major**) or the list has trailing
+   entries never cited (**Minor**).
 
 8. **Re-run cross-artifact staleness after any audit or reframe.** When a headline number
    is corrected or an analysis is re-framed, the fix often lands only in the body while a

--- a/skills/self-review/scripts/check_citation_order.py
+++ b/skills/self-review/scripts/check_citation_order.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Float citation-ORDER gate (journal technical-check pass).
+"""Citation-ORDER gate — numbered floats and the in-text reference series (journal technical-check pass).
 
 Journals (KJR, Radiology, AJR, and most others) require that numbered floats be
 **cited in ascending order of first appearance** in the narrative text, evaluated
@@ -10,6 +10,14 @@ per series independently:
     Suppl. Tables (Table S1, S2, … / Supplementary Table S1, …)
     Suppl. Figures(Supplementary Figure S1, … / Figure S1, …)
 
+The same Vancouver discipline governs a FIFTH series the float scan never saw: the
+**in-text reference numbers** ("[12]", "[4–11]"). They too must ascend by first
+appearance, be contiguous from 1, and reach the reference-list length. A citeproc
+manuscript renumbers "[@key]" at render and so has no numbers to check here; but a
+HAND-TYPED "[N]" manuscript (the Word/Zotero placeholder path) has no gate at all,
+and an out-of-order or gapped reference series is a desk-check reject just like an
+out-of-order table.
+
 This is a deterministic, pre-peer-review desk/technical-check item: editorial
 offices "unsubmit" manuscripts for it before a reviewer ever sees them. Existing
 self-review gates lint xref *resolution* (does the callout resolve to a section)
@@ -18,15 +26,25 @@ but never *order*.
 What it does: scans the NARRATIVE body (everything before the first float-definition
 / back-matter section header — Figure Legends, Tables, Supplementary, References —
 so a legends block that lists figures in order does not mask an out-of-order body),
-extracts the first-citation position of every numbered float per series, and flags
-any series whose first-appearance number sequence is not ascending.
+extracts the first-citation position of every numbered float per series AND of every
+bracketed reference number, EXPANDS ranges ("4–11" → 4..11 — so a number inside a
+rendered range is never read as a false gap), and flags any series whose first-
+appearance sequence is not ascending (or, for references, is gapped or overruns the list).
 
 Verdicts:
-  CITATION_ORDER (Major)  a series is cited out of numerical order (e.g., Table 3
+  CITATION_ORDER (Major)  a float series is cited out of numerical order (e.g., Table 3
                           first-cited before Table 1, or Suppl. Tables cited
                           S4, S9, S16, S12, …). Technical-check-fatal.
-  CITATION_GAP  (Minor)   a series' cited numbers are not contiguous from 1
+  CITATION_GAP  (Minor)   a float series' cited numbers are not contiguous from 1
                           (a possible missing / mis-numbered float). Report-only.
+  REFERENCE_ORDER (Major) in-text reference numbers are cited out of order (e.g. [12]
+                          before [5]) — the Vancouver list is mis-numbered. Ranges are
+                          expanded first, so a re-citation inside "[4–11]" is not a fault.
+  REFERENCE_GAP (Minor)   cited reference numbers are not contiguous from 1 (a number
+                          never cited) — a missing or mis-numbered citation. Report-only.
+  REFERENCE_COUNT_MISMATCH  the highest cited reference overruns the reference-list length
+        (Major/Minor)     ([N] resolves to nothing → Major dangling), or the list has
+                          trailing entries never cited (→ Minor). Needs a numbered list.
   UNCITED_FLOAT (Minor)   a float that HAS a legend/caption in the back matter is never
                           cited anywhere in the narrative body — a display item the reader
                           is never pointed to (uncited supplements/tables/figures are a
@@ -78,8 +96,47 @@ MENTION_RE = re.compile(
     r"\b(Tables?|Figures?)\s+"
     r"(S?\d+(?:\s*(?:,|&|–|-|and)\s*S?\d+)*)", re.IGNORECASE)
 
-# Individual S?<number> token inside a numlist.
-TOKEN_RE = re.compile(r"(S?)(\d+)", re.IGNORECASE)
+# One citation token inside a numlist: optional S-prefix, a number, and an optional
+# "A–B" range tail. Ranges MUST be expanded before ordering/gap analysis — an
+# endpoint-only read of "4–11" as {4, 11} both hides the interior (5..10) and reports
+# every interior number as a false gap. Shared by the float scan and the reference scan.
+TOKEN_RANGE_RE = re.compile(r"(S?)(\d+)(?:\s*[–—-]\s*(S?)(\d+))?", re.IGNORECASE)
+
+
+def _expand_numlist(numlist: str):
+    """Yield (supp_bool, number, offset) for every number in a citation numlist,
+    expanding an "A–B" range to A..B. offset is the token's start within numlist so a
+    caller can recover first-appearance position; a range's members share the range
+    token's offset. The S-prefix of a range is taken from its start token. An inverted
+    or absurdly wide (> 500) range degrades to its two endpoints rather than expanding."""
+    for m in TOKEN_RANGE_RE.finditer(numlist):
+        supp = bool(m.group(1))
+        a = int(m.group(2))
+        if m.group(4) is not None:
+            b = int(m.group(4))
+            if a <= b <= a + 500:
+                for k in range(a, b + 1):
+                    yield supp, k, m.start()
+            else:
+                yield supp, a, m.start()
+                yield bool(m.group(3)) or supp, b, m.start(4)
+        else:
+            yield supp, a, m.start()
+
+
+# An in-text numbered reference citation: a bracketed numlist ("[12]", "[4,5]",
+# "[4–11]"). Guards against the other square-bracket syntaxes: a wikilink "[[1]]"
+# (leading "["), an image "![alt]" (leading "!"), a markdown link "[1](url)" or link-
+# definition "[1]:" (trailing "(" / ":"), and a footnote "[^1]" (the "^" is not a digit,
+# so it never matches). Only the bracketed Vancouver form is scanned — parenthetical
+# "(1)" is left alone: it is indistinguishable from equation, panel, group-size and
+# CI-bound numbers.
+REF_CITE_RE = re.compile(r"(?<![\[!])\[(\d[\d\s,;&–—-]*)\](?!\s*[:(\[])")
+# A numbered entry in the reference list ("1. …", "[1] …", "1) …").
+REF_LIST_ITEM_RE = re.compile(r"(?m)^\s{0,3}(?:\[(\d+)\]|(\d+)[.)])\s+\S")
+# Below this many distinct in-text reference numbers there is too little signal to tell
+# a Vancouver citation apart from a stray "[1]", so the reference-series check stays silent.
+REF_MIN_DISTINCT = 3
 
 SERIES_LABEL = {
     ("table", False): "Table",
@@ -158,18 +215,17 @@ def _first_appearance(text: str):
     seen: dict[str, dict[int, int]] = {}  # label -> {number: first_position}
     for m in MENTION_RE.finditer(text):
         kind = "table" if m.group(1).lower().startswith("table") else "figure"
-        for tm in TOKEN_RE.finditer(m.group(2)):
-            supp = bool(tm.group(1))
-            num = int(tm.group(2))
+        for supp, num, off in _expand_numlist(m.group(2)):
             label = SERIES_LABEL[(kind, supp)]
             seen.setdefault(label, {})
             # keep the EARLIEST position for each number
-            pos = m.start() + tm.start()
+            pos = m.start() + off
             if num not in seen[label] or pos < seen[label][num]:
                 seen[label][num] = pos
     order = {}
     for label, num_pos in seen.items():
-        order[label] = [n for n, _ in sorted(num_pos.items(), key=lambda kv: kv[1])]
+        # tie-break by number so a range's members read ascending at their shared position
+        order[label] = [n for n, _ in sorted(num_pos.items(), key=lambda kv: (kv[1], kv[0]))]
     return order
 
 
@@ -218,6 +274,81 @@ def _check_uncited_floats(clean: str) -> list[dict]:
     return claims
 
 
+def _reference_list_length(text: str) -> "int | None":
+    """Highest number in the numbered reference/bibliography list, or None if there is no
+    such list (e.g. a citeproc manuscript whose bibliography is generated at render)."""
+    m = REF_HEADER_RE.search(text)
+    if not m:
+        return None
+    nums = [int(im.group(1) or im.group(2)) for im in REF_LIST_ITEM_RE.finditer(text[m.end():])]
+    return max(nums) if nums else None
+
+
+def _reference_series(body: str, full_text: str) -> list[dict]:
+    """Bracketed in-text reference citations ("[12]", "[4–11]") must be cited in ascending
+    order of first appearance, be contiguous from 1, and reach the reference-list length —
+    the Vancouver numbering discipline a hand-typed "[N]" manuscript has no other gate for.
+    Ranges are expanded first, so a number inside "[4–11]" is never a false gap; citeproc
+    "[@key]" manuscripts match nothing here and stay silent."""
+    first: dict[int, int] = {}  # reference number -> earliest position
+    for m in REF_CITE_RE.finditer(body):
+        for _supp, num, off in _expand_numlist(m.group(1)):
+            pos = m.start() + off
+            if num not in first or pos < first[num]:
+                first[num] = pos
+    if len(first) < REF_MIN_DISTINCT:
+        return []  # too little signal to distinguish citations from stray brackets
+    seq = [n for n, _ in sorted(first.items(), key=lambda kv: (kv[1], kv[0]))]
+    pretty = ", ".join(str(n) for n in seq)
+    claims: list[dict] = []
+    if seq != sorted(seq):
+        inv = next((seq[i] for i in range(1, len(seq)) if seq[i] < seq[i - 1]), seq[-1])
+        claims.append({
+            "verdict": "REFERENCE_ORDER",
+            "severity": "Major",
+            "detail": (f"in-text references are cited out of numerical order — first-citation "
+                       f"sequence is [{pretty}]; Vancouver numbering must ascend by first "
+                       f"appearance (renumber the reference list and remap every [N], or correct "
+                       f"the marker; first inversion at [{inv}])"),
+            "where": "reference series",
+        })
+        return claims  # order is wrong; gap/count numbers are not yet meaningful
+    cited = set(first)
+    hi = max(cited)
+    length = _reference_list_length(full_text)
+    if length is not None and hi > length:
+        # A citation points past the end of the list — the dominant fault. The apparent
+        # gap up to [hi] is an artifact of the dangling number, so report only this.
+        claims.append({
+            "verdict": "REFERENCE_COUNT_MISMATCH",
+            "severity": "Major",
+            "detail": (f"the highest in-text reference cited is [{hi}] but the reference list has "
+                       f"only {length} entries — [{hi}] resolves to nothing (dangling citation)"),
+            "where": "reference series",
+        })
+        return claims
+    missing = [n for n in range(1, hi + 1) if n not in cited]
+    if missing:
+        claims.append({
+            "verdict": "REFERENCE_GAP",
+            "severity": "Minor",
+            "detail": (f"in-text references cited [{pretty}] are not contiguous from 1 (never "
+                       f"cited: {', '.join(str(n) for n in missing)}) — a missing or mis-numbered "
+                       f"citation (ranges like [4–11] are expanded before this check)"),
+            "where": "reference series",
+        })
+    if length is not None and hi < length:
+        claims.append({
+            "verdict": "REFERENCE_COUNT_MISMATCH",
+            "severity": "Minor",
+            "detail": (f"in-text references reach [{hi}] but the reference list has {length} "
+                       f"entries — {length - hi} trailing reference(s) are never cited (or the "
+                       f"list is mis-numbered)"),
+            "where": "reference series",
+        })
+    return claims
+
+
 def check(text: str, include_back_matter: bool) -> list[dict]:
     claims = []
     # Strip any leading YAML front matter first: a `status:`/changelog block that narrates a
@@ -226,6 +357,7 @@ def check(text: str, include_back_matter: bool) -> list[dict]:
     body = _body(clean, include_back_matter)
     claims += _check_section_xref(body)
     claims += _check_uncited_floats(clean)
+    claims += _reference_series(body, clean)
     order = _first_appearance(body)
     for label in ("Table", "Figure", "Supplementary Table", "Supplementary Figure"):
         seq = order.get(label)

--- a/skills/self-review/tests/fixtures/citation_order_ref_gap.md
+++ b/skills/self-review/tests/fixtures/citation_order_ref_gap.md
@@ -1,0 +1,20 @@
+# Introduction
+
+The task has a long methodological history [1, 2] and a well-characterized failure mode
+[3]. Reporting standards were consolidated more recently [4].
+
+# Methods
+
+We followed the pre-registered analysis plan [5] and the agreement conventions [6]. The
+external cohort was described previously [8].
+
+# References
+
+1. First reference.
+2. Second reference.
+3. Third reference.
+4. Fourth reference.
+5. Fifth reference.
+6. Sixth reference.
+7. Seventh reference.
+8. Eighth reference.

--- a/skills/self-review/tests/fixtures/citation_order_ref_good.md
+++ b/skills/self-review/tests/fixtures/citation_order_ref_good.md
@@ -1,0 +1,21 @@
+# Introduction
+
+The clinical problem is well described [1], and two prior cohorts established feasibility
+[2, 3].
+
+# Methods
+
+Analyses followed the pre-registered plan [4] and the agreement conventions of prior work
+[5].
+
+# Discussion
+
+All in-text references are cited in ascending order of first appearance, with no gaps.
+
+# References
+
+1. First reference.
+2. Second reference.
+3. Third reference.
+4. Fourth reference.
+5. Fifth reference.

--- a/skills/self-review/tests/fixtures/citation_order_ref_order_bad.md
+++ b/skills/self-review/tests/fixtures/citation_order_ref_order_bad.md
@@ -1,0 +1,25 @@
+# Introduction
+
+Deep-learning triage now matches expert readers on several perceptual tasks [12], yet
+post-deployment calibration drift is common and under-reported [5]. Early surveys framed
+the problem [1] and motivated the reporting guidance we adopt here [2, 3].
+
+# Methods
+
+Predictions were compared against the adjudicated reference standard [4]. Agreement was
+summarized following prior methodology [6].
+
+# References
+
+1. First reference.
+2. Second reference.
+3. Third reference.
+4. Fourth reference.
+5. Fifth reference.
+6. Sixth reference.
+7. Seventh reference.
+8. Eighth reference.
+9. Ninth reference.
+10. Tenth reference.
+11. Eleventh reference.
+12. Twelfth reference.

--- a/skills/self-review/tests/fixtures/citation_order_ref_range_ok.md
+++ b/skills/self-review/tests/fixtures/citation_order_ref_range_ok.md
@@ -1,0 +1,31 @@
+# Introduction
+
+Automated triage has an established evidence base [1], with two influential early cohorts
+[2, 3]. A broad body of downstream validation work followed [4–11], and the current
+consensus guidance builds on it [12]. Two further multi-site cohorts extended the setting
+[13–15], and the reporting extension we apply is the most recent [16].
+
+# Methods
+
+Numbers inside a cited range — for example reference 10 inside [4–11], and references 13
+and 14 inside [13–15] — are never cited on their own line, yet they are cited. Expanding
+the range before the gap check is what keeps them from reading as false gaps.
+
+# References
+
+1. First reference.
+2. Second reference.
+3. Third reference.
+4. Fourth reference.
+5. Fifth reference.
+6. Sixth reference.
+7. Seventh reference.
+8. Eighth reference.
+9. Ninth reference.
+10. Tenth reference.
+11. Eleventh reference.
+12. Twelfth reference.
+13. Thirteenth reference.
+14. Fourteenth reference.
+15. Fifteenth reference.
+16. Sixteenth reference.

--- a/skills/self-review/tests/test_citation_order.sh
+++ b/skills/self-review/tests/test_citation_order.sh
@@ -37,6 +37,17 @@ d=json.load(open('$OUT'))
 n=sum(1 for c in d['claims'] if c['verdict']=='UNCITED_FLOAT')
 assert n==$1, f'expected $1 UNCITED_FLOAT, got {n}'
 "; }
+count_verdict() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+n=sum(1 for c in d['claims'] if c['verdict']=='$1')
+assert n==$2, f'expected $2 $1, got {n}: {[c[\"verdict\"] for c in d[\"claims\"]]}'
+"; }
+no_claims() { python3 -c "
+import json
+d=json.load(open('$OUT'))
+assert not d['claims'], d['claims']
+"; }
 
 [[ -f "$SCRIPT" ]] || { echo "ENV-ERR: script missing" >&2; exit 2; }
 
@@ -96,6 +107,30 @@ assert u and u[0]['where']=='Supplementary Figure S1', [c['where'] for c in u]
 # (7) the clean fixture defines nothing uncited -> no UNCITED_FLOAT (no over-fire).
 python3 "$SCRIPT" --manuscript "$GOOD" --out "$OUT" --strict --quiet >/dev/null 2>&1
 check "no UNCITED_FLOAT on the clean manuscript (no over-fire)" count_uncited 0
+
+# --- reference (in-text [N]) series: the fifth series the float scan never saw ----------
+FX="$HERE/fixtures"
+
+# (8) hand-typed [N] manuscript that cites [12] before [5] -> REFERENCE_ORDER (Major), exit 1
+python3 "$SCRIPT" --manuscript "$FX/citation_order_ref_order_bad.md" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 1 when in-text references are out of order ([12] before [5])" test "$?" -eq 1
+check "one REFERENCE_ORDER flagged" count_verdict REFERENCE_ORDER 1
+
+# (9) references cited [1..6, 8] with 7 never cited -> REFERENCE_GAP (Minor), exit 0
+python3 "$SCRIPT" --manuscript "$FX/citation_order_ref_gap.md" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 on a reference gap (Minor, not Major)" test "$?" -eq 0
+check "one REFERENCE_GAP for the hole at [7]" count_verdict REFERENCE_GAP 1
+
+# (10) NEGATIVE range trap: 5-10 and 13-14 sit INSIDE rendered ranges [4-11]/[13-15] ->
+#      ranges are expanded, so NO false gap -> clean (the case the ad-hoc script got wrong)
+python3 "$SCRIPT" --manuscript "$FX/citation_order_ref_range_ok.md" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 when the only 'gaps' sit inside a rendered range" test "$?" -eq 0
+check "no claim from a reference range (range expanded before gap check)" no_claims
+
+# (11) NEGATIVE clean: contiguous [1..5] in order with a matching 5-entry list -> no over-fire
+python3 "$SCRIPT" --manuscript "$FX/citation_order_ref_good.md" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 on a clean reference series" test "$?" -eq 0
+check "no claim on a clean contiguous reference series (no over-fire)" no_claims
 
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## What

`check_citation_order` audited numbered **floats** only (Tables, Figures, Supplementary
Tables, Supplementary Figures). This adds the **fifth Vancouver series** it never saw: the
**in-text reference numbers** themselves (`[12]`, `[4–11]`).

New verdicts:

| Verdict | Severity | Fires when |
|---|---|---|
| `REFERENCE_ORDER` | Major | first-appearance sequence not ascending (`[12]` before `[5]`) |
| `REFERENCE_GAP` | Minor | cited numbers not contiguous from 1 (a number never cited) |
| `REFERENCE_COUNT_MISMATCH` | Major / Minor | a `[N]` overruns the reference list (dangling → Major); the list has trailing entries never cited (→ Minor) |

## Why

A **citeproc `[@key]` manuscript** renumbers at render, so it has no numbers to check and
stays silent. But a **hand-typed `[N]` manuscript** — the Word/Zotero placeholder path — had
**no gate at all**, and an out-of-order or gapped reference series is a desk-check reject just
like an out-of-order table. citeproc had been masking the fault on rendered builds.

## Range expansion (fixes both series)

Ranges are now **expanded** (`[4–11]` → 4..11) *before* ordering and gap analysis — for the
reference series **and** the existing float series. An endpoint-only reader saw `4–11` as
`{4, 11}` and reported every interior number (`[10]`, `[37]` inside `4–11` / `36–38`) as a
**false gap**; expansion removes that. The `citation_order_ref_range_ok.md` fixture is exactly
this negative case.

## Scope / safety

- **No new detector** — the count stays **80** (this extends an existing `check_*.py`). No
  `catalog_counts.json` / `MEDSCI_AUDIT.md` / family-map change; `detectors_catalog.json`
  regenerated (description only).
- Parenthetical `(1)` citations are deliberately **not** scanned (indistinguishable from
  equation / panel / group-size / CI-bound numbers). Bracketed `[N]` only.
- Guards against markdown that reuses square brackets: wikilinks `[[1]]`, images `![alt]`,
  links `[1](url)`, link-defs `[1]:`, footnotes `[^1]`, and `[@key]` (non-numeric).
- Silent below 3 distinct reference numbers (too little signal vs a stray `[1]`).

## Verification

- Existing float suite: **no regression** (range expansion only makes the float GAP check
  more accurate).
- Clean on the bracketed-citation demo manuscript **and** all three demos (0 claims).
- Four new fixtures: out-of-order → `REFERENCE_ORDER`; hole at `[7]` → `REFERENCE_GAP`; the
  **range-trap negative** → clean; a clean contiguous series → clean.
- Full local CI mirror green (**182/182**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
