### PR TITLE
feat(architecture-zoo): the 2024-2026 segmentation wave — scale the CNN, and interactive-3D labelling

### DIFF
--- a/docs/skills/architecture-zoo.md
+++ b/docs/skills/architecture-zoo.md
@@ -2,13 +2,13 @@
 
 # architecture-zoo
 
-> Choose a model architecture for a medical-imaging research question before scaffolding. Maps the task (classification, segmentation, detection, transfer), modality and dimensionality, labelled-data scale, and class imbalance to a shortlist of architectures, each grounded in its source paper with a when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet, ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net, Mask R-CNN; SAM/MedSAM, TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN — for brain connectomes). It teaches archetypes and the task-to-architecture logic, not a live SOTA leaderboard.
+> Choose a model architecture for a medical-imaging research question before scaffolding. Maps the task (classification, segmentation, detection, transfer), modality and dimensionality, labelled-data scale, and class imbalance to a shortlist of architectures, each grounded in its source paper with a when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet, ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net (+ ResEnc/MedNeXt/STU-Net), Mask R-CNN; SAM/MedSAM, nnInteractive/VISTA3D interactive-3D, TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN — for brain connectomes). It teaches archetypes and the task-to-architecture logic (including the "scale the CNN, new≠better" rigour caveat), not a live SOTA leaderboard.
 
 **Invoke:** `/architecture-zoo` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
 
 ## When to use
 
-`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone.
+`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation.
 
 ## Quality Card
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -468,8 +468,8 @@
     },
     {
       "path": "skills/architecture-zoo/SKILL.md",
-      "size": 6094,
-      "sha256": "abb4656f36e0ef068508269ce2ec87c832b7c8fb13c4cbc44af27b2dc8058bff"
+      "size": 6381,
+      "sha256": "1f8aa8ac4cd81153d9fcbd338b1176ebb5376d305341ccea76846ca627063d60"
     },
     {
       "path": "skills/architecture-zoo/references/classification.md",
@@ -483,8 +483,8 @@
     },
     {
       "path": "skills/architecture-zoo/references/foundation_models.md",
-      "size": 5267,
-      "sha256": "495453b025f1cb13d5ba0bac9be6d3b0d63dd958ea48d2b9e55bc222e9c26786"
+      "size": 7382,
+      "sha256": "63024c2959cb21178825e654e0505469e2e039ee69f62621fca8c5f8d4a88d5d"
     },
     {
       "path": "skills/architecture-zoo/references/graph.md",
@@ -493,13 +493,13 @@
     },
     {
       "path": "skills/architecture-zoo/references/index.md",
-      "size": 4334,
-      "sha256": "f812ec9afe2ba06c42da8de851cea08632d61eb98e87cd3edd7cdd17f39e226e"
+      "size": 4943,
+      "sha256": "59615e3a75d6f167e86d1b7609373baa4c1aca54820a936bbe605d231852dd8c"
     },
     {
       "path": "skills/architecture-zoo/references/segmentation.md",
-      "size": 6508,
-      "sha256": "17618fe3d6884cf89b034ededcd69e081a65d7bfd473495eb2ab1fb5d8b15d8b"
+      "size": 10352,
+      "sha256": "33b22ddb466f22b0e0af0bbaec8f361f2b0264766f429ead364b259e44dc5c3a"
     },
     {
       "path": "skills/architecture-zoo/references/synthesis.md",

--- a/skills/architecture-zoo/SKILL.md
+++ b/skills/architecture-zoo/SKILL.md
@@ -6,11 +6,12 @@ description: >
   and class imbalance to a shortlist of architectures, each grounded in its source paper with a
   when-to-use, a medical-imaging use, a reference implementation, the typical validation setup, and the
   matching model-scaffold template. Covers the foundational curriculum (ResNet, DenseNet, EfficientNet,
-  ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net, Mask R-CNN; SAM/MedSAM,
-  TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN —
-  for brain connectomes). It teaches archetypes and the task-to-architecture logic, not a live SOTA
-  leaderboard.
-triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone
+  ViT, Swin; U-Net, 3-D U-Net, Attention/Residual U-Net, nnU-Net (+ ResEnc/MedNeXt/STU-Net), Mask R-CNN;
+  SAM/MedSAM, nnInteractive/VISTA3D interactive-3D, TotalSegmentator, BiomedCLIP, DINO/MAE/SimCLR; and
+  graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN — for brain connectomes). It teaches archetypes and
+  the task-to-architecture logic (including the "scale the CNN, new≠better" rigour caveat), not a live
+  SOTA leaderboard.
+triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
 ---

