### PR TITLE
fix(revise): grade quote matches so a dirty extraction is not reported as a missing edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **A correct quote read through a dirty extraction is no longer reported as an edit the
+  author never made.** `check_response_claims` verified a quoted addition by searching the
+  manuscript for a **contiguous** string. That assumption breaks the moment the haystack comes
+  out of an extractor, because extractors wedge in tokens the source never had: a two-column
+  PDF bleeds a reference line into the middle of a sentence (`learners form independent` |
+  `civile. Rev Med Suisse 2019;15:1122.` | `assessments before seeing AI output`), a
+  line-numbered proof drops the line number inside the clause (`were` | `86` | `performed`),
+  footnote and superscript markers land mid-clause, and hyphenation across a line break splits
+  one word in two. Every such quote is present and correct; the substring test called it
+  **absent** and fired a **major** verdict. In one submission-day session that single
+  assumption produced thirteen false positives and came one step from instructing an author to
+  delete two accurate verbatim quotes.
+
+  Matching now lives in `_quote_match.py` and **grades** the match instead of answering
+  yes/no: `EXACT` (contiguous) · `INTERLEAVED` (all words in order, bounded foreign tokens
+  between) · `PARTIAL` (≥80% of words in order — extraction damage) · `ABSENT`. Only `ABSENT`
+  still yields the major `RESPONSE_QUOTE_UNVERIFIED`; the middle two yield a new **minor**
+  `RESPONSE_QUOTE_UNRESOLVED` that reports the doubt and does **not** fail `--strict`.
+  Line-break hyphenation is repaired outright, so that case produces no finding at all.
+
+  Precision comes from an **interruption count**, not a token budget — a real extraction
+  artifact interrupts a sentence once or twice (and an interruption can be long), while a
+  spurious "match" interrupts at nearly every word. So at most 4 interrupted joins, ≤25 foreign
+  tokens at any one join, plus a total sanity cap. A quote whose words are scattered a
+  paragraph apart across a Discussion is still `ABSENT` and still major — locked down by a test.
+  `--strict` now halts on major findings only, which is what its help text always promised.
+  No new detector: the count stays **80** (`_quote_match.py` is a helper, imported same-dir).
+
 ### Added
 
 - **`/polish-language` now reads figure SOURCES, catching spelling a rendered raster hides —

--- a/docs/skills/revise.md
+++ b/docs/skills/revise.md
@@ -44,6 +44,7 @@
 
 **Scripts** (`skills/revise/scripts/`):
 
