### PR TITLE
fix(self-review): cohort-arithmetic was binding numbers that belong to something else

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -544,6 +544,9 @@ jobs:
       - name: "Run self-review confounding findings-contract challenge (a status row is not a finding)"
         run: bash skills/self-review/scripts/confounding_findings_challenge/verify.sh
 
+      - name: "Run self-review cohort-arithmetic binding challenge (a label digit is not an event count)"
+        run: bash skills/self-review/scripts/cohort_arith_binding_challenge/verify.sh
+
       - name: Run self-review binning-consistency gate test
         run: bash skills/self-review/tests/test_binning_consistency.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ### Fixed
 
+- **`check_cohort_arithmetic` was binding numbers that belong to something else — every one
+  of its observed fires on a real manuscript was false.** The arithmetic was never wrong; the
+  inputs were. Three captures, three ways of latching onto the wrong digit:
+
+  - `"882 KSAR S4-1 events occurred"` bound the **1 of the label "S4-1"** as the event count
+    and declared 2.48 per 100 person-years irreconcilable with one event. A hyphen or slash
+    before the digit now means it belongs to a label, and when the numerator cannot be bound
+    the check says **nothing** — an unbindable count is not evidence of an arithmetic error.
+  - `"over 35,581.3 person-years"` — the integer part could not reach the noun past the decimal
+    point, so the **fractional digit** matched instead: a cohort of "3 person-years". Person-time
+    is now read with its decimal, and the same lookbehind stops a fractional tail standing alone.
+  - A one-letter column hint matched a longer word: `"n"` found **`"Normal"`** in the header of
+    an exposure-stratified Table 1, so characteristic rows were summed as if they were strata.
+    Hints under three characters are now matched exactly, longer ones on a word boundary. The
+    identical one-character-substring bug was found and fixed once in
+    `check_confounding_completeness`, and never here.
+
+  Found by the detector-precision harvest: precision **0.00 (0/3)** across two `--out` names on
+  a live cohort project. A detector whose every observed fire is false teaches its user to skip
+  the whole class — and this class (rate back-calculation, exclusion cascades, tier partitions)
+  is one nothing else covers, so the cost of the noise was the coverage.
+
+  Both rate false positives are reproduced **verbatim against the pre-fix version** and are
+  silent after it. The 16-case challenge card fails **7 assertions** on that version. Its other
+  half is the one that matters: an impossible rate, a non-disjoint partition, and a wrong rate
+  over *fractional* person-time all still fire — the fix must not buy silence by going blind.
+
+  No new detector: the count stays **83**.
+
 - **A status row is not a finding: `check_confounding_completeness` was reporting ~45
   non-defects as findings, and corrupting the measurement built on top of them.** Its
   `findings` array was the whole per-covariate audit table, and two of that table's three

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -26,6 +26,7 @@
 
 **Validation**
 
+- `bash scripts/cohort_arith_binding_challenge/verify.sh`
 - `bash scripts/confounding_findings_challenge/verify.sh`
 - `python3 scripts/check_reviewer_team_consistency.py`
 - `python3 scripts/check_domain_probe_sync.py --strict`
@@ -108,6 +109,7 @@
 - `check_supplement_hygiene.py`
 - `check_table_percentages.py`
 - `check_table_percentages_challenge/` (6 files)
