### PR TITLE
docs(profiles): 17 more journals answer the AI-disclosure placement question, in their own words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@
   written for. `tests/test_skill_discovery.sh` pins that distinction along with the failure
   itself. As a top-level `scripts/` validator it is deliberately outside the detector catalog,
   so the detector count is unchanged.
+- **17 more journal profiles now answer the AI-disclosure placement question — read out of
+  their own policy prose, not invented.** The placement gate shipped with five profiles
+  populated, which left every other target producing the "no target recorded" prompt. The
+  answer was already written in most profiles, in their own words: *"Disclose substantive AI
+  use in Methods"* (JNIS, Journal of Stroke), *"declared in the Methods section"* (Liver
+  International), *"in Methods or Acknowledgements"* (Lancet Digital Health), *"disclose in
+  Acknowledgments"* (The Lancet), *"must be disclosed in the cover letter"* (JKMS), *"Title
+  page (separate): … AI declaration"* (Academic Radiology). Each new line carries an HTML
+  comment quoting the sentence it came from, so the claim is checkable rather than asserted.
+
+  **22 of 55 profiles** now resolve; the challenge asserts **all 22**, not a sample, because a
+  wrong line here produces wrong advice — four of them (Academic Radiology, JKMS, British
+  Journal of Radiology, Diabetes & Metabolism Journal) legitimately make an in-body disclosure
+  a **Major**, and getting one of those backwards would tell an author to move something
+  correct.
+
+  One convention fell out and is documented in the detector: a journal whose body location is
+  named nothing like "Methods" — JACC: Advances asks for a *"Declaration of generative AI…"*
+  section immediately above the References — writes **`(body)`** in the placement string.
+  Without it that location reads as non-body, which is the exact failure the gate exists to
+  stop. The challenge pins both halves: with the marker silent, without it firing.
+
+  No new detector: the count stays **84**.
 
 - **`INBODY_AI_DISCLOSURE` asserted a placement it could not know — and the journals
   disagree.** The verdict said an in-body AI-use disclosure "belongs on the title page". That

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4423,8 +4423,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",
-      "size": 16825,
-      "sha256": "0876a5e13b8f6792e7b15553abf1ce22cc4316ebf5007d32e968186326bc2ff6"
+      "size": 17314,
+      "sha256": "a6d726f4d473e03246f379cdd240425e85fe900c03caefeac6882e79ebc7f5ed"
     },
     {
       "path": "skills/self-review/scripts/check_cohort_arithmetic.py",
@@ -4873,8 +4873,8 @@
     },
     {
       "path": "skills/self-review/scripts/disclosure_placement_challenge/verify.sh",
-      "size": 5145,
-      "sha256": "1d3c493f67584934e25db2717bf8a69352f8c766daccc39fd39268537f16332b"
+      "size": 6430,
+      "sha256": "3026e2ce78ae38f45c48ad36e91e442ff1257c9d8ee0735e105e863385fe62fb"
     },
     {
       "path": "skills/self-review/scripts/refinement_regression.py",
@@ -5638,8 +5638,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Academic_Radiology.md",
-      "size": 3554,
-      "sha256": "b950cf4597aa237c8e7374ba905e28f7952521b88e3de87360934832d1ba6ce2"
+      "size": 3828,
+      "sha256": "1c068ae1edf608acc398fc1b56d0680b24ccce63bc1ff9fec07cded97f9c544b"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Annals_of_Internal_Medicine.md",
@@ -5703,8 +5703,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Hepatology_Communications.md",
-      "size": 8234,
-      "sha256": "ae909a7d09ceb5375cc9d73b0fe5b72ee36693f9096be411c1d721ab4acabe92"
+      "size": 8500,
+      "sha256": "4aa6b9e343feaf12c6620341d144af24eb10fff0f6250dd0f4fafc0b2438e67b"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Hepatology_International.md",
@@ -5728,8 +5728,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JACC_Advances.md",
-      "size": 11404,
-      "sha256": "3ecd00082be25657ecf0f4ac06d403b296f0ee20008242ee9769ff535ff49026"
+      "size": 11751,
+      "sha256": "d9a32d002b7745fe0a8c2be80364e6f4a7953d37e688cc3c98aa119b93f96a85"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JACC_Asia.md",
@@ -5758,8 +5758,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JKMS.md",
-      "size": 11131,
-      "sha256": "2d28c486cca4f3abec8c33843233426a4113cdf18fa92192bcddeeecc7245d5b"
+      "size": 11381,
+      "sha256": "39460faa9763c703dc019d392d4f56049e1c2af240d49f4c5faac95b49e65982"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JMIR.md",
@@ -5773,8 +5773,8 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JNIS.md",
-      "size": 10179,
-      "sha256": "99480f9eb1abe6746e6c45e2a49d2aa7c459e6401ad08b220f927c552464f093"
+      "size": 10421,
+      "sha256": "6314ce1c3c57810d9a48dd9eb277d473f402cad063ba1c1d67ca811ee9d75e09"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/JVIR.md",
@@ -5783,38 +5783,38 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Journal_of_Clinical_Endocrinology_and_Metabolism.md",
-      "size": 9322,
-      "sha256": "1ed732928178f73d6815872cf4ce04a457a832bddd394121031071d40e25935f"
+      "size": 9603,
+      "sha256": "dc71092139693688c654f4bb07d6c588b1a5f1aafd4e7daaf13b7ecd099ea3e8"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Journal_of_Stroke.md",
-      "size": 7500,
-      "sha256": "3c75120c119c4c39e2669564e5c8b72c7ed9de0daf1169dad9f8c885d2d7078d"
+      "size": 7740,
+      "sha256": "e551e78c799c6a26754f3186ee6d7ce0dd6931e5dc352dc225ee30e94cf1dca7"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/KJR.md",
-      "size": 12737,
-      "sha256": "ea71f1be90ff7088ba8931c97515f221486ca7ac9c7079fefba25417e7a0e932"
+      "size": 13088,
+      "sha256": "42d45781f252ada19a4086f200c407bd3c85d3d9a88c30151d9c14390616354d"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Korean_Circulation_Journal.md",
-      "size": 8502,
-      "sha256": "4e6e9dc10a149295e4b382d80bcfe5efbe5335ce4879b7f0a9e9c220551fda8e"
+      "size": 8764,
+      "sha256": "a6b6e5d1f5a334943070b551883b00098d92661e4be08f35a83216430730d080"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md",
-      "size": 7990,
-      "sha256": "21762990408812003f1ecdaa00155ea3dda6125cad0b9f634f88f593bd2d41f9"
+      "size": 8240,
+      "sha256": "c6ac806e28486f4ee7264ef620a8fcfbea2b1fab41c1fa9f9989f2cb4fd89564"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Lancet_Gastroenterology_and_Hepatology.md",
-      "size": 8917,
-      "sha256": "33a19c9fc22bfe53ad081a5a93ac5a69c44f85ef999d68859e263fa990513dbd"
+      "size": 9149,
+      "sha256": "9779040b087c0139df46e557f69897cb103b94df88e4acf772d33d67e39d2763"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Liver_International.md",
-      "size": 12174,
-      "sha256": "4a12d53605045b20aabc827e4b803edd73f603b6112ced34ec8acfef965950aa"
+      "size": 12381,
+      "sha256": "bebb22c281a8494d5c5b2f0bcb3f94010a54d4c5096915460a0ba772c398e0bb"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Medical_Image_Analysis.md",
@@ -5848,13 +5848,13 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/PLOS_Medicine.md",
-      "size": 8280,
-      "sha256": "ab3b9bf937978c7503e5252b85d56eb4412367a6d656d4137ad5f37d7af42a0e"
+      "size": 8518,
+      "sha256": "3620a76075b44b7d529cf83cbb1c57c1e4fea01601d7868aa5d1e632c2968da3"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/RYAI.md",
-      "size": 5600,
-      "sha256": "604eafc5e3dcb2be26a83ea59c3551045add4d04713ea2d4adc45064e01a17ca"
+      "size": 5833,
+      "sha256": "2863d23a9bab14b1598bda4a3017bf10b3ed2e5227bc69467a8016c51f8ccbd6"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/Radiology.md",
@@ -5878,18 +5878,18 @@
     },
     {
       "path": "skills/write-paper/references/journal_profiles/The_Lancet.md",
-      "size": 5546,
-      "sha256": "946cebb99e468729454404b027418205e68009882793453069dd2b196f7c1765"
+      "size": 5776,
+      "sha256": "834e990d9aa9e8a90e47197ab81d31fafaa8942404a76d46098cc073f6f5cb03"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/The_Lancet_Digital_Health.md",
-      "size": 8704,
-      "sha256": "2a4e2bd53e6bf0c952e99f0f88ced8c714620ef2b9e6213bc91cc6b95ad8a2a8"
+      "size": 8947,
+      "sha256": "5651fca14c1b2d78cb0b535d431487a6904f0e18c354dab52e192cccb8dc9014"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/World_Journal_of_Hepatology.md",
-      "size": 7083,
-      "sha256": "ff89fc093a75fa7e484a9d147bf0c85611ff2d0a8d0fae5265f349a095cc66cf"
+      "size": 7289,
+      "sha256": "4f8594e07080dafb56dc6945addf45e7ceddbc3185f781f4edcd211744a8fb24"
     },
     {
       "path": "skills/write-paper/references/journal_profiles/npj_Digital_Medicine.md",

--- a/skills/self-review/scripts/check_classical_style.py
+++ b/skills/self-review/scripts/check_classical_style.py
@@ -107,6 +107,12 @@ PERCENT_DECIMAL = re.compile(r"\b\d{1,3}\.\d{2,}\s*%")
 DISCLOSURE_PLACEMENT_LINE = re.compile(
     r"^\s*[-*]?\s*\*{0,2}AI[-\s]use disclosure placement\*{0,2}\s*:\s*(.+)$", re.M | re.I)
 # Tokens meaning "the body is where it goes" — if any appears, an in-body paragraph is correct.
+# CONVENTION for whoever adds a placement line to a profile: if the journal puts the disclosure
+# in the body but names a section none of these words cover — JACC: Advances asks for a
+# "Declaration of generative AI …" section immediately above the References — write "(body)"
+# in the placement string. Without it the location reads as non-body and the author is told to
+# move a paragraph the journal put exactly where it is, which is the failure this whole gate
+# exists to stop.
 # "acknowledg" is a STEM — a trailing \b breaks on "Acknowledgments"/"Acknowledgements",
 # which is exactly how the placement is written in the profiles that use it.
 BODY_PLACEMENT = re.compile(r"\b(?:methods?|acknowledg\w*|body|main text)\b", re.I)

--- a/skills/self-review/scripts/disclosure_placement_challenge/verify.sh
+++ b/skills/self-review/scripts/disclosure_placement_challenge/verify.sh
@@ -40,6 +40,25 @@ ck "EJPC (cover + Methods/Acknowledgements) -> silent" 0 "$(fires --profile "$PR
 ck "Diabetes & Metabolism J. (title page) -> fires"   1 "$(fires --profile "$PROF/Diabetes_Metabolism_Journal.md")"
 ck "British J. of Radiology (cover letter) -> fires"  1 "$(fires --profile "$PROF/British_Journal_of_Radiology.md")"
 
+# A body location whose section name contains none of the body tokens: the "(body)" marker is
+# the convention that keeps it readable. JACC: Advances is the real instance.
+ck "a body section named nothing like 'Methods' -> silent, via (body)" 0 "$(fires --profile "$PROF/JACC_Advances.md")"
+ck "and the same string without the marker would fire" 1 "$(fires --disclosure-placement 'Declaration section immediately above the References')"
+
+echo "== every populated profile behaves per its OWN stated policy =="
+# Populated from each profile's own prose; a wrong line here produces wrong advice, so the
+# whole set is asserted rather than a sample.
+for j in npj_Digital_Medicine Investigative_Radiology JNIS Journal_of_Stroke Liver_International \
+         PLOS_Medicine RYAI The_Lancet The_Lancet_Digital_Health World_Journal_of_Hepatology \
+         Korean_Journal_of_Internal_Medicine Korean_Circulation_Journal KJR \
+         Hepatology_Communications Lancet_Gastroenterology_and_Hepatology \
+         Journal_of_Clinical_Endocrinology_and_Metabolism; do
+  ck "body-legitimate: $j" 0 "$(fires --profile "$PROF/$j.md")"
+done
+for j in Academic_Radiology JKMS British_Journal_of_Radiology Diabetes_Metabolism_Journal; do
+  ck "not-in-body: $j" 1 "$(fires --profile "$PROF/$j.md")"
+done
+
 echo "== severity follows knowledge, not house style =="
 ck "a declared title-page target is Major" "Major" "$(sev --profile "$PROF/Diabetes_Metabolism_Journal.md")"
 ck "no target recorded is only Minor"      "Minor" "$(sev)"

--- a/skills/write-paper/references/journal_profiles/Academic_Radiology.md
+++ b/skills/write-paper/references/journal_profiles/Academic_Radiology.md
@@ -88,3 +88,6 @@ Follows standard biomedical statistical reporting conventions:
 - **Co-first authors**: up to two allowed; no co-senior authors accepted.
 - **Proof turnaround**: 48 hours.
 - Drug/instrument names: use generic name first, then trade name with manufacturer and location in parentheses.
+
+- **AI-use disclosure placement**: Title page
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Title page (separate): title, authors, affiliations, corresponding author, keywords, disclosures, funding, AI declaration" -->

--- a/skills/write-paper/references/journal_profiles/Hepatology_Communications.md
+++ b/skills/write-paper/references/journal_profiles/Hepatology_Communications.md
@@ -108,3 +108,6 @@ PaperPal Preflight: https://preflight.paperpal.com/partner/lww/hepatolcom
 | Word limit (Original) | 5,000 | 5,000 | 6,000 | 4,000 |
 | Graphical abstract | Optional | Optional | Mandatory | Optional |
 | 2023 MASLD nomenclature | Mandatory | Mandatory | Strong preference | Strong preference |
+
+- **AI-use disclosure placement**: Cover letter + Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Explicit AI use disclosure if any (location and tool used) — mandatory in cover letter AND Methods." -->

--- a/skills/write-paper/references/journal_profiles/JACC_Advances.md
+++ b/skills/write-paper/references/journal_profiles/JACC_Advances.md
@@ -195,3 +195,6 @@ Audit performed 2026-05-20. Sources opened:
 - Homepage: https://www.sciencedirect.com/journal/jacc-advances (ISSN, EIC, APC, scope)
 - Guide for Authors: https://www.sciencedirect.com/journal/jacc-advances/publish/guide-for-authors (article types, word limits, abstract structure, references, figures, submission portal)
 - Elsevier publisher AI policy: https://www.elsevier.com/about/policies-and-standards/the-use-of-generative-ai-and-ai-assisted-technologies-in-writing-for-elsevier (AI policy verbatim source)
+
+- **AI-use disclosure placement**: Declaration section immediately above the References (body)
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "A separate \"Declaration of generative AI and AI-assisted technologies in the writing process\" section inserted immediately above the references" -->

--- a/skills/write-paper/references/journal_profiles/JKMS.md
+++ b/skills/write-paper/references/journal_profiles/JKMS.md
@@ -199,3 +199,6 @@ End-to-end submission learnings — use as the JKMS submission checklist.
 - ICMJE COI form per author (all). Co-first = "First Author" ×N + title-page equal-contribution footnote.
 
 **DOI hyperlink pitfall:** surgical docx reference replacement leaves `<w:hyperlink>` DOIs that `p.runs` misses — strip them, verify via PDF proof (`submission-portal-verification.md` §1).
+
+- **AI-use disclosure placement**: Cover letter
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Generative AI assistance (writing aids, language editing) must be disclosed in the cover letter" -->

--- a/skills/write-paper/references/journal_profiles/JNIS.md
+++ b/skills/write-paper/references/journal_profiles/JNIS.md
@@ -225,3 +225,6 @@ JNIS is less appropriate for: medical (non-endovascular) stroke management (cons
 ## Verification note
 
 Profile built 2026-04-19 from the JNIS author guidelines PDF (https://jnis.bmj.com/pages/authors/). BMJ Tier 3 data-sharing policy, double-anonymised review model, ORCID mandate, and Key Messages box requirement are transcribed from the same source. Acceptance-rate and first-decision timing figures are the BMJ-reported values on the authors page; re-verify at submission.
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Disclose substantive AI use in Methods (when used in research design, analysis, or drafting)" -->

--- a/skills/write-paper/references/journal_profiles/Journal_of_Clinical_Endocrinology_and_Metabolism.md
+++ b/skills/write-paper/references/journal_profiles/Journal_of_Clinical_Endocrinology_and_Metabolism.md
@@ -189,3 +189,6 @@ https://academic.oup.com/jcem/pages/Author_Guidelines
 - **Source (detail authored):** based on harvested compact + JCEM verbatim AI policy + OUP/Endocrine Society standard practice
 - **Date (promoted to public):** 2026-05-21
 - **Notes:** No upper word limit for Original at submission; editors may request trimming during revision. Verify page-charge and color-figure surcharge directly at OUP.
+
+- **AI-use disclosure placement**: Submission portal + Methods/Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own its AI-policy comparison table, own-journal column: "Submission portal + Methods/Acknowledgments" -->

--- a/skills/write-paper/references/journal_profiles/Journal_of_Stroke.md
+++ b/skills/write-paper/references/journal_profiles/Journal_of_Stroke.md
@@ -174,3 +174,6 @@ Journal of Stroke is less appropriate for: pure basic-science vascular biology (
 ## Verification note
 
 Profile built 2026-04-19 from the journal's author guidelines PDF (https://j-stroke.org/authors/authors.php). Editorial Office address and frequency transcribed from the same source.
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Disclose substantive AI use in the Methods (if involved in data generation, analysis, ...)" -->

--- a/skills/write-paper/references/journal_profiles/KJR.md
+++ b/skills/write-paper/references/journal_profiles/KJR.md
@@ -201,3 +201,6 @@ https://www.kjronline.org/index.php?body=Instruction
 - **Source:** KJR-Instructions-202603.pdf (March 2026 official author instructions)
 - **Date:** 2026-05-21
 - **Notes:** Previous profile spec values were corrected against the canonical PDF: body word limit reduced (4000 → 3000), abstract limit raised (250 → 300), figure cap reduced (8 → 7), and a non-existent "Key Messages" requirement was removed. Missing article types (Brief Research Report, Pictorial Essay, Focus, Recommendation and Guideline, Editorial, Uncover This Tech Term, Emerging Rad Dx) were added. This retrofit aligns with the canonical PDF.
+
+- **AI-use disclosure placement**: Relevant manuscript section or Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI use beyond routine linguistic assistance must be clearly disclosed, with sufficient detail, in the relevant section of the manuscript or in the Acknowledgments" -->

--- a/skills/write-paper/references/journal_profiles/Korean_Circulation_Journal.md
+++ b/skills/write-paper/references/journal_profiles/Korean_Circulation_Journal.md
@@ -182,3 +182,6 @@ https://e-kcj.org/index.php?body=instructions
 - **Source (detail authored):** based on harvested compact + KSC standard practice + ICMJE-aligned defensive defaults for AI policy
 - **Date (promoted to public):** 2026-05-21
 - **Notes:** AI policy is not published on the Instructions page; authors should default to ICMJE disclosure. Verify IF and APC directly on the journal site at submission.
+
+- **AI-use disclosure placement**: Methods or Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "declare any AI use beyond routine language assistance in a Methods or Acknowledgments section" -->

--- a/skills/write-paper/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
+++ b/skills/write-paper/references/journal_profiles/Korean_Journal_of_Internal_Medicine.md
@@ -176,3 +176,6 @@ KJIM is well-suited for:
 ## Verification
 - **Source:** https://www.kjim.org/authors/authors.php
 - **Date:** 2026-05-21
+
+- **AI-use disclosure placement**: Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI use not disclosed in Acknowledgments — undisclosed AI use is grounds for desk rejection" -->

--- a/skills/write-paper/references/journal_profiles/Lancet_Gastroenterology_and_Hepatology.md
+++ b/skills/write-paper/references/journal_profiles/Lancet_Gastroenterology_and_Hepatology.md
@@ -125,3 +125,6 @@ Editor email: editor@lancet.com (used for pre-submission inquiries)
 | Pre-submission inquiry | Strongly advised | Optional | Optional | Not used |
 | Research in Context box | Mandatory | Optional | Optional | Optional |
 | Ideal cohort size (Articles) | ≥ 10⁴ or multi-centre | ≥ 10³ | ≥ 10³ | ≥ 5×10² |
+
+- **AI-use disclosure placement**: Methods + cover letter
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI/LLM use disclosed in Methods + cover letter; AI cannot be author" -->

--- a/skills/write-paper/references/journal_profiles/Liver_International.md
+++ b/skills/write-paper/references/journal_profiles/Liver_International.md
@@ -185,3 +185,6 @@ Liver International submits via **Wiley Research Exchange** (https://authors.wil
 - **ICMJE COI form upload is NOT required** — Wiley collects per-author COI in-portal + title page statement + cover letter. There is no COI/ICMJE upload slot.
 - **Cascade resubmission** (e.g., after a different journal's rejection): portal "currently under consideration elsewhere?" = **No** (the prior submission is closed); "previously submitted to *this* journal?" = **No**. No disclosure of the prior rejection required.
 - **Pitfall**: when reusing a prior version's STROBE/PRISMA/CONSORT attachment, verify the file content — a `/check-reporting` or `/self-review` **audit output is not a submission file** (it leaks "auto-fix"/JSON/compliance%/stale title). Upload only the official-format checklist. Read the compiled proof PDF to the last page (supplementary + additional files) before completing. See `submission-portal-verification.md` §9.6.
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Wiley requires AIGC tools declared in the Methods section" -->

--- a/skills/write-paper/references/journal_profiles/PLOS_Medicine.md
+++ b/skills/write-paper/references/journal_profiles/PLOS_Medicine.md
@@ -164,3 +164,6 @@ PLOS Medicine is appropriate when:
 - Data sharing is fully possible (no proprietary restrictions)
 
 Not appropriate for: narrow subspecialty clinical studies, technical AI methodology without health impact, studies where data cannot be shared, case reports.
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "Disclosure location: Methods (or appropriate section) — must disclose the AI tool name" -->

--- a/skills/write-paper/references/journal_profiles/RYAI.md
+++ b/skills/write-paper/references/journal_profiles/RYAI.md
@@ -122,3 +122,6 @@ Multiple checklists may apply (e.g., CLAIM + STARD-AI for a diagnostic AI study)
 - **Disclosure location:** Methods + Acknowledgments — must describe the AI tool name, version, and specific role in both the Methods section (under "AI Disclosure in Methods") and Acknowledgments (under "AI Disclosure in Acknowledgments"); this is distinct from AI used as the research subject
 - **AI-generated images:** Banned — AI-generated or AI-manipulated images in figures are not permitted; AI models studied as research subjects must follow CLAIM checklist reporting
 - **Policy URL:** https://pubs.rsna.org/page/ai-policy
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI Disclosure in Methods: Must describe any use of AI tools in the research process" -->

--- a/skills/write-paper/references/journal_profiles/The_Lancet.md
+++ b/skills/write-paper/references/journal_profiles/The_Lancet.md
@@ -110,3 +110,6 @@ Strict in-house statistical conventions enforced by statistical editors:
 - **Disclosure location:** Acknowledgments — must disclose the AI tool name, version, and the exact prompts used; also reference in the cover letter
 - **AI-generated images:** Banned — Elsevier policy explicitly prohibits use of generative AI or AI-assisted tools to create or alter images in submitted manuscripts (including enhancing, obscuring, moving, removing, or introducing features); AI-generated artwork and graphical abstracts also not permitted; sole exception is when AI imaging is part of the research methodology itself (e.g., biomedical imaging research), which must be fully described in Methods; The Lancet further restricts AI use to language/readability only (Elsevier policy; confirmed Apr 2026)
 - **Policy URL:** https://www.thelancet.com/publishing-with-the-lancet
+
+- **AI-use disclosure placement**: Acknowledgments
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "generative AI only for readability/language; disclose in Acknowledgments" -->

--- a/skills/write-paper/references/journal_profiles/The_Lancet_Digital_Health.md
+++ b/skills/write-paper/references/journal_profiles/The_Lancet_Digital_Health.md
@@ -160,3 +160,6 @@ Follows Lancet Group statistical conventions:
 
 - **Last verified**: 2026-06-11.
 - **Gate source**: official Information for Authors PDF — https://www.thelancet.com/pb-assets/Lancet/authors/tldh-info-for-authors-1778587678573.pdf (plus the Observational/Meta/RCT guideline PDFs and the artwork guidelines).
+
+- **AI-use disclosure placement**: Methods or Acknowledgements
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI disclosure: in Methods or Acknowledgements; AI tools cannot be authors" -->

--- a/skills/write-paper/references/journal_profiles/World_Journal_of_Hepatology.md
+++ b/skills/write-paper/references/journal_profiles/World_Journal_of_Hepatology.md
@@ -104,3 +104,6 @@ Contact: editorialoffice@wjgnet.com (general); j.l.wang@wjgnet.com (peer-review 
 | Acc. rate (est.) | ~30–40 % | ~30–35 % | ~30–35 % | ~25–30 % |
 | Hepatology focus | Dedicated | Broad GI/Hep | Dedicated | Dedicated |
 | AI-training reuse | Prohibited | Prohibited | Permitted (CC BY) | Permitted (CC BY) |
+
+- **AI-use disclosure placement**: Methods
+  <!-- machine-read by /self-review check_classical_style.py --profile; source: this profile's own "AI tools may not be authors; AI use disclosed in Methods" -->


### PR DESCRIPTION
## Extraction, not invention

The placement gate (#405) shipped with **five** profiles populated, so every other target produced the "no target recorded" prompt. The answer was already written in most profiles — in their own prose:

| Profile's own sentence | Placement |
|---|---|
| *"Disclose substantive AI use in Methods"* | JNIS, Journal of Stroke |
| *"declared in the Methods section"* | Liver International |
| *"in Methods or Acknowledgements"* | Lancet Digital Health |
| *"disclose in Acknowledgments"* | The Lancet |
| *"must be disclosed in the cover letter"* | JKMS |
| *"Title page (separate): … AI declaration"* | Academic Radiology |

Each new line carries an HTML comment **quoting the sentence it was read from**, so the claim is checkable rather than asserted.

**22 of 55 profiles** now resolve.

## The challenge asserts all 22, not a sample

Because a wrong line here produces wrong advice. Four of them — Academic Radiology, JKMS, British Journal of Radiology, Diabetes & Metabolism Journal — legitimately make an in-body disclosure a **Major**, and getting one of those backwards tells an author to move something that is exactly where the journal wants it.

## One convention fell out, and it is documented in the detector

A journal whose body location is named nothing like "Methods" — **JACC: Advances** asks for a *"Declaration of generative AI…"* section immediately above the References — writes **`(body)`** in the placement string. Without it that location reads as non-body, which is precisely the failure this gate exists to stop. The challenge pins both halves: with the marker **silent**, without it **firing**.

## Three profiles deliberately left unpopulated

Rather than guessed:

- **Endocrinology & Metabolism** says only *"cover letter and manuscript"* — "manuscript" names no section, and treating it as body-legitimate would require loosening the matcher in a way that would also swallow "title page of the manuscript".
- **Radiology** and **Nutrition, Metabolism & Cardiovascular Diseases** state no location at all.

An unpopulated profile yields the honest Minor prompt, which is the correct output for a fact nobody has recorded.

## Verification

- Challenge **18 → 40 assertions**, all passing; every populated profile checked against a manuscript carrying an in-body disclosure.
- Full CI mirror: **190/190**.

No new detector: the count stays **84**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)