### PR TITLE
fix(imaging): a single-organ study on a multi-organ atlas was measured on the wrong organ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@
 
 ### Fixed
 
+- **A single-organ study run against a multi-organ atlas was measured on the wrong organ, and
+  the imbalance gate went quiet because of it.** `profile_imaging_dataset.py` computed
+  foreground as every non-zero label index. On a binary dataset that is the target; on a
+  15-organ atlas it is the whole annotated upper abdomen. Profiling AMOS22 for a **spleen**
+  study, the shipped profiler reported a median foreground of **3.2 %** (CT) and **7.9 %**
+  (MRI) where the spleen actually occupies **0.20 %** and **0.58 %** — inflated 15.7× and
+  13.6×. The default imbalance threshold is 1 %, so the reported number sat *above* it and the
+  true one *below*: `EXTREME_IMBALANCE` and `ACCURACY_UNDER_IMBALANCE` stayed silent on a
+  dataset where predicting background everywhere scores 99.8 %. It is not a cosmetic
+  discrepancy because it crosses the threshold, and it errs in the unsafe direction every
+  time — the union of organs is always the larger number.
+
+  The same blind spot hid missing ground truth. `LABEL_EMPTY` asks whether a label file has any
+  foreground; on an atlas the answer is yes even when the *target* is absent. **3 of AMOS22's
+  360 labelled cases carry no spleen at all** (2 CT, 1 MRI) — cases that would have entered an
+  external-validation arm and scored Dice 0 with nothing on the record to explain why.
+
+  `profile_imaging_dataset.py` gains `--target-label N`, which computes foreground and target
+  volume on that index alone (the union is still recorded as `all_label_foreground_fraction`,
+  so nothing is lost) and makes `LABEL_EMPTY` mean *this case has none of the target*.
+  `--target-label all` declares a genuinely multi-class study. When more than one structure is
+  declared and no target is, `check_dataset_profile.py` now raises the minor
+  `TARGET_LABEL_UNDECLARED` instead of quietly reporting a number about a different organ.
+
+- **`TEST_SET_UNLABELLED` could not see a test split whose name carried a qualifier.** The
+  check tested split names for exact membership in `{test, holdout, held_out, external, eval}`,
+  so `amos_test`, `external_ct`, `held-out-set` and `test-fold1` — the names people actually
+  write — all slipped it. That is the worst way for this verdict to fail: the split it exists
+  for is the split it cannot see. Matching is now over name *tokens* plus adjacent-token joins
+  (so two-word members like `held_out` survive tokenisation), and it deliberately does **not**
+  reduce to substring search: `contest`, `pretest` and `protest_cohort` are still not test
+  splits, with tests holding that line. `testing` joins the synonym set.
+
+- **The preprocessing-leakage gate treated all resampling as leakage-free, and said so in its
+  own docstring.** `FIT_BASED_TYPES` omitted `resample`, on the stated reasoning that
+  "resample to a fixed spacing … never leaks". True when the spacing is fixed — but nnU-Net
+  derives its target spacing from a percentile of the dataset fingerprint, so a resample fitted
+  over every case carries held-out geometry into the training grid exactly as an intensity
+  statistic does. Audited on a real manifest, the gate flagged the two intensity transforms and
+  stayed silent on the resample sitting beside them. Resampling types are now fit-based; a
+  target that really is chosen in advance declares `fit_scope: fixed` and stays silent, which
+  is the case the docstring had mistaken for the only one.
+
+  All three surfaced by running the shipped skills against AMOS22 and MSD Task09 rather than
+  against fixtures. No new detector script: the count stays **80**.
+
 - **A correct quote read through a dirty extraction is no longer reported as an edit the
   author never made.** `check_response_claims` verified a quoted addition by searching the
   manuscript for a **contiguous** string. That assumption breaks the moment the haystack comes

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3493,8 +3493,8 @@
     },
     {
       "path": "skills/preprocess-imaging/SKILL.md",
-      "size": 7068,
-      "sha256": "e17b73b0760194d4e6e3924ec2a0452601adc27122e7455cc5f2993d5af1d0d0"
+      "size": 7539,
+      "sha256": "a15d5cc9da4f5d434ebac30e2ec8694363b5bfa403c741af8a93262698ef1659"
     },
     {
       "path": "skills/preprocess-imaging/references/preprocessing_guide.md",
@@ -3503,8 +3503,8 @@
     },
     {
       "path": "skills/preprocess-imaging/scripts/check_preprocessing_leakage.py",
-      "size": 13039,
-      "sha256": "dbd204c5ac40470a6fba8f44c14477bf754ef0f31f82c7f5cac6049679c8372d"
+      "size": 14121,
+      "sha256": "c0118907fb4382d4459700c7cf36d53966e59503ad03ad2b25df03894d85ce08"
     },
     {
       "path": "skills/preprocess-imaging/scripts/check_preprocessing_leakage_challenge/expected/clean.txt",
@@ -3688,13 +3688,13 @@
     },
     {
       "path": "skills/profile-imaging/SKILL.md",
-      "size": 9445,
-      "sha256": "2ea8e6300d6da2a02e84c33245513d2a2978f545302472fef060ff813ac5f918"
+      "size": 10382,
+      "sha256": "e66d9d34bf9622736206baf1ca98bbbece1bf98d86d8cc67598aef6579debcdb"
     },
     {
       "path": "skills/profile-imaging/scripts/check_dataset_profile.py",
-      "size": 13584,
-      "sha256": "09d27d14fea759b372e6938f4e14410620b06f6dfeb1f9a5a2f7391e6da735c5"
+      "size": 16672,
+      "sha256": "3726e8205fe69cfcb06f4854cc97be95bd2c6fc89e02400fff11153a68be61e7"
     },
     {
       "path": "skills/profile-imaging/scripts/check_dataset_profile_challenge/expected/clean.txt",
@@ -3728,8 +3728,8 @@
     },
     {
       "path": "skills/profile-imaging/scripts/profile_imaging_dataset.py",
-      "size": 5388,
-      "sha256": "c1d3346c48ca7f1fd1cfcc8ef967d4bb5b2d67a3c4eca88d4802828ab2f9d410"
+      "size": 6996,
+      "sha256": "379283bde44c048664b5ba2c92b1742995c900749146108fb78c7a2fa1ccc3c2"
     },
     {
       "path": "skills/profile-imaging/skill.yml",

--- a/skills/preprocess-imaging/SKILL.md
+++ b/skills/preprocess-imaging/SKILL.md
@@ -78,8 +78,14 @@ Write a declarative JSON manifest that `model-scaffold` consumes and the gate ch
 }
 ```
 
-`fit_scope`: `train` (OK) · `all`/`full`/`dataset`/`test` (leak) · `sample`/`per_image`/`none`
+`fit_scope`: `train` (OK) · `all`/`full`/`dataset`/`test` (leak) · `sample`/`per_image`/`none`/`fixed`
 (not data-fitted, leakage-free). `stage`: `before_split` / `after_split`.
+
+**Declare the fit scope of resampling too.** A target spacing you chose in advance is fixed and
+never leaks (`fit_scope: fixed`). A target *derived* from the cohort does: nnU-Net sets its target
+spacing from a percentile of the dataset fingerprint, so a resample fitted over every case carries
+held-out geometry into the training grid exactly as an intensity statistic would. Which one you
+have is decided by the fingerprint's scope, not by the word "resample".
 
 ### Phase 4 — Gate the manifest (deterministic)
 ```bash