+- `cohort_arith_binding_challenge/` (4 files)
 - `confounding_findings_challenge/` (4 files)
 - `refinement_regression.py`
 - `refinement_regression_challenge/` (20 files)

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4428,8 +4428,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
-      "size": 37883,
-      "sha256": "ef239b1896f1b17f3b0d75b7d45ef2d3e285d96320a357c31aced06f823cf38b"
+      "size": 39325,
+      "sha256": "def2a226b76c5702fe0a6b87bc11a38af3ae0dae233ae0f6132b67704995f9ca"
     },
     {
       "path": "skills/self-review/scripts/check_confounding_completeness.py",
@@ -4822,6 +4822,26 @@
       "sha256": "b4c9eb16f291841c1d6dc74a5554a49b5dc60d3562d0e328e01a78797f8d32ad"
     },
     {
+      "path": "skills/self-review/scripts/cohort_arith_binding_challenge/fixture/decimal_person_time.md",
+      "size": 152,
+      "sha256": "e4c40f0d5982e7c34d3ef0bd4e3d833f94c592344aebddb30fa3f5a29f8bf3de"
+    },
+    {
+      "path": "skills/self-review/scripts/cohort_arith_binding_challenge/fixture/genuine_defects.md",
+      "size": 287,
+      "sha256": "d530e9b75800fc5bd5744ce26fbcdc051f58b16e9c988976d0310bd551de39a8"
+    },
+    {
+      "path": "skills/self-review/scripts/cohort_arith_binding_challenge/fixture/real_negatives.md",
+      "size": 737,
+      "sha256": "7498d7db7ce8eada7e6f559bf47ff74dc1654857fb59ca49aef5d706bb19a37b"
+    },
+    {
+      "path": "skills/self-review/scripts/cohort_arith_binding_challenge/verify.sh",
+      "size": 5248,
+      "sha256": "d9164487af02fdc2cebc1b3c119e8d0354db318a6b3e0207bba09179c91baf31"
+    },
+    {
       "path": "skills/self-review/scripts/confounding_findings_challenge/fixture/adjusted.txt",
       "size": 21,
       "sha256": "360bf0d4cfc7eb600003ea5c9d1a50f537afb63379d4a44f62e3a887a858fbea"
@@ -5063,8 +5083,8 @@
     },
     {
       "path": "skills/self-review/skill.yml",
-      "size": 4462,
-      "sha256": "354a9e12fb464a868896072cb2a5023882344d17ec79ad7c237655bb9451aefa"
+      "size": 4522,
+      "sha256": "05df4d9adff66350fcd941502be8ca9290e2b9097605833328b907d5679c4f9d"
     },
     {
       "path": "skills/setup-medsci/SKILL.md",

--- a/skills/self-review/scripts/check_cohort_arithmetic.py
+++ b/skills/self-review/scripts/check_cohort_arithmetic.py
@@ -125,6 +125,10 @@ def _is_total_label(label: str) -> bool:
     return any(n == t or n.startswith(t + " ") or n == t.replace(" ", "") for t in TOTAL_LABELS)
 
 
+# A hint shorter than this is matched only exactly — never as a substring.
+MIN_SUBSTRING_HINT = 3
+
+
 def _pick(header: list[str], hints: tuple[str, ...]):
     norm = [_norm(h) for h in header]
     for hint in hints:
@@ -132,10 +136,18 @@ def _pick(header: list[str], hints: tuple[str, ...]):
         for i, col in enumerate(norm):
             if col == h and h:
                 return i
+    # Substring fallback, with the guard the exact pass does not need. A hint of one or two
+    # characters has no business matching a longer word: the hint "n" found "Normal" in the
+    # header of an exposure-stratified Table 1, so every characteristic row's Normal-column
+    # value was summed as if it were a stratum size (8,299 "strata" against a "total" of 194).
+    # The same one-character-substring bug was fixed once in check_confounding_completeness
+    # and never here. Longer hints still match, but only on a word boundary.
     for hint in hints:
         h = _norm(hint)
+        if len(h) < MIN_SUBSTRING_HINT:
+            continue
         for i, col in enumerate(norm):
-            if h and h in col:
+            if col and re.search(rf"(?<![a-z0-9]){re.escape(h)}(?![a-z0-9])", col):
                 return i
     return None
 
@@ -150,9 +162,17 @@ RATE_LINE_RE = re.compile(
 #       fractional part ("0.97") is never captured as the numerator;
 #   (b) drop the bare "incident" alternative, which matched the word in "incident
 #       rate" and bound the nearest stray small integer (the false-positive source).
+#   (c) a HYPHEN or slash before the digit means it belongs to a label, not to the count:
+#       "882 KSAR S4-1 events occurred" bound the 1 of "S4-1" and reported the rate as
+#       irreconcilable with 1 event. When the count cannot be bound the check must say
+#       nothing — an unbindable numerator is not evidence of an arithmetic error.
 EVENTS_NEAR_RE = re.compile(
-    r"(?<![A-Za-z0-9.])([0-9][0-9,]*)\s*(?:incident\s+)?(?:events?|cases?)\b", re.I)
-PY_NEAR_RE = re.compile(r"([0-9][0-9,]*)\s*(?:person[-\s]?years?|py\b)", re.I)
+    r"(?<![A-Za-z0-9.\-\u2013\u2014/])([0-9][0-9,]*)\s*(?:incident\s+)?(?:events?|cases?)\b", re.I)
+# Person-time is frequently reported to one decimal ("35,581.3 person-years"). Without the
+# decimal branch the integer part failed to reach the noun and the FRACTIONAL DIGIT matched
+# instead — a cohort of "3 person-years" — so the same lookbehind applies here.
+PY_NEAR_RE = re.compile(
+    r"(?<![A-Za-z0-9.\-\u2013\u2014/])([0-9][0-9,]*(?:\.[0-9]+)?)\s*(?:person[-\s]?years?|py\b)", re.I)
 
 
 def _sentences(text: str) -> list[str]:
@@ -184,8 +204,8 @@ def check_rate_text(text: str) -> list[dict]:
         em = EVENTS_NEAR_RE.search(line)
         # the PY in "rate per <scale> person-years" is the scale, not the cohort PY;
         # the cohort PY is a *different*, larger person-time figure in the same span.
-        py_candidates = [int(g.replace(",", "")) for g in PY_NEAR_RE.findall(line)]
-        py_candidates = [p for p in py_candidates if p != int(scale)]
+        py_candidates = [float(g.replace(",", "")) for g in PY_NEAR_RE.findall(line)]
+        py_candidates = [p for p in py_candidates if abs(p - scale) > 1e-9]
         if not em or not py_candidates:
             continue
         events = _num(em.group(1))
@@ -200,7 +220,7 @@ def check_rate_text(text: str) -> list[dict]:
                 "verdict": "RATE_BACKCALC",
                 "severity": "Major",
                 "detail": (f"reported rate {rate:g} per {int(scale):,} PY does not recompute "
-                           f"from {int(events):,} events / {int(py):,} PY "
+                           f"from {int(events):,} events / {py:,.6g} PY "
                            f"(= {expected:.4g} per {int(scale):,})"),
                 "where": line.strip()[:160],
             })

