### PR TITLE
fix(ci): a test CI never runs is a test that never runs — gate the omission

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -617,6 +617,51 @@ jobs:
       - name: Run verify-refs pagination-placeholder gate test
         run: bash skills/verify-refs/tests/test_pagination_placeholder.sh
 
+      # --- Tests that shipped on disk but no workflow ran. check_test_wiring.py below is what
+      #     keeps this list from growing again by omission; these twelve were the standing backlog
+      #     it found on 2026-07-25 (six of them declared in a skill.yml CI never reads).
+      - name: "Run design-study adjustment-set challenge"
+        run: bash skills/design-study/scripts/adjustment_set_challenge/verify.sh
+
+      - name: "Run find-journal acceptance-readiness challenge"
+        run: bash skills/find-journal/scripts/acceptance_readiness_challenge/verify.sh
+
+      - name: "Run make-figures portal-TIFF export challenge"
+        run: bash skills/make-figures/scripts/export_portal_tiff_challenge/verify.sh
+
+      - name: "Run make-figures core-figure render challenge"
+        run: bash skills/make-figures/scripts/render_core_figures_challenge/verify.sh
+
+      - name: "Run meta-analysis extraction-assist challenge"
+        run: bash skills/meta-analysis/scripts/extract_assist_challenge/verify.sh
+
+      - name: "Run search-lit snowball challenge"
+        run: bash skills/search-lit/references/snowball_challenge/verify.sh
+
+      - name: Run meta-analysis screening-reconcile test
+        run: bash skills/meta-analysis/tests/test_screening_reconcile.sh
+
+      - name: Run model-sourcing model-provenance test
+        run: bash skills/model-sourcing/tests/test_model_provenance.sh
+
+      - name: Run present-paper backup-off-the-clock test
+        run: python3 skills/present-paper/tests/test_backup_off_the_clock.py
+
+      - name: Run present-paper markdown-parity test
+        run: python3 skills/present-paper/tests/test_md_parity.py
+
+      - name: Run Phase-1a gate test
+        run: bash tests/test_phase1a_gates.sh
+
+      - name: Run Phase-1c hook test
+        run: bash tests/test_phase1c_hooks.sh
+
+      - name: "Run check_test_wiring.py (a test CI never runs is a test that never runs)"
+        run: python3 scripts/check_test_wiring.py
+
+      - name: "Run test-wiring gate self-test (restore the real omission; the gate must FAIL)"
+        run: bash tests/test_test_wiring.sh
+
       - name: Verify demo manifest.lock files (reproducibility lock)
         run: |
           for d in demo/01_wisconsin_bc demo/02_metafor_bcg demo/03_nhanes_obesity; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Fixed
 