--- a/skills/architecture-zoo/references/foundation_models.md
+++ b/skills/architecture-zoo/references/foundation_models.md
@@ -55,6 +55,30 @@ validation/experiment setup.**
 - **Validation setup**: report performance **by prompt type** and whether prompts were
   human or automated; for a fully-automatic claim, no oracle prompts at test time.
 
+### Interactive 3-D promptable segmentation — nnInteractive / VISTA3D / SAM-Med3D (labelling acceleration)
+- **Papers/tools**: nnInteractive (Isensee et al., DKFZ, 2025); VISTA3D (NVIDIA / Project-MONAI,
+  2024–25); SAM-Med3D (Wang et al., 2023); MedSAM2 / SAM2 (Meta SAM2, 2024) for 3-D + video.
+- **Core idea**: **native-3-D** promptable models — a click / scribble / box / lasso on a few
+  slices yields the whole volumetric mask — trained on many 3-D datasets, so they generalise
+  across organs and modalities without task-specific training. (2-D SAM/MedSAM applied
+  slice-by-slice loses through-plane coherence; these are built for the volume.)
+- **When to use**: the **labelling-throughput lever**. When expert 3-D labels are the
+  bottleneck (e.g. neuro-faculty ground truth), an interactive model turns from-scratch
+  hand-segmentation into a **prompt-and-correct** pass — often several-fold faster per case.
+  Also a strong zero-training 3-D baseline, or an interactive tool in the reading loop.
+- **Medical-imaging use**: expert-in-the-loop CT/MR volume labelling; semi-automatic organ /
+  lesion / vessel masks that seed the training set a dedicated nnU-Net then learns.
+- **Reference impl**: `MIC-DKFZ/nnInteractive` (fast; point/scribble/box/lasso),
+  `Project-MONAI/VISTA` (VISTA3D), `uni-medical/SAM-Med3D`. **Licence — check before
+  commercial use**: nnInteractive **code is Apache-2.0 but its released weights are
+  CC BY-NC-SA 4.0 (non-commercial)**; confirm the VISTA3D and SAM-Med3D *weight* licences too
+  (bundled model licences often differ from the code repo). This matters when the labels feed
+  a product, not only a paper.
+- **Validation setup**: masks produced this way are **silver labels** — an expert must
+  correct/adjudicate them, and model-derived labels must not evaluate the same or a related
+  model (circularity — `/model-validation` MD8). Report the **human-correction effort**
+  (edits or time per case), not only the final Dice.
+
 ### TotalSegmentator / SegVol (automatic CT organ masks)
 - **Papers**: Wasserthal et al., TotalSegmentator, *Radiology: AI* 2023; SegVol (2024).
 - **Core idea**: released models that segment 100+ anatomical structures from CT
@@ -81,7 +105,9 @@ validation/experiment setup.**
 ## Choosing among these
 Many unlabelled scans + few labels → **SSL pretrain (DINO/MAE/SimCLR) → fine-tune**, and
 report the label-efficiency curve. Need masks now, no budget → **TotalSegmentator (CT) /
-MedSAM2 (interactive)**. Zero-shot classification/retrieval → **BiomedCLIP**. In every case
+MedSAM2 (interactive)**. Accelerate expert 3-D labelling → **interactive FM (nnInteractive /
+VISTA3D)** — mind the non-commercial weight licence. Zero-shot classification/retrieval →
+**BiomedCLIP**. In every case
 keep the pretraining/transfer corpus disjoint from the test patients and disclose
 model-derived labels. Record the choice + paper, then hand the fine-tuning to
 `/model-scaffold` and validate with `/model-validation`.

--- a/skills/architecture-zoo/references/index.md
+++ b/skills/architecture-zoo/references/index.md
@@ -43,9 +43,11 @@ per-paper detail and the `/model-scaffold` template to instantiate.
 |---|---|---|
 | 2-D multi-label CXR classification | **ResNet-50 / EfficientNet (pretrained, `timm`)** | strong, cheap, well-calibrated baselines |
 | 3-D organ / lesion segmentation | **nnU-Net (v2)** | self-configuring; the standard to beat |
+| 3-D segmentation, tensor-core GPU, max accuracy | **nnU-Net ResEnc (M/L/XL)** | the 2024 "Revisited" frontier; still self-configuring (`segmentation.md`) |
 | 2-D segmentation, custom pipeline | **U-Net / Attention U-Net (MONAI)** | transparent, controllable |
 | few labels, many unlabelled scans | **SSL pretrain (DINO/MAE) → fine-tune**, or **MedSAM/TotalSegmentator transfer** | label-efficient |
 | zero-/few-shot organ masks on CT | **TotalSegmentator / MedSAM2** | released weights, no training |