--- a/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/decimal_person_time.md
+++ b/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/decimal_person_time.md
@@ -1,0 +1,3 @@
+# Person-time reported to one decimal, and the rate is wrong
+
+**Results.** Over 35,581.3 person-years, 882 events occurred (9.90 per 100 person-years).

--- a/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/genuine_defects.md
+++ b/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/genuine_defects.md
@@ -1,0 +1,10 @@
+# A cohort whose arithmetic really does not close
+
+**Results.** Over 10,000 person-years, 1,000 events occurred (25.0 per 100 person-years).
+
+| Stratum | N | Events |
+|---|---|---|
+| Low risk | 4,000 | 40 |
+| Medium risk | 3,500 | 70 |
+| High risk | 2,000 | 90 |
+| Total | 9,000 | 200 |

--- a/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/real_negatives.md
+++ b/skills/self-review/scripts/cohort_arith_binding_challenge/fixture/real_negatives.md
@@ -1,0 +1,16 @@
+# Gallbladder polyp natural history
+
+*Synthetic manuscript reproducing three real sentences, verbatim in shape, that this detector
+used to flag. Every number below is internally consistent: 882 / 35,581 x 100 = 2.48.*
+
+**Results.** Over 35,581 person-years, 882 KSAR S4-1 events occurred (2.48 per 100 person-years).
+
+Of those screened, 6,990 (54.5%) had a subsequent ultrasound and formed the primary cohort,
+contributing 882 KSAR Statement 4-1 events and 8 competing deaths over 35,581.3 person-years.
+
+| Characteristic | Normal | Steatosis-only | Combined-adverse |
+|---|---|---|---|
+| Age, years | 52.1 | 54.3 | 56.8 |
+| Male, n (%) | 194 | 2,051 | 6,054 |
+| Body mass index | 23.1 | 26.4 | 29.7 |
+| Total, n | 194 | 2,051 | 6,054 |

