### PR TITLE
fix(self-review): the AI-disclosure verdict asserted a placement it could not know

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -547,6 +547,9 @@ jobs:
       - name: "Run self-review cohort-arithmetic binding challenge (a label digit is not an event count)"
         run: bash skills/self-review/scripts/cohort_arith_binding_challenge/verify.sh
 
+      - name: "Run self-review AI-disclosure placement challenge (the journals disagree; the target decides)"
+        run: bash skills/self-review/scripts/disclosure_placement_challenge/verify.sh
+
       - name: Run self-review binning-consistency gate test
         run: bash skills/self-review/tests/test_binning_consistency.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 ### Fixed
 
+- **`INBODY_AI_DISCLOSURE` asserted a placement it could not know — and the journals
+  disagree.** The verdict said an in-body AI-use disclosure "belongs on the title page". That
+  is true at some journals and false at others, and the profiles in this repo already said so
+  in their own words: npj Digital Medicine *"document use in Methods section"*, Investigative
+  Radiology *"disclosed in cover letter and Acknowledgments section"*, Diabetes & Metabolism
+  Journal *"must be declared on title page"*, British Journal of Radiology *"AI disclosure in
+  the cover letter is required"*. So it fired identically at a journal that wants the paragraph
+  exactly where it is and at one that forbids it there, telling the author to move something
+  correct.
+
+  Across five real projects it produced eight fires and **not one could be scored** real or
+  spurious, because the answer depended on a target nobody had told the detector — the largest
+  block of unscoreable labels in the precision ledger. A verdict that cannot be scored can
+  never be shown to work.
+
+  The target now decides, read from the journal profile (`--profile`) or given inline
+  (`--disclosure-placement`): a **body-legitimate** target (Methods / Acknowledgments) is
+  **silent**; a **title-page or cover-letter-only** target is **Major** and names where the
+  journal puts it; and with **no target recorded** it drops to **Minor**, naming the ambiguity
+  instead of asserting a placement — so an unknown target no longer fails a `--strict` build.
+  Five profiles gained an explicit `AI-use disclosure placement` line, each sourced from that
+  profile's own existing policy prose and commented with where it came from.
+
+  18-case challenge card wired into CI. `Acknowledgments` is matched as a **stem** — the first
+  implementation used a trailing word boundary and fired on Investigative Radiology, whose
+  placement is written exactly that way.
+
+  No new detector: the count stays **83**.
+
 - **`check_cohort_arithmetic` was binding numbers that belong to something else — every one
   of its observed fires on a real manuscript was false.** The arithmetic was never wrong; the
   inputs were. Three captures, three ways of latching onto the wrong digit:

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -26,6 +26,7 @@
 
 **Validation**
 
+- `bash scripts/disclosure_placement_challenge/verify.sh`
 - `bash scripts/cohort_arith_binding_challenge/verify.sh`
 - `bash scripts/confounding_findings_challenge/verify.sh`
 - `python3 scripts/check_reviewer_team_consistency.py`
@@ -111,6 +112,7 @@
 - `check_table_percentages_challenge/` (6 files)
 - `cohort_arith_binding_challenge/` (4 files)
 - `confounding_findings_challenge/` (4 files)
+- `disclosure_placement_challenge/` (3 files)
 - `refinement_regression.py`
 - `refinement_regression_challenge/` (20 files)
 - `refinement_stop.py`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4423,8 +4423,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",