+- `_quote_match.py`
 - `check_density_complaint.py`
 - `check_response_claims.py`
 - `density_complaint_challenge/` (5 files)

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3138,8 +3138,8 @@
     },
     {
       "path": "skills/peer-review/SKILL.md",
-      "size": 80908,
-      "sha256": "4780c77300c38440edd1873d6fb0073713599052482988c88e66252255585a6b"
+      "size": 81126,
+      "sha256": "d1783e25bcd55642cb42c200ef4151525758e1080a498e4ba6db01b54b036a98"
     },
     {
       "path": "skills/peer-review/references/aczel_2021_reviewer2_patterns.md",
@@ -3933,13 +3933,18 @@
     },
     {
       "path": "skills/revise/SKILL.md",
-      "size": 31212,
-      "sha256": "5645ac1bb98b14611bfcad374edb01d232a44ae2c90de915b1b69d1d02b7019d"
+      "size": 31941,
+      "sha256": "3d6bd4fa1db09d6bae88a2e7b8470f3494df8f4c03d45abba924184ead3977bc"
     },
     {
       "path": "skills/revise/references/r2r_voice.md",
       "size": 17042,
       "sha256": "d6e657ab4d864e0c12c6d3c8e7db5060dfcea0c56d0f9afccd876702f8b8adcf"
+    },
+    {
+      "path": "skills/revise/scripts/_quote_match.py",
+      "size": 7904,
+      "sha256": "dd71e2359602fc149d6330ee00155f04838e46ec15ef137fbf782b7cb263c0b1"
     },
     {
       "path": "skills/revise/scripts/check_density_complaint.py",
@@ -3948,8 +3953,8 @@
     },
     {
       "path": "skills/revise/scripts/check_response_claims.py",
-      "size": 9839,
-      "sha256": "d8c810a21ff973dd9a5c3f9ccd7c9607cfa9d106053406495f06cbc5786a3fc5"
+      "size": 13516,
+      "sha256": "9da2d8852dc70bb15f758e374c0d5b55e3dbfd6a3c22257be0f0b0a205f5ac11"
     },
     {
       "path": "skills/revise/scripts/density_complaint_challenge/fixture/decision_letter.md",

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -93,6 +93,9 @@ every PDF that actually carried a packet.
    confirmed, raise it (the author-side `/revise` skill runs the same gate; see
    `~/.claude/rules/peer-review-response-verification.md`). If the whole round already had one
    response-vs-body mismatch, re-verify **every** prior comment, not a sample.
+
+   `RESPONSE_QUOTE_UNRESOLVED` (minor) is the opposite verdict — never write it up. The words ARE
+   there in order with extraction debris between them; look before accusing an author of skipping an edit they made.
 3. **Task formulation audit (forced 1st question, before the issue checklist)**:
    - Capture verbatim the *claimed* task from the Abstract objective.
    - Capture verbatim the *measured* task from Methods (inputs → outputs).

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -383,6 +383,15 @@ discrepancy: either insert the promised edit or correct the response wording. Th
 enforces the *"quote the new manuscript text verbatim"* discipline above, and is the same
 check a reviewer runs against your revision (see `/peer-review`).
 
+A third verdict, `RESPONSE_QUOTE_UNRESOLVED` (**minor**, never drift), exists because the
+manuscript is often read through an extractor. When the quoted words are all present **in
+order** but separated by foreign tokens — a reference column bled into the sentence by a
+two-column PDF, line numbers from a supplement proof, a footnote marker, a hyphen split across
+a line — the text is there and only the extraction is dirty. A contiguous substring test
+cannot tell that from a missing edit and reports the correct quote as absent; that once came
+one step from having two accurate verbatim quotes deleted. So those cases are reported for a
+human to eyeball and do **not** fail `--strict`; only a genuinely absent quote does.
+
 **If a reviewer called the manuscript too long or too dense, prove the body got shorter.** Answering
 a density comment point-by-point is a trap: each point is answered by adding a sentence, so the
 revision that responds to "shorten this" comes back *longer*. One real revision did exactly that —

--- a/skills/revise/scripts/_quote_match.py
+++ b/skills/revise/scripts/_quote_match.py
@@ -1,0 +1,172 @@
+"""Quote matching that survives an extraction layer — the substrate under quote gates.
+
+WHY THIS EXISTS (the failure it removes)
+
+Verifying "the manuscript contains this quoted sentence" by searching a CONTIGUOUS string
+is wrong whenever the haystack came out of an extractor, because extractors interleave
+tokens the source never had. In one submission-day session that single assumption produced
+thirteen false positives, all the same shape:
+
+  * a two-column PDF bled reference-list text into the middle of a sentence
+    ("learners form independent" | "civile." | "assessments before seeing AI output");
+  * a line-numbered supplement PDF put the line number inside the sentence
+    ("were" | "86" | "performed");
+  * superscript markers and footnote references landed mid-clause;
+  * hyphenation across a line break split one word into two ("assess-" + "ments").
+
+Every one of those quotes was CORRECT and present. The contiguous check called them absent.
+It came within one step of instructing an author to delete two accurate verbatim quotes.
+
+THE RULE THIS ENCODES
+
+A quote that cannot be matched contiguously is not thereby "not in the source". It is
+UNRESOLVED until something stronger says otherwise. So this module grades a match instead
+of answering yes/no:
+
+  EXACT        the normalized quote is a contiguous substring — verified, no doubt.
+  INTERLEAVED  every quote token appears IN ORDER, with only a bounded number of foreign
+               tokens wedged between them — the text is there and the extraction is dirty.
+  PARTIAL      most quote tokens appear in order but some are missing — consistent with
+               extraction damage (hyphen splits, dropped glyphs); too weak to call absent.
+  ABSENT       not even a partial ordered run — the text really is not there.
+
+Only ABSENT justifies a "you claimed an edit you did not make" verdict. INTERLEAVED and
+PARTIAL are reported as unresolved so a human looks, rather than as a defect.
+
+WHY THE GAPS ARE BOUNDED (the precision that makes this safe)
+
+An unbounded subsequence match is worthless: the tokens of almost any short sentence appear
+"in order" somewhere in a long document if you allow arbitrary distance. The bound that works
+is not a token budget but an INTERRUPTION COUNT, because the two cases differ in shape:
+
+    a real extraction artifact interrupts a sentence once or twice, and each interruption can
+    be long (a bled reference line is a dozen tokens);
+
+    a spurious "match" interrupts at nearly every token, each time by a little.
+
+So the limits are: at most MAX_GAP foreign tokens at any single join, at most
+MAX_INTERRUPTIONS joins that are interrupted at all, and a total-insertion sanity cap. A
+quote whose words are scattered one-by-one across a Discussion section needs an interruption
+at every join and fails, while a quote split once by a column bleed passes.
+
+Not a detector: a helper imported by the gates that need it (leading underscore keeps it out
+of the detector catalog glob). Stdlib only.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# At most this many foreign tokens may sit at ONE join. A bled reference line ("civile. Rev
+# Med Suisse 2019;15:1122.") is around a dozen tokens; a running header a handful.
+MAX_GAP = 25
+# At most this many joins may be interrupted AT ALL. This is the limit that separates a dirty
+# extraction (one or two interruptions) from a spurious scatter (an interruption per token).
+MAX_INTERRUPTIONS = 4
+# Sanity cap on total foreign tokens, so a short quote cannot absorb an entire paragraph.
+MAX_TOTAL_INSERT_FRAC = 5.0
+MIN_TOTAL_INSERT = 20
+# A PARTIAL match must still account for this share of the quote's tokens; below it, ABSENT.
+PARTIAL_COVERAGE = 0.80
+
+_TOKEN_RE = re.compile(r"[0-9a-z]+(?:'[a-z]+)?", re.IGNORECASE)
+
+
+def normalize(s: str) -> str:
+    """Casefold, unify quotes/dashes, drop markdown emphasis, repair line-break hyphenation,
+    and collapse whitespace. Hyphenation repair matters: an extractor that wraps "assess-
+    ments" across a line otherwise destroys the token the quote is looking for."""
+    s = unicodedata.normalize("NFKC", s)
+    s = s.replace("’", "'").replace("‘", "'")
+    s = s.replace("“", '"').replace("”", '"')
+    # join a word split by a hyphen at a line break: "assess-\n  ments" -> "assessments"
+    s = re.sub(r"(\w)[-‐‑]\s*\n\s*(\w)", r"\1\2", s)
+    s = re.sub(r"[*_`]", "", s)
+    s = re.sub(r"\s+", " ", s)
+    return s.casefold().strip()
+
+
+def tokens(s: str) -> list[str]:
+    """Normalized word/number tokens. Punctuation is dropped, so an injected '.' or a stray
+    bracket never breaks a match on its own."""
+    return _TOKEN_RE.findall(normalize(s))
+
+
+def _ordered_run(needle: list[str], hay: list[str], allow_missing: bool):
+    """Best ordered match of `needle` inside `hay`.
+
+    Walks every candidate start and consumes needle tokens in order, skipping at most
+    MAX_GAP foreign tokens per join, at most MAX_INTERRUPTIONS interrupted joins, and a
+    total-insertion sanity cap. With allow_missing, a needle token that cannot be found
+    within the gap window is skipped (counted as missing) instead of failing the run.
+
+    Returns (matched_count, inserted_count) for the best run, or (0, 0)."""
+    if not needle or not hay:
+        return (0, 0)
+    budget = max(MIN_TOTAL_INSERT, int(len(needle) * MAX_TOTAL_INSERT_FRAC))
+    max_missing = len(needle) - int(len(needle) * PARTIAL_COVERAGE)
+    best = (0, 0)
+    first = needle[0]
+    starts = [i for i, t in enumerate(hay) if t == first]
+    if allow_missing and not starts:
+        # the opening token itself may be the damaged one — try any token of the quote
+        wanted = set(needle)
+        starts = [i for i, t in enumerate(hay) if t in wanted]
+    for start in starts:
+        hi = start
+        matched = inserted = missing = interruptions = 0
+        for tok in needle:
+            found = -1
+            for j in range(hi, min(hi + MAX_GAP + 1, len(hay))):
+                if hay[j] == tok:
+                    found = j
+                    break
+            if found < 0:
+                if not allow_missing:
+                    break
+                missing += 1
+                if missing > max_missing:
+                    break
+                continue
+            gap = found - hi
+            if gap:
+                interruptions += 1
+                if interruptions > MAX_INTERRUPTIONS:
+                    break
+            inserted += gap
+            if inserted > budget:
+                break
+            matched += 1
+            hi = found + 1
+        if matched > best[0]:
+            best = (matched, inserted)
+        if matched == len(needle):
+            break
+    return best
+
+
+def match_quality(quote: str, haystack: str) -> dict:
+    """Grade how well `quote` is present in `haystack`.
+
+    Returns {"grade": EXACT|INTERLEAVED|PARTIAL|ABSENT, "matched", "total", "inserted",
+             "coverage"}. Only ABSENT means "this text is not in the document"."""
+    nq, nh = normalize(quote), normalize(haystack)
+    q_tok = tokens(quote)
+    total = len(q_tok)
+    if total == 0:
+        return {"grade": "ABSENT", "matched": 0, "total": 0, "inserted": 0, "coverage": 0.0}
+    if nq and nq in nh:
+        return {"grade": "EXACT", "matched": total, "total": total, "inserted": 0, "coverage": 1.0}
+
+    h_tok = tokens(haystack)
+    matched, inserted = _ordered_run(q_tok, h_tok, allow_missing=False)
+    if matched == total:
+        return {"grade": "INTERLEAVED", "matched": matched, "total": total,
+                "inserted": inserted, "coverage": 1.0}
+
+    matched, inserted = _ordered_run(q_tok, h_tok, allow_missing=True)
+    coverage = matched / total
+    grade = "PARTIAL" if coverage >= PARTIAL_COVERAGE else "ABSENT"
+    return {"grade": grade, "matched": matched, "total": total,
+            "inserted": inserted, "coverage": round(coverage, 3)}

--- a/skills/revise/scripts/check_response_claims.py
+++ b/skills/revise/scripts/check_response_claims.py
@@ -16,6 +16,14 @@ checkable anchor, so paraphrase and honest rewording do not false-positive:
   * RESPONSE_QUOTE_UNVERIFIED (major) — the letter says specific text was
     added / inserted / "now reads" and quotes it verbatim, but that quoted text
     is absent from the revised manuscript body.
+  * RESPONSE_QUOTE_UNRESOLVED (minor) — the quoted text IS there in order, but
+    only once foreign tokens are allowed between its words, or a word or two is
+    missing. That is the signature of a dirty extraction (a bled reference
+    column, PDF line numbers, a footnote marker, a hyphen split across a line),
+    not of an edit that was never made. Reported so a human looks; never counted
+    as drift. A contiguous substring test cannot tell these apart and calls a
+    correct quote absent — the failure that once came one step from having two
+    accurate verbatim quotes deleted. Matching lives in _quote_match.py.
   * RESPONSE_CITATION_UNVERIFIED (major) — the letter says a citation was added
     / "now cite(d)", but none of the cited tokens ([N] / [@key] / Author et al.)
     appear in the revised manuscript body.
@@ -42,6 +50,9 @@ import re
 import sys
 import unicodedata
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _quote_match import match_quality  # noqa: E402  (same-dir helper)
 
 # A claim that asserts an addition/edit to the manuscript.
 CLAIM_VERB = re.compile(
@@ -140,8 +151,15 @@ def extract_claims(response: str):
     return claims
 
 
-def body_has_quote(norm_body: str, quote: str) -> bool:
-    return normalize(quote) in norm_body
+def grade_quote(body: str, quote: str) -> dict:
+    """Grade the quote's presence in the body via the extraction-tolerant matcher.
+
+    A contiguous search alone is not safe here: the manuscript may arrive as a .docx whose
+    extraction wedges a footnote marker, a line number, or a bled column of reference text
+    into the middle of the very sentence being checked. Those quotes are present and correct,
+    and a substring test calls them absent — the failure that once nearly had two accurate
+    verbatim quotes deleted. See _quote_match.py."""
+    return match_quality(quote, body)
 
 
 def body_has_citation(body: str, norm_body: str, cits) -> bool:
@@ -165,13 +183,47 @@ def build_report(response_path: Path, manuscript_path: Path) -> dict:
     findings = []
     for kind, anchor, ctx in extract_claims(response):
         if kind == "quote":
-            if not body_has_quote(norm_body, anchor):
+            g = grade_quote(body, anchor)
+            if g["grade"] == "INTERLEAVED":
+                findings.append(
+                    {
+                        "verdict": "RESPONSE_QUOTE_UNRESOLVED",
+                        "severity": "minor",
+                        "claimed_text": anchor,
+                        "context": ctx,
+                        "match": g,
+                        "message": (
+                            f"Every word of the quoted text appears in order, but with {g['inserted']} "
+                            "foreign token(s) wedged in — consistent with a dirty extraction (a bled "
+                            "reference column, line numbers, a footnote marker), not a missing edit. "
+                            "Confirm by eye; do not treat as absent."
+                        ),
+                    }
+                )
+            elif g["grade"] == "PARTIAL":
+                findings.append(
+                    {
+                        "verdict": "RESPONSE_QUOTE_UNRESOLVED",
+                        "severity": "minor",
+                        "claimed_text": anchor,
+                        "context": ctx,
+                        "match": g,
+                        "message": (
+                            f"{g['matched']} of {g['total']} words of the quoted text appear in order "
+                            "— enough to be the same sentence damaged in extraction (a hyphen split "
+                            "across a line, a dropped glyph) rather than an edit that was never made. "
+                            "Confirm by eye."
+                        ),
+                    }
+                )
+            elif g["grade"] == "ABSENT":
                 findings.append(
                     {
                         "verdict": "RESPONSE_QUOTE_UNVERIFIED",
                         "severity": "major",
                         "claimed_text": anchor,
                         "context": ctx,
+                        "match": g,
                         "message": "Response quotes added text that is absent from the revised manuscript body.",
                     }
                 )
@@ -186,11 +238,16 @@ def build_report(response_path: Path, manuscript_path: Path) -> dict:
                         "message": "Response claims a citation was added but none of the cited tokens appear in the revised manuscript body.",
                     }
                 )
