### PR TITLE
feat(architecture-zoo): detection + classification 2024-2026 wave (nnDetection, ConvNeXt)

### DIFF
--- a/docs/skills/architecture-zoo.md
+++ b/docs/skills/architecture-zoo.md
@@ -8,7 +8,7 @@
 
 ## When to use
 
-`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation.
+`architecture-zoo` activates on requests such as: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation, nnDetection, lesion detection, ConvNeXt, YOLO, YOLOv8, RT-DETR, DETR, RetinaNet, detection architecture.
 
 ## Quality Card
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -468,18 +468,18 @@
     },
     {
       "path": "skills/architecture-zoo/SKILL.md",
-      "size": 6381,
-      "sha256": "1f8aa8ac4cd81153d9fcbd338b1176ebb5376d305341ccea76846ca627063d60"
+      "size": 6486,
+      "sha256": "8da760addd9e528528e777e1e06195a53a97af44326e4af69838aff8559fc2ca"
     },
     {
       "path": "skills/architecture-zoo/references/classification.md",
-      "size": 5986,
-      "sha256": "035e0fddaccb0e19e23ffd7756b075154f847ee20f9a512cd2a010c0db4210fa"
+      "size": 7279,
+      "sha256": "cf6f79be97395e672b06bc934c483735c827ff8ea89301e822bba30fbb7bbb8f"
     },
     {
       "path": "skills/architecture-zoo/references/detection.md",
-      "size": 3917,
-      "sha256": "60549b53a87dcb149c442498695321e94c28f0c8853316dda995a2dd730dfeec"
+      "size": 5994,
+      "sha256": "a651e6b5487fd6fe9726101d6068985b0aeb297bfaaefbaadd1af2b543bf3dfc"
     },
     {
       "path": "skills/architecture-zoo/references/foundation_models.md",
@@ -493,8 +493,8 @@
     },
     {
       "path": "skills/architecture-zoo/references/index.md",
-      "size": 4943,
-      "sha256": "59615e3a75d6f167e86d1b7609373baa4c1aca54820a936bbe605d231852dd8c"
+      "size": 5121,
+      "sha256": "56c24d68cf529b0dcd33c7a0d55a2cd6a36ec79852b2aa00890e2e0ad6f6e67f"
     },
     {
       "path": "skills/architecture-zoo/references/segmentation.md",

--- a/skills/architecture-zoo/SKILL.md
+++ b/skills/architecture-zoo/SKILL.md
@@ -11,7 +11,7 @@ description: >
   graph neural nets — GCN/GraphSAGE/GAT/GIN/BrainGNN — for brain connectomes). It teaches archetypes and
   the task-to-architecture logic (including the "scale the CNN, new≠better" rigour caveat), not a live
   SOTA leaderboard.
-triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation
+triggers: architecture zoo, which architecture, choose a model, model selection, ResNet vs ViT, U-Net vs nnU-Net, what backbone, foundation model for, transfer learning choice, MedSAM, TotalSegmentator, DINO, MAE, self-supervised, graph neural network, GNN, brain connectome, GCN, GAT, GraphSAGE, BrainGNN, population graph, paper to architecture, reference implementation, when to use ViT, segmentation architecture, classification backbone, nnU-Net ResEnc, MedNeXt, STU-Net, nnInteractive, VISTA3D, SAM-Med3D, Mamba, U-Mamba, interactive segmentation, labelling acceleration, promptable segmentation, nnDetection, lesion detection, ConvNeXt, YOLO, YOLOv8, RT-DETR, DETR, RetinaNet, detection architecture
 tools: Read, Write, Edit, Grep, Glob
 model: inherit
 ---

--- a/skills/architecture-zoo/references/classification.md
+++ b/skills/architecture-zoo/references/classification.md
@@ -63,6 +63,24 @@ note; never quote a benchmark you have not cited.
 - **When to use**: legacy strong baseline; multi-scale lesions. Usually ResNet/EfficientNet
   preferred now.
 
+### ConvNeXt / ConvNeXt V2 — the modern CNN (CNNs, reasserted)
+- **Papers**: Liu et al., "A ConvNet for the 2020s" (ConvNeXt), *CVPR* 2022; Woo et al.,
+  ConvNeXt V2 (FCMAE masked-autoencoder pretraining + Global Response Normalisation), *CVPR*
+  2023.
+- **Core idea**: a pure CNN modernised with transformer-era design choices (large kernels,
+  LayerNorm, inverted bottlenecks) that **matches or beats ViT/Swin at equal compute** — the
+  classification counterpart to the "scale the CNN, new≠better" lesson in `segmentation.md`.
+- **When to use**: a strong modern backbone when you want CNN inductive bias + good transfer
+  without ViT's data appetite; a sensible default alongside ResNet/EfficientNet for medical
+  classification.
+- **Reference impl**: `timm` (`convnext_*`, `convnextv2_*`).
+- **Licence**: ConvNeXt (V1) code **and weights MIT** (commercial OK); ConvNeXt **V2 code is
+  MIT but its ImageNet weights are CC-BY-NC** (non-commercial) — use V1 weights or your own
+  pretraining if the model feeds a product.
+- **Validation setup**: as ResNet; if you use V2's self-supervised weights, keep the
+  pretraining corpus disjoint from the test patients (contamination — `/model-validation`
+  MD1/MD3).
+
 ---
 
 ## Vision transformers (when data is large)
@@ -96,7 +114,8 @@ note; never quote a benchmark you have not cited.
 ---
 
 ## Choosing among these
-Small/medium labelled data → **pretrained ResNet/DenseNet/EfficientNet**. Large data or a
-strong pretrained transformer → **ViT/Swin**. Always pretrained, always patient-level split,
+Small/medium labelled data → **pretrained ResNet/DenseNet/EfficientNet**, or **ConvNeXt** for
+a modern CNN backbone (mind the V2 weight licence). Large data or a strong pretrained
+transformer → **ViT/Swin**. Always pretrained, always patient-level split,
 always AUROC **and** AUPRC with CIs. Record the choice + paper in the decision note and hand
 to `/model-scaffold`; validate with `/model-validation`, evaluate with `/model-evaluation`.

--- a/skills/architecture-zoo/references/detection.md
+++ b/skills/architecture-zoo/references/detection.md
@@ -10,6 +10,27 @@ validation/experiment setup.**
 
 ---
 
+## Self-configuring 3-D detection (the default to beat)
+
+### nnDetection
+- **Paper**: Baumgartner et al., "nnDetection: A Self-configuring Method for Medical Object
+  Detection," *MICCAI* 2021.
+- **Core idea**: nnU-Net's philosophy applied to **detection** — auto-configures
+  preprocessing, anchors, network topology, and training from the dataset fingerprint for
+  **3-D volumetric** lesion detection, with no manual tuning. (First release is 3-D only; no
+  2-D / Mask R-CNN.)
+- **When to use**: the **default to beat** for 3-D medical lesion detection (nodules,
+  aneurysms, focal lesions on CT/MR), exactly as nnU-Net is for segmentation — start here and
+  justify any custom detector against it; it removes the anchor/scale tuning a torchvision
+  detector needs.
+- **Medical-imaging use**: LUNA16-style nodule detection, 3-D lesion / aneurysm detection.
+- **Reference impl**: `MIC-DKFZ/nnDetection` (Apache-2.0). Integrate, do not reimplement.
+- **Validation setup**: report **FROC** (sensitivity per false-positive-per-scan); its
+  internal CV is development-time optimism correction, not external validation
+  (`/model-validation` MD3/MD6); keep the patient-level split consistent end to end.
+
+---
+
 ## Two-stage detectors (region proposal → classify)
 
 ### R-CNN → Fast R-CNN → Faster R-CNN (+ FPN)
@@ -43,26 +64,35 @@ validation/experiment setup.**
 - **When to use**: faster than two-stage, strong under heavy class imbalance.
 - **Reference impl**: torchvision `retinanet_resnet50_fpn`; MONAI detection.
 
-### YOLO family
-- **Papers**: Redmon et al., YOLO, *CVPR* 2016; later YOLOv3+/YOLOX.
+### YOLO family (incl. modern Ultralytics)
+- **Papers**: Redmon et al., YOLO, *CVPR* 2016; YOLOv3+/YOLOX; **YOLOv8 / YOLOv11**
+  (Ultralytics, 2023–24) are the current widely-used releases.
 - **Core idea**: a single network predicts boxes + classes directly on a grid — real-time.
-- **When to use**: speed-critical / interactive settings; usually two-stage detectors are
-  preferred for maximal sensitivity on small medical lesions.
+- **When to use**: speed-critical / interactive settings; for maximal sensitivity on small
+  medical lesions, two-stage detectors or **nnDetection** (3-D) are usually preferred.
+- **Licence — check before commercial use**: **Ultralytics YOLOv8/v11 are AGPL-3.0** (strong
+  copyleft — a deployed derivative must itself be open-sourced, or you buy Ultralytics'
+  commercial licence). If that is a problem, prefer an Apache/MIT detector — **RT-DETR**
+  (real-time DETR), torchvision Faster R-CNN, or MONAI RetinaNet.
 
-### DETR (transformer, set prediction)
-- **Paper**: Carion et al., "End-to-End Object Detection with Transformers," *ECCV* 2020.
+### DETR / RT-DETR (transformer, set prediction)
+- **Papers**: Carion et al., "End-to-End Object Detection with Transformers," *ECCV* 2020;
+  **RT-DETR** (Zhao et al., *CVPR* 2024) — a real-time, permissively licensed variant.
 - **Core idea**: a transformer treats detection as direct **set prediction** (no anchors /
-  NMS) via learned object queries + bipartite matching.
+  NMS) via learned object queries + bipartite matching; RT-DETR makes it real-time.
 - **When to use**: large datasets where an anchor-free, end-to-end pipeline is attractive;
-  more data-hungry and slower to converge than CNN detectors.
-- **Reference impl**: the official DETR repo; Deformable DETR for faster convergence.
+  more data-hungry and slower to converge than CNN detectors. **RT-DETR (Apache-2.0)** is the
+  permissively licensed real-time alternative to Ultralytics YOLO's AGPL.
+- **Reference impl**: the official DETR repo; Deformable DETR for faster convergence; RT-DETR.
 
 ---
 
 ## Choosing among these
-Default lesion detection → **Faster R-CNN + FPN** (torchvision; `/model-scaffold --task
+**3-D volumetric lesion detection → nnDetection** (self-configuring, the default to beat).
+2-D lesion detection → **Faster R-CNN + FPN** (torchvision; `/model-scaffold --task
 detection`). Sparse lesions / imbalance → **RetinaNet (focal loss)**. Count + delineate
