### PR TITLE
feat(make-figures): export_portal_tiff.py — portal-ready TIFF (LZW + RGBA→RGB white-flatten)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- **`/make-figures` gains `export_portal_tiff.py` — a portal-ready TIFF export that a raw
+  `magick … output.tiff` cannot safely produce.** Submission portals collide with a rendered
+  PNG in two ways: some accept only `.tiff`/`.jpeg`/`.eps` and **reject `.png`** (Springer
+  Nature SNAPP), and others **cap a figure at 25 MB** (JACC: Asia) that a raw uncompressed
+  600-dpi RGBA TIFF sails past. The exporter LZW-compresses (lossless) and **flattens the
+  alpha channel onto white** (a TIFF that keeps alpha prints the transparent regions *black*
+  on many production pipelines), then **verifies the output is pixel-identical** to that
+  flatten before handing it over — and, with `--max-mb`, refuses (exit 1) an output still over
+  the cap so the failure surfaces here, not at the upload button. It is a figure producer
+  (Pillow, like `render_core_figures.py`), not a detector — **detector count unchanged**. Ships
+  `export_portal_tiff_challenge/` (synthetic RGBA fixture generated at runtime, no committed
+  binary): positive asserts LZW + RGB + white-flatten + smaller-than-uncompressed, and two
+  negatives prove the flatten and the size-cap assertions bite. Grounded in a JACC: Asia /
+  SNAPP submission cycle where a raw RGBA TIFF exceeded the portal cap.
+
 - **`check_citation_order` now audits the in-text reference series, not just numbered floats.**
   The Vancouver rule that governs Tables and Figures governs a fifth series the gate never
   saw: the bracketed reference numbers themselves (`[12]`, `[4–11]`). They must ascend by

--- a/docs/skills/make-figures.md
+++ b/docs/skills/make-figures.md
@@ -30,6 +30,7 @@
 - `python3 scripts/validate_pptx_mac_compat.py <file>`
 - `python3 tests/test_pptx_mac_compat.py`
 - `bash scripts/render_core_figures_challenge/verify.sh`
+- `bash scripts/export_portal_tiff_challenge/verify.sh`
 
 **Evidence** — `demo`
 
@@ -59,6 +60,8 @@
 - `build_strobe_template.py`
 - `critic_figure.py`
 - `derive_figure_legend_counts.py`
+- `export_portal_tiff.py`
+- `export_portal_tiff_challenge/` (2 files)
 - `extract_exemplar_from_pdf.py`
 - `fetch_official_templates.sh`
 - `fill_prisma_template.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1918,8 +1918,8 @@
     },
     {
       "path": "skills/make-figures/SKILL.md",
-      "size": 46740,
-      "sha256": "37708a13b21368040891f2250cfece89ab5ef0c1dd21b68a78710c1a1cbf2557"
+      "size": 47509,
+      "sha256": "45e779aa3e41d716d2514cdf750b943129a2d5bb65ebee67dae1505f091abe53"
     },
     {
       "path": "skills/make-figures/references/critic_rubrics/data_plot.md",
@@ -2247,6 +2247,21 @@
       "sha256": "14cab7426080526b9ca67c26f791958a995ef726636b48a9a311c19c8e61ee64"
     },
     {
+      "path": "skills/make-figures/scripts/export_portal_tiff.py",
+      "size": 7658,
+      "sha256": "828184a8f88a4c52675775b32525536006726d13bbc064dbdfc62c9e68ad02b6"
+    },
+    {
+      "path": "skills/make-figures/scripts/export_portal_tiff_challenge/problem.md",
+      "size": 1776,
+      "sha256": "3aba5bf8d996f5449147dd312b1a07173329ef55563ec2e71c4a7ec958003628"
+    },
+    {
+      "path": "skills/make-figures/scripts/export_portal_tiff_challenge/verify.sh",
+      "size": 3709,
+      "sha256": "bd29e3fc4533458e9e4bd34c588c0a128ae1339ba5939b3c5b2fdc13fe4023d2"
+    },
+    {
       "path": "skills/make-figures/scripts/extract_exemplar_from_pdf.py",
       "size": 6944,
       "sha256": "74c52e3edfe24657eecdd31cb36577291e01f509ebcddc87b95934fb2fec77e0"
@@ -2303,8 +2318,8 @@
     },
     {
       "path": "skills/make-figures/skill.yml",
-      "size": 2249,
-      "sha256": "6a8ebbe077c2073bb546a044bbecb5d483dbe2d2a50b31adabba6cf5e3a87990"
+      "size": 2307,
+      "sha256": "73fde538f13feb5698ca51dca35e6de87f98b8bb8d7073576dc9a93fa0c069db"
     },
     {
       "path": "skills/make-figures/templates/official/NOTES.md",

--- a/skills/make-figures/SKILL.md
+++ b/skills/make-figures/SKILL.md
@@ -869,7 +869,23 @@ magick input.png -resize 1200x -quality 95 output.jpg
 
 # CMYK conversion (some print journals require this)
 magick input.png -colorspace CMYK output.tiff
+```
 