+    n_major = sum(1 for f in findings if f["severity"] == "major")
     return {
         "response": str(response_path),
         "manuscript": str(manuscript_path),
         "findings": findings,
-        "submission_safe": len(findings) == 0,
+        "summary": {"major": n_major, "unresolved": len(findings) - n_major},
+        # An UNRESOLVED quote is a "look at this", not a defect: the words are demonstrably
+        # there and only the extraction is suspect. Safety therefore turns on MAJOR findings,
+        # which is what --strict has always documented.
+        "submission_safe": n_major == 0,
     }
 
 
@@ -214,14 +271,20 @@ def main(argv: list[str] | None = None) -> int:
         args.out.write_text(json.dumps({"detector": "check_response_claims", **report}, indent=2, ensure_ascii=False), encoding="utf-8")
 
     if not args.quiet:
-        if report["submission_safe"]:
+        s = report["summary"]
+        if not report["findings"]:
             print("OK: every anchored response claim is verified against the revised manuscript.")
         else:
-            print(f"RESPONSE_CLAIM DRIFT ({len(report['findings'])}):")
+            print(f"RESPONSE_CLAIM findings — {s['major']} major, {s['unresolved']} unresolved:")
             for f in report["findings"]:
                 anchor = f.get("claimed_text") or ", ".join(f.get("claimed_citation", []))
