### PR TITLE
feat(polish-language): figure-source locale drift + fix US/UK families counting universal words

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -384,6 +384,9 @@ jobs:
       - name: Run polish-language consistency-linter challenge
         run: bash skills/polish-language/scripts/lint_challenge/verify.sh
 
+      - name: "Run polish-language figure-source locale challenge (UK word in a .pptx/.py label fires; universals stay silent)"
+        run: bash skills/polish-language/scripts/lint_figure_locale_challenge/verify.sh
+
       - name: Run deidentify PHI-scan contract test
         run: bash skills/deidentify/tests/test_deidentify_scan.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 ### Added
 
+- **`/polish-language` now reads figure SOURCES, catching spelling a rendered raster hides —
+  and the shared US/UK families stopped counting words that are identical in both dialects.**
+  Phase 1 only sees prose; text baked into a figure lives in a PNG/TIFF where no grep reaches,
+  so a co-author's "Behavioural alignment" in a PowerPoint panel ships a UK word into a US
+  manuscript and surfaces only when someone opens the image. New `lint_figure_locale.py` scans
+  the sources instead — `<a:t>` runs inside `*.pptx` slide XML and the text of `*.py`/`*.R`
+  plotting scripts — against a `spelling:` front-matter field or the body's own US/UK majority,
+  emitting `FIGURE_LOCALE_DRIFT` (Minor). No OCR; a missing figures directory exits 0. It is a
+  linter alongside `lint_consistency.py`, **not** a MedSci-Audit detector — **detector count
+  stays 80**.
+
+### Fixed
+
+- **The US↔UK spelling families counted four universal words as UK evidence.** The `-ise/-ize`
+  families matched the UK side with a greedy `\w*` suffix, so words spelled *identically* in
+  both dialects were tallied as British: **analysis / analyses**, **organism(s)**,
+  **optimism**, and — worst — **characteristic(s)**, the single most common table label in
+  clinical medicine. Any US manuscript containing "Baseline characteristics" therefore
+  contributed phantom UK evidence to `lint_consistency.py`'s dominant-variant tally. The four
+  families now enumerate the genuinely dialectal inflections (`analyse|analysed|analysing|…`),
+  with a comment recording why the greedy form must not come back; `randomise`/`standardise`
+  have no universal collision and are unchanged. Verified: all seven universals now silent,
+  all genuine UK forms still caught (no false negatives), and the existing consistency
+  challenge passes unchanged — its "predominantly UK" verdict rests on real UK spellings
+  (`analyse`, `Tumour`), not on the phantom hit. Found while building the figure-source gate,
+  which would otherwise have inherited the noise directly.
+
 - **The submission pre-flight now catches two portal pitfalls the export default can't:
   over-cap / wrong-format figures, and `≥`/`≤` characters a portal expands to words.** A
   figure bounces at the upload button for reasons decidable from the file on disk — a byte

--- a/docs/skills/polish-language.md
+++ b/docs/skills/polish-language.md
@@ -28,6 +28,8 @@
 
 - `python3 scripts/lint_consistency.py <manuscript.md>`
 - `bash scripts/lint_challenge/verify.sh  # deterministic, network-free`
+- `python3 scripts/lint_figure_locale.py --manuscript <manuscript.md> --figures-dir <figures/>`
+- `bash scripts/lint_figure_locale_challenge/verify.sh  # deterministic, network-free`
 
 **Evidence** — `bundled_script`
 
@@ -37,6 +39,8 @@
 
 - `lint_challenge/` (4 files)
 - `lint_consistency.py`