+| accelerate expert 3-D labelling | **interactive FM (nnInteractive / VISTA3D)** | prompt-and-correct, not from-scratch; check the weight licence (`foundation_models.md`) |
 
 ## Step 4 — write the decision note
 Record the choice as a short note (`decisions/architecture_choice.md`): the **task**, the
@@ -56,4 +58,7 @@ quote a benchmark number you have not cited. Then hand the choice to `/model-sca
 
 > The zoo describes **archetypes**, not a live leaderboard. SOTA churns; the task →
 > family → constraint logic does not. When a newer model claims to beat these, evaluate
-> it with `/model-validation` rather than adopting it on the strength of a headline.
+> it with `/model-validation` rather than adopting it on the strength of a headline. The
+> canonical warning is *nnU-Net Revisited* (Isensee et al., *MICCAI* 2024): under matched
+> compute, Transformer- and Mamba-based segmentors did **not** beat a scaled CNN nnU-Net,
+> and U-Mamba's Mamba layers ablated to zero contribution — the "advance" was a bigger CNN.

--- a/skills/architecture-zoo/references/segmentation.md
+++ b/skills/architecture-zoo/references/segmentation.md
@@ -79,6 +79,59 @@ a 3-D model; do not collapse to independent slices if the structure is volumetri
 
 ---
 
+## The 2024–2026 wave — scale the CNN (and the rigour caveat)
+
+**Read this before adopting any "beats nnU-Net" architecture.** Isensee et al., "nnU-Net
+Revisited: A Call for Rigorous Validation in 3D Medical Image Segmentation" (*MICCAI* 2024,
+arXiv 2404.09556) re-ran the field under matched compute and pipeline and found the **CNN
+U-Net still wins**: Transformer- and Mamba-based nets did not beat a properly scaled nnU-Net,
+and most headline gains came from confounded comparisons. An ablation showed **U-Mamba's
+Mamba layers contribute nothing** — its gain was the residual U-Net it was bolted onto. So
+"newer" here means *a bigger CNN*, not a new paradigm. Adopt a Transformer/Mamba seg model
+only after `/model-validation` reproduces its claim **on your data**, never on its headline.
+
+### nnU-Net ResEnc presets (M / L / XL) — the current strong default
+- **Paper**: Isensee et al., nnU-Net Revisited, *MICCAI* 2024 (the ResEnc presets ship in
+  nnU-Net v2).
+- **Core idea**: nnU-Net with a **residual encoder** and preset compute budgets (M/L/XL) that
+  scale the network to modern GPUs — the accuracy frontier for 3-D segmentation as of 2026,
+  still self-configuring.
+- **When to use**: the **default to beat** when you have a tensor-core GPU and want maximum
+  accuracy; pick the preset by VRAM (M ≈ mid-range, L/XL for larger cards). Plain nnU-Net
+  stays the choice on limited compute (a Pascal-class GPU without tensor cores gains little).
+- **Reference impl**: `nnunetv2` (`-p nnUNetResEncUNetMPlans` / `L` / `XL`), MIC-DKFZ,
+  Apache-2.0. Integrate, do not reimplement.
+- **Validation setup**: identical to nnU-Net (its CV is development-time, not external);
+  **disclose the preset used** — a reduced preset chosen for compute reasons is a stated
+  deviation (`/model-evaluation`).
+
+### MedNeXt — a ConvNeXt-scaled CNN
+- **Paper**: Roy et al., "MedNeXt: Transformer-driven Scaling of ConvNets for Medical Image
+  Segmentation," *MICCAI* 2023.
+- **Core idea**: a fully ConvNeXt-style 3-D encoder–decoder with a scalable block design;
+  often tops the "revisited" benchmarks, at a higher training cost.
+- **When to use**: you want a modern CNN backbone that scales and can afford the extra
+  training time; a strong nnU-Net-adjacent option on BTCV/ACDC/AMOS-type tasks.
+- **Reference impl**: `MIC-DKFZ/MedNeXt` (Apache-2.0, code + weights — commercial OK).
+- **Validation setup**: as nnU-Net; report **training cost alongside accuracy** (its edge is
+  not free).
+
+### STU-Net — scalable + transferable (pretrained on TotalSegmentator)
+- **Paper**: Huang et al., "STU-Net: Scalable and Transferable Medical Image Segmentation
+  Models," 2023.
+- **Core idea**: a U-Net scaled from small to **1.4 B parameters, pretrained on the
+  TotalSegmentator corpus** (104 structures) — a transfer-learning starting point, not only a
+  from-scratch trainer.
+- **When to use**: you want a **pretrained** 3-D seg backbone to fine-tune on a small labelled
+  set (transfer), or a scalable baseline; pairs with `/model-scaffold` fine-tuning mode.
+- **Reference impl**: `uni-medical/STU-Net` (Apache-2.0, code + weights S/B/L/H — commercial
+  OK).
+- **Validation setup**: keep the fine-tuning set disjoint from the test patients; if the
+  pretraining corpus (TotalSegmentator) overlaps your task's public data, state it
+  (contamination — `/model-validation` MD1).
+
+---
+
 ## Instance / detection bridge
 
 ### Mask R-CNN (instance segmentation + detection)
@@ -98,13 +151,18 @@ a 3-D model; do not collapse to independent slices if the structure is volumetri
 ---
 
 ## Promptable / foundation segmentation
-SAM / MedSAM / MedSAM2 / SegVol / TotalSegmentator (released weights, little or no training)
+SAM / MedSAM / MedSAM2 / SegVol / TotalSegmentator and the **native-3-D interactive** models
+(nnInteractive / VISTA3D / SAM-Med3D — prompt-and-correct to accelerate expert labelling)
 live in `foundation_models.md`. For organ masks on CT with no training budget, start there
-(TotalSegmentator / MedSAM2) before building a U-Net.
+(TotalSegmentator / MedSAM2); when expert 3-D labels are the bottleneck, an interactive model
+turns hand-segmentation into a correction pass before you train a dedicated U-Net.
 
 ## Choosing among these
-2-D, custom, transparent → **U-Net / Attention U-Net (MONAI)**. 3-D, default → **nnU-Net**.
-Few labels / no training budget → **TotalSegmentator / MedSAM2** (`foundation_models.md`).
+2-D, custom, transparent → **U-Net / Attention U-Net (MONAI)**. 3-D, default → **nnU-Net**
+(→ **nnU-Net ResEnc M/L/XL** for maximum accuracy on a tensor-core GPU). Few labels / no
+training budget → **TotalSegmentator / MedSAM2** (`foundation_models.md`); pretrained backbone
+to fine-tune → **STU-Net**. Accelerate expert 3-D labelling → **interactive FM (nnInteractive /
+VISTA3D)** — mind the weight licence.
 Count + localise instances → **Mask R-CNN + FPN**. Always patient-level split, always Dice
 **and** a boundary metric per structure. Record the choice + paper, hand to `/model-scaffold`,
 validate with `/model-validation`.


### PR DESCRIPTION
## What
Extends `architecture-zoo` with the post-nnU-Net segmentation layer the cards were missing (they stopped at ~2023 archetypes). **Reference-only enrichment — no new detector or skill.**

### segmentation.md
- **nnU-Net ResEnc (M/L/XL)**, **MedNeXt**, **STU-Net** — the CNN-scaling frontier, each with when-to-use + verified repo/licence + validation note.
- A prominent **rigour caveat** grounded in *nnU-Net Revisited* (Isensee et al., MICCAI 2024, arXiv 2404.09556): under matched compute a scaled CNN still beats Transformer/Mamba, and U-Mamba's Mamba layers ablate to zero contribution. "New ≠ better."

### foundation_models.md
- **Interactive 3-D promptable** card: nnInteractive / VISTA3D / SAM-Med3D — framed as the labelling-throughput lever (prompt-and-correct instead of from-scratch), with the silver-label/circularity discipline.
- **Licence flag**: nnInteractive code is Apache-2.0 but its released **weights are CC BY-NC-SA 4.0 (non-commercial)**; VISTA3D / SAM-Med3D weight licences flagged "verify before commercial use".

### index.md
- Decision-tree rows for ResEnc (tensor-core GPU, max accuracy) and interactive labelling; the Revisited finding added as the canonical "evaluate with /model-validation, don't adopt on a headline" example.

### SKILL.md
- `triggers` extended (nnInteractive, VISTA3D, MedNeXt, STU-Net, ResEnc, Mamba, …) for discoverability; regenerated skill doc + distribution manifest.

## Grounding
Licences and repos verified against each GitHub repo, not memory. The skill's "not a live leaderboard" framing is preserved — archetypes + task→model logic, not benchmark numbers.

## Checks
Full local CI mirror: **192/192 gates pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)