+- **Twelve tests shipped on disk that no workflow ran, and the omission had no gate.** PR #412
+  wired four unrun challenge cards by hand after a manual sweep — but a hand-maintained list of
+  "tests CI should run" has nothing that catches the *next* omission, so the same defect was
+  already back: twelve more test assets, six of them declared in a `skill.yml`'s
+  `validation_commands`, were green because nothing executed them. All twelve are now wired (they
+  pass, offline), and `scripts/check_test_wiring.py` makes the class structurally impossible: every
+  `verify.sh` / `test_*.py` / `test_*.sh` must be named by a `run:` step, or by a non-test script a
+  `run:` step invokes, or carry a written exemption. Declaring a command in `skill.yml` is not
+  wiring — CI does not read that file. This is the third sibling of `check_detector_reachability`
+  and `check_script_reachability`; both of their docstrings close the "a test is not a caller"
+  direction and left this one open. The gate has no `--strict` — a violation exits 1 always.
+  Verified by restoring the real defect: against `validate.yml` as it stood before PR #412 it names
+  all four of that PR's detectors, and its self-test deletes a live step and requires the failure.
 - **Four detectors were catalogued and shipped but never CI-tested, and two headline claims were
   false — an independent architecture review (different-substrate cross-check) found them.**
   `check_analysis_definitions`, `check_review_request_types`, and `check_model_provenance` each

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""A test CI never runs is a test that never runs — the third sibling of the reachability gates.
+
+`check_detector_reachability.py` asks whether a *skill* calls a detector.
+`check_script_reachability.py` asks whether a *skill* calls a script.
+Both docstrings say the same thing out loud:
+
+    "A test, a challenge card, or a CI step does NOT make a script reachable."
+
+That sentence closes one direction and leaves the other one open, and nothing else was watching it.
+The open direction is this: a challenge card can sit on disk, be listed in its skill's
+`validation_commands`, be counted in the distribution manifest, be announced in the CHANGELOG — and
+never be named in a workflow. It is green because it is never run. On 2026-07-25, with the two
+reachability gates in place and 202 `run:` steps hand-listed in `validate.yml`, twelve test assets
+were in exactly that state, six of them declared in a `skill.yml` as validation commands. Four more
+had been in it until PR #412 wired them by hand, one at a time, after a manual sweep found them.
+
+The manual sweep is the bug. A hand-maintained list of "tests CI should run" has no gate that
+catches an omission, so the omission is invisible for as long as nobody happens to look.
+
+A test asset is WIRED if:
+  * a `run:` step in any `.github/workflows/*.yml` names its path, or
+  * a NON-TEST file that a `run:` step names contains its path (one hop — `validate_skills.sh` runs
+    `tests/test_precedent_hashing.sh`, and that counts).
+
+The hop deliberately excludes test assets themselves, and that exclusion is load-bearing rather than
+tidy: the first draft let any wired file vouch for a path, and this gate's own self-test — which
+names a challenge in a shell variable in order to *delete its step* — thereby certified that
+challenge as wired. The gate passed its own regression case by reading its own source. A test that
+mentions another test is not running it, which is the sibling gates' doctrine one category over.
+
+Being declared in `skill.yml` does NOT make it wired: `validation_commands` is documentation of how
+to run a thing, and CI does not read it. That gap is what this gate exists to close.
+
+Exemptions live in EXEMPT below and each one carries a reason. There is no `--strict`: a violation
+exits 1 always, because a gate that reports a failure while exiting 0 is the failure mode this
+repository keeps re-learning.
+
+Usage:
+    check_test_wiring.py [--root DIR] [--json] [--quiet]
+
+Needs PyYAML (maintainer tool, same as run_ci_mirror.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Where test assets live and what they are called.
+ASSET_GLOBS = (
+    "skills/**/verify.sh",
+    "skills/**/test_*.py",
+    "skills/**/test_*.sh",
+    "tests/test_*.py",
+    "tests/test_*.sh",
+)
+
+# path -> reason. A test that CI genuinely must not run needs a stated reason, not silence.
+EXEMPT: dict[str, str] = {}
+
+
+def _iter_run_commands(root: Path) -> list[str]:
+    try:
+        import yaml  # noqa: PLC0415
+    except ModuleNotFoundError:
+        sys.stderr.write(
+            "check_test_wiring needs PyYAML (pip install pyyaml). It is a maintainer tool.\n"
+        )
+        raise SystemExit(1)
+
+    wf_dir = root / ".github" / "workflows"
+    cmds: list[str] = []
+    for wf in sorted(wf_dir.glob("*.yml")) + sorted(wf_dir.glob("*.yaml")):
+        doc = yaml.safe_load(wf.read_text(encoding="utf-8")) or {}
+        for job in (doc.get("jobs") or {}).values():
+            for step in (job or {}).get("steps") or []:
+                run = (step or {}).get("run")
+                if run:
+                    cmds.append(run)
+    return cmds
+
+
+def _referenced_repo_files(root: Path, cmds: list[str]) -> list[Path]:
+    """Repo files named by a run: command — the one-hop frontier."""
+    out: list[Path] = []
+    for cmd in cmds:
+        for token in cmd.replace("&&", " ").replace("|", " ").replace(";", " ").split():
+            token = token.strip("\"'()")
+            if "/" not in token or token.startswith("-"):
+                continue
+            candidate = root / token
+            if candidate.is_file():
+                out.append(candidate)
+    return out
+
+
+def collect(root: Path = ROOT) -> dict:
+    assets = sorted(
+        {p.relative_to(root).as_posix() for glob in ASSET_GLOBS for p in root.glob(glob)}
+    )
+    cmds = _iter_run_commands(root)
+    joined = "\n".join(cmds)
+
+    asset_set = set(assets)
+    hop_text = []
+    for f in _referenced_repo_files(root, cmds):
+        if f.relative_to(root).as_posix() in asset_set:
+            continue  # a test does not wire another test — see the docstring
+        try:
+            hop_text.append(f.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    hop_joined = "\n".join(hop_text)
+
+    unwired = []
+    for a in assets:
+        if a in EXEMPT or a in joined:
+            continue
+        if a in hop_joined:  # one hop: a wired script runs it
+            continue
+        unwired.append(a)
+
+    return {
+        "detector": "check_test_wiring",
+        "verdict": "TEST_NOT_WIRED" if unwired else "OK",
+        "assets": len(assets),
+        "exempt": len(EXEMPT),
+        "unwired": unwired,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", type=Path, default=ROOT,
+                    help="repo root to audit (default: this checkout) — the self-test points it "
+                         "at a synthetic tree")
+    ap.add_argument("--json", action="store_true", help="emit the report as JSON")
+    ap.add_argument("--quiet", action="store_true", help="print nothing when clean")
+    a = ap.parse_args()
+
+    report = collect(a.root.resolve())
+    if a.json:
+        print(json.dumps(report, indent=2))
+    elif report["unwired"]:
+        print(f"TEST_NOT_WIRED: {len(report['unwired'])} test asset(s) no workflow runs.")
+        print("Each of these is green because nothing executes it:\n")
+        for u in report["unwired"]:
+            print(f"  {u}")
+        print(
+            "\nWire each one as a step in .github/workflows/validate.yml, or add it to EXEMPT in "
+            f"{Path(__file__).name} with a reason.\n"
+            "Declaring it in skill.yml validation_commands is not wiring — CI does not read that file."
+        )
+    elif not a.quiet:
+        print(f"OK: all {report['assets']} test assets are run by a workflow "
+              f"({report['exempt']} exempt).")
+
+    return 1 if report["unwired"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_test_wiring.sh
+++ b/tests/test_test_wiring.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_test_wiring.py.
+#
+# The defect: four challenge cards — check_review_request_types, check_model_provenance,
+# check_citation_keys, check_analysis_definitions — shipped with fixtures, expected output and a
+# skill.yml validation_commands entry, and `validate.yml` named none of them. They were green
+# because nothing ran them. PR #412 wired those four by hand after a manual sweep; on 2026-07-25
+# twelve more were still in the same state. Case 2 restores that defect on the real workflow and
+# asserts the gate FAILS.
+#
+#  1) live repo passes                                    (all twelve are now wired)
+#  2) a wired step deleted from the real workflow -> FAILS  <-- THE DEFECT
+#  3) declared in skill.yml but not in any workflow -> FAILS (validation_commands is not wiring)
+#  4) one hop through a script a run: step invokes -> silent NEGATIVE FIXTURE
+#  5) named only in a step `name:` (never executed) -> FAILS (a label is not an invocation)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE="$ROOT/scripts/check_test_wiring.py"
+
+# 1) live repo passes
+python3 "$GATE" --quiet || { echo "FAIL: live repo should have every test asset wired" >&2; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+real="$tmp/real"; mkdir -p "$real"
+cp -R "$ROOT/skills" "$ROOT/scripts" "$ROOT/tests" "$ROOT/.github" "$real/"
+
+python3 "$GATE" --root "$real" --quiet \
+  || { echo "FAIL: an untouched copy must pass" >&2; exit 1; }
+
+# 2) THE DEFECT: delete the step that runs one challenge. Its fixtures, its expected output, its
+#    skill.yml entry and its manifest row all stay. If any of those counted as wiring, this case
+#    would pass — and that is exactly the bug the four of PR #412 had.
+victim="skills/manage-refs/scripts/check_citation_keys_challenge/verify.sh"
+python3 - "$real/.github/workflows/validate.yml" "$victim" <<'PY'
+import re, sys
+path, victim = sys.argv[1], sys.argv[2]
+text = open(path, encoding="utf-8").read()
+# drop the whole `- name: ...` block whose run: names the victim
+blocks = re.split(r"(?m)(?=^      - name:)", text)
+kept = [b for b in blocks if victim not in b]
+assert len(kept) == len(blocks) - 1, f"expected to drop exactly one step, dropped {len(blocks)-len(kept)}"
+open(path, "w", encoding="utf-8").write("".join(kept))
+PY
+
+if python3 "$GATE" --root "$real" >/dev/null 2>&1; then
+  echo "FAIL: a challenge no workflow runs must exit 1 (fixtures and skill.yml must not count)" >&2
+  exit 1
+fi
+report="$(python3 "$GATE" --root "$real" 2>&1 || true)"
+grep -q "check_citation_keys_challenge" <<<"$report" \
+  || { echo "FAIL: the report must name the unwired challenge" >&2; echo "$report" >&2; exit 1; }
+grep -q "validation_commands is not wiring" <<<"$report" \
+  || { echo "FAIL: the report should say skill.yml is not wiring" >&2; echo "$report" >&2; exit 1; }
+cp "$ROOT/.github/workflows/validate.yml" "$real/.github/workflows/validate.yml"   # restore
+python3 "$GATE" --root "$real" --quiet \
+  || { echo "FAIL: restore should return the copy to clean" >&2; exit 1; }
+
+# --- synthetic tree: the remaining edges, in isolation ---
+syn="$tmp/syn"
+mkdir -p "$syn/.github/workflows" "$syn/skills/alpha/scripts/thing_challenge" "$syn/tests" "$syn/scripts"
+
+cat > "$syn/skills/alpha/scripts/thing_challenge/verify.sh" <<'SH'
+echo PASS
+SH
+cat > "$syn/skills/alpha/skill.yml" <<'YML'
+name: alpha
+validation_commands:
+  - bash scripts/thing_challenge/verify.sh
+YML
+cat > "$syn/tests/test_hopped.sh" <<'SH'
+echo hopped
+SH
+cat > "$syn/scripts/runner.sh" <<'SH'
+bash tests/test_hopped.sh
+SH
+
+# 3) declared in skill.yml, absent from every workflow
+cat > "$syn/.github/workflows/validate.yml" <<'YML'
+name: validate
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run the hop runner
+        run: bash scripts/runner.sh
+YML
+if python3 "$GATE" --root "$syn" >/dev/null 2>&1; then
+  echo "FAIL: a challenge only skill.yml declares must exit 1" >&2; exit 1
+fi
+report="$(python3 "$GATE" --root "$syn" 2>&1 || true)"
+grep -q "thing_challenge" <<<"$report" || { echo "FAIL: report must name it" >&2; exit 1; }
+# 4) NEGATIVE FIXTURE, same run: tests/test_hopped.sh is named only inside scripts/runner.sh.
+#    A workflow-text grep would call it unwired; it is wired one hop away, exactly as
+#    tests/test_precedent_hashing.sh is by scripts/validate_skills.sh.
+grep -q "test_hopped.sh" <<<"$report" \
+  && { echo "FAIL: a test invoked one hop away must NOT be reported" >&2; exit 1; }
+
+# 5) a `name:` mentioning the path is a label, not an invocation
+cat > "$syn/.github/workflows/validate.yml" <<'YML'
+name: validate
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run skills/alpha/scripts/thing_challenge/verify.sh"
+        run: echo "we renamed the step and forgot the command"
+      - name: Run the hop runner
+        run: bash scripts/runner.sh
+YML
+if python3 "$GATE" --root "$syn" >/dev/null 2>&1; then
+  echo "FAIL: a path named only in a step label must still exit 1" >&2; exit 1
+fi
+
+# now wire it for real
+cat > "$syn/.github/workflows/validate.yml" <<'YML'
+name: validate
+on: [push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run the alpha challenge
+        run: bash skills/alpha/scripts/thing_challenge/verify.sh
+      - name: Run the hop runner
+        run: bash scripts/runner.sh
+YML
+python3 "$GATE" --root "$syn" --quiet \
+  || { echo "FAIL: a genuinely wired tree must pass" >&2; exit 1; }
+
+echo "PASS: test-wiring gate — live repo clean; a deleted step, a skill.yml-only declaration and a"
+echo "      label-without-a-command all fail; a test wired one hop away stays silent."


### PR DESCRIPTION
## What this fixes

PR #412 wired four unrun challenge cards by hand after a manual sweep. **The sweep is the bug.** A hand-maintained list of "tests CI should run" has no gate that catches the *next* omission, so the defect was already back when I looked:

**Twelve test assets on disk that no workflow ran** — six of them declared in a `skill.yml`'s `validation_commands`, which CI does not read. All twelve pass, offline, and are now wired.

## The gate

`scripts/check_test_wiring.py` — every `verify.sh` / `test_*.py` / `test_*.sh` must be

- named by a `run:` step in any workflow, **or**
- named by a **non-test** script that a `run:` step invokes (one hop — `validate_skills.sh` runs `tests/test_precedent_hashing.sh`), **or**
- carry a written exemption.

No `--strict`. A violation exits 1 always.

This is the third sibling of `check_detector_reachability` (does a skill call it?) and `check_script_reachability` (does a skill call it?). Both docstrings say *"a test, a challenge card, or a CI step does NOT make a script reachable"* — that sentence closes one direction and leaves this one open, and nothing else was watching it.

## Verified by failing first, not by passing

- Against `validate.yml` **as it stood before #412**, the gate names all four of that PR's detectors — 4/4, none missed.
- The self-test deletes a live step from the real workflow and **requires** the failure; the report must name the orphan and must say `skill.yml` is not wiring.
- Negative fixtures: a test wired one hop away stays silent; a path appearing only in a step `name:` still fails (a label is not an invocation).

## One finding worth naming

The first draft let **any** wired file vouch for a path. This gate's own self-test names a challenge in a shell variable *in order to delete its step* — so the gate read its own source and certified that challenge as wired. It passed its own regression case for the wrong reason. The hop now excludes test assets themselves: a test that mentions another test is not running it.

## Checks

`scripts/run_ci_mirror.py` — **210/210 green** locally (the 12 new steps + gate + self-test included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)