-instances → **Mask R-CNN**. Speed-critical → **YOLO**. Large data, anchor-free → **DETR**.
+instances → **Mask R-CNN**. Speed-critical → **YOLO** (mind the **AGPL-3.0** licence) or
+**RT-DETR** (Apache-2.0). Large data, anchor-free → **DETR**.
 Always report **FROC / mAP with the IoU criterion stated**, per-lesion with patient-level
 clustering disclosed. Record the choice + paper, hand to `/model-scaffold`, validate with
 `/model-validation` and `/model-evaluation`.

--- a/skills/architecture-zoo/references/index.md
+++ b/skills/architecture-zoo/references/index.md
@@ -41,7 +41,8 @@ per-paper detail and the `/model-scaffold` template to instantiate.
 ## Step 3 — default picks (a safe starting point, then justify deviations)
 | Task + setting | Default | Why |
 |---|---|---|
-| 2-D multi-label CXR classification | **ResNet-50 / EfficientNet (pretrained, `timm`)** | strong, cheap, well-calibrated baselines |
+| 2-D multi-label CXR classification | **ResNet-50 / EfficientNet (pretrained, `timm`)** | strong, cheap, well-calibrated baselines (**ConvNeXt** for a modern CNN — `classification.md`) |
+| 3-D lesion detection (boxes, FROC) | **nnDetection** | self-configuring — the nnU-Net of detection (`detection.md`) |
 | 3-D organ / lesion segmentation | **nnU-Net (v2)** | self-configuring; the standard to beat |
 | 3-D segmentation, tensor-core GPU, max accuracy | **nnU-Net ResEnc (M/L/XL)** | the 2024 "Revisited" frontier; still self-configuring (`segmentation.md`) |
 | 2-D segmentation, custom pipeline | **U-Net / Attention U-Net (MONAI)** | transparent, controllable |