-                print(f"  [{f['verdict']}] {anchor!r}")
+                print(f"  [{f['verdict']}] ({f['severity']}) {anchor!r}")
                 print(f"      near: {f['context']}")
+                if f["severity"] == "minor":
+                    print(f"      {f['message']}")
+            if s["major"] == 0:
+                print("\nNo major drift: the unresolved item(s) are extraction-quality doubts, "
+                      "not claims of an edit that was never made.")
 
     if args.strict and not report["submission_safe"]:
         print("\nRESPONSE_CLAIM_UNVERIFIED: a response-letter claim is not reflected in the revised manuscript.", file=sys.stderr)

--- a/skills/revise/tests/test_response_claims.sh
+++ b/skills/revise/tests/test_response_claims.sh
@@ -92,6 +92,68 @@ OUT="$(python3 "$V" --response "$TMP/response.md" --manuscript "$TMP/body_bad.md
 echo "$OUT" | grep -q RESPONSE_QUOTE_UNVERIFIED && echo "$OUT" | grep -q RESPONSE_CITATION_UNVERIFIED
 ck "both expected verdicts present" 0 "$?"
 
+# --- extraction tolerance: a CORRECT quote must survive a dirty extraction ---------------
+# Each manuscript below really does contain the claimed sentence; the variants are what an
+# extractor emits, not what the author wrote. A contiguous substring test calls every one of
+# them "absent" — the false-positive class that once nearly had accurate quotes deleted.
+cat > "$TMP/resp_quote.md" <<'MD'
+**Response 1.** We added the sentence "learners form independent assessments before seeing AI output" to the Discussion.
+MD
+
+# (a) two-column PDF: a reference line bled into the middle of the sentence
+cat > "$TMP/body_bleed.md" <<'MD'
+## Discussion
+We note that learners form independent civile. Rev Med Suisse 2019;15:1122. assessments before seeing AI output.
+MD
+# (b) line-numbered supplement PDF: line numbers sit inside the sentence
+cat > "$TMP/body_linenum.md" <<'MD'
+## Discussion
+86 We note that learners form 87 independent assessments 88 before seeing AI output.
+MD
+# (c) a superscript / footnote marker landed mid-clause
+cat > "$TMP/body_supersc.md" <<'MD'
+## Discussion
+learners form independent 3 assessments before seeing AI output
+MD
+# (d) hyphenation across a line break split one word in two
+cat > "$TMP/body_hyphen.md" <<'MD'
+## Discussion
+learners form independent assess-
+ments before seeing AI output
+MD
+
+for variant in bleed linenum supersc hyphen; do
+  python3 "$V" --response "$TMP/resp_quote.md" --manuscript "$TMP/body_$variant.md" --strict > /dev/null 2>&1
+  ck "dirty extraction ($variant) is not drift (--strict)" 0 "$?"
+done
+
+# the interleaved variants must SAY so (unresolved), not pass silently
+for variant in bleed linenum supersc; do
+  python3 "$V" --response "$TMP/resp_quote.md" --manuscript "$TMP/body_$variant.md" 2>&1 \
+    | grep -q RESPONSE_QUOTE_UNRESOLVED
+  ck "dirty extraction ($variant) reports UNRESOLVED" 0 "$?"
+done
+
+# the hyphen split is repaired outright -> no finding at all
+python3 "$V" --response "$TMP/resp_quote.md" --manuscript "$TMP/body_hyphen.md" 2>&1 \
+  | grep -q RESPONSE_QUOTE
+ck "line-break hyphenation repaired (no finding)" 1 "$?"
+
+# PRECISION GUARD: tolerance must not excuse a genuine miss. The words below appear in
+# order but scattered a paragraph apart — that is not the claimed sentence.
+{
+  echo "## Discussion"
+  echo "Some learners were enrolled."
+  for _ in $(seq 1 12); do echo "The study reported outcomes across sites and years."; done
+  echo "We form working groups."
+  for _ in $(seq 1 12); do echo "The study reported outcomes across sites and years."; done
+  echo "An independent committee met."
+  for _ in $(seq 1 12); do echo "The study reported outcomes across sites and years."; done
+  echo "Their assessments were filed before seeing AI output."
+} > "$TMP/body_scattered.md"
+python3 "$V" --response "$TMP/resp_quote.md" --manuscript "$TMP/body_scattered.md" --strict > /dev/null 2>&1
+ck "scattered words are still MAJOR drift (--strict)" 1 "$?"
+
 echo "----"
 echo "test_response_claims: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## The bug