--- a/skills/preprocess-imaging/scripts/check_preprocessing_leakage.py
+++ b/skills/preprocess-imaging/scripts/check_preprocessing_leakage.py
@@ -34,8 +34,16 @@ CHECKS (verdicts):
 
 A data-fitted transform is one whose `type` is a fitted operation (normalization,
 standardize, scaler, min-max, clip_percentile, histogram_match, pca, whitening,
-feature_selection, …) AND whose `fit_scope` is not per-sample/none. A fixed transform
-(fixed HU window, resample to a fixed spacing) is not data-fitted and never leaks.
+feature_selection, resample, …) AND whose `fit_scope` is not per-sample/none/fixed.
+A genuinely fixed transform (a fixed HU window, a resample to a spacing you chose
+in advance) is not data-fitted and never leaks — declare `fit_scope: fixed` and it
+stays silent.
+
+Resampling is on that list because the *target* is so often derived rather than
+chosen: nnU-Net sets its target spacing from a percentile of the dataset
+fingerprint, so a resample fitted over every case carries held-out geometry into
+the training grid just as an intensity statistic would. "Resample to a fixed
+spacing never leaks" is true only when the spacing really is fixed.
 
 MANIFEST (JSON)
   {
@@ -82,6 +90,14 @@ FIT_BASED_TYPES = {
     "histogram_equalization", "histogram_equalisation", "pca", "whitening",
     "feature_selection", "intensity_normalization", "intensity_normalisation",
     "nyul", "zca",
+    # Resampling belongs here whenever the *target* is derived from the data. nnU-Net's
+    # target spacing is a percentile of the dataset fingerprint, so a resample fitted over
+    # all cases carries held-out geometry into the training grid exactly as an intensity
+    # statistic would. A target that is genuinely fixed declares fit_scope=fixed and drops
+    # out in _is_fit_based -- that is the case the docstring used to describe as if it
+    # were the only one.
+    "resample", "resampling", "respacing", "resample_spacing", "target_spacing",
+    "spacing_normalization", "spacing_normalisation",
 }
 # fit_scope values that make a transform NOT data-fitted (per-sample or fixed).
 SAMPLE_SCOPES = {

--- a/skills/preprocess-imaging/tests/test_preprocessing_leakage.sh
+++ b/skills/preprocess-imaging/tests/test_preprocessing_leakage.sh
@@ -70,7 +70,33 @@ check "per-image transform before split does NOT fire PREPROCESS_BEFORE_SPLIT" n
 python3 "$SCRIPT" --manifest "$TMP/persample.json" --strict --quiet >/dev/null 2>&1
 check "exit 0 on per-image-safe manifest" test "$?" -eq 0
 
-# (6) the shipped challenge card passes
+# (6) resampling. A target spacing chosen in advance is fixed and never leaks; a target
+# derived from the cohort (nnU-Net takes a percentile of the dataset fingerprint) is a
+# fitted parameter, and fitting it over every case carries held-out geometry into the
+# training grid exactly as an intensity statistic would.
+cat > "$TMP/resample_fitted.json" <<'EOF'
+{"split_seed": 42,
+ "transforms": [{"name": "resample_to_fingerprint_median", "type": "resample",
+                 "fit_scope": "all", "stage": "before_split"}],
+ "split_assignment": [{"patient_id": "A", "split": "train"}, {"patient_id": "B", "split": "test"}]}
+EOF
+python3 "$SCRIPT" --manifest "$TMP/resample_fitted.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "data-derived resample target before split fires PREPROCESS_BEFORE_SPLIT" \
+      has_verdict PREPROCESS_BEFORE_SPLIT
+
+cat > "$TMP/resample_fixed.json" <<'EOF'
+{"split_seed": 42,
+ "transforms": [{"name": "resample_to_1mm_iso", "type": "resample",
+                 "fit_scope": "fixed", "stage": "before_split"}],
+ "split_assignment": [{"patient_id": "A", "split": "train"}, {"patient_id": "B", "split": "test"}]}
+EOF
+python3 "$SCRIPT" --manifest "$TMP/resample_fixed.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "resample to a declared fixed spacing does NOT fire PREPROCESS_BEFORE_SPLIT" \
+      no_verdict PREPROCESS_BEFORE_SPLIT
+python3 "$SCRIPT" --manifest "$TMP/resample_fixed.json" --strict --quiet >/dev/null 2>&1
+check "exit 0 on fixed-spacing resample" test "$?" -eq 0
+
+# (7) the shipped challenge card passes
 check "challenge verify.sh passes" bash "$CH/verify.sh"
 
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"

--- a/skills/profile-imaging/SKILL.md
+++ b/skills/profile-imaging/SKILL.md
@@ -67,6 +67,7 @@ python3 scripts/profile_imaging_dataset.py \
     --split test:imagesTs \
     --dataset "MSD Task09 Spleen" \
     --declared-labels 0=background,1=spleen \
+    --target-label 1 \
     --plan resample=true,reorient=false,loss=dice_ce,metrics=dice+hd95 \
     --out eda/profile.json
 ```
@@ -74,6 +75,15 @@ python3 scripts/profile_imaging_dataset.py \
 One record per case: grid, spacing, orientation, intensity percentiles, the label values actually
 present, foreground fraction, and target volume in mL. A `--split` given no label directory is
 recorded as **unlabelled** — which is itself a finding.
+
+**`--target-label` on a multi-structure atlas.** Foreground defaults to every non-zero index, which
+is the whole annotated anatomy. Run a single-organ study against a 15-organ atlas and the reported
+fraction describes the upper abdomen, not the target — measured on AMOS22 that is 3.2 % rather than
+the spleen's 0.2 %, so the pooled number sits *above* the 1 % imbalance threshold while the real
+target sits far below it, and the imbalance verdicts go quiet exactly where the risk is. Naming the
+target also makes `LABEL_EMPTY` mean *this case has no spleen*, which a multi-organ label file
+otherwise hides behind the other organs. Pass `--target-label all` for a genuinely multi-class
+study; leave it out on a multi-structure atlas and the gate raises `TARGET_LABEL_UNDECLARED`.
 
 Requires `nibabel` + `numpy` (it has to open images). The gate below does not.
 
@@ -91,13 +101,14 @@ Stdlib-only, so the audit re-runs anywhere the JSON travels. Verdicts:
 | `LABEL_SHAPE_MISMATCH` | Major | label grid ≠ image grid |
 | `LABEL_EMPTY` | Major | a labelled case has zero foreground |
 | `LABEL_VALUE_UNEXPECTED` | Major | label values outside the declared set |
-| `TEST_SET_UNLABELLED` | Major | a split named test/held-out/external carries no labels |
+| `TEST_SET_UNLABELLED` | Major | a split whose name contains test/held-out/external/eval carries no labels |
 | `ACCURACY_UNDER_IMBALANCE` | Major | accuracy is planned while the target is a sliver of the volume |
 | `LABEL_MISSING` | Minor | a case in a labelled split has no label file |
 | `SPACING_HETEROGENEOUS` | Minor | spacing spans ≥ ratio on an axis and no resampling is declared |
 | `ORIENTATION_MIXED` | Minor | >1 orientation code and no reorientation declared |
 | `INTENSITY_SCALE_INCONSISTENT` | Minor | some cases sit on the HU scale and others do not |
 | `EXTREME_IMBALANCE` | Minor | median foreground below the threshold with no Dice-family loss |
+| `TARGET_LABEL_UNDECLARED` | Minor | >1 structure declared but no target named, so foreground pools them all |
 
 **The gate flags an undeclared decision, not variability itself.** A dataset with 5× spacing spread
 and two orientation codes passes cleanly once resampling and reorientation are declared —

--- a/skills/profile-imaging/scripts/check_dataset_profile.py
+++ b/skills/profile-imaging/scripts/check_dataset_profile.py
@@ -40,6 +40,18 @@ CHECKS (verdicts):
   9. EXTREME_IMBALANCE        median foreground fraction below --imbalance-frac and the
                               plan declares no Dice-family (region/overlap) loss.
  10. LABEL_MISSING            cases in a labelled split with no label file.
+ 11. TARGET_LABEL_UNDECLARED  the declared label set holds more than one structure but the
+                              profile names no target, so `foreground_fraction` pools every
+                              annotated organ. The imbalance verdicts then describe the
+                              union rather than the thing being segmented — and the union
+                              can sit above the threshold while the target sits far below.
+                              Re-profile with `--target-label N`, or `--target-label all`
+                              to declare a genuinely multi-class study.
+
+SPLIT NAMES
+  A split counts as a test/held-out split when any *token* of its name is one of
+  {test, holdout, held_out, external, eval} — so `amos_test` and `external_ct` are
+  matched, not just the bare words.
 
 THRESHOLDS
   --spacing-ratio (default 2.0) and --imbalance-frac (default 0.01) are **screening
@@ -72,10 +84,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 from statistics import median
 
-TEST_SPLIT_NAMES = {"test", "holdout", "hold_out", "held_out", "heldout", "external", "eval"}
+TEST_SPLIT_NAMES = {"test", "testing", "holdout", "hold_out", "held_out", "heldout",
+                    "external", "eval"}
+# separator-free forms, so a name tokenised into pieces can be rejoined and matched
+_TEST_SPLIT_GRAMS = {re.sub(r"[^a-z0-9]+", "", n) for n in TEST_SPLIT_NAMES}
 DICE_FAMILY = ("dice", "tversky", "focal_tversky", "jaccard", "iou", "generalized_dice", "gdl", "lovasz")
 ACCURACY_TERMS = ("accuracy", "acc", "pixel_accuracy", "voxel_accuracy")
 # A CT case is expected to bottom out near air (-1000 HU). Anything whose 1st percentile
@@ -85,6 +101,25 @@ CT_AIR_P01_MAX = -500.0
 
 def _norm(s) -> str:
     return str(s).strip().lower()
+
+
+def _is_test_split(name: str) -> bool:
+    """Match on tokens and adjacent-token joins, not on the whole string.
+
+    Researchers qualify split names -- `amos_test`, `external_ct`, `held-out-set`,
+    `test-fold1` -- and an exact-set membership test silently misses every one of them,
+    which is the worst way for TEST_SET_UNLABELLED to fail: the split it exists for is the
+    split it cannot see.
+
+    Joins are needed because some members are two words (`held_out`), and they are built
+    from *adjacent tokens* rather than by substring search, so `contest` does not read as
+    `test`.
+    """
+    toks = [t for t in re.split(r"[^a-z0-9]+", _norm(name)) if t]
+    grams = set(toks)
+    for n in (2, 3):
+        grams |= {"".join(toks[i:i + n]) for i in range(len(toks) - n + 1)}
+    return bool(grams & _TEST_SPLIT_GRAMS)
 
 
 def _plan(profile: dict) -> dict:
@@ -110,6 +145,9 @@ def analyze(profile_path: str, spacing_ratio: float, imbalance_frac: float) -> d
     plan = _plan(profile)
     labelled = _labelled_splits(profile)
     declared = {int(k) for k in (profile.get("declared_labels") or {}).keys()} or None
+    target_label = profile.get("target_label")
+    # Structures = declared labels minus background. >1 means foreground_fraction pools them.
+    n_structures = len((declared or set()) - {0})
 
     claims: list[dict] = []
 
@@ -142,8 +180,10 @@ def analyze(profile_path: str, spacing_ratio: float, imbalance_frac: float) -> d
               "label grid differs from the image grid; the pair is not usable supervision as-is",
               shape_mismatch)
     if empty:
+        what = (f"no voxel of the target label {target_label}"
+                if target_label not in (None, "", "all") else "no foreground voxel")
         claim("LABEL_EMPTY", "Major",
-              "case is in a labelled split but its label contains no foreground voxel", empty)
+              f"case is in a labelled split but its label contains {what}", empty)
     if unexpected:
         claim("LABEL_VALUE_UNEXPECTED", "Major",
               f"label values outside the declared set {sorted(declared or [])}", unexpected)
@@ -151,9 +191,22 @@ def analyze(profile_path: str, spacing_ratio: float, imbalance_frac: float) -> d
         claim("LABEL_MISSING", "Minor",
               "case sits in a split declared labelled but has no label file", missing)
 
+    # ---- whose foreground is this? -----------------------------------------
+    # On a multi-structure atlas, foreground_fraction is the union of every annotated
+    # organ. If the study segments one of them, every imbalance verdict below is reading
+    # the wrong quantity -- and reading it in the unsafe direction, since the union is
+    # always the larger number and therefore the one that clears the threshold.
+    if n_structures > 1 and target_label in (None, ""):
+        claim("TARGET_LABEL_UNDECLARED", "Minor",
+              f"{n_structures} structures are declared but no target label is; "
+              "foreground_fraction pools all of them, so the imbalance verdicts describe "
+              "the annotated anatomy rather than the segmentation target. Re-profile with "
+              "--target-label N, or --target-label all for a genuinely multi-class study",
+              [])
+
     # ---- an unlabelled test set --------------------------------------------
     for name, is_lab in labelled.items():
-        if name in TEST_SPLIT_NAMES and not is_lab:
+        if _is_test_split(name) and not is_lab:
             n = sum(1 for c in cases if _norm(c.get("split")) == name)
             claim("TEST_SET_UNLABELLED", "Major",
                   f"split '{name}' ({n} case(s)) has no ground truth — it cannot yield Dice, "

--- a/skills/profile-imaging/scripts/profile_imaging_dataset.py
+++ b/skills/profile-imaging/scripts/profile_imaging_dataset.py
@@ -22,6 +22,14 @@ Usage
 
 A --split with no label directory is recorded as unlabelled, which is itself a
 finding: a split named `test` with no labels cannot produce a held-out metric.
+
+--target-label matters on a multi-structure atlas. Foreground defaults to every
+non-zero index, which is the whole annotated anatomy — so on a 15-organ atlas used
+for a single-organ study the reported fraction describes the upper abdomen, not the
+target, and it can sit above the imbalance threshold while the target sits far
+below it. Pass `--target-label 1` for a single-structure study (foreground and
+target volume are then computed on that index alone, and a case carrying none of it
+reads as empty), or `--target-label all` to declare a genuinely multi-class study.
 """
 from __future__ import annotations
 
@@ -33,7 +41,8 @@ import nibabel as nib
 import numpy as np
 
 
-def profile_case(img_p: Path, lab_p: Path | None, split: str) -> dict:
+def profile_case(img_p: Path, lab_p: Path | None, split: str,
+                 target_label: str | None = None) -> dict:
     img = nib.load(str(img_p))
     zooms = tuple(float(z) for z in img.header.get_zooms()[:3])
     shape = tuple(int(s) for s in img.shape[:3])
@@ -46,6 +55,7 @@ def profile_case(img_p: Path, lab_p: Path | None, split: str) -> dict:
         "voxel_volume_mm3": float(np.prod(zooms)),
         "label_values": None,
         "foreground_fraction": None,
+        "all_label_foreground_fraction": None,
         "target_volume_ml": None,
         "flags": [],
     }
@@ -70,10 +80,22 @@ def profile_case(img_p: Path, lab_p: Path | None, split: str) -> dict:
     if tuple(int(s) for s in lab.shape[:3]) != shape:
         rec["flags"].append("LABEL_SHAPE_MISMATCH")
     rec["label_values"] = [int(v) for v in np.unique(lab)]
-    n_fg = int((lab > 0).sum())
+    n_all = int((lab > 0).sum())
+    rec["all_label_foreground_fraction"] = n_all / int(lab.size)
+    # Foreground is the *target* when one is declared. On a multi-structure atlas the
+    # union of every index is the annotated anatomy, not the thing being segmented, and
+    # the gate's imbalance verdicts read this number.
+    if target_label is None or _norm_target(target_label) == "all":
+        n_fg = n_all
+    else:
+        n_fg = int((lab == int(target_label)).sum())
     rec["foreground_fraction"] = n_fg / int(lab.size)
     rec["target_volume_ml"] = n_fg * rec["voxel_volume_mm3"] / 1000.0
     return rec
+
+
+def _norm_target(t) -> str:
+    return str(t).strip().lower() if t is not None else ""
 
 
 def parse_kv(s: str | None, sep: str = ",") -> dict:
@@ -103,6 +125,10 @@ def main() -> None:
                     help="comma list, e.g. 0=background,1=spleen")
     ap.add_argument("--plan", default="",
                     help="comma list, e.g. resample=true,reorient=false,loss=dice_ce,metrics=dice+hd95")
+    ap.add_argument("--target-label", default=None,
+                    help="label index this study segments (e.g. 1), so foreground/target volume "
+                         "describe that structure instead of every annotated one; 'all' declares "
+                         "a genuinely multi-class study")
     ap.add_argument("--limit", type=int, default=0, help="profile at most N cases per split (0 = all)")
     ap.add_argument("--out", required=True)
     a = ap.parse_args()
@@ -118,13 +144,15 @@ def main() -> None:
         if a.limit:
             imgs = imgs[: a.limit]
         for i, p in enumerate(imgs, 1):
-            cases.append(profile_case(p, (Path(lab_dir) / p.name) if lab_dir else None, name))
+            cases.append(profile_case(p, (Path(lab_dir) / p.name) if lab_dir else None, name,
+                                      a.target_label))
             print(f"[{name} {i}/{len(imgs)}] {p.name}", flush=True)
 
     labels_raw = parse_kv(a.declared_labels)
     profile = {
         "dataset": a.dataset,
         "declared_labels": {str(k): v for k, v in labels_raw.items()},
+        "target_label": a.target_label,
         "plan": parse_kv(a.plan),
         "splits": splits,
         "cases": cases,

--- a/skills/profile-imaging/tests/test_dataset_profile.sh
+++ b/skills/profile-imaging/tests/test_dataset_profile.sh
@@ -50,7 +50,95 @@ check "no TEST_SET_UNLABELLED when the held-out split is labelled" no_verdict TE
 python3 "$SCRIPT" --profile "$CH/fixture/profile_defect.json" --spacing-ratio 99 --out "$OUT" --quiet >/dev/null 2>&1
 check "spacing flag silenced by --spacing-ratio 99" no_verdict SPACING_HETEROGENEOUS
 
-# (4) challenge card reproduces
+# (4) a multi-structure atlas used for a single-structure study.
+# foreground_fraction pools every annotated organ, so the imbalance verdicts read the
+# union rather than the target -- and the union is always the larger number, so it is the
+# one that clears the threshold. The gate has to say the target was never named.
+write_atlas() {  # $1=out path  $2=target_label ("none" to omit)  $3=foreground fraction
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+out, target, frac = sys.argv[1], sys.argv[2], float(sys.argv[3])
+p = {"dataset": "multi-organ atlas",
+     "declared_labels": {"0": "background", "1": "spleen", "2": "liver", "3": "pancreas"},
+     "plan": {"resample": True, "reorient": True, "loss": "cross_entropy",
+              "metrics": ["dice", "hd95"]},
+     "splits": [{"name": "external_ct", "labelled": True}],
+     "cases": [{"case": "c%d" % i, "split": "external_ct", "shape": [512, 512, 100],
+                "spacing_mm": [0.8, 0.8, 5.0], "orientation": "RAS",
+                "voxel_volume_mm3": 3.2, "label_values": [0, 1, 2, 3],
+                "foreground_fraction": frac, "target_volume_ml": 200.0,
+                "intensity": {"min": -1024.0, "p01": -1000.0, "p50": 40.0,
+                              "p99": 300.0, "max": 1500.0}, "flags": []}
+               for i in range(4)]}
+if target != "none":
+    p["target_label"] = target
+json.dump(p, open(out, "w"))
+PY
+}
+
+# 4a) three structures declared, no target named -> fires. 3.2 % pooled foreground sits
+#     ABOVE the 1 % threshold, so the imbalance verdict stays silent while the real
+#     target (0.2 %) is far below it: the exact false negative this verdict exists for.
+write_atlas "$TMP/atlas_undeclared.json" none 0.032
+python3 "$SCRIPT" --profile "$TMP/atlas_undeclared.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "TARGET_LABEL_UNDECLARED on a multi-structure atlas with no target" \
+      has_verdict TARGET_LABEL_UNDECLARED
+check "pooled foreground clears the threshold, so EXTREME_IMBALANCE stays silent" \
+      no_verdict EXTREME_IMBALANCE
+
+# 4b) same atlas, target named, target-specific foreground -> the imbalance is visible
+write_atlas "$TMP/atlas_target.json" 1 0.002
+python3 "$SCRIPT" --profile "$TMP/atlas_target.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "no TARGET_LABEL_UNDECLARED once a target label is declared" \
+      no_verdict TARGET_LABEL_UNDECLARED
+check "target-specific foreground now trips EXTREME_IMBALANCE" has_verdict EXTREME_IMBALANCE
+
+# 4c) 'all' is a declaration too -- a genuinely multi-class study
+write_atlas "$TMP/atlas_all.json" all 0.032
+python3 "$SCRIPT" --profile "$TMP/atlas_all.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "no TARGET_LABEL_UNDECLARED when 'all' is declared" no_verdict TARGET_LABEL_UNDECLARED
+
+# 4d) a single-structure dataset never raises the question
+python3 "$SCRIPT" --profile "$CH/fixture/profile_clean.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "no TARGET_LABEL_UNDECLARED on a binary dataset" no_verdict TARGET_LABEL_UNDECLARED
+
+# (5) split names carry qualifiers in real projects. An exact-set membership test misses
+# every one of them, which is the worst way for TEST_SET_UNLABELLED to fail: the split it
+# exists for is the split it cannot see.
+write_qualified() {  # $1=out  $2=split name  $3=labelled(true/false)
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+out, name, lab = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+case = {"case": "c1", "split": name, "shape": [512, 512, 100],
+        "spacing_mm": [0.8, 0.8, 5.0], "orientation": "RAS", "voxel_volume_mm3": 3.2,
+        "label_values": [0, 1] if lab else None,
+        "foreground_fraction": 0.004 if lab else None,
+        "target_volume_ml": 200.0 if lab else None,
+        "intensity": {"min": -1024.0, "p01": -1000.0, "p50": 40.0, "p99": 300.0,
+                      "max": 1500.0}, "flags": []}
+json.dump({"dataset": "d", "declared_labels": {"0": "background", "1": "spleen"},
+           "target_label": "1",
+           "plan": {"resample": True, "reorient": True, "loss": "dice_ce",
+                    "metrics": ["dice", "hd95"]},
+           "splits": [{"name": name, "labelled": lab}], "cases": [case]},
+          open(out, "w"))
+PY
+}
+for qname in amos_test external_ct held-out-set test-fold1 testing_set; do
+  write_qualified "$TMP/q.json" "$qname" false
+  python3 "$SCRIPT" --profile "$TMP/q.json" --out "$OUT" --quiet >/dev/null 2>&1
+  check "TEST_SET_UNLABELLED on qualified split name '$qname'" has_verdict TEST_SET_UNLABELLED
+done
+write_qualified "$TMP/q.json" amos_test true
+python3 "$SCRIPT" --profile "$TMP/q.json" --out "$OUT" --quiet >/dev/null 2>&1
+check "no TEST_SET_UNLABELLED when the qualified split IS labelled" no_verdict TEST_SET_UNLABELLED
+for safe in train contest pretest protest_cohort validation; do
+  write_qualified "$TMP/q.json" "$safe" false
+  python3 "$SCRIPT" --profile "$TMP/q.json" --out "$OUT" --quiet >/dev/null 2>&1
+  check "no TEST_SET_UNLABELLED on unlabelled split named '$safe'" no_verdict TEST_SET_UNLABELLED
+done
+
+# (6) challenge card reproduces
 check "challenge card verify.sh" bash "$CH/verify.sh"
 
 echo


### PR DESCRIPTION
Three false negatives in the imaging gates, all surfaced by running the **shipped** skills against real datasets (AMOS22, MSD Task09) rather than against fixtures.

## 1. Foreground was the whole atlas, not the target

`profile_imaging_dataset.py` computed foreground as every non-zero label index. On a binary dataset that is the target; on a 15-organ atlas it is the annotated upper abdomen.

Profiling AMOS22 for a **spleen** study:

| arm | reported foreground | actual spleen | inflation |
|---|---|---|---|
| CT (n=300) | 3.17 % | **0.20 %** | 15.7x |
| MRI (n=60) | 7.94 % | **0.58 %** | 13.6x |

The default imbalance threshold is 1 %. The reported number sits **above** it and the true one **below**, so `EXTREME_IMBALANCE` and `ACCURACY_UNDER_IMBALANCE` stayed silent on a dataset where predicting background everywhere scores 99.8 %. It crosses the threshold, and it errs in the unsafe direction every time — the union of organs is always the larger number.

The same blind spot hid missing ground truth: **3 of AMOS22's 360 labelled cases carry no spleen at all** (2 CT, 1 MRI). `LABEL_EMPTY` sees the other organs and passes them, so they would have entered an external-validation arm and scored Dice 0 with nothing on the record to explain why.

**Fix** — `--target-label N` computes foreground and target volume on that index alone (the union is retained as `all_label_foreground_fraction`), and `LABEL_EMPTY` then means *this case has none of the target*. `--target-label all` declares a genuinely multi-class study. A multi-structure atlas that names no target raises the new minor `TARGET_LABEL_UNDECLARED`.

## 2. `TEST_SET_UNLABELLED` could not see a qualified split name

Split names were matched by exact membership in `{test, holdout, held_out, external, eval}`, so `amos_test`, `external_ct`, `held-out-set`, `test-fold1` all slipped it — the split the verdict exists for is the split it could not see.

Matching is now over name tokens **plus adjacent-token joins** (so two-word members like `held_out` survive tokenisation). It deliberately does not reduce to substring search: `contest`, `pretest`, `protest_cohort` are still not test splits, and tests hold that line. `testing` joins the synonym set.

## 3. Resampling was assumed leakage-free

`FIT_BASED_TYPES` omitted `resample`, on the docstring's stated reasoning that "resample to a fixed spacing never leaks". True when the spacing is fixed — but nnU-Net derives its target spacing from a percentile of the dataset fingerprint, so a resample fitted over every case carries held-out geometry into the training grid exactly as an intensity statistic does. On a real manifest the gate flagged the two intensity transforms and stayed silent on the resample beside them.

Resampling types are now fit-based. A target genuinely chosen in advance declares `fit_scope: fixed` and stays silent — the case the docstring had mistaken for the only one.

## Verification

Every new test was run against the **pre-change** scripts first and fails there:

```
FAIL  TARGET_LABEL_UNDECLARED on a multi-structure atlas with no target
FAIL  TEST_SET_UNLABELLED on qualified split name 'amos_test'
FAIL  TEST_SET_UNLABELLED on qualified split name 'external_ct'
FAIL  TEST_SET_UNLABELLED on qualified split name 'held-out-set'
FAIL  TEST_SET_UNLABELLED on qualified split name 'test-fold1'
FAIL  data-derived resample target before split fires PREPROCESS_BEFORE_SPLIT
```

All pass after, with negative fixtures for each (declared target, declared `all`, binary dataset, labelled qualified split, non-test names containing `test`, fixed-spacing resample). Full local CI mirror: **185/185 gates pass**.

No new detector script — the count stays **80**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)