+- `lint_figure_locale.py`
+- `lint_figure_locale_challenge/` (2 files)
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3443,8 +3443,8 @@
     },
     {
       "path": "skills/polish-language/SKILL.md",
-      "size": 6585,
-      "sha256": "5d68e807703817b5771f0b3f05beafe71eb34c0e68b2df4b74b995e871a1c679"
+      "size": 7649,
+      "sha256": "27c9d79d48c6b4b3e5a840e30962c4e731f8486e9dab75c16ac70d6067bc4c76"
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/expected/report.txt",
@@ -3468,13 +3468,28 @@
     },
     {
       "path": "skills/polish-language/scripts/lint_consistency.py",
-      "size": 12990,
-      "sha256": "e6f7034f8c53bbb6565cecff911b94497f9e4e3d003e707175186316ebce6811"
+      "size": 13850,
+      "sha256": "ed6067e9d8968dec7d913aec92be06676d1d250aaee613b390355dcb872392c1"
+    },
+    {
+      "path": "skills/polish-language/scripts/lint_figure_locale.py",
+      "size": 9910,
+      "sha256": "fd177e21948f6995f6c124cc55dc19a98f3d56f6f38c7ff12a87a2aef3cf3263"
+    },
+    {
+      "path": "skills/polish-language/scripts/lint_figure_locale_challenge/problem.md",
+      "size": 2282,
+      "sha256": "29631f1c7d4d78c94b1810d23085b9eae823646d1254d951f5e683ede768361c"
+    },
+    {
+      "path": "skills/polish-language/scripts/lint_figure_locale_challenge/verify.sh",
+      "size": 4118,
+      "sha256": "6dc0d2bae3bf6dd9394514f73dfefa6f29cd3b49a10f39d9e6ddcddba9a7b702"
     },
     {
       "path": "skills/polish-language/skill.yml",
-      "size": 1753,
-      "sha256": "ce4996820b24c230584890c501860c8d37dfd07521195954077d2fdd1a26f419"
+      "size": 2033,
+      "sha256": "1a513a7d532d5a335acd6fa91566a551b5dc17d6ba3021f9d39a52848a7df571"
     },
     {
       "path": "skills/preprocess-imaging/SKILL.md",

--- a/skills/polish-language/SKILL.md
+++ b/skills/polish-language/SKILL.md
@@ -70,6 +70,24 @@ count:
 Present the report to the user. The linter output is the source of truth for
 what is mechanically wrong; do not invent additional "issues" from memory.
 
+### Phase 1b: Figure-SOURCE locale drift (text no grep can reach)
+
+Phase 1 only sees prose. Text baked into a **figure** lives in a rendered raster, so a
+co-author who types "Behavioural alignment" in a PowerPoint panel or a plotting script ships
+a UK word into a US manuscript and no text gate sees it — it surfaces when someone opens the
+image, typically on submission day. Scan the figure **sources** instead (no OCR):
+
+```bash
+python3 scripts/lint_figure_locale.py --manuscript path/to/manuscript.md --figures-dir figures/
+# --spelling us|uk forces the target; otherwise it reads a `spelling:` front-matter field,
+# then falls back to the body's own US/UK majority. --strict exits non-zero on any drift.
+```
+
+It reads `<a:t>` runs inside `*.pptx` slide XML and the text of `*.py` / `*.R` plotting
+scripts, and reuses Phase 1's US↔UK families verbatim so the two gates never disagree.
+`FIGURE_LOCALE_DRIFT` is **Minor** — copy-edit the source before the raster is re-exported.
+A missing figures directory is not an error; it exits 0 with nothing judged.
+
 ### Phase 2: Triage with the user (gate)
 
 Walk the user through the report. Some flags are author choices (a journal may

--- a/skills/polish-language/scripts/lint_consistency.py
+++ b/skills/polish-language/scripts/lint_consistency.py
@@ -37,12 +37,23 @@ ABBR_WHITELIST = {
     "ID", "OK", "PDF", "URL", "HTML", "API", "AND", "OR", "NOT", "ROC",
 }
 
-# US ↔ UK spelling families: canonical "us" form -> regex matching both.
+# US ↔ UK spelling families: canonical "us" form -> regex matching the UK variant.
+#
+# PRECISION NOTE — do NOT "simplify" the first four back to a trailing `\w*`. The -ise/-ize
+# families collide with words that are IDENTICAL in both dialects, and a greedy suffix match
+# counts them as UK evidence:
+#     analys + \w*        -> "analysis", "analyses"      (universal nouns)
+#     organis + \w*       -> "organism", "organisms"     (universal)
+#     characteris + \w*   -> "characteristic(s)"         (universal — and the single most
+#                                                         common table label in medicine)
+#     optimis + \w*       -> "optimism"                  (universal)
+# Enumerating the genuinely dialectal inflections keeps the US/UK tally honest. (randomise /
+# standardise have no universal collision, so their `\w*` form is left alone.)
 SPELLING_FAMILIES = [
-    ("analyze", r"\banalys[ei]([sdz]|zing|sing|zed|sed)?\b", r"analy(s)"),
-    ("organize", r"\borganis[ei]?\w*\b", r"organis"),
-    ("characterize", r"\bcharacteris\w*\b", r"characteris"),
-    ("optimize", r"\boptimis\w*\b", r"optimis"),
+    ("analyze", r"\banalys(e|ed|ing|able)\b", r"analy(s)"),
+    ("organize", r"\borganis(e|es|ed|ing|ation|ations|ational|er|ers)\b", r"organis"),
+    ("characterize", r"\bcharacteris(e|es|ed|ing|ation|ations)\b", r"characteris"),
+    ("optimize", r"\boptimis(e|es|ed|ing|ation|ations)\b", r"optimis"),
     ("randomize", r"\brandomis\w*\b", r"randomis"),
     ("standardize", r"\bstandardis\w*\b", r"standardis"),
     ("tumor", r"\btumour(s)?\b", r"tumour"),

--- a/skills/polish-language/scripts/lint_figure_locale.py
+++ b/skills/polish-language/scripts/lint_figure_locale.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Figure-SOURCE locale drift — US/UK spelling in a figure that no text gate can see.
+
+A manuscript declares (or consistently uses) one spelling — say US — and every text gate
+(polish-language's lint_consistency, a repo-wide locale sweep) enforces it across the prose.
+None of them reach the text baked into a FIGURE, because that text lives in a rendered
+raster (a PNG/TIFF) that a grep cannot read. So a co-author who builds a panel in PowerPoint
+or a plotting script and types "Behavioural alignment" ships a UK word into a US manuscript,
+and it is found only by opening the image on submission day.
+
+This gate reads the figure SOURCES instead of the raster — no OCR:
+
+  * `*.pptx` (and `.pptm`) — the `<a:t>` text runs inside `ppt/slides/slide*.xml`;
+  * `*.py` / `*.R` / `*.r` figure scripts — the file text (label literals live there).
+
+It compares each source against the manuscript's spelling (declared in a `spelling:` YAML
+front-matter field, or inferred from the body's own US/UK majority) and flags any word in the
+OPPOSITE variant. It reuses lint_consistency's US↔UK spelling families verbatim, so the two
+gates never disagree on what "US" and "UK" mean.
+
+Verdict:
+  FIGURE_LOCALE_DRIFT (Minor)  a figure source uses the spelling the manuscript does not
+                               (e.g. "Behavioural" in a US manuscript). Copy-edit before
+                               the raster is exported; the raster itself stays out of scope.
+
+INPUT
+  --figures-dir DIR   directory scanned recursively for figure sources (.pptx/.pptm/.py/.R/.r).
+                      Default: <manuscript-dir>/figures, then ./figures.
+  --manuscript FILE   manuscript markdown — supplies the spelling target (front matter or body
+                      majority) and, if --figures-dir is absent, the default figures directory.
+  --spelling us|uk    force the target spelling (overrides front matter / inference).
+
+OUTPUT (--out PATH)
+  {"detector": "lint_figure_locale", "spelling", "scanned", "findings":
+     [{path, kind, word, expected, line, severity}], "summary", "submission_safe"}
+
+Stdlib-only. Exit codes: 0 clean / no figure sources / spelling undetermined (nothing judged),
+1 drift found under --strict, 2 input/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+# Reuse the US↔UK spelling families verbatim so this gate and lint_consistency never disagree.
+from lint_consistency import SPELLING_FAMILIES, SPELLING_US
+
+FIGURE_SCRIPT_EXTS = {".py", ".r"}          # .R lowercases to .r
+PPTX_EXTS = {".pptx", ".pptm"}
+AT_RE = re.compile(r"<a:t>(.*?)</a:t>", re.S)
+FRONT_SPELLING_RE = re.compile(r"(?im)^\s*spelling\s*:\s*['\"]?(us|uk|american|british)\b")
+
+_US_RES = {k: re.compile(v, re.IGNORECASE) for k, v in SPELLING_US.items()}
+_UK_RES = {us: re.compile(uk, re.IGNORECASE) for us, uk, _ in SPELLING_FAMILIES}
+
+
+def _front_matter(text: str) -> str:
+    """Return the leading YAML front-matter block (between the first two '---' lines), or ''."""
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    return m.group(1) if m else ""
+
+
+def target_spelling(manuscript_text: str) -> "str | None":
+    """'us' / 'uk' from a `spelling:` front-matter field, else the body's US/UK majority, else None."""
+    fm = _front_matter(manuscript_text)
+    m = FRONT_SPELLING_RE.search(fm)
+    if m:
+        return "uk" if m.group(1).lower().startswith(("uk", "brit")) else "us"
+    us = sum(len(r.findall(manuscript_text)) for r in _US_RES.values())
+    uk = sum(len(r.findall(manuscript_text)) for r in _UK_RES.values())
+    if us == uk:
+        return None  # no signal / perfectly split — cannot judge a target
+    return "us" if us > uk else "uk"
+
+
+def _opposite_hits(text: str, spelling: str):
+    """Yield (word, expected_us_form) for every word in the variant OPPOSITE to `spelling`."""
+    wrong = _UK_RES if spelling == "us" else _US_RES
+    for us_form, rx in wrong.items():
+        for m in rx.finditer(text):
+            yield m.group(0), us_form
+
+
+def _pptx_runs(path: Path):
+    """Text runs from a .pptx/.pptm's slide XML. Returns [] on a corrupt/non-zip file."""
+    try:
+        with zipfile.ZipFile(path) as z:
+            names = [n for n in z.namelist()
+                     if n.startswith("ppt/slides/slide") and n.endswith(".xml")]
+            runs = []
+            for n in sorted(names):
+                xml = z.read(n).decode("utf-8", "replace")
+                runs += AT_RE.findall(xml)
+            return runs
+    except (zipfile.BadZipFile, OSError):
+        return []
+
+
+def _collect_sources(figures_dir: Path):
+    """(pptx_paths, script_paths) under figures_dir."""
+    pptx, scripts = [], []
+    for p in sorted(figures_dir.rglob("*")):
+        if not p.is_file():
+            continue
+        ext = p.suffix.lower()
+        if ext in PPTX_EXTS:
+            pptx.append(p)
+        elif ext in FIGURE_SCRIPT_EXTS:
+            scripts.append(p)
+    return pptx, scripts
+
+
+def analyze(figures_dir: Path, spelling: str) -> dict:
+    pptx, scripts = _collect_sources(figures_dir)
+    findings: list[dict] = []
+
+    def _emit(path, word, us_form):
+        expected = us_form if spelling == "us" else next(
+            (uk for us, uk, _ in SPELLING_FAMILIES if us == us_form), us_form)
+        findings.append({
+            "path": str(path), "kind": "FIGURE_LOCALE_DRIFT", "word": word,
+            "expected_variant": spelling.upper(), "family": us_form, "severity": "Minor",
+            "label": (f'"{word}" is {"UK" if spelling == "us" else "US"} spelling in a '
+                      f'{spelling.upper()} manuscript — copy-edit the figure source '
+                      f'(expected the {spelling.upper()} form, e.g. "{expected}")'),
+        })
+
+    for p in pptx:
+        for run in _pptx_runs(p):
+            for word, us_form in _opposite_hits(run, spelling):
+                _emit(p, word, us_form)
+    for p in scripts:
+        text = p.read_text(encoding="utf-8", errors="replace")
+        for word, us_form in _opposite_hits(text, spelling):
+            _emit(p, word, us_form)
+
+    # de-dup identical (path, word) pairs (a word repeated across runs/lines counts once)
+    seen, uniq = set(), []
+    for f in findings:
+        key = (f["path"], f["word"].lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(f)
+    return {
+        "spelling": spelling,
+        "scanned": {"pptx": len(pptx), "scripts": len(scripts)},
+        "findings": uniq,
+        "summary": {"drift": len(uniq)},
+        "submission_safe": not uniq,
+    }
+
+
+def render(result: dict) -> str:
+    lines = ["| Figure source | Word | Detail |", "|---|---|---|"]
+    for f in result["findings"]:
+        lines.append(f"| {Path(f['path']).name} | {f['word']} | {f['label']} |")
+    if len(lines) == 2:
+        lines.append("| (none) | — | no locale drift in any figure source |")
+    return "\n".join(lines)
+
+
+def _resolve_figures_dir(args) -> "Path | None":
+    if args.figures_dir:
+        d = Path(args.figures_dir)
+        return d if d.is_dir() else None
+    if args.manuscript:
+        cand = Path(args.manuscript).resolve().parent / "figures"
+        if cand.is_dir():
+            return cand
+    cand = Path("figures")
+    return cand if cand.is_dir() else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Figure-source US/UK locale drift gate (no OCR).")
+    ap.add_argument("--figures-dir", help="directory of figure sources (.pptx/.py/.R); default <manuscript-dir>/figures")
+    ap.add_argument("--manuscript", help="manuscript markdown (spelling target + default figures dir)")
+    ap.add_argument("--spelling", choices=["us", "uk"], help="force the target spelling (overrides inference)")
+    ap.add_argument("--out", help="write JSON artifact to this path")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any drift is found")
+    ap.add_argument("--quiet", action="store_true", help="suppress stdout table")
+    args = ap.parse_args()
+
+    figures_dir = _resolve_figures_dir(args)
+    if figures_dir is None:
+        if not args.quiet:
+            print("OK: no figure-source directory found — nothing to scan.")
+        return 0  # no sources: nothing to judge (also the crossfire-safe path)
+
+    spelling = args.spelling
+    if not spelling:
+        if not args.manuscript:
+            sys.stderr.write("ERROR: need --spelling us|uk or --manuscript to determine the target spelling\n")
+            return 2
+        mtext = Path(args.manuscript).read_text(encoding="utf-8", errors="replace")
+        spelling = target_spelling(mtext)
+        if spelling is None:
+            if not args.quiet:
+                print("OK: manuscript spelling could not be determined (no US/UK signal) — nothing judged.")
+            return 0
+
+    result = analyze(figures_dir, spelling)
+
+    if not args.quiet:
+        print("=" * 44)
+        print(" Figure-Source Locale Drift")
+        print("=" * 44)
+        print(render(result))
+        print()
+        n = result["summary"]["drift"]
+        if n:
+            print(f"DRIFT: {n} figure-source word(s) in the wrong spelling for a "
+                  f"{spelling.upper()} manuscript — copy-edit the source before export.")
+        else:
+            print(f"OK: {result['scanned']['pptx']} pptx + {result['scanned']['scripts']} script "
+                  f"source(s) match the {spelling.upper()} spelling.")
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(
+            json.dumps({"detector": "lint_figure_locale", **result}, indent=2, ensure_ascii=False),
+            encoding="utf-8")
+        if not args.quiet:
+            print(f"\nwrote {args.out}")
+
+    return 1 if (args.strict and result["findings"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/polish-language/scripts/lint_figure_locale_challenge/problem.md
+++ b/skills/polish-language/scripts/lint_figure_locale_challenge/problem.md
@@ -1,0 +1,39 @@
+# Challenge — figure-SOURCE locale drift (no OCR)
+
+A manuscript declares US spelling. Every text gate enforces it across the prose. Then a
+co-author builds a panel in PowerPoint and types **"Behavioural alignment"**, or a plotting
+script sets `ax.set_title("Tumour colour")` — and the word ships inside a **rendered raster**,
+where no grep can reach it. A full locale sweep over manuscript + supplement + cover letter
+returns exactly one hit, and it is an internal YAML comment. The real one is found by opening
+the image, on submission day.
+
+`lint_figure_locale.py` reads the figure **sources** instead of the raster — `<a:t>` runs inside
+`*.pptx` slide XML, and the text of `*.py` / `*.R` plotting scripts — and compares them against
+the manuscript's spelling (a `spelling:` front-matter field, or the body's own US/UK majority).
+
+## The precision trap this card exists to lock down
+
+The shared US↔UK families in `lint_consistency.py` originally matched the UK side with a greedy
+`\w*` suffix, so words that are **identical in both dialects** counted as UK evidence:
+
+| greedy pattern | universal word it wrongly matched |
+|---|---|
+| `analys` + `\w*` | **analysis**, **analyses** |
+| `organis` + `\w*` | **organism(s)** |
+| `characteris` + `\w*` | **characteristic(s)** — the most common table label in medicine |
+| `optimis` + `\w*` | **optimism** |
+
+A figure-source gate inherits that noise directly: "Baseline characteristics" is a figure label
+in almost every clinical paper, and it is not a spelling error. The families now enumerate the
+genuinely dialectal inflections, and this card asserts both halves of the contract.
+
+## What `verify.sh` asserts (network-free, no committed binaries)
+
+- **Positive**: in a US manuscript, `Behavioural` (a `.py` label) and `Randomised` / `centre`
+  (a `.pptx` `<a:t>` run) are flagged `FIGURE_LOCALE_DRIFT`.
+- **Negative — the precision guard**: `characteristics`, `analysis`, `organisms` appear in the
+  very same sources and **must stay silent**.
+- **Negative — clean**: US-spelled figure sources in a US manuscript produce nothing.
+- **No sources**: a missing figures directory exits 0 (nothing to judge), never an error.
+
+Fixtures are written at runtime (the `.pptx` via python-pptx), so nothing binary is committed.

--- a/skills/polish-language/scripts/lint_figure_locale_challenge/verify.sh
+++ b/skills/polish-language/scripts/lint_figure_locale_challenge/verify.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the figure-SOURCE locale-drift challenge card.
+# Network-free, no committed binaries (the .pptx is written at runtime via python-pptx).
+#   Positive: genuine UK words in a .py label and a .pptx <a:t> run are flagged in a US manuscript.
+#   Negative: universal words (characteristics / analysis / organisms) sitting in the SAME
+#             sources must stay silent — the precision trap the shared families used to fail.
+#   Negative: US-spelled sources are clean; a missing figures dir exits 0 (nothing judged).
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DET="$HERE/../lint_figure_locale.py"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+[ -f "$DET" ] || { echo "ENV-ERR: lint_figure_locale.py missing" >&2; exit 2; }
+
+figs="$tmp/figures"; mkdir -p "$figs"
+cat > "$tmp/manuscript.md" <<'MD'
+---
+title: Test manuscript
+spelling: US
+---
+
+We analyzed the baseline characteristics and the analysis of tumor color in the center.
+MD
+
+# A plotting script whose labels mix a genuine UK word with two universals.
+cat > "$figs/panel.py" <<'PY'
+ax.set_title("Behavioural alignment")
+ax.set_xlabel("Baseline characteristics")
+ax.set_ylabel("Analysis of organisms")
+PY
+
+have_pptx=0
+if python3 -c "import pptx" 2>/dev/null; then
+  have_pptx=1
+  python3 - "$figs/panel.pptx" <<'PY'
+import sys
+from pptx import Presentation
+from pptx.util import Inches
+prs = Presentation(); s = prs.slides.add_slide(prs.slide_layouts[6])
+tb = s.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+tb.text_frame.text = "Randomised centre — analysis of characteristics"
+prs.save(sys.argv[1])
+PY
+else
+  echo "NOTE: python-pptx unavailable — the .pptx source stage is skipped (script stage still runs)."
+fi
+
+# (1) Positive + (2) precision guard, in one scan.
+python3 "$DET" --manuscript "$tmp/manuscript.md" --figures-dir "$figs" \
+  --strict --quiet --out "$tmp/drift.json" && { echo "FAIL: UK drift in a US manuscript did not flag" >&2; exit 1; }
+
+python3 - "$tmp/drift.json" "$have_pptx" <<'PY'
+import json, os, sys
+d = json.load(open(sys.argv[1])); have_pptx = sys.argv[2] == "1"
+assert d["detector"] == "lint_figure_locale", "envelope does not self-identify"
+assert d["spelling"] == "us", d["spelling"]
+words = {f["word"].lower() for f in d["findings"]}
+# Positive: genuine UK spellings are caught.
+assert "behavioural" in words, f"missed the .py UK label: {words}"
+if have_pptx:
+    assert "randomised" in words, f"missed a .pptx <a:t> UK word: {words}"
+    assert "centre" in words, f"missed a .pptx <a:t> UK word: {words}"
+# Negative (precision guard): universals in the SAME sources must be silent.
+for universal in ("characteristics", "analysis", "organisms", "characteristic", "analyses", "organism"):
+    assert universal not in words, (
+        f"FALSE POSITIVE — '{universal}' is identical in US and UK spelling: {sorted(words)}")
+print(f"OK-POSITIVE+PRECISION: flagged {sorted(words)}; universals stayed silent")
+PY
+
+# (3) Negative — US-spelled sources in a US manuscript are clean.
+clean="$tmp/clean_figs"; mkdir -p "$clean"
+cat > "$clean/panel.py" <<'PY'
+ax.set_title("Behavioral alignment")
+ax.set_xlabel("Baseline characteristics")
+ax.set_ylabel("Analysis of organisms")
+PY
+python3 "$DET" --manuscript "$tmp/manuscript.md" --figures-dir "$clean" \
+  --strict --quiet --out "$tmp/clean.json" || { echo "FAIL: clean US sources flagged (false positive)" >&2; cat "$tmp/clean.json" >&2; exit 1; }
+grep -qE '"kind":' "$tmp/clean.json" && { echo "FAIL: clean fixture produced a finding" >&2; cat "$tmp/clean.json" >&2; exit 1; }
+echo "OK-CLEAN: US-spelled figure sources are silent"
+
+# (4) No figures directory -> exit 0 (nothing to judge), never an error.
+python3 "$DET" --manuscript "$tmp/manuscript.md" --figures-dir "$tmp/nope" --quiet \
+  || { echo "FAIL: a missing figures dir must exit 0" >&2; exit 1; }
+echo "OK-NOSOURCE: a missing figures directory exits 0"
+
+echo "PASS: figure-source locale drift flags genuine UK spellings in .py labels and .pptx runs, stays silent on universals (characteristics/analysis/organisms) and on US-spelled sources."

--- a/skills/polish-language/skill.yml
+++ b/skills/polish-language/skill.yml
@@ -14,6 +14,7 @@ outputs:
   - "style-only polished revision after user approval"
 deterministic_scripts:
   - scripts/lint_consistency.py  # challenge card in scripts/lint_challenge/
+  - scripts/lint_figure_locale.py  # challenge card in scripts/lint_figure_locale_challenge/
 side_effects:
   - writes_project_artifacts
 downstream_consumers:
@@ -35,4 +36,6 @@ known_limitations:
 validation_commands:
   - "python3 scripts/lint_consistency.py <manuscript.md>"
   - "bash scripts/lint_challenge/verify.sh  # deterministic, network-free"
+  - "python3 scripts/lint_figure_locale.py --manuscript <manuscript.md> --figures-dir <figures/>"
+  - "bash scripts/lint_figure_locale_challenge/verify.sh  # deterministic, network-free"
 evidence_surface: bundled_script


### PR DESCRIPTION
## What

Two things, one of which was found by building the other.

### 1. `lint_figure_locale.py` — figure-SOURCE locale drift (no OCR)

Phase 1 of `/polish-language` only sees prose. Text baked into a **figure** lives in a
rendered raster where no grep reaches — so a co-author who builds a panel in PowerPoint and
types **"Behavioural alignment"**, or a plotting script that sets `ax.set_title("Tumour
colour")`, ships a UK word into a US manuscript. A full locale sweep returns one hit, and it
is an internal YAML comment; the real one surfaces when someone opens the image on submission
day.

The gate reads the **sources** instead: `<a:t>` runs inside `*.pptx` slide XML and the text of
`*.py`/`*.R` plotting scripts, compared against a `spelling:` front-matter field or the body's
own US/UK majority. Emits `FIGURE_LOCALE_DRIFT` (Minor). A missing figures directory exits 0.

It is a **linter alongside `lint_consistency.py`, not a MedSci-Audit detector** (`lint_*` is
outside the `check_*`/`detect_*` glob) — the **detector count stays 80**, and it is outside the
crossfire glob by construction.

### 2. Fix — the US↔UK families were counting words identical in both dialects

The `-ise/-ize` families matched the UK side with a greedy `\w*` suffix:

| pattern | universal word wrongly counted as UK |
|---|---|
| `analys` + `\w*` | **analysis**, **analyses** |
| `organis` + `\w*` | **organism(s)** |
| `optimis` + `\w*` | **optimism** |
| `characteris` + `\w*` | **characteristic(s)** — the most common table label in clinical medicine |

So every US manuscript containing "Baseline characteristics" fed **phantom UK evidence** into
`lint_consistency.py`'s dominant-variant tally. The four families now enumerate the genuinely
dialectal inflections, with a comment recording why the greedy form must not come back
(`randomise`/`standardise` have no universal collision and are unchanged).

**The figure gate would have inherited this noise directly** — "Baseline characteristics" is a
figure label in almost every clinical paper.

## Verification

- 7 universals now silent; 7 genuine UK forms still caught (**no false negatives**).
- The existing `lint_challenge` passes **unchanged** — its "predominantly UK" verdict rests on
  real UK spellings (`analyse`, `Tumour`, 2) outnumbering the US one (1), not on the phantom hit.
- New challenge card asserts the positive (`Behavioural` in a `.py` label; `Randomised`/`centre`
  in a `.pptx` run) **and the precision guard** (`characteristics`/`analysis`/`organisms` in the
  same sources stay silent), plus clean-source silence and the no-sources exit-0 path. Fixtures
  are written at runtime — **no committed binaries**.
- **The gate bites**: re-introducing the greedy `characteris\w*` makes the new challenge exit 1
  on its false-positive assertion; restoring the fix returns it to 0.
- Full local CI mirror green (**184/184** — the new challenge is the +1 step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