`check_response_claims` verified a quoted addition by searching the manuscript for a
**contiguous** string. That assumption breaks the moment the haystack comes out of an
extractor, because extractors wedge in tokens the source never had:

| extraction artifact | what the sentence becomes |
|---|---|
| two-column PDF bleeds a reference line | `learners form independent` \| `civile. Rev Med Suisse 2019;15:1122.` \| `assessments before seeing AI output` |
| line-numbered proof | `were` \| `86` \| `performed` |
| footnote / superscript marker | lands mid-clause |
| hyphenation across a line break | `assess-` + `ments` |

**Every one of those quotes is present and correct.** The substring test called them absent and
fired a **major** verdict. In one submission-day session this single assumption produced
**thirteen false positives** — and came one step from instructing an author to delete two
accurate verbatim quotes.

## The fix

Matching moves to `_quote_match.py`, which **grades** the match instead of answering yes/no:

| grade | meaning | verdict |
|---|---|---|
| `EXACT` | contiguous substring | — verified |
| `INTERLEAVED` | all words in order, bounded foreign tokens between | `RESPONSE_QUOTE_UNRESOLVED` (**minor**) |
| `PARTIAL` | ≥80% of words in order — extraction damage | `RESPONSE_QUOTE_UNRESOLVED` (**minor**) |
| `ABSENT` | not even a partial ordered run | `RESPONSE_QUOTE_UNVERIFIED` (**major**) |