### PR DESCRIPTION
## What
Second currency slice for `architecture-zoo`, continuing the segmentation-wave work (#409). Same discipline: verified licences, no leaderboard numbers, archetypes + task→model logic. **Reference-only — no new detector or skill.**

### detection.md
- **nnDetection** (Baumgartner et al., MICCAI 2021) added as the **self-configuring 3-D detection default** — the nnU-Net of detection, which the cards were missing.
- Modernised the **YOLO** card (YOLOv8/v11, Ultralytics) with an **AGPL-3.0 copyleft warning** (a deployed derivative must be open-sourced, or buy the commercial licence).
- Merged **DETR / RT-DETR** — RT-DETR (Apache-2.0) as the permissively licensed real-time alternative to Ultralytics' AGPL.

### classification.md
- **ConvNeXt / ConvNeXt V2** — the modern CNN that matches/beats ViT/Swin at equal compute (the classification counterpart to "scale the CNN, new ≠ better"). Flags that **V2's ImageNet weights are CC-BY-NC** while V1 code + weights are MIT.

### index.md
- Decision-tree rows for 3-D detection (nnDetection) and a modern-CNN (ConvNeXt) note.

### SKILL.md
- `triggers` extended (nnDetection, ConvNeXt, YOLOv8, RT-DETR, …); regenerated skill doc + distribution manifest.

## Grounding
Licences confirmed via the GitHub API, not memory: nnDetection **Apache-2.0**, ConvNeXt **MIT**, Ultralytics **AGPL-3.0**, ConvNeXt V2 weights **CC-BY-NC**.

## Checks
Full local CI mirror: **192/192 gates pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)