-      "size": 13165,
-      "sha256": "e26683579615b905a0529e90221bc97e942ff151721a5a9fad63f4338b152837"
+      "size": 16825,
+      "sha256": "0876a5e13b8f6792e7b15553abf1ce22cc4316ebf5007d32e968186326bc2ff6"
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
@@ -4862,6 +4862,21 @@
       "sha256": "8cdee343a6244f5b0e0c517581c0e1fde9e483eafd4aeea75eb43b135a6c4f8b"
     },
     {
+      "path": "skills/self-review/scripts/disclosure_placement_challenge/fixture/about_disclosure.md",
+      "size": 403,
+      "sha256": "12ac993290181e13fc9d25af1714d4c251177a2b13afa3217c59fd7bd437d43e"
+    },
+    {
+      "path": "skills/self-review/scripts/disclosure_placement_challenge/fixture/manuscript.md",
+      "size": 453,
+      "sha256": "645a8b931d802828aaa61dacdda5c9660646f5adcbd125947dccefa5647f0501"
+    },
+    {
+      "path": "skills/self-review/scripts/disclosure_placement_challenge/verify.sh",
+      "size": 5145,
+      "sha256": "1d3c493f67584934e25db2717bf8a69352f8c766daccc39fd39268537f16332b"
+    },
+    {
       "path": "skills/self-review/scripts/refinement_regression.py",
       "size": 8977,
       "sha256": "f59f7029a27eba978a58cdc19ec81970b4119368295982c2810e6ce684ddd304"
@@ -5083,8 +5098,8 @@
     },
     {
       "path": "skills/self-review/skill.yml",
-      "size": 4522,
-      "sha256": "05df4d9adff66350fcd941502be8ca9290e2b9097605833328b907d5679c4f9d"
+      "size": 4582,
+      "sha256": "06ce6497317b1ca6cb06ce348a37c0e962871faea3aa80cc1496426a5638cd4f"
     },
     {
       "path": "skills/setup-medsci/SKILL.md",
@@ -5638,8 +5653,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/British_Journal_of_Radiology.md",
-      "size": 7104,
-      "sha256": "3483e4b948e039e48cd6161d108627197538e2febdfb5555036283d98b62e408"
+      "size": 7333,
+      "sha256": "2e6eca7a4d83d787a6693d04cb25fe5aee5885c1846a46d58939d5f0c6c68df2"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/CVIR.md",
@@ -5663,8 +5678,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md",
-      "size": 6978,
-      "sha256": "7c66d144d23ea8e815fe0cd48860dbde36572256beaf7d29bcf4941088caee84"
+      "size": 7217,
+      "sha256": "4daf7d32d76c1ccbfbb0ca34381d22aa32dca04c2d475755137818d8256de95f"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Diagnostic_and_Interventional_Radiology.md",
@@ -5678,8 +5693,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/European_Journal_of_Preventive_Cardiology.md",
-      "size": 9182,
-      "sha256": "d6abcbb36a88fe807fb4d403504a0394165c343ea533d7f044503e34e0f4aa25"
+      "size": 9387,
+      "sha256": "015a6771a91129c995ed644bef6185305f616806123835066d0f4401f31e1b0f"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/European_Radiology.md",
@@ -5708,8 +5723,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Investigative_Radiology.md",
-      "size": 3487,
-      "sha256": "ea7980f6b6ce8d8f7c4fdae345f037dc8910184ced3e44e31bf77a6e3490a7b2"
+      "size": 3723,
+      "sha256": "f4e95b3b0d6c9024bbab92bf464ef1c0d2caa6123c410cdaf7aee04376952a79"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JACC_Advances.md",
@@ -5878,8 +5893,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/npj_Digital_Medicine.md",
-      "size": 5804,
-      "sha256": "9b046bcc4df7f0a741547383b1f886774b38397ecb51427b76095c443ed69afc"
+      "size": 6000,
+      "sha256": "c896f587a00c04613d23fdc170eefb66378201e7043c71e160ca0c0c9d95e9cf"
     },
     {
       "path": "skills/write-paper/references/paper_types/ai_validation.md",

--- a/skills/self-review/scripts/check_classical_style.py
+++ b/skills/self-review/scripts/check_classical_style.py
@@ -7,10 +7,17 @@ gate rather than a prose checklist (manuscript-style-classical.md §5/§6/§7/§
 
   SECTION_SYMBOL        (Major) the § symbol anywhere in the body — the canonical
                         AI tell; also catches "see Methods §2" self-references.
-  INBODY_AI_DISCLOSURE  (Major) an AI/LLM-use disclosure paragraph in the body
-                        ("Generative AI was not used", "During the preparation of
-                        this manuscript the authors used …"). For a classical /
-                        senior-MA target this belongs on the title page, not the body.
+  INBODY_AI_DISCLOSURE  an AI/LLM-use disclosure paragraph in the body. WHERE IT
+                        BELONGS IS A JOURNAL FACT, and the journals disagree: npj
+                        Digital Medicine says "document use in Methods", Investigative
+                        Radiology says cover letter + Acknowledgments, Diabetes &
+                        Metabolism Journal says title page. So the placement is read
+                        from the target's profile (--profile) or given inline
+                        (--disclosure-placement):
+                          body-legitimate target (methods / acknowledgements) -> silent
+                          title-page / cover-letter-only target -> Major
+                          NO target recorded -> Minor, naming the ambiguity rather
+                          than asserting a placement it cannot know.
   ELIGIBILITY_PROSE     (Minor) eligibility/inclusion criteria written as a prose
                         sentence rather than a numbered list.
   DECIMAL_INCONSISTENCY (Minor) OR/HR/RR reported with mixed decimal places (some
@@ -93,7 +100,29 @@ EFFECT_DECIMAL = re.compile(
 PERCENT_DECIMAL = re.compile(r"\b\d{1,3}\.\d{2,}\s*%")
 
 
-def check(text: str, em_dash_max: int) -> list[dict]:
+# Where an AI-use disclosure belongs is set by the target journal, not by house style. A
+# profile states it in prose already ("document use in Methods section", "declared on title
+# page", "disclosed in cover letter and Acknowledgments"); this reads that line if the profile
+# carries the explicit machine-readable form, and otherwise falls back to the prose.
+DISCLOSURE_PLACEMENT_LINE = re.compile(
+    r"^\s*[-*]?\s*\*{0,2}AI[-\s]use disclosure placement\*{0,2}\s*:\s*(.+)$", re.M | re.I)
+# Tokens meaning "the body is where it goes" — if any appears, an in-body paragraph is correct.
+# "acknowledg" is a STEM — a trailing \b breaks on "Acknowledgments"/"Acknowledgements",
+# which is exactly how the placement is written in the profiles that use it.
+BODY_PLACEMENT = re.compile(r"\b(?:methods?|acknowledg\w*|body|main text)\b", re.I)
+
+
+def disclosure_placement(profile_text: str | None, inline: str | None) -> str | None:
+    """The declared placement string, or None when nothing was recorded."""
+    if inline:
+        return inline
+    if not profile_text:
+        return None
+    m = DISCLOSURE_PLACEMENT_LINE.search(profile_text)
+    return m.group(1).strip() if m else None
+
+
+def check(text: str, em_dash_max: int, placement: str | None = None) -> list[dict]:
     claims = []
 
     # SECTION_SYMBOL (Major) — only § used as a section cross-reference, not the
@@ -116,13 +145,31 @@ def check(text: str, em_dash_max: int) -> list[dict]:
     if m and AI_DISCLOSURE_SUBJECT.search(text[max(0, m.start() - 200):m.end() + 200]):
         m = None
     if m:
-        claims.append({
-            "verdict": "INBODY_AI_DISCLOSURE",
-            "severity": "Major",
-            "detail": "an AI/LLM-use disclosure paragraph is in the body; for a classical / "
-                      "senior-MA target it belongs on the title page (manuscript-style-classical §7)",
-            "where": m.group(0)[:120],
-        })
+        # The target decides. Firing "this belongs on the title page" at a journal that
+        # requires it in Methods tells the author to move a paragraph the journal wants
+        # exactly where it is — and this verdict fired that way across five real projects,
+        # none of which could be scored real or spurious without knowing the target.
+        if placement and BODY_PLACEMENT.search(placement):
+            pass  # the body IS where this journal puts it
+        elif placement:
+            claims.append({
+                "verdict": "INBODY_AI_DISCLOSURE",
+                "severity": "Major",
+                "detail": (f"an AI/LLM-use disclosure paragraph is in the body, but the target "
+                           f"places it in: {placement} (manuscript-style-classical §7)"),
+                "where": m.group(0)[:120],
+            })
+        else:
+            claims.append({
+                "verdict": "INBODY_AI_DISCLOSURE",
+                "severity": "Minor",
+                "detail": ("an AI/LLM-use disclosure paragraph is in the body and no target "
+                           "journal is recorded — journals disagree (npj Digital Medicine asks "
+                           "for Methods, Diabetes & Metabolism Journal for the title page, "
+                           "Investigative Radiology for the cover letter and Acknowledgments), "
+                           "so pass --profile or --disclosure-placement to settle it"),
+                "where": m.group(0)[:120],
+            })
 
     # ELIGIBILITY_PROSE (Minor)
     em = ELIGIBILITY_LEAD.search(text)
@@ -217,15 +264,16 @@ def _count_em_dashes(text: str) -> tuple[int, int]:
     return prose, structural
 
 
-def analyze(manuscript: str, em_dash_max: int) -> dict:
+def analyze(manuscript: str, em_dash_max: int, placement: str | None = None) -> dict:
     p = Path(manuscript)
     if not p.is_file():
         sys.stderr.write(f"ERROR: manuscript not found: {manuscript}\n")
         sys.exit(2)
-    claims = check(p.read_text(encoding="utf-8"), em_dash_max)
+    claims = check(p.read_text(encoding="utf-8"), em_dash_max, placement)
     n_major = sum(1 for c in claims if c["severity"] == "Major")
     return {
         "manuscript": str(p),
+        "disclosure_placement": placement,
         "claims": claims,
         "summary": {
             "n_claims": len(claims),
@@ -249,12 +297,24 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Classical-style body lint (§J).")
     ap.add_argument("--manuscript", required=True, help="manuscript markdown/text")
     ap.add_argument("--em-dash-max", type=int, default=25, help="em-dash threshold (default 25)")
+    ap.add_argument("--profile", help="target journal profile .md (for AI-disclosure placement)")
+    ap.add_argument("--disclosure-placement",
+                    help="where the target puts an AI-use disclosure, e.g. 'Methods' or "
+                         "'title page' — overrides --profile")
     ap.add_argument("--out", help="write JSON artifact to this path")
     ap.add_argument("--strict", action="store_true", help="exit 1 if any Major claim exists")
     ap.add_argument("--quiet", action="store_true", help="suppress stdout table")
     args = ap.parse_args()
 
-    result = analyze(args.manuscript, args.em_dash_max)
+    profile_text = None
+    if args.profile:
+        pp = Path(args.profile)
+        if not pp.is_file():
+            sys.stderr.write(f"ERROR: profile not found: {args.profile}\n")
+            return 2
+        profile_text = pp.read_text(encoding="utf-8", errors="replace")
+    placement = disclosure_placement(profile_text, args.disclosure_placement)
+    result = analyze(args.manuscript, args.em_dash_max, placement)
 
     if not args.quiet:
         print("=" * 41)

--- a/skills/self-review/scripts/disclosure_placement_challenge/fixture/about_disclosure.md
+++ b/skills/self-review/scripts/disclosure_placement_challenge/fixture/about_disclosure.md
@@ -1,0 +1,9 @@
+# How AI-disclosure statements are reported in clinical journals
+
+*A paper whose SUBJECT is disclosure. The phrasing appears as an object of study, not as the
+paper's own disclosure, and must not fire.*
+
+## Results
+
+Of the journals surveyed, 41% required an AI disclosure statement. A representative example
+reads: "During the preparation of this manuscript the authors used ChatGPT to draft sections."

--- a/skills/self-review/scripts/disclosure_placement_challenge/fixture/manuscript.md
+++ b/skills/self-review/scripts/disclosure_placement_challenge/fixture/manuscript.md
@@ -1,0 +1,13 @@
+# Deferred release of automated advice in a reporting workflow
+
+*Synthetic manuscript carrying an in-body AI-use disclosure — correct at some journals,
+wrong at others, which is the whole point.*
+
+## Methods
+
+Patients were enrolled consecutively at a single centre.
+
+## Acknowledgements
+
+During the preparation of this manuscript the authors used Claude to assist with language
+editing. All authors reviewed the output and take responsibility for it.

--- a/skills/self-review/scripts/disclosure_placement_challenge/verify.sh
+++ b/skills/self-review/scripts/disclosure_placement_challenge/verify.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Deterministic verifier for the AI-disclosure PLACEMENT challenge.
+#
+# INBODY_AI_DISCLOSURE used to assert a placement it could not know: "for a classical /
+# senior-MA target this belongs on the title page". That is true for some journals and false
+# for others, and the profiles in this repo already said so, in their own words:
+#
+#   npj Digital Medicine        "document use in Methods section"
+#   Investigative Radiology     "disclosed in cover letter and Acknowledgments section"
+#   Diabetes & Metabolism J.    "must be declared on title page"
+#   British J. of Radiology     "AI disclosure in the cover letter is required"
+#
+# So the verdict fired identically at a journal that wants the paragraph exactly where it is
+# and at one that forbids it there — telling the author to move something correct. Across five
+# real projects this produced eight fires, and NOT ONE of them could be scored real or
+# spurious, because the answer depended on a target nobody had told the detector. A verdict
+# that cannot be scored can never be shown to work.
+#
+# Now the target decides: body-legitimate -> silent, title-page/cover-letter-only -> Major,
+# and NO target recorded -> Minor, naming the ambiguity instead of asserting a placement.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DET="$HERE/../check_classical_style.py"
+FIX="$HERE/fixture"
+PROF="$HERE/../../../write-paper/references/journal_profiles"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ck() { if [ "$2" = "$3" ]; then printf '  PASS  %-58s got=%s\n' "$1" "$3"; pass=$((pass+1));
+       else printf '  FAIL  %-58s want=%s got=%s\n' "$1" "$2" "$3"; fail=$((fail+1)); fi; }
+fires() { python3 "$DET" --manuscript "$FIX/manuscript.md" "$@" 2>&1 | grep -c "INBODY_AI_DISCLOSURE"; }
+sev()  { python3 "$DET" --manuscript "$FIX/manuscript.md" "$@" 2>&1 \
+           | grep "INBODY_AI_DISCLOSURE" | grep -oE "Major|Minor" | head -1; }
+
+echo "== the journals disagree, and each profile is obeyed =="
+ck "npj Digital Medicine (Methods) -> silent"        0 "$(fires --profile "$PROF/npj_Digital_Medicine.md")"
+# the case that exposed a stem bug: "Acknowledgments" is a BODY section, so the body is correct
+ck "Investigative Radiology (cover + Acknowledgments) -> silent" 0 "$(fires --profile "$PROF/Investigative_Radiology.md")"
+ck "EJPC (cover + Methods/Acknowledgements) -> silent" 0 "$(fires --profile "$PROF/European_Journal_of_Preventive_Cardiology.md")"
+ck "Diabetes & Metabolism J. (title page) -> fires"   1 "$(fires --profile "$PROF/Diabetes_Metabolism_Journal.md")"
+ck "British J. of Radiology (cover letter) -> fires"  1 "$(fires --profile "$PROF/British_Journal_of_Radiology.md")"
+
+echo "== severity follows knowledge, not house style =="
+ck "a declared title-page target is Major" "Major" "$(sev --profile "$PROF/Diabetes_Metabolism_Journal.md")"
+ck "no target recorded is only Minor"      "Minor" "$(sev)"
+OUT="$(python3 "$DET" --manuscript "$FIX/manuscript.md" 2>&1)"
+if echo "$OUT" | grep -q "no target journal is recorded"; then ck "and it names the ambiguity" 0 0
+else ck "and it names the ambiguity" 0 1; fi
+if echo "$OUT" | grep -q "belongs on the title page"; then ck "never asserting a placement it cannot know" 0 1
+else ck "never asserting a placement it cannot know" 0 0; fi
+
+echo "== --strict: an unknown target must not fail a build =="
+python3 "$DET" --manuscript "$FIX/manuscript.md" --strict >/dev/null 2>&1
+ck "no target -> exit 0 (Minor)" 0 "$?"
+python3 "$DET" --manuscript "$FIX/manuscript.md" --profile "$PROF/Diabetes_Metabolism_Journal.md" --strict >/dev/null 2>&1
+ck "title-page target -> exit 1 (Major)" 1 "$?"
+python3 "$DET" --manuscript "$FIX/manuscript.md" --profile "$PROF/npj_Digital_Medicine.md" --strict >/dev/null 2>&1
+ck "Methods target -> exit 0 (silent)" 0 "$?"
+
+echo "== the inline override, for a target with no profile on disk =="
+ck "--disclosure-placement 'title page' fires"  1 "$(fires --disclosure-placement 'title page')"
+ck "--disclosure-placement 'Methods' silent"    0 "$(fires --disclosure-placement 'Methods')"
+ck "inline beats the profile"                   1 "$(fires --profile "$PROF/npj_Digital_Medicine.md" --disclosure-placement 'title page')"
+
+echo "== pre-existing behaviour is untouched =="
+N="$(python3 "$DET" --manuscript "$FIX/about_disclosure.md" 2>&1 | grep -c "INBODY_AI_DISCLOSURE")"
+ck "a paper ABOUT disclosure still does not fire" 0 "$N"
+printf '# T\n\nSee Methods §2 for the model.\n' > "$TMP/sec.md"
+S="$(python3 "$DET" --manuscript "$TMP/sec.md" 2>&1 | grep -c "SECTION_SYMBOL")"
+ck "the section-symbol verdict is unaffected" 1 "$S"
+
+echo "== the artifact names its own author =="
+python3 "$DET" --manuscript "$FIX/manuscript.md" --profile "$PROF/npj_Digital_Medicine.md" \
+  --out "$TMP/r.json" >/dev/null 2>&1
+R="$(python3 -c "import json;d=json.load(open('$TMP/r.json'));print(d.get('detector')=='check_classical_style' and d.get('disclosure_placement') is not None)")"
+ck "qc JSON names the detector AND records the placement" "True" "$R"
+
+echo
+printf 'AI-disclosure placement challenge: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/skills/self-review/skill.yml
+++ b/skills/self-review/skill.yml
@@ -52,6 +52,7 @@ known_limitations:
   - "Anticipates likely reviewer comments; cannot predict a specific reviewer's focus."
   - "Advisory; produces recommendations, not manuscript edits."
 validation_commands:
+  - "bash scripts/disclosure_placement_challenge/verify.sh"
   - "bash scripts/cohort_arith_binding_challenge/verify.sh"
   - "bash scripts/confounding_findings_challenge/verify.sh"
   - "python3 scripts/check_reviewer_team_consistency.py"

--- a/skills/write-paper/references/journal_profiles/British_Journal_of_Radiology.md
+++ b/skills/write-paper/references/journal_profiles/British_Journal_of_Radiology.md
@@ -159,3 +159,6 @@ BJR is well-suited for:
 ## Verification
 - **Source:** https://academic.oup.com/bjr/pages/author-guidelines
 - **Date:** 2026-05-21
+
+- **AI-use disclosure placement**: Cover letter
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: the profile's own AI Writing Disclosure Policy: "AI disclosure in the cover letter is required" -->

--- a/skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md
+++ b/skills/write-paper/references/journal_profiles/Diabetes_Metabolism_Journal.md
@@ -161,3 +161,6 @@ DMJ is well-suited for:
 ## Verification
 - **Source:** https://e-dmj.org/authors/authors.php
 - **Date:** 2026-05-21
+
+- **AI-use disclosure placement**: Title page
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: the profile's own rejection note: "must be declared on title page including tool/version/manufacturer/role" -->

--- a/skills/write-paper/references/journal_profiles/European_Journal_of_Preventive_Cardiology.md
+++ b/skills/write-paper/references/journal_profiles/European_Journal_of_Preventive_Cardiology.md
@@ -190,3 +190,6 @@ https://academic.oup.com/eurjpc/pages/general-instructions
 Audit performed 2026-05-20. Sources opened:
 - Homepage: https://academic.oup.com/eurjpc (ISSN, society sponsorship, author-guidelines link)
 - General Instructions: https://academic.oup.com/eurjpc/pages/general-instructions (article types, word limits, abstract structure, references, AI policy verbatim, submission portal)
+
+- **AI-use disclosure placement**: Cover letter + Methods/Acknowledgements
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: the profile's own AI disclosure location row -->

--- a/skills/write-paper/references/journal_profiles/Investigative_Radiology.md
+++ b/skills/write-paper/references/journal_profiles/Investigative_Radiology.md
@@ -84,3 +84,6 @@ Follows ICMJE statistical reporting recommendations:
 - **Figures**: line art minimum 1200 dpi; photographs minimum 300 dpi.
 - Tables must be created in Word (NOT Excel).
 - Running head maximum 45 characters including spaces.
+
+- **AI-use disclosure placement**: Cover letter + Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: the profile's own AI policy: "disclosed in cover letter and Acknowledgments section" -->

--- a/skills/write-paper/references/journal_profiles/npj_Digital_Medicine.md
+++ b/skills/write-paper/references/journal_profiles/npj_Digital_Medicine.md
@@ -120,3 +120,6 @@ submission form. Read by `/sync-submission` `check_portal_mirror.py`.
 - **Preprints** encouraged and do not compromise novelty.
 - **Manuscript transfer service**: rejected papers can transfer to other Nature Portfolio journals with referee reports.
 - **Statistics section mandatory**: must include test name, n, alpha level, one-tailed vs two-tailed, exact P values.
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: the profile's own AI policy line: "document use in Methods section" -->


### PR DESCRIPTION
## The verdict was telling authors to move something correct

`INBODY_AI_DISCLOSURE` said an in-body AI-use disclosure *"belongs on the title page"*. That is true at some journals and false at others — and **the profiles in this repo already said so, in their own words**:

| Profile | Its own policy line |
|---|---|
| npj Digital Medicine | *"document use in **Methods** section"* |
| Investigative Radiology | *"disclosed in **cover letter and Acknowledgments** section"* |
| Diabetes & Metabolism Journal | *"must be declared on **title page**"* |
| British Journal of Radiology | *"AI disclosure in the **cover letter** is required"* |

So it fired identically at a journal that wants the paragraph exactly where it is and at one that forbids it there.

## Why this one was worth fixing before adding anything else

Across five real projects it produced **eight fires, and not one could be scored** real or spurious — the answer depended on a target nobody had told the detector. It was the **largest block of unscoreable labels in the precision ledger**.

A verdict that cannot be scored can never be shown to work. It is not that it was wrong; it is that it was unfalsifiable.

## The target decides now

Read from the journal profile (`--profile`) or given inline (`--disclosure-placement`):

| Target says | Result |
|---|---|
| Methods / Acknowledgments (body-legitimate) | **silent** |
| Title page, or cover letter only | **Major**, naming where the journal puts it |
| nothing recorded | **Minor**, naming the ambiguity — an unknown target no longer fails a `--strict` build |

Five profiles gained an explicit `AI-use disclosure placement` line, each **sourced from that profile's own existing policy prose** and commented with where it came from, so the claim is traceable rather than asserted.

## One bug found by running it against every populated profile

`Acknowledgments` is matched as a **stem**. My first implementation used a trailing word boundary — `\backnowledg\b` — which fails on "Acknowledg**ments**", the exact spelling Investigative Radiology's placement uses. It fired on the one journal I had cited as the reason for the fix. Caught by testing all five profiles rather than the one I had in mind.

## Verification

- **18-case challenge** wired into CI, asserting each of the five profiles behaves per its own stated policy, plus the severity ladder, the `--strict` consequences, the inline override, and that the pre-existing subject-exemption (a paper *about* disclosure) and the `SECTION_SYMBOL` verdict are untouched.
- **Against `main`'s detector the challenge fails 12 of 18** — the two decisive ones being `no target recorded is only Minor: want=Minor got=Major` and `never asserting a placement it cannot know`. (Some of the twelve are argparse rejecting the new flags, which is expected and not evidence on its own.)
- Full CI mirror: **190/190**.

No new detector: the count stays **83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)