+### Portal-ready TIFF (SNAPP `.png`-not-accepted / 25 MB cap)
+
+A raw `magick ... output.tiff` keeps the alpha channel (transparent regions print **black**
+on many production pipelines) and stays uncompressed (a 600-dpi RGBA TIFF blows past a
+portal's 25 MB cap). `export_portal_tiff.py` does the flatten-and-compress a human otherwise
+does by hand and **verifies the result is pixel-identical** to that white-flatten before
+handing it over — use it when a portal accepts only `.tiff`/`.jpeg`/`.eps` (Springer Nature
+SNAPP) or caps figure size (JACC: Asia):
+
+```bash
+python3 scripts/export_portal_tiff.py --in figure.png --out figure.tiff --max-mb 25
+# LZW-compressed, RGBA→RGB white-flattened, pixel-identity-verified; exit 1 if still over the cap
+```
+
+```bash
 # Multi-panel figure assembly (A/B/C/D panels)
 magick montage panelA.png panelB.png panelC.png panelD.png \
   -tile 2x2 -geometry +10+10 -density 300 combined.png

--- a/skills/make-figures/scripts/export_portal_tiff.py
+++ b/skills/make-figures/scripts/export_portal_tiff.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Export a figure to a portal-ready TIFF — LZW-compressed, RGBA→RGB white-flattened.
+
+Why this exists. Two submission-portal facts collide on figure upload:
+
+  1. Some portals accept only a fixed raster set and NOT PNG. Springer Nature's SNAPP,
+     for one, takes `.jpeg` / `.tiff` / `.eps` — a PNG has to be converted on the spot.
+  2. A portal caps figure size (JACC: Asia rejects a figure over 25 MB). A raw,
+     uncompressed 600-dpi RGBA TIFF blows straight past that; the *same* image saved
+     LZW-compressed with the alpha channel flattened away is a fraction of the size and
+     pixel-identical.
+
+The naive conversion also introduces a print defect: a TIFF that keeps an alpha channel
+renders the transparent regions BLACK on many print/production pipelines. Flattening the
+alpha onto a white background (the paper) is what a human does by hand in Photoshop; this
+does it deterministically and then PROVES the result is pixel-identical to that flatten
+before it hands you the file.
+
+What it does:
+  * opens the input raster (any PIL-readable format — PNG, TIFF, BMP, …);
+  * if it carries alpha/transparency (RGBA / LA / palette-with-transparency), composites
+    it onto a solid background (white by default) to get RGB; a plain RGB/L image is kept;
+  * saves TIFF with LZW compression (lossless), preserving dpi;
+  * VERIFIES the output by independently re-flattening the source and comparing bytes —
+    refuses (exit 1) if the produced TIFF is not pixel-identical to the expected flatten;
+  * reports the before/after byte size and, with --max-mb, refuses an output that still
+    exceeds the portal cap (so the failure surfaces here, not at the upload button).
+
+This is a figure PRODUCER (like render_core_figures.py), not a manuscript detector. It
+requires Pillow — the same runtime dependency every raster figure helper in this skill
+already has — and does nothing over the network.
+
+Usage:
+  export_portal_tiff.py --in figure.png                    # -> figure.tiff (white bg, LZW)
+  export_portal_tiff.py --in fig.png --out fig.tiff --max-mb 25
+  export_portal_tiff.py --in fig.png --background 255,255,255 --dpi 600
+
+Exit codes: 0 success (verified), 1 verification mismatch / over the --max-mb cap,
+2 input/usage error (missing file, unreadable image, Pillow absent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# A palette image can carry per-pixel transparency via a `transparency` info key.
+ALPHA_MODES = ("RGBA", "LA", "PA", "La")
+
+
+def _load_pillow():
+    try:
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        sys.stderr.write(
+            "ERROR: Pillow is required (pip install Pillow) — the same dependency the "
+            "other raster figure helpers in /make-figures use.\n")
+        sys.exit(2)
+    from PIL import Image
+    return Image
+
+
+def _has_alpha(img) -> bool:
+    """True if the image carries per-pixel transparency that a flatten must resolve."""
+    if img.mode in ALPHA_MODES:
+        return True
+    # A palette (P) or grayscale image can still declare a transparent colour.
+    return "transparency" in img.info
+
+
+def flatten_to_rgb(img, background):
+    """Return an RGB copy with any alpha composited onto `background` (an (R,G,B) tuple).
+    A plain RGB/grayscale image (no transparency) is converted straight to RGB. This is the
+    single definition of the flatten, used both to produce the output and to verify it."""
+    if not _has_alpha(img):
+        return img.convert("RGB")
+    rgba = img.convert("RGBA")
+    Image = _load_pillow()
+    bg = Image.new("RGB", rgba.size, background)
+    bg.paste(rgba, mask=rgba.split()[-1])  # last band is alpha
+    return bg
+
+
+def _parse_bg(s: str):
+    parts = s.split(",")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("background must be R,G,B (e.g. 255,255,255)")
+    try:
+        vals = tuple(int(p) for p in parts)
+    except ValueError:
+        raise argparse.ArgumentTypeError("background components must be integers 0-255")
+    if not all(0 <= v <= 255 for v in vals):
+        raise argparse.ArgumentTypeError("background components must be 0-255")
+    return vals
+
+
+def export(in_path: Path, out_path: Path, background, dpi, max_mb):
+    Image = _load_pillow()
+    try:
+        src = Image.open(in_path)
+        src.load()
+    except Exception as e:  # noqa: BLE001 — PIL raises a variety of decode errors
+        sys.stderr.write(f"ERROR: could not open image {in_path}: {e}\n")
+        sys.exit(2)
+
+    expected = flatten_to_rgb(src, background)
+
+    save_kwargs = {"format": "TIFF", "compression": "tiff_lzw"}
+    src_dpi = dpi or src.info.get("dpi")
+    if src_dpi:
+        save_kwargs["dpi"] = tuple(src_dpi) if not isinstance(src_dpi, (int, float)) else (src_dpi, src_dpi)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    expected.save(out_path, **save_kwargs)
+
+    # Verify: reopen the produced TIFF and require it to be pixel-identical to the flatten,
+    # LZW-compressed, and alpha-free. A silent decode surprise fails here, not at upload.
+    with Image.open(out_path) as produced:
+        produced.load()
+        compression = produced.tag_v2.get(259) if hasattr(produced, "tag_v2") else None
+        prod_rgb = produced.convert("RGB")
+        identical = prod_rgb.tobytes() == expected.tobytes()
+
+    problems = []
+    if compression != 5:  # TIFF Compression tag: 5 == LZW
+        problems.append(f"output is not LZW-compressed (Compression tag={compression}, expected 5)")
+    if not identical:
+        problems.append("output TIFF is NOT pixel-identical to the white-flattened source")
+
+    in_mb = in_path.stat().st_size / (1024 * 1024)
+    out_mb = out_path.stat().st_size / (1024 * 1024)
+    if max_mb is not None and out_mb > max_mb:
+        problems.append(f"output is {out_mb:.1f} MB, over the --max-mb {max_mb} portal cap")
+
+    print("=" * 52)
+    print(" Portal TIFF export")
+    print("=" * 52)
+    print(f"  in:          {in_path}  ({in_mb:.2f} MB, mode {src.mode})")
+    print(f"  out:         {out_path}  ({out_mb:.2f} MB, mode RGB, LZW)")
+    print(f"  flattened:   {'alpha composited onto ' + str(background) if _has_alpha(src) else 'no alpha (RGB kept)'}")
+    print(f"  pixel-check: {'identical to source flatten' if identical else 'MISMATCH'}")
+    if problems:
+        print("\nFAIL: " + "; ".join(problems))
+        return 1
+    print("\nOK: portal-ready TIFF (LZW, RGB, pixel-identical to source).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Export a figure to a portal-ready TIFF (LZW, RGBA→RGB white-flatten).")
+    ap.add_argument("--in", dest="inp", required=True, help="input raster image (PNG/TIFF/…)")
+    ap.add_argument("--out", default=None, help="output .tiff (default: input stem + .tiff)")
+    ap.add_argument("--background", type=_parse_bg, default=(255, 255, 255),
+                    help="RGB fill for transparent regions (default 255,255,255 = white)")
+    ap.add_argument("--dpi", type=int, default=None, help="override dpi (default: keep source dpi)")
+    ap.add_argument("--max-mb", type=float, default=None,
+                    help="refuse (exit 1) if the output still exceeds this many MB (e.g. 25 for a portal cap)")
+    args = ap.parse_args()
+
+    in_path = Path(args.inp)
+    if not in_path.is_file():
+        sys.stderr.write(f"ERROR: input not found: {in_path}\n")
+        return 2
+    out_path = Path(args.out) if args.out else in_path.with_suffix(".tiff")
+    return export(in_path, out_path, args.background, args.dpi, args.max_mb)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/make-figures/scripts/export_portal_tiff_challenge/problem.md
+++ b/skills/make-figures/scripts/export_portal_tiff_challenge/problem.md
@@ -1,0 +1,32 @@
+# Challenge — portal-ready TIFF export (LZW + RGBA→RGB white-flatten)
+
+A submission portal rejects a figure and the author cannot see why. Two facts collide at
+the upload button:
+
+1. The portal accepts only `.jpeg` / `.tiff` / `.eps` — **not** the `.png` the figure was
+   rendered as (Springer Nature SNAPP does exactly this).
+2. The portal caps a figure at 25 MB (JACC: Asia). A raw, uncompressed 600-dpi **RGBA**
+   TIFF sails past the cap; the same pixels saved **LZW-compressed** with the alpha channel
+   **flattened onto white** are a fraction of the size — and a TIFF that keeps its alpha
+   renders the transparent regions **black** on many production pipelines.
+
+`export_portal_tiff.py` does the conversion a human otherwise does by hand in Photoshop, and
+then **proves** the result is pixel-identical to that white-flatten before handing it over.
+
+## What `verify.sh` asserts (network-free, Pillow-only)
+
+Positive — on a synthetic RGBA PNG with a transparent quadrant and a colour gradient:
+
+- the output is a **TIFF**, mode **RGB** (no alpha), **LZW**-compressed (Compression tag 5);
+- the once-transparent region is now **white** and the opaque pixels are unchanged;
+- the LZW output is strictly **smaller** than an uncompressed TIFF of the same pixels.
+
+Negative — the assertions must bite, not merely pass:
+
+- flattening the same source onto **black** yields **different** bytes, so the pixel-identity
+  check would have caught a wrong background or an ignored alpha channel;
+- with `--max-mb` set below the output size, the exporter **refuses (exit 1)** rather than
+  handing back a file that will bounce at the portal.
+
+Skips cleanly if Pillow is unavailable (the same runtime dependency every raster figure
+helper in this skill already carries).

--- a/skills/make-figures/scripts/export_portal_tiff_challenge/verify.sh
+++ b/skills/make-figures/scripts/export_portal_tiff_challenge/verify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the portal-TIFF export challenge (make-figures).
+# Network-free. Generates a synthetic RGBA PNG, exports it to a portal-ready TIFF, and
+# asserts the output is LZW + RGB + white-flattened + pixel-identical + smaller than raw;
+# then confirms the flatten and the size-cap assertions actually BITE. Exit 0 = all hold.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GEN="$HERE/../export_portal_tiff.py"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+[ -f "$GEN" ] || { echo "ENV-ERR: export_portal_tiff.py missing" >&2; exit 2; }
+python3 -c "import PIL" 2>/dev/null \
+  || { echo "SKIP: Pillow unavailable on this host"; exit 0; }
+
+# --- synthetic fixture: RGBA with a fully transparent top-left quadrant + a gradient -----
+python3 - "$TMP" <<'PY'
+import sys
+from PIL import Image
+d = sys.argv[1]
+img = Image.new("RGBA", (200, 200), (0, 0, 0, 0))
+px = img.load()
+for y in range(200):
+    for x in range(200):
+        a = 0 if (x < 100 and y < 100) else 255      # top-left transparent
+        px[x, y] = ((x * 255) // 200, (y * 255) // 200, 128, a)
+img.save(f"{d}/fig.png")
+PY
+
+# (1) Positive: the exporter runs and self-verifies.
+python3 "$GEN" --in "$TMP/fig.png" --out "$TMP/fig.tiff" --max-mb 25 >"$TMP/log" 2>&1 \
+  || { echo "FAIL: valid figure did not export/verify" >&2; cat "$TMP/log" >&2; exit 1; }
+[ -s "$TMP/fig.tiff" ] || { echo "FAIL: fig.tiff not written" >&2; exit 1; }
+grep -q "OK: portal-ready TIFF" "$TMP/log" || { echo "FAIL: export did not report success" >&2; cat "$TMP/log" >&2; exit 1; }
+
+# (2) Independent structural assertions on the produced TIFF.
+python3 - "$TMP" <<'PY'
+import os, sys
+from PIL import Image
+d = sys.argv[1]
+im = Image.open(f"{d}/fig.tiff"); im.load()
+assert im.mode == "RGB", f"expected RGB, got {im.mode}"
+assert im.tag_v2.get(259) == 5, f"expected LZW (Compression 5), got {im.tag_v2.get(259)}"
+rgb = im.convert("RGB")
+assert rgb.getpixel((10, 10)) == (255, 255, 255), f"transparent quadrant not white: {rgb.getpixel((10,10))}"
+assert rgb.getpixel((150, 150)) == (191, 191, 128), f"opaque pixel altered: {rgb.getpixel((150,150))}"
+# LZW must be genuinely smaller than an uncompressed TIFF of the same pixels.
+rgb.save(f"{d}/raw.tiff", format="TIFF", compression="none")
+lzw, raw = os.path.getsize(f"{d}/fig.tiff"), os.path.getsize(f"{d}/raw.tiff")
+assert lzw < raw, f"LZW ({lzw}) not smaller than uncompressed ({raw})"
+print(f"OK-STRUCT: RGB + LZW + white-flatten + {lzw} < {raw} bytes")
+PY
+
+# (3) Negative — the flatten discriminates: onto BLACK yields different bytes, so the
+#     pixel-identity check would have caught a wrong background / ignored alpha.
+python3 - "$TMP" "$GEN" <<'PY'
+import importlib.util, sys
+from PIL import Image
+d, gen = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("ept", gen)
+ept = importlib.util.module_from_spec(spec); spec.loader.exec_module(ept)
+src = Image.open(f"{d}/fig.png"); src.load()
+white = ept.flatten_to_rgb(src, (255, 255, 255)).tobytes()
+black = ept.flatten_to_rgb(src, (0, 0, 0)).tobytes()
+assert white != black, "flatten ignored alpha — white and black backgrounds produced identical bytes"
+print("OK-NEG-FLATTEN: white != black flatten (alpha is genuinely composited)")
+PY
+
+# (4) Negative — the size cap bites: a cap below the output size must exit 1.
+if python3 "$GEN" --in "$TMP/fig.png" --out "$TMP/tiny.tiff" --max-mb 0.001 >/dev/null 2>&1; then
+  echo "FAIL: --max-mb 0.001 did not refuse an over-cap output" >&2; exit 1
+fi
+echo "OK-NEG-CAP: --max-mb below output size refuses (exit 1)"
+
+echo "PASS: portal TIFF is LZW + RGB + white-flattened + pixel-identical + under cap; the flatten and size-cap assertions both bite."

--- a/skills/make-figures/skill.yml
+++ b/skills/make-figures/skill.yml
@@ -52,4 +52,5 @@ validation_commands:
   - "python3 scripts/validate_pptx_mac_compat.py <file>"
   - "python3 tests/test_pptx_mac_compat.py"
   - "bash scripts/render_core_figures_challenge/verify.sh"
+  - "bash scripts/export_portal_tiff_challenge/verify.sh"
 evidence_surface: demo


### PR DESCRIPTION
## What

`/make-figures` gains `export_portal_tiff.py` — a **portal-ready TIFF export** that a raw
`magick … output.tiff` cannot safely produce.

```bash
python3 scripts/export_portal_tiff.py --in figure.png --out figure.tiff --max-mb 25
```

## Why

Two submission-portal facts collide on figure upload:

| Fact | Portal | The producer's answer |
|---|---|---|
| Accepts only `.tiff`/`.jpeg`/`.eps` — **rejects `.png`** | Springer Nature SNAPP | emits a `.tiff` |
| Caps a figure at **25 MB** | JACC: Asia | LZW compression + `--max-mb` refusal |
| A TIFF that keeps **alpha** prints transparent regions **black** | many production pipelines | RGBA→RGB **white-flatten** |

The exporter does the flatten-and-compress a human otherwise does by hand in Photoshop, then
**verifies the output is pixel-identical** to that white-flatten before handing it over. With
`--max-mb` it refuses (exit 1) an output still over the cap, so the failure surfaces here — not
at the upload button after a long submission session.

## Scope / safety

- **Figure producer** (Pillow, like `render_core_figures.py` / `generate_visual_abstract.py`),
  **not a detector** — the detector count is unchanged (**80**). No `catalog_counts.json` /
  `MEDSCI_AUDIT.md` change.
- Named in `make-figures` SKILL.md (satisfies `check_script_reachability`) and wired into
  `skill.yml` validation_commands.
- Ships `export_portal_tiff_challenge/` following the `render_core_figures_challenge`
  convention: the RGBA fixture is **generated at runtime** (no committed binary), and the
  verifier **skips cleanly without Pillow** (the same runtime dependency every raster figure
  helper here already carries), so it is not added to the CI `validate` job.

## Verification

- **Positive** (challenge): a synthetic RGBA PNG with a transparent quadrant → TIFF that is
  **RGB** (no alpha), **LZW** (Compression tag 5), transparent region now **white**, opaque
  pixels unchanged, and **smaller** than an uncompressed TIFF of the same pixels.
- **Negatives** (assertions bite): flattening onto **black** yields different bytes (so the
  pixel-identity check would catch a wrong background / ignored alpha); `--max-mb` below the
  output size **refuses (exit 1)**.
- Full local CI mirror green (**182/182**); challenge `verify.sh` passes locally with Pillow.

## Not in this PR (follow-up)

The `sync-submission` preflight figure format/size **gate** and the portal-ASCII (`≥`/`≤`
verbose-expansion) text check are a separate deterministic, stdlib, CI-testable piece — the
export *default* here is the root-cause fix (figures are portal-ready by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
