### PR TITLE
docs(readme): gh skill install paths + discovery guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ cp -r medsci-skills/skills/* ~/.claude/skills/
 
 Restart Claude Code, then start with **`/orchestrate`** — it classifies your request and routes you to the right skill. Full install options (Codex, Cursor, individual skills) are in [Installation](#installation).
 
+### Install with `gh skill`
+
+MedSci Skills follows the [Agent Skills standard](https://agentskills.io), so GitHub CLI ≥ 2.90 can search, preview, and install any skill straight from this repo — no clone (a `gh` preview feature):
+
+```bash
+gh skill search medsci                                   # list the whole collection
+gh skill preview Aperivue/medsci-skills check-reporting  # read a skill before installing
+gh skill install Aperivue/medsci-skills check-reporting  # install just that one
+gh skill install --all Aperivue/medsci-skills            # or install every skill
+```
+
+Search by a skill's own name (`check-reporting`, `verify-refs`, `meta-analysis`) or by `medsci` to list them all — both return this repo directly. A broad topic word like `systematic review` is shared by hundreds of skills across GitHub, so add `--owner Aperivue` to see only ours.
+
 ### Install as a Claude Code plugin
 
 Prefer plugins? One line adds the marketplace; `/plugin` then lets you browse nine category plugins and enable the ones you want:
@@ -603,6 +616,19 @@ npx medsci-skills doctor             # quick Node/Python/skill-folder check
 ```
 
 Requires Node 18+ and (for `install`/`doctor`) `python3` on your PATH.
+
+### Option 5: GitHub CLI (`gh skill`)
+
+If you use [GitHub CLI](https://cli.github.com/) ≥ 2.90, `gh skill` installs skills from any Agent-Skills repo — this one included — without cloning. It is a `gh` **preview** feature, so the exact flags may change.
+
+```bash
+gh skill search medsci                                   # list every MedSci skill
+gh skill preview Aperivue/medsci-skills check-reporting  # inspect one first
+gh skill install Aperivue/medsci-skills check-reporting  # install a single skill
+gh skill install --all Aperivue/medsci-skills            # or install all of them
+```
+
+`gh skill install` places skills in the host-specific folder for the agent you pick with `--agent` (`claude-code` → `~/.claude/skills/`, `codex` → `~/.agents/skills/`, and many others), at user or project `--scope` — the same folders the npx and git paths above populate. Discovery works best by a skill's exact name or by `medsci`; for a broad topic word, scope with `--owner Aperivue`.
 
 ### Platform notes
 


### PR DESCRIPTION
Adds `gh skill` install paths to the README, and folds in a measured discovery finding.

## `gh skill` install paths (part 1)

`gh skill` (GitHub CLI ≥ 2.90, a `gh` **preview** feature) resolves this repository’s canonical top-level `skills/` layout with no restructuring — verified: `gh skill preview Aperivue/medsci-skills check-reporting` works today. Documented in **Quick Start** and as **Installation Option 5**, with host-specific placement chosen by `--agent` (`claude-code` → `~/.claude/skills/`, `codex` → `~/.agents/skills/`, …) and the `--all` bulk path.

## Discovery guidance (part 2)

Investigated why our skills seemed to rank poorly. The measured picture:

| query | result |
|---|---|
| `gh skill search check-reporting` (unique name) | **we are #1** |
| `gh skill search medsci` | returns **all** our skills |
| `gh skill search meta-analysis --owner Aperivue` | our `meta-analysis` **#1** |
| `gh skill search meta-analysis` (unscoped, default limit) | ours **below the fetched page** |
| `gh skill search meta-analysis --limit 80` | ours floats to **#2** |

So it is **not** an indexing gap and **not** a bloat problem needing a 58-file rewrite. `gh skill search` uses the GitHub Code Search API and applies a name-first re-rank **to the results it fetched**; for a crowded generic term (a word shared by hundreds of skills across GitHub) our file sits below the default page depth, so the re-rank never reaches it. Stars don’t buy it either — star-0 repos rank above us on generic terms.

The README now routes users to the discovery paths that work: **a skill’s exact name, `medsci`, or `--owner Aperivue`** — rather than a broad topic word. That is the practical remedy; closing the generic-term gap would require reducing SKILL.md size for term density (a separate, unproven, large effort) and is deliberately **not** done here.

## Verification

- `gh skill preview` / `search` behavior confirmed against the live repo (gh 2.96.0)
- `scripts/run_ci_mirror.py` — **192/192**
- README-only; no CHANGELOG entry (not a user-facing release note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)