--- a/skills/self-review/scripts/cohort_arith_binding_challenge/verify.sh
+++ b/skills/self-review/scripts/cohort_arith_binding_challenge/verify.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the cohort-arithmetic NUMBER-BINDING challenge.
+#
+# The arithmetic in this detector was never wrong. What was wrong is which numbers it fed
+# into it: on a real manuscript every one of its three observed fires was false, because each
+# capture latched onto a digit belonging to something else.
+#
+#   "882 KSAR S4-1 events occurred"        -> bound the 1 of the label "S4-1" as the event
+#                                             count, and declared 2.48 per 100 PY irreconcilable
+#                                             with 1 event.
+#   "over 35,581.3 person-years"           -> the integer part could not reach the noun past
+#                                             the decimal point, so the FRACTIONAL DIGIT matched:
+#                                             a cohort of "3 person-years".
+#   "| Characteristic | Normal | ... |"     -> the one-letter column hint "n" matched the word
+#                                             "Normal", so each characteristic row's value was
+#                                             summed as a stratum size: 8,299 against a
+#                                             "stated total" of 194. (The identical
+#                                             one-character-substring bug was fixed once in
+#                                             check_confounding_completeness and never here.)
+#
+# A detector whose every observed fire is false teaches its user to skip the whole class, and
+# this class — rate back-calculation, exclusion cascades, tier partitions — is one nothing else
+# covers. So the fix is binding, not thresholds: when a number cannot be bound to its quantity,
+# the check now says NOTHING. An unbindable numerator is not evidence of an arithmetic error.
+#
+# Which makes the second half of this card the important half: the genuine defects must still
+# fire, or the fix has merely bought silence.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DET="$HERE/../check_cohort_arithmetic.py"
+FIX="$HERE/fixture"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ck() { if [ "$2" = "$3" ]; then printf '  PASS  %-58s got=%s\n' "$1" "$3"; pass=$((pass+1));
+       else printf '  FAIL  %-58s want=%s got=%s\n' "$1" "$2" "$3"; fail=$((fail+1)); fi; }
+has() { if echo "$2" | grep -q "$3"; then ck "$1" 0 0; else ck "$1" 0 1; fi; }
+hasnt() { if echo "$2" | grep -q "$3"; then ck "$1" 0 1; else ck "$1" 0 0; fi; }
+
+echo "== the three real false positives are silent =="
+python3 "$DET" --manuscript "$FIX/real_negatives.md" --strict >/dev/null 2>&1
+ck "a manuscript whose arithmetic closes -> exit 0" 0 "$?"
+OUT="$(python3 "$DET" --manuscript "$FIX/real_negatives.md" 2>&1)"
+hasnt "no rate back-calculation fired"        "$OUT" "RATE_BACKCALC"
+hasnt "no partition overlap fired"            "$OUT" "PARTITION_OVERLAP"
+hasnt "and the label digit was never read as a count" "$OUT" "1 events"
+hasnt "nor the decimal tail as the person-time"       "$OUT" "/ 3 PY"
+
+echo "== a Table 1 is not a stratum partition =="
+# The header that broke it. "Normal" must not answer to the hint "n".
+printf '| Characteristic | Normal | Adverse |\n|---|---|---|\n| Age, years | 52.1 | 56.8 |\n| Male, n (%%) | 4,051 | 6,054 |\n| Body mass index | 23.1 | 29.7 |\n| Total, n | 194 | 6,054 |\n' > "$TMP/t1.md"
+OUT="$(python3 "$DET" --manuscript "$TMP/t1.md" 2>&1)"
+hasnt "an exposure-stratified Table 1 stays silent" "$OUT" "PARTITION_OVERLAP"
+
+echo "== THE OTHER HALF: genuine defects must still fire =="
+python3 "$DET" --manuscript "$FIX/genuine_defects.md" --strict >/dev/null 2>&1
+ck "a real discrepancy -> exit 1" 1 "$?"
+OUT="$(python3 "$DET" --manuscript "$FIX/genuine_defects.md" 2>&1)"
+has "the impossible rate is named"            "$OUT" "RATE_BACKCALC"
+has "with the correct recomputation"          "$OUT" "10 per 100"
+has "the non-disjoint partition is named"     "$OUT" "PARTITION_OVERLAP"
+has "with the correct sum"                    "$OUT" "9,500"
+
+echo "== decimal person-time is now READ, not skipped =="
+# The fix must not buy its silence by ignoring fractional person-time: here the same decimal
+# figure is present and the rate really is wrong, so it must fire — and with the full number.
+python3 "$DET" --manuscript "$FIX/decimal_person_time.md" --strict >/dev/null 2>&1
+ck "a wrong rate over fractional person-time -> exit 1" 1 "$?"
+OUT="$(python3 "$DET" --manuscript "$FIX/decimal_person_time.md" 2>&1)"
+has "the whole person-time is used, not its tail" "$OUT" "35,581.3 PY"
+hasnt "and not the fractional digit"              "$OUT" "/ 3 PY"
+
+echo "== a column genuinely called n still resolves =="
+printf '| Stratum | n | Events |\n|---|---|---|\n| A | 10 | 1 |\n| B | 20 | 2 |\n| Total | 40 | 3 |\n' > "$TMP/n.md"
+OUT="$(python3 "$DET" --manuscript "$TMP/n.md" 2>&1)"
+has "an exact one-letter header still matches" "$OUT" "PARTITION_OVERLAP"
+
+echo "== the artifact names its own author =="
+python3 "$DET" --manuscript "$FIX/genuine_defects.md" --out "$TMP/r.json" >/dev/null 2>&1
+has "qc JSON carries the detector key" "$(cat "$TMP/r.json")" '"detector": "check_cohort_arithmetic"'
+
+echo
+printf 'cohort-arithmetic binding challenge: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -52,6 +52,7 @@ known_limitations:
   - "Anticipates likely reviewer comments; cannot predict a specific reviewer's focus."
   - "Advisory; produces recommendations, not manuscript edits."
 validation_commands:
+  - "bash scripts/cohort_arith_binding_challenge/verify.sh"
   - "bash scripts/confounding_findings_challenge/verify.sh"
   - "python3 scripts/check_reviewer_team_consistency.py"
   - "python3 scripts/check_domain_probe_sync.py --strict"


### PR DESCRIPTION
## The arithmetic was never wrong. The inputs were.

`check_cohort_arithmetic` scored **precision 0.00 (0/3)** in the detector-precision harvest — every one of its observed fires on a real cohort manuscript was false, across two `--out` names. Three captures, three ways of latching onto a digit that belongs to something else:

| Real sentence | Should bind | Bound instead |
|---|---|---|
| `882 KSAR S4-1 events occurred` | 882 | **1** — the label's index digit |
| `over 35,581.3 person-years` | 35,581.3 | **3** — the fractional digit |
| `\| Characteristic \| Normal \| …` | (nothing) | the hint **`n`** matched **`Normal`** |

## The fixes

1. **A hyphen or slash before a digit means it belongs to a label.** And when the numerator cannot be bound, the check now says **nothing** — an unbindable count is not evidence of an arithmetic error. Same conservatism as the quote matcher: unresolved is not a defect.
2. **Person-time is read with its decimal.** Without the decimal branch the integer part could not reach the noun, so the fractional tail matched alone; the lookbehind now stops that too.
3. **A hint under three characters is matched exactly, longer ones on a word boundary.** The identical one-character-substring bug was found and fixed once in `check_confounding_completeness` — and never here.

## Why noise was the expensive part

A detector whose every observed fire is false teaches its user to skip the whole class. This class — rate back-calculation, exclusion cascades, tier partitions — is one **nothing else covers**, so the cost of the noise was the coverage.

## Verification, and what it does and does not establish

- **Both rate false positives reproduce verbatim against the pre-fix version** and are silent after it. Checked by running `git show main:` copy of the detector on the real sentences, not by mutating the working file.
- **The 16-case challenge fails 7 assertions against that pre-fix version.**
- **The half that matters**: an impossible rate, a non-disjoint partition, and a wrong rate over *fractional* person-time all still fire, and a column genuinely headed `n` still resolves. A fix that buys silence by going blind is not a fix.
- **Honest limit on the third one**: the partition case is reconstructed *faithfully in shape* (a characteristics table with a total row), but the stored qc artifact predates edits to that manuscript, so it no longer reproduces from today's text. That guard is **hardening, not a reproduced fix** — though the challenge shows it is load-bearing on the reconstruction, and a one-letter substring match is wrong on its face.

## Process note

Three of my own regression attempts silently did nothing — the search strings did not match the file's escaping — and reported the gate as *not* biting. The mutation script now **asserts its target exists** before mutating, and the decisive check runs the challenge against `main`'s actual detector rather than against a hand-mutated copy. A regression that does not apply proves nothing, and looks exactly like a gate that does not work.

No new detector: the count stays **83**. Full CI mirror: **189/189**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)