### PR TITLE
refactor(self-review): share the prose extractor, keep the sentence splitters apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@
   re-enumerated the observational O-probes inline and announced "CP1–CP4" while
   `clinical_prediction_model.md` had grown to CP1–CP6. The inline copy is removed; the module is
   the single source for the probe list and its numbering.
+- **Two prose detectors carried a byte-identical copy of the same extractor — and only *part* of
+  what looked duplicated actually was.** `check_aphorism_density` and `check_rhetorical_density`
+  measure different tells over *the same text* (body prose with front matter, headings, tables,
+  quotes, fences, list items, citations and inline markup removed) and each held its own copy of
+  that extractor: one drift away from reporting densities over different denominators while
+  claiming to describe the same prose. The extractor and its three regexes now live in a shared
+  same-directory `_prose.py`, the pattern `_frontmatter.py` already established. **Sentence
+  splitting is deliberately NOT shared**: the two splitters genuinely differ — the rhetorical one
+  starts a sentence at a digit or an opening parenthesis and keeps one-word fragments, the aphorism
+  one does neither — so folding them together would have moved every density in both detectors, a
+  behaviour change wearing a refactor's clothes. Proven inert: all ten detector outputs across five
+  fixtures are byte-identical before and after, and the detector count is unchanged at 84.
 
 - **Four detectors were catalogued and shipped but never CI-tested, and two headline claims were
   false — an independent architecture review (different-substrate cross-check) found them.**

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -67,6 +67,7 @@
 **Scripts** (`skills/self-review/scripts/`):
 
 - `_frontmatter.py`