Only `ABSENT` still means "you claimed an edit you did not make". Line-break hyphenation is
repaired outright, so that case produces no finding at all. `--strict` now halts on **major**
findings only — which is what its help text always promised (the code halted on any finding).

## Why the precision holds

An unbounded subsequence match is worthless: any short sentence's words appear "in order"
somewhere in a long document. The bound that works is an **interruption count**, not a token
budget, because the two cases differ in *shape* —

- a real extraction artifact interrupts a sentence **once or twice**, and each interruption can
  be long (a bled reference line is a dozen tokens);
- a spurious match interrupts at **nearly every token**, each time by a little.

So: ≤4 interrupted joins, ≤25 foreign tokens at any one join, plus a total sanity cap. A quote
whose words are scattered a paragraph apart across a Discussion is still `ABSENT` and still
major — and that is a test, not a claim.

## Verification

- The 6 existing tests pass **unchanged**; 9 added — the three extraction fixtures this was
  required to carry (**two-column bleed · line-numbered · superscript**), the hyphen repair, the
  UNRESOLVED reporting, and the **scattered-words precision guard**.
- **The gate bites**: reverting `grade_quote` to the old contiguous test makes **8 of the new
  tests fail** (all four dirty-extraction variants become "drift" again).
- `check_phase_budget` caught my `/peer-review` doc addition pushing Phase 2 to 85 lines; fixed
  by compressing the note, not by exempting the section.
- Full local CI mirror green (**184/184**).

## Scope

**No new detector** — the count stays **80** (`_quote_match.py` is a helper, imported same-dir,
outside the detector glob). Reviewer-side `/peer-review` docs now warn that `UNRESOLVED` must
never be written up as a finding: accusing an author of skipping an edit they *made* is the
costliest false positive available here.

This is the substrate Cluster A (claim-fidelity) is meant to build on — it is deliberately
landed first so A does not inherit the contiguous-match bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
