### PR TITLE
fix(self-review): a status row is not a finding — confounding-completeness was reporting ~45 non-defects

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -541,6 +541,9 @@ jobs:
       - name: Run manage-refs duplicate-bibliography gate test
         run: bash skills/manage-refs/tests/test_reference_duplication.sh
 
+      - name: "Run self-review confounding findings-contract challenge (a status row is not a finding)"
+        run: bash skills/self-review/scripts/confounding_findings_challenge/verify.sh
+
       - name: Run self-review binning-consistency gate test
         run: bash skills/self-review/tests/test_binning_consistency.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Fixed
 
+- **A status row is not a finding: `check_confounding_completeness` was reporting ~45
+  non-defects as findings, and corrupting the measurement built on top of them.** Its
+  `findings` array was the whole per-covariate audit table, and two of that table's three
+  verdicts mean *this is fine*: `ADJUSTED` says the covariate was handled, and
+  `EXPOSURE_DEFINING_EXEMPT` records a deliberate exemption (adjusting for a component of the
+  exposure's own diagnostic criteria is over-adjustment — probe O7). Nothing was wrong with
+  the analysis. What was wrong is that every consumer aggregating a project's `qc/` directory
+  counts entries in `findings`, so a run reporting "four covariates examined, none of them a
+  problem" arrived as **four findings**, with empty messages.
+
+  Found by running the detector-precision harvest over real projects: three runs of this
+  detector in one cohort project contributed ~45 pseudo-findings, enough to make it the
+  loudest detector in the suite and to seat a 0.00-precision row in the ledger that is
+  supposed to grade detectors. A measurement corrupted by the thing it measures.
+
+  `findings` now carries only `UNADJUSTED_IMBALANCED`, each with the **`severity` and
+  `message` it never had** — which is why its entries rendered blank in every report. The
+  full table is still emitted as **`covariates`**, and the human-readable render walks that,
+  so the printed table, all three counts (`n_imbalanced`, `n_unadjusted_imbalanced`,
+  `n_exposure_defining_exempt`) and both `--strict` exit codes are unchanged. 19-case
+  challenge card wired into CI; restoring the old envelope fails 8 of its assertions.
+
+  No new detector: the count stays **83** (a challenge card, not a gate).
+
+
 - **A single-organ study run against a multi-organ atlas was measured on the wrong organ, and
   the imbalance gate went quiet because of it.** `profile_imaging_dataset.py` computed
   foreground as every non-zero label index. On a binary dataset that is the target; on a

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -26,6 +26,7 @@
 
 **Validation**
 
+- `bash scripts/confounding_findings_challenge/verify.sh`
 - `python3 scripts/check_reviewer_team_consistency.py`
 - `python3 scripts/check_domain_probe_sync.py --strict`
 - `bash tests/test_panel_mode.sh`
@@ -107,6 +108,7 @@
 - `check_supplement_hygiene.py`
 - `check_table_percentages.py`
 - `check_table_percentages_challenge/` (6 files)
+- `confounding_findings_challenge/` (4 files)
 - `refinement_regression.py`
 - `refinement_regression_challenge/` (20 files)
 - `refinement_stop.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4378,8 +4378,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",
-      "size": 21556,
-      "sha256": "f03067e65dffa0e1fe7d76229d9a66a69d177486b31240123bdbbbb18b4c15c3"
+      "size": 22605,
+      "sha256": "ca532200a7cb7732357bcb60378d1b0246b8667af07383fab30b003c2308fbdf"
     },
     {
       "path": "skills/self-review/scripts/check_cv_leakage.py",
@@ -4767,6 +4767,26 @@
       "sha256": "b4c9eb16f291841c1d6dc74a5554a49b5dc60d3562d0e328e01a78797f8d32ad"
     },
     {
+      "path": "skills/self-review/scripts/confounding_findings_challenge/fixture/adjusted.txt",
+      "size": 21,
+      "sha256": "360bf0d4cfc7eb600003ea5c9d1a50f537afb63379d4a44f62e3a887a858fbea"
+    },
+    {
+      "path": "skills/self-review/scripts/confounding_findings_challenge/fixture/defining.txt",
+      "size": 32,
+      "sha256": "888f481dc479a3ead1dacbdfa20e40b25571dee0fff6b5a5c7dd74e64764c366"
+    },
+    {
+      "path": "skills/self-review/scripts/confounding_findings_challenge/fixture/table1.csv",
+      "size": 310,
+      "sha256": "4d1b57eda2969340841f3e51402d29d736c1f3d7cb104dbe0d8104365fd7607b"
+    },
+    {
+      "path": "skills/self-review/scripts/confounding_findings_challenge/verify.sh",
+      "size": 5131,
+      "sha256": "8cdee343a6244f5b0e0c517581c0e1fde9e483eafd4aeea75eb43b135a6c4f8b"
+    },
+    {
       "path": "skills/self-review/scripts/refinement_regression.py",
       "size": 8977,
       "sha256": "f59f7029a27eba978a58cdc19ec81970b4119368295982c2810e6ce684ddd304"
@@ -4988,8 +5008,8 @@
     },
     {
       "path": "skills/self-review/skill.yml",
-      "size": 4402,
-      "sha256": "74bf178b823ad2a0d3e05485fbb30d49b08040e19849d67c49fd4d160fab2554"
+      "size": 4462,
+      "sha256": "354a9e12fb464a868896072cb2a5023882344d17ec79ad7c237655bb9451aefa"
     },
     {
       "path": "skills/setup-medsci/SKILL.md",

--- a/skills/self-review/scripts/check_confounding_completeness.py
+++ b/skills/self-review/scripts/check_confounding_completeness.py
@@ -342,7 +342,7 @@ def analyze(table1: str, adj: list[str], name_col, p_col, smd_col,
     def_norm = [_norm(d) for d in defining]
     def_concepts = set().union(*(_concepts(d) for d in defining)) if defining else set()
     smd_source = "reported" if (pi is not None or si is not None) else "computed_from_mean_sd"
-    findings = []
+    covariates = []
     for r in rows[1:]:
         if ni >= len(r):
             continue
@@ -368,7 +368,7 @@ def analyze(table1: str, adj: list[str], name_col, p_col, smd_col,
         else:
             adjusted = in_adjustment_set(cov, adj_norm, adj_concepts)
             verdict = "ADJUSTED" if adjusted else "UNADJUSTED_IMBALANCED"
-        findings.append({
+        covariates.append({
             "covariate": cov,
             "imbalance_p": pval,
             "smd": round(smd, 4) if smd is not None else None,
@@ -376,17 +376,31 @@ def analyze(table1: str, adj: list[str], name_col, p_col, smd_col,
             "verdict": verdict,
         })
 
-    unadjusted = [f for f in findings if f["verdict"] == "UNADJUSTED_IMBALANCED"]
-    exempt = [f for f in findings if f["verdict"] == "EXPOSURE_DEFINING_EXEMPT"]
+    unadjusted = [f for f in covariates if f["verdict"] == "UNADJUSTED_IMBALANCED"]
+    exempt = [f for f in covariates if f["verdict"] == "EXPOSURE_DEFINING_EXEMPT"]
+    # `findings` is the DEFECT list and nothing else. It used to be the whole per-covariate
+    # audit table, two of whose three verdicts mean "this is fine": ADJUSTED says the
+    # covariate WAS handled and EXPOSURE_DEFINING_EXEMPT records a deliberate exemption.
+    # Every consumer that aggregates qc/ counted those as fires — in one real project that
+    # was ~45 pseudo-findings from three runs, enough to make this the loudest detector in
+    # the suite and to corrupt the precision ledger built on top of it. The full table is
+    # still emitted, as `covariates`, which is what the human-readable render walks.
+    findings = [dict(f, severity="major", message=(
+        f"{f['covariate']} is imbalanced by exposure "
+        + (f"(p={f['imbalance_p']:.4g})" if f["imbalance_p"] is not None else
+           f"(SMD={f['smd']:.3g})" if f["smd"] is not None else "")
+        + " and is not in the adjustment set; report an extended-adjustment sensitivity model."
+    )) for f in unadjusted]
     return {
         "table1": str(p),
         "adjustment_set": adj,
         "exposure_defining": defining,
         "thresholds": {"p": P_THRESHOLD, "smd": SMD_THRESHOLD},
         "smd_source": smd_source,
-        "n_imbalanced": len(findings),
+        "n_imbalanced": len(covariates),
         "n_unadjusted_imbalanced": len(unadjusted),
         "n_exposure_defining_exempt": len(exempt),
+        "covariates": covariates,
         "findings": findings,
         "verdict": "MAJOR_CANDIDATE" if unadjusted else "OK",
         "suggested_fix": (
@@ -408,7 +422,7 @@ def render_table(result: dict) -> str:
         "ADJUSTED": "✓",
         "EXPOSURE_DEFINING_EXEMPT": "⊘ exposure-defining (exempt; adjusting = over-adjustment)",
     }
-    for f in result["findings"]:
+    for f in result["covariates"]:
         p = "—" if f["imbalance_p"] is None else f"{f['imbalance_p']:.4g}"
         s = "—" if f["smd"] is None else f"{f['smd']:.3g}"
         mark = marks.get(f["verdict"], f["verdict"])

--- a/skills/self-review/scripts/confounding_findings_challenge/fixture/adjusted.txt
+++ b/skills/self-review/scripts/confounding_findings_challenge/fixture/adjusted.txt
@@ -1,0 +1,2 @@
+Age (years)
+Male sex

--- a/skills/self-review/scripts/confounding_findings_challenge/fixture/defining.txt
+++ b/skills/self-review/scripts/confounding_findings_challenge/fixture/defining.txt
@@ -1,0 +1,2 @@
+Body mass index
+Fasting glucose

--- a/skills/self-review/scripts/confounding_findings_challenge/fixture/table1.csv
+++ b/skills/self-review/scripts/confounding_findings_challenge/fixture/table1.csv
@@ -1,0 +1,7 @@
+Covariate,Exposed,Unexposed,p
+Age (years),58.2 (9.1),54.6 (8.8),0.001
+Male sex (%),61.0 (48.8),44.2 (49.7),0.002
+Body mass index,29.8 (4.1),24.1 (3.2),0.0001
+Fasting glucose,112.4 (18.0),94.2 (10.1),0.0001
+Prior cardiovascular disease (%),18.4 (38.8),9.1 (28.8),0.0003
+Smoking (%),31.0 (46.3),29.4 (45.6),0.62

--- a/skills/self-review/scripts/confounding_findings_challenge/verify.sh
+++ b/skills/self-review/scripts/confounding_findings_challenge/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the confounding-completeness findings-contract challenge.
+#
+# `findings` is the DEFECT list. It used to be the whole per-covariate audit table, and two of
+# that table's three verdicts mean "this is fine": ADJUSTED says the covariate WAS handled,
+# and EXPOSURE_DEFINING_EXEMPT records a deliberate exemption (adjusting for a component of
+# the exposure's own diagnostic criteria is over-adjustment, probe O7).
+#
+# Nothing was wrong with the analysis. What was wrong is that every consumer aggregating a
+# project's qc/ directory counts entries in `findings`, so a run reporting "four covariates
+# examined, none of them a problem" arrived as FOUR FINDINGS. In one real project three such
+# runs contributed ~45 pseudo-findings — enough to make this the loudest detector in the
+# suite and to put a 0.00 precision row into the ledger built on top of it. The measurement
+# that was supposed to grade the detectors was being corrupted by one detector's envelope.
+#
+# So: the full table is still emitted, as `covariates`, and the human-readable render walks
+# that. `findings` carries only UNADJUSTED_IMBALANCED, each with a severity and a message —
+# the two fields it never had, and the reason its entries showed up blank in every report.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DET="$HERE/../check_confounding_completeness.py"
+FIX="$HERE/fixture"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ck() { if [ "$2" = "$3" ]; then printf '  PASS  %-56s got=%s\n' "$1" "$3"; pass=$((pass+1));
+       else printf '  FAIL  %-56s want=%s got=%s\n' "$1" "$2" "$3"; fail=$((fail+1)); fi; }
+jq_() { python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(eval(sys.argv[2]))" "$1" "$2"; }
+
+run() { python3 "$DET" --table1 "$1" --adjusted "$FIX/adjusted.txt" \
+          --exposure-defining "$FIX/defining.txt" --out "$2" 2>&1; }
+
+echo "== a genuine defect: one finding, carrying the fields it must carry =="
+OUT="$(run "$FIX/table1.csv" "$TMP/defect.json")"
+ck "the audit table still holds every imbalanced covariate" 5 "$(jq_ "$TMP/defect.json" "len(d['covariates'])")"
+ck "but findings holds only the defect"                     1 "$(jq_ "$TMP/defect.json" "len(d['findings'])")"
+ck "the finding is UNADJUSTED_IMBALANCED"      "UNADJUSTED_IMBALANCED" "$(jq_ "$TMP/defect.json" "d['findings'][0]['verdict']")"
+ck "it carries a severity"                                  "major" "$(jq_ "$TMP/defect.json" "d['findings'][0]['severity']")"
+ck "and a non-empty message"                                True "$(jq_ "$TMP/defect.json" "len(d['findings'][0].get('message','')) > 40")"
+ck "the covariate is named in it"                           True "$(jq_ "$TMP/defect.json" "'Prior cardiovascular disease' in d['findings'][0]['message']")"
+
+echo "== THE REGRESSION: a status row must never reach findings =="
+ck "no ADJUSTED in findings"        0 "$(jq_ "$TMP/defect.json" "sum(1 for f in d['findings'] if f['verdict']=='ADJUSTED')")"
+ck "no EXEMPT in findings"          0 "$(jq_ "$TMP/defect.json" "sum(1 for f in d['findings'] if f['verdict']=='EXPOSURE_DEFINING_EXEMPT')")"
+# NB: no braces in these expressions — the shell brace-expands them into separate words.
+ck "though both ARE in the audit table" True "$(jq_ "$TMP/defect.json" "set(c['verdict'] for c in d['covariates']) >= set(['ADJUSTED','EXPOSURE_DEFINING_EXEMPT'])")"
+
+echo "== a run with nothing wrong reports nothing wrong =="
+grep -v "Prior cardiovascular" "$FIX/table1.csv" > "$TMP/clean.csv"
+run "$TMP/clean.csv" "$TMP/clean.json" >/dev/null 2>&1
+ck "four covariates examined"       4 "$(jq_ "$TMP/clean.json" "len(d['covariates'])")"
+ck "ZERO findings (it reported 4 before)" 0 "$(jq_ "$TMP/clean.json" "len(d['findings'])")"
+
+echo "== the human-readable table is unchanged: it walks covariates =="
+OUT="$(run "$FIX/table1.csv" "$TMP/x.json")"
+ck "adjusted rows still rendered"   True "$(python3 -c "print('Age (years)' in '''$OUT''')")"
+ck "exempt rows still rendered"     True "$(python3 -c "print('exposure-defining' in '''$OUT''')")"
+
+echo "== counts and exit codes are unchanged =="
+ck "n_imbalanced counts the whole table"      5 "$(jq_ "$TMP/defect.json" "d['n_imbalanced']")"
+ck "n_unadjusted_imbalanced"                  1 "$(jq_ "$TMP/defect.json" "d['n_unadjusted_imbalanced']")"
+ck "n_exposure_defining_exempt"               2 "$(jq_ "$TMP/defect.json" "d['n_exposure_defining_exempt']")"
+python3 "$DET" --table1 "$FIX/table1.csv" --adjusted "$FIX/adjusted.txt" \
+  --exposure-defining "$FIX/defining.txt" --strict >/dev/null 2>&1
+ck "--strict still fails on a real defect" 1 "$?"
+python3 "$DET" --table1 "$TMP/clean.csv" --adjusted "$FIX/adjusted.txt" \
+  --exposure-defining "$FIX/defining.txt" --strict >/dev/null 2>&1
+ck "--strict still passes when there is none" 0 "$?"
+
+echo "== the artifact names its own author =="
+ck "qc JSON carries the detector key" True "$(jq_ "$TMP/defect.json" "d.get('detector')=='check_confounding_completeness'")"
+
+echo
+printf 'confounding findings-contract challenge: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -52,6 +52,7 @@ known_limitations:
   - "Anticipates likely reviewer comments; cannot predict a specific reviewer's focus."
   - "Advisory; produces recommendations, not manuscript edits."
 validation_commands:
+  - "bash scripts/confounding_findings_challenge/verify.sh"
   - "python3 scripts/check_reviewer_team_consistency.py"
   - "python3 scripts/check_domain_probe_sync.py --strict"
   - "bash tests/test_panel_mode.sh"

--- a/skills/self-review/tests/test_confounding_completeness.sh
+++ b/skills/self-review/tests/test_confounding_completeness.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# NOTE: `findings` is the DEFECT list (UNADJUSTED_IMBALANCED only); the full per-covariate
+# audit table — including the ADJUSTED and EXPOSURE_DEFINING_EXEMPT status rows — is
+# `covariates`. Assertions about whether a covariate was RESOLVED or EXEMPT read
+# `covariates`; assertions about defects read `findings`. See confounding_findings_challenge.
 # Regression test for the confounding-completeness gate (self-review Phase 2.5e).
 # Synthetic, PII-free fixture mirroring the canonical failure pattern: five
 # measured covariates imbalanced by exposure (uric acid, pack-years, HDL, total
@@ -13,8 +17,10 @@ OUT="$(mktemp -t cc_XXXX).json"
 trap 'rm -f "$OUT"' EXIT
 
 fail=0
+ran=0
 check() {  # check "label" expr...
     local label="$1"; shift
+    ran=$((ran+1))
     if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
     else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
 }
@@ -79,7 +85,7 @@ for cov in he_sbp he_dbp b_chol_t b_chol_hdl b_tg b_uric b_hba1c he_bmi; do
     check "db-code adjusted (alias resolved): $cov" python3 -c "
 import json
 d=json.load(open('$DBOUT'))
-assert any(f['covariate']=='$cov' and f['in_adjustment_set'] for f in d['findings']), '$cov not resolved'
+assert any(f['covariate']=='$cov' and f['in_adjustment_set'] for f in d['covariates']), '$cov not resolved'
 "
 done
 for cov in alc he_wc he_hb he_glu; do
@@ -125,7 +131,8 @@ assert any(f['covariate']=='fib-4' and f['verdict']=='UNADJUSTED_IMBALANCED' for
 check "A4: defining covariate not a Major" python3 -c "
 import json
 d=json.load(open('$MSOUT'))
-assert all(f['verdict']=='EXPOSURE_DEFINING_EXEMPT' for f in d['findings'] if 'body mass' in f['covariate'])"
+assert any(f['verdict']=='EXPOSURE_DEFINING_EXEMPT' for f in d['covariates'] if 'body mass' in f['covariate'])
+assert not any('body mass' in f['covariate'] for f in d['findings'])"
 
 # 9. A4 + adjust the non-defining prognostic covariate -> clean (exit 0)
 python3 "$SCRIPT" --table1 "$MSFIX" --adjusted-list "age, FIB-4" \
@@ -133,6 +140,6 @@ python3 "$SCRIPT" --table1 "$MSFIX" --adjusted-list "age, FIB-4" \
     --strict >/dev/null 2>&1
 check "exit 0 when defining exempt + non-defining adjusted" test "$?" -eq 0
 
-echo "ran=$(( ${fail} + 0 )) fail=$fail"
+echo "ran=$ran fail=$fail"
 [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"


### PR DESCRIPTION
## What was wrong

`check_confounding_completeness`'s `findings` array was the **whole per-covariate audit table**, and two of that table's three verdicts mean *this is fine*:

- `ADJUSTED` — the covariate **was** handled.
- `EXPOSURE_DEFINING_EXEMPT` — a deliberate exemption (adjusting for a component of the exposure's own diagnostic criteria is over-adjustment, probe O7).

Nothing was wrong with the analysis. What was wrong is that **every consumer aggregating a project's `qc/` directory counts entries in `findings`** — so a run reporting *"four covariates examined, none of them a problem"* arrived as **four findings**, with empty messages, because these rows carried neither a `severity` nor a `message`.

## How it was found, and why it mattered more than it looks

Running the detector-precision harvest over real projects. Three runs of this detector in one cohort project contributed **~45 pseudo-findings** — enough to make it the loudest detector in the suite and to seat a **0.00-precision row** in the ledger that exists to grade detectors.

**A measurement corrupted by the thing it measures.** That is the reason this is worth a PR rather than a tidy-up: every conclusion drawn from `qc/` aggregation — fire distribution, precision, any prune decision — was being skewed by one detector's envelope.

## The fix

`findings` now carries **only `UNADJUSTED_IMBALANCED`**, each with the `severity` and `message` it never had. The full table is still emitted as **`covariates`**, which the human-readable render walks.

**Unchanged**: the printed table, all three counts (`n_imbalanced`, `n_unadjusted_imbalanced`, `n_exposure_defining_exempt`), and both `--strict` exit codes. Detector count stays **83** — this is a challenge card, not a new gate.

## Two things it surfaced in the existing A11 test

1. Its assertions about whether a covariate was **RESOLVED** or **EXEMPT** were reading the *defect* list. After the split one of them (`all(...)` over an empty set) would have **passed vacuously** — green, and proving nothing. They now read `covariates`, and additionally assert absence from `findings`.
2. Its summary line printed the **failure** count under the name `ran`, so a clean run always said `ran=0` — indistinguishable from a run where nothing executed. It now counts checks: `ran=35`.

## Verification

- **19-case challenge card** wired into CI, including the negative that is the whole point: a run where every covariate is adjusted-or-exempt now yields **zero** findings (it yielded four).
- **Gate proven to bite**: restoring the old envelope (`"findings": covariates`) fails **8 of 19** assertions, reproducing the exact defect.
- **Full CI mirror: 188/188**, with the new step confirmed present.

## Scope note

The candidate that produced this also proposed a repo-wide contract — *every* `findings` entry must carry a message and a severity. **Not done here**, and deliberately: a source-level survey says **19 of 35** findings-emitting detectors would fail it today. That is a refactor across nineteen files, not a fix, and it deserves its own decision rather than riding along. The number is recorded so the decision is informed rather than vaguely deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)