+- `_prose.py`
 - `_qc_findings.py`
 - `check_analysis_definitions.py`
 - `check_analysis_definitions_challenge/` (6 files)

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4377,6 +4377,11 @@
       "sha256": "129e1785593629dd63e2b4a264e8cadb034e41ed058cdfe784375e3f765cb5de"
     },
     {
+      "path": "skills/self-review/scripts/_prose.py",
+      "size": 2526,
+      "sha256": "0daca1dbc31d6aa9bc2a7bde16d6b59e8d3229644cd5b18e8a24dd0ccc71bd98"
+    },
+    {
       "path": "skills/self-review/scripts/_qc_findings.py",
       "size": 3187,
       "sha256": "eac1b20db8c5c66d12243602e9272d60e1fcc9ef3ed0046d5081a74ef33a9343"
@@ -4418,8 +4423,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_aphorism_density.py",
-      "size": 9219,
-      "sha256": "432ae0071a2f130b212978a6eea7c493494ea7e1a88169233e24e9d13c6a84bd"
+      "size": 8409,
+      "sha256": "39eeb7a5b2a59d3c037381508e0db557b360201010f62d02e0b8035c17171de1"
     },
     {
       "path": "skills/self-review/scripts/check_artifact_coverage.py",
@@ -4843,8 +4848,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_rhetorical_density.py",
-      "size": 11760,
-      "sha256": "67574a067970b02a82daf0894db38da0a43f02a3b8d248175bfaea103d37b111"
+      "size": 10957,
+      "sha256": "f2d1586af84aacd9079255b5f5eb45a9716fc3cf34abd6395bc0a77ad27f7c61"
     },
     {
       "path": "skills/self-review/scripts/check_rounded_delta.py",

--- a/skills/self-review/scripts/_prose.py
+++ b/skills/self-review/scripts/_prose.py
@@ -1,0 +1,57 @@
+"""Body-prose extraction shared by the prose-rhythm detectors.
+
+`check_aphorism_density.py` and `check_rhetorical_density.py` measure different tells — negative
+definitions and short-declarative rhythm on one side, antithesis and cleft constructions on the
+other — over *the same text*: the manuscript's body prose with front matter, headings, tables,
+block quotes, code fences, list items, citation markers and inline markup removed. Both carried a
+byte-identical copy of that extractor. Two copies of one definition is one drift away from two
+detectors reporting densities over different denominators and no longer being comparable.
+
+WHAT IS **NOT** SHARED, DELIBERATELY: sentence splitting. The two detectors genuinely differ there
+and unifying them would change what they measure:
+
+    aphorism    SENT_SPLIT_RE = (?<=[.!?])\\s+(?=[A-Z"“])          sentences: >= 2 words
+    rhetorical  SENT_SPLIT_RE = (?<=[.!?])\\s+(?=["“(]?[A-Z0-9])   sentences: any non-empty
+
+The rhetorical splitter starts a sentence at a digit or an opening parenthesis; the aphorism one
+does not, and it drops one-word fragments so a run of them cannot masquerade as clipped
+declaratives. Those choices belong to what each gate measures. Folding them together would silently
+move every density in both detectors — a behaviour change wearing a refactor's clothes — so each
+detector keeps its own splitter and its own sentence filter.
+
+Same-directory import, like `_frontmatter`: skills are self-contained and cross-skill imports are
+forbidden, so `humanize/scripts/check_sentence_variety.py` keeps its own extractor by design.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import re
+
+from _frontmatter import strip_frontmatter
+
+FENCE_RE = re.compile(r"```.*?```", re.S)
+
+CITE_RE = re.compile(r"\[@[^\]]+\]|\[\d+(?:[,–-]\d+)*\]")
+
+INLINE_RE = re.compile(r"[*_`]")
+
+
+def body_text(md: str) -> str:
+    """Body prose only: no headings, tables, block quotes, code, citations, markup."""
+    md = strip_frontmatter(md)   # a `status:`/build-note YAML block is not prose rhythm
+    md = FENCE_RE.sub(" ", md)
+    keep = []
+    for line in md.splitlines():
+        s = line.strip()
+        if not s or s.startswith(("#", "|", ">", "!", "---")):
+            continue
+        if re.match(r"^\s*(?:[-*+]|\d+\.)\s", line):   # list items are not prose rhythm
+            continue
+        keep.append(s)
+    txt = " ".join(keep)
+    txt = CITE_RE.sub("", txt)
+    txt = INLINE_RE.sub("", txt)
+    return re.sub(r"\s+", " ", txt).strip()
+

--- a/skills/self-review/scripts/check_aphorism_density.py
+++ b/skills/self-review/scripts/check_aphorism_density.py
@@ -53,11 +53,8 @@ import statistics
 import sys
 from pathlib import Path
 
-from _frontmatter import strip_frontmatter
+from _prose import body_text
 
-FENCE_RE = re.compile(r"```.*?```", re.S)
-CITE_RE = re.compile(r"\[@[^\]]+\]|\[\d+(?:[,–-]\d+)*\]")
-INLINE_RE = re.compile(r"[*_`]")
 SENT_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z\"“])")
 
 # `X is not Y` where the complement is a bare noun phrase, not a clause or a
@@ -78,23 +75,6 @@ SHORT_MAX_WORDS = 9          # "very short declarative"
 NEG_DEF_MAX_WORDS = 14       # a negative definition only counts inside a short sentence
 MIN_SENTENCES = 40           # below this a rate is noise
 
-
-def body_text(md: str) -> str:
-    """Body prose only: no headings, tables, block quotes, code, citations, markup."""
-    md = strip_frontmatter(md)   # a `status:`/build-note YAML block is not prose rhythm
-    md = FENCE_RE.sub(" ", md)
-    keep = []
-    for line in md.splitlines():
-        s = line.strip()
-        if not s or s.startswith(("#", "|", ">", "!", "---")):
-            continue
-        if re.match(r"^\s*(?:[-*+]|\d+\.)\s", line):   # list items are not prose rhythm
-            continue
-        keep.append(s)
-    txt = " ".join(keep)
-    txt = CITE_RE.sub("", txt)
-    txt = INLINE_RE.sub("", txt)
-    return re.sub(r"\s+", " ", txt).strip()
 
 
 def sentences(txt: str) -> list[str]:

--- a/skills/self-review/scripts/check_rhetorical_density.py
+++ b/skills/self-review/scripts/check_rhetorical_density.py
@@ -59,13 +59,10 @@ import re
 import sys
 from pathlib import Path
 
-from _frontmatter import strip_frontmatter
+from _prose import body_text
 
 DETECTOR = "check_rhetorical_density"
 
-FENCE_RE = re.compile(r"```.*?```", re.S)
-CITE_RE = re.compile(r"\[@[^\]]+\]|\[\d+(?:[,–-]\d+)*\]")
-INLINE_RE = re.compile(r"[*_`]")
 WORD_RE = re.compile(r"[A-Za-z0-9']+")
 SENT_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[\"“(]?[A-Z0-9])")
 
@@ -97,24 +94,6 @@ IT_CLEFT_RE = re.compile(
     r"^It\s+(?:is|was|has\s+been)\s+[\w'-].*?\b(?:that|which|who)\b", re.I
 )
 
-
-def body_text(md: str) -> str:
-    """Body prose only: no front matter, headings, tables, block quotes, code, list
-    items, citations, or inline markup. Same extractor the aphorism-density gate uses."""
-    md = strip_frontmatter(md)
-    md = FENCE_RE.sub(" ", md)
-    keep = []
-    for line in md.splitlines():
-        s = line.strip()
-        if not s or s.startswith(("#", "|", ">", "!", "---")):
-            continue
-        if re.match(r"^\s*(?:[-*+]|\d+\.)\s", line):
-            continue
-        keep.append(s)
-    txt = " ".join(keep)
-    txt = CITE_RE.sub("", txt)
-    txt = INLINE_RE.sub("", txt)
-    return re.sub(r"\s+", " ", txt).strip()
 
 
 def sentences(txt: str) -> list:


### PR DESCRIPTION
## What this does

`check_aphorism_density` and `check_rhetorical_density` measure **different tells over the same text** — body prose with front matter, headings, tables, quotes, fences, list items, citations and inline markup removed — and each carried its own byte-identical copy of that extractor. Two copies of one definition is one drift away from two detectors reporting densities over **different denominators** while both claim to describe the same prose.

The extractor and its three regexes move to a shared same-directory `_prose.py` — the pattern `_frontmatter.py` already established here.

## What is NOT shared, and why that matters

The independent review that prompted this called all three prose detectors duplicative. Reading them says otherwise:

| | sentence boundary | sentence filter |
|---|---|---|
| aphorism | `(?<=[.!?])\s+(?=[A-Z"“])` | ≥ 2 words |
| rhetorical | `(?<=[.!?])\s+(?=["“(]?[A-Z0-9])` | any non-empty |

The rhetorical splitter starts a sentence at a **digit or an opening parenthesis**; the aphorism one does not, and it **drops one-word fragments** so a run of them cannot masquerade as clipped declaratives. Those choices belong to what each gate measures. **Unifying them would have moved every density in both detectors — a behaviour change wearing a refactor's clothes.** Each keeps its own splitter.

`humanize/check_sentence_variety` keeps its own extractor: skills are self-contained and cross-skill imports are forbidden. That is architecture, not duplication.

## Proven inert

- **10 detector outputs across 5 fixtures — byte-identical before and after.**
- Both test suites pass; `run_ci_mirror.py` **196/196**.
- Detector count unchanged at **84** (`_prose.py` does not match the catalog glob; both CLIs remain).

## One process note

The first draft of `_prose.py` was hand-copied, and three definitions came out subtly different (`[*_`]` vs `` [*_`]+ ``, a reordered character class). It was regenerated **programmatically from the source** — which is the same failure mode the extraction exists to prevent, caught by diffing the definitions rather than trusting that they looked the same.

## Merge note

Branched from `main` before #416 and #418. No file overlap with either, but re-run the full mirror on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)