### PR TITLE
feat(reverse-engineer): the validation loss — measure the detectors on papers they were never allowed to learn from

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Run detector-crossfire self-test (restores the real 18pt vs 20pt bug; the gate must catch it)
         run: bash tests/test_detector_crossfire.sh
 
+      - name: Run held-out crossfire self-test (the instrument must withhold a rate it cannot support)
+        run: bash reverse_engineer/scripts/test_heldout_crossfire.sh
+
       - name: Run check_python_floor.py (everything a user runs must parse on the Python we promise)
         run: python3 scripts/check_python_floor.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Every detector in this repo was tested only against fixtures written alongside it — a training
+  set — and nothing ever measured the other number.** A challenge card proving a detector fires on
+  its own planted defect is a training accuracy of 100%: true, and uninformative. So as the
+  detector count climbed there was no way to answer the question that matters — is the stack
+  getting better, or getting better at satisfying itself? `check_detector_crossfire.py` already
+  named the gap in its closing paragraph ("a new detector still owes what *no shippable corpus can
+  supply*: two real manuscripts, at least one of them known-good"), and no shippable corpus can
+  supply it because published papers cannot be committed here.
+  `reverse_engineer/scripts/heldout_crossfire.py` points that same machinery (imported, not
+  re-implemented — its invocation rules were paid for with 31 clobbered fixtures) at a **local,
+  gitignored corpus of real accepted open-access papers** marked `split: heldout` in the manifest.
+  What ships is the number, not the papers.
+  It is an instrument, not a gate: it never fails a build, and it refuses to overclaim in three
+  specific ways. A **fire is not a false positive** — a published paper is not a defect-free
+  paper, so the false-positive rate is *withheld entirely* until a human labels the fires
+  (`real`/`spurious`/`unsure`) and is always printed with its coverage; treating every fire as an
+  error would manufacture the alarming trend it claims to detect. **"Never fired" is reported
+  separately from "never ran"** — silence from a detector that was exercised is evidence, silence
+  from one that never got a readable subject is not, and the prune decision in the harvest loop
+  turns on exactly that distinction, which harvesting project `qc/` directories cannot supply
+  because it only sees detectors somebody happened to run. And a corpus is **checked for
+  separation, not counted**: six papers sharing one declared `coverage` profile are one pattern
+  measured six times, so concentration and identical profiles are named — the corpus-side of the
+  rule `check_panel_diversity` already applies to reviewers.
+  The trend is the signal, so the ledger is protected from us: a `--only` run cannot be appended,
+  because letting a filter enter the series would make the next comparison read our own behaviour
+  as a change in the detectors.
+- **A held-out source now authorizes nothing, including `synthetic`.** `distill.py` gained a
+  development firewall alongside its copyright one: `split: heldout` denies every reuse mode, and
+  `frozen_at` (ISO date, required) is what makes "no detector was written knowing this paper"
+  checkable rather than asserted. Denying `synthetic` is deliberate — reuse can be non-derivative
+  in copyright terms and total in measurement terms, and reading a held-out paper to author a
+  fresh probe is exactly how a detector comes to know it. Protocol in
+  `reverse_engineer/HELDOUT.md`, which also records what a buffer plus a ledger is *not* yet:
+  interleaved replay with distillation (promotion that adds one detector per episode is
+  memorisation in the costume of learning), and associative retrieval that edits an existing
+  detector instead of appending a new one.
+
 ### Fixed
 
 - **Twelve tests shipped on disk that no workflow ran, and the omission had no gate.** PR #412

--- a/reverse_engineer/HELDOUT.md
+++ b/reverse_engineer/HELDOUT.md
@@ -1,0 +1,105 @@
+# The held-out split — measuring whether this project is still converging
+
+Every detector in this repo is tested against fixtures authored alongside it: a challenge card
+proving it fires on a planted defect, and `check_detector_crossfire.py` proving it stays silent on
+the demo manuscripts. Both are necessary. Neither is independent. In machine-learning terms they
+are a **training set**, and a detector passing its own challenge card is a training accuracy of
+100% — true, and uninformative about anything.
+
+That leaves one question unanswerable, and it is the question that matters as the detector count
+climbs: **is the stack getting better, or is it getting better at satisfying itself?**
+
+An improvement loop whose generator and evaluator share a framing drifts toward the evaluator
+rather than the goal — the measured quality rises while the unmeasured quality falls. The
+counterweight is not another gate. Adding gates is what produces the drift. The counterweight is a
+set of cases the gates were never allowed to learn from, scored periodically, whose trend can
+contradict us.
+
+## What the split is
+
+| split | meaning |
+|---|---|
+| `train` (default) | May inform detectors, probes, exemplars, rubrics. The normal path. |
+| `heldout` | **Measurement only.** `distill.py` denies every reuse mode for it — including `synthetic`, which every other known-license source is allowed. |
+
+Denying `synthetic` looks over-strict until the claim is said out loud. A fire rate measured on
+held-out papers asserts *"no detector was written knowing this paper."* Reading one to author a
+fresh probe is exactly how a detector comes to know it. The reuse is non-derivative in copyright
+terms and total in measurement terms — the license firewall and this firewall answer different
+questions, and only this one answers "is the number still honest?"
+
+`frozen_at` is required on every held-out record, because the claim is chronological: a freeze date
+that precedes the detector is what makes it checkable rather than asserted.
+
+## Building one
+
+The papers are real, published, accepted open-access articles. They are **never committed** — they
+live under `_corpus/heldout/`, which is gitignored, exactly like the rest of the corpus
+(`LICENSING.md`). What gets published is the *number*, which is not copyrightable expression.
+
+1. Acquire OA papers as usual (`acquire.py`), convert to `.md` under `_corpus/heldout/`.
+   The filename stem must equal the manifest `record_id`.
+2. In `_corpus/manifest.json`, set `split: "heldout"`, `frozen_at: "YYYY-MM-DD"`, and a
+   `coverage` map declaring what design the paper *is*.
+3. Never open them again except to label a fire.
+
+Choose papers that **span designs**. Six papers that are all retrospective single-centre CT
+detection studies are one pattern measured six times: a detector silent across them is silent on
+that pattern, and the denominator is inflated sixfold. That is what `coverage` is for, and the
+instrument reports concentration and identical profiles rather than trusting the count.
+
+## Reading the output
+
+```bash
+python3 reverse_engineer/scripts/heldout_crossfire.py \
+  --corpus _corpus/heldout --manifest _corpus/manifest.json \
+  --worksheet _corpus/fires_to_label.csv --ledger _corpus/heldout_ledger.jsonl \
+  --out _corpus/heldout_run.json
+```
+
+**Fire rate** (`fired_pairs / ran_pairs`) needs no judgment and means only "how often does the
+stack speak on already-accepted work". Its *trend* is the signal: the corpus is frozen, so a rise
+across runs is a change in the detectors. Detector count up and fire rate up together is the
+overfitting signature — prune or label before adding more.
+
+**False-positive rate** is withheld until a human labels the fires. A published paper is not a
+defect-free paper; this project exists because reviewers miss things, so a fire may be exactly
+right. Calling every fire a false positive would manufacture the alarming trend it claims to
+detect. Label the worksheet (`real` / `spurious` / `unsure`) and the rate appears with its
+coverage.
+
+**Silent-when-run vs skipped** are reported separately and mean opposite things. A detector that
+ran and stayed quiet is *observed* clean. A detector that never got a subject it could read is
+*unobserved* — no evidence either way. The prune decision turns on exactly this distinction, and
+harvesting project `qc/` directories cannot supply it: that only sees detectors somebody happened
+to run. A frozen corpus observes all of them, every run.
+
+The instrument never fails a build. It is an instrument, not a gate.
+
+## What this is not yet
+
+A buffer plus a ledger is the trivial version of a memory system. The mechanisms that make
+biological consolidation work are richer, and two of them are not built here:
+
+- **Interleaved replay with distillation.** Consolidation currently runs one way — episode becomes
+  rule — and nothing replays old episodes against the newly consolidated state, so interference is
+  never checked. The sharper half is distillation: many episodes should compress into *one* general
+  detector. Promotion that adds one detector per episode is memorisation wearing the costume of
+  learning, and the ratio (episodes resolved ÷ detectors added) is measurable.
+- **Associative retrieval and editing.** Recall is currently exact-fingerprint matching, so a new
+  episode either collides or looks novel. Retrieval from a partial cue, with the default action
+  being to *edit an existing detector* rather than append a new one, is what would keep the slow
+  store from growing linearly with experience.
+
+Both are follow-on work, and both depend on this split existing first: without a set held out from
+development, neither replay nor compression has anything independent to be scored against.
+
+## Related
+
+- `LICENSING.md` — the copyright firewall (a different question from this one)
+- `scripts/heldout_crossfire.py` — the instrument
+- `scripts/test_heldout_crossfire.sh` — its self-test (wired in `validate.yml`)
+- `../scripts/check_detector_crossfire.py` — the training-set sibling, whose closing paragraph
+  names the gap this file fills
+- McClelland, McNaughton & O'Reilly (1995), *Psychological Review* 102(3):419-457 — complementary
+  learning systems: why a fast episodic store and a slow statistical one need interleaved replay

--- a/reverse_engineer/LICENSING.md
+++ b/reverse_engineer/LICENSING.md
@@ -74,6 +74,13 @@ The firewall is the same in spirit: **learn from any artifact privately; publish
 synthesis**, unless that specific artifact's license is verified-permissive for the reuse you
 intend. A linked artifact with an unknown/empty license authorizes nothing.
 
+## A second, separate firewall
+
+This document governs *copyright*: what expression may be committed. `HELDOUT.md` governs
+*measurement*: which sources may inform the suite at all. They are independent, and a source can
+clear one while failing the other — a CC-BY paper marked `split: heldout` authorizes nothing here,
+because it exists to score the detectors rather than to teach them. `distill.py` enforces both.
+
 ## Distribution note
 
 `reverse_engineer/` is maintainer tooling. It is excluded from the npm tarball

--- a/reverse_engineer/PLAYBOOK.md
+++ b/reverse_engineer/PLAYBOOK.md
@@ -43,6 +43,12 @@ Read `LICENSING.md` first — it is binding on every artifact this loop commits.
 
 ## Step A — Acquire
 
+> **Before acquiring, decide the split.** A source is `train` (informs the suite — the normal
+> path) or `heldout` (measurement only; `distill.py` denies every reuse mode, including
+> `synthetic`). The held-out set is how this program checks that it is converging on the goal
+> rather than on its own gates — see `HELDOUT.md`. The decision is effectively one-way: moving a
+> source back to `train` invalidates every measurement already taken on it.
+
 1. Pull the next batch (N ≈ 5) of `record_id`s / DOIs from `doi_lists/queue.txt`.
 2. Fetch full text into `_corpus/papers/<record_id>.md` (use the `fulltext-retrieval`
    skill for OA articles; open-review APIs for review reports). `scripts/acquire.py`

--- a/reverse_engineer/scripts/distill.py
+++ b/reverse_engineer/scripts/distill.py
@@ -33,6 +33,7 @@ REPO_ROOT = RE_DIR.parent
 SCHEMA = RE_DIR / "source_manifest.schema.json"
 MANIFEST = REPO_ROOT / "_corpus" / "manifest.json"
 RECORD_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_]{2,79}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 MODES = ("synthetic", "paraphrase", "verbatim")
 
 # Licenses that permit derivative reuse (paraphrase / verbatim). Compared lower-cased.
@@ -89,6 +90,7 @@ def load_schema_enums() -> dict:
         "required": rec["required"],
         "source_type": rec["properties"]["source_type"]["enum"],
         "public_reuse_policy": rec["properties"]["public_reuse_policy"]["enum"],
+        "split": rec["properties"]["split"]["enum"],
         "artifact_required": art["required"],
         "artifact_type": art["properties"]["artifact_type"]["enum"],
     }
@@ -137,6 +139,13 @@ def validate_record(r: dict, enums: dict) -> list[str]:
         errs.append(f"{tag}: policy 'cc_by_attribution' requires a non-empty attribution")
     if r.get("verbatim_allowed") is True and policy != "cc_by_attribution":
         errs.append(f"{tag}: verbatim_allowed requires public_reuse_policy 'cc_by_attribution'")
+    # Development firewall. A held-out source is measurement-only; the freeze date is what makes
+    # "no detector was built knowing this paper" checkable rather than asserted.
+    split = r.get("split", "train")
+    if split not in enums["split"]:
+        errs.append(f"{tag}: split must be one of {enums['split']}")
+    if split == "heldout" and not DATE_RE.match(str(r.get("frozen_at", ""))):
+        errs.append(f"{tag}: split 'heldout' requires frozen_at as an ISO date (YYYY-MM-DD)")
     # Linked artifacts (supplementary / code repo / dataset / model card) — each carries its
     # OWN license, verified independently of the article.
     arts = r.get("linked_artifacts")
@@ -211,7 +220,32 @@ def find_record(manifest: dict, rid: str) -> dict | None:
     return None
 
 
+def heldout_denial(rec: dict) -> str | None:
+    """The development firewall, one function so both dispatch paths obey it.
+
+    A held-out source is the measurement set. It authorizes NOTHING — not even `synthetic`,
+    which every other known-license source is allowed. That looks over-strict until you say the
+    claim out loud: a fire rate measured on held-out papers means "no detector was written
+    knowing this paper". Reading one to author a fresh probe is exactly how a detector comes to
+    know it, and the reuse is non-derivative in copyright terms while being total in measurement
+    terms. The license firewall and this firewall are asking different questions; only this one
+    can answer "is the number still honest?".
+    """
+    if rec.get("split") == "heldout":
+        return (
+            f"source is in the HELD-OUT split (frozen {rec.get('frozen_at', '?')}) — it exists to "
+            "be measured against, not learned from. Distilling it silently converts the "
+            "measurement set into a training set and every fire rate taken on it becomes "
+            "uninterpretable. Use a train-split source, or move this one to train and discard "
+            "the measurements already taken on it."
+        )
+    return None
+
+
 def authorize(rec: dict, mode: str) -> tuple[bool, str]:
+    denial = heldout_denial(rec)
+    if denial:
+        return False, denial
     lic = rec.get("license")
     if not license_known(lic):
         return False, "license is unknown/empty — acquire a real license before any reuse"
@@ -301,6 +335,13 @@ def main() -> int:
         ok, reason = authorize(rec, mode)
         print(f"{'ALLOW' if ok else 'DENY'}: {rid} / {mode} — {reason}")
         return 0 if ok else 1
+
+    # A linked artifact inherits its parent's split: the code repo of a held-out paper is a
+    # different door into the same paper.
+    denial = heldout_denial(rec)
+    if denial:
+        print(f"DENY: {target} / {mode} — {denial}")
+        return 1
 
     # Authorize a specific linked artifact. A '#' with a malformed/empty index fails closed
     # (ASCII-digits only — some Unicode digits pass str.isdigit() but break int()).

--- a/reverse_engineer/scripts/heldout_crossfire.py
+++ b/reverse_engineer/scripts/heldout_crossfire.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""The validation loss this project has never measured.
+
+`scripts/check_detector_crossfire.py` runs every detector across the fixtures this repo ships as
+its own picture of good work, and its closing paragraph names the gap it cannot close:
+
+    "A new detector still owes what NO SHIPPABLE CORPUS CAN SUPPLY: two real manuscripts, at
+     least one of them known-good."
+
+No shippable corpus can supply it because published papers cannot be committed here (see
+LICENSING.md). So the detectors are tested exclusively against fixtures authored ALONGSIDE THEM —
+challenge cards, demo manuscripts. In machine-learning terms that is a training set, and a
+detector passing its own challenge card is a training accuracy of 100%: true, and uninformative.
+Nothing in this repo has ever measured the other number.
+
+This does. It points the crossfire machinery (imported, never re-implemented — its invocation
+rules were paid for with 31 clobbered fixtures) at a LOCAL corpus of real, accepted, published
+open-access papers under `_corpus/heldout/`, which are gitignored and never distilled. If detector
+count keeps climbing while the fire rate on already-accepted papers climbs with it, that is
+recursive verification drift with a number attached instead of a feeling.
+
+WHY A FIRE IS NOT A FALSE POSITIVE
+    A published paper is not a defect-free paper. This whole project exists because reviewers miss
+    things, so a detector firing on an accepted paper may be exactly right. Calling every fire a
+    false positive would manufacture the alarming trend it claims to detect — the same class of
+    error as a derived quantity crossing its own threshold.
+
+    So this reports two different things and refuses to conflate them:
+
+      fire rate            fired_pairs / ran_pairs. Always computable, needs no judgment, means
+                           only "how often does the stack speak on already-accepted work".
+      false-positive rate  spurious / (real + spurious), from HUMAN dispositions. Withheld
+                           entirely until labels exist, and always printed with its coverage.
+
+    The trend in fire rate is interpretable before any labelling, because the corpus is frozen:
+    the papers do not change, so a rise across runs is a change in the detectors.
+
+WHY "NEVER FIRED" IS REPORTED SEPARATELY FROM "NEVER RAN"
+    `fired == 0` has two causes that look identical in a summary and mean opposite things: the
+    detector was exercised and stayed silent (evidence), or it never got a subject it could read
+    (no evidence). The prune decision in review-harvest turns on exactly this distinction, and
+    project `qc/` harvesting cannot supply it — that only observes detectors somebody happened to
+    run. A frozen corpus observes all of them on every run.
+
+INPUTS
+  --corpus       directory of held-out papers as .md/.txt (default: _corpus/heldout/).
+  --manifest     optional _corpus/manifest.json. When given, a paper is measured only if a record
+                 whose record_id equals its filename stem declares split=heldout. Unbacked papers
+                 are named and excluded — an unverified corpus makes an unverifiable number.
+  --dispositions optional CSV (paper,detector,verdict,disposition,note) with disposition in
+                 {real, spurious, unsure}. Without it, no false-positive rate is printed.
+  --worksheet    write unlabelled fires to this CSV for a human to label.
+  --ledger       JSONL run history; append this run and print the delta against the last entry.
+  --only         comma-separated detector names, for tests and for re-checking one detector.
+  --out          JSON artifact.
+
+Exit: 0 measurement completed (never blocks — this is an instrument, not a gate), 2 harness broke.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+RE_DIR = Path(__file__).resolve().parents[1]
+REPO = RE_DIR.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+try:
+    import check_detector_crossfire as cf  # noqa: E402  (path set above)
+except Exception as exc:  # pragma: no cover - import failure is a harness break
+    print(f"harness: cannot import the crossfire machinery: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+DEFAULT_CORPUS = REPO / "_corpus" / "heldout"
+DISPOSITIONS = ("real", "spurious", "unsure")
+SEPARATOR_RE = re.compile(r"^[\s=~*_\-─—–]+$")
+VERDICT_TOKEN_RE = re.compile(r"^[A-Z][A-Z0-9_]{3,}$")
+
+
+def verdict_line(stdout: str, stderr: str) -> str:
+    """The one line a human needs to label this fire — and it is usually not on stdout.
+
+    Detectors in this repo print a banner to stdout and the verdict CODE to stderr. A first
+    draft read `stdout or stderr` and wrote a row of '=' into every worksheet row, which is a
+    worksheet nobody can label. Read both, skip rules, prefer a verdict token.
+    """
+    lines = [ln.strip() for ln in ((stderr or "") + "\n" + (stdout or "")).splitlines()]
+    lines = [ln for ln in lines if ln and not SEPARATOR_RE.match(ln)]
+    for ln in lines:
+        if VERDICT_TOKEN_RE.match(ln):
+            return ln[:200]
+    for ln in lines:
+        if ln.lower().startswith("verdict:"):
+            return ln[:200]
+    return lines[0][:200] if lines else ""
+
+
+def load_heldout(manifest_path: Path) -> Dict[str, dict]:
+    """record_id -> {frozen_at, coverage}, for records actually declared held out."""
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"harness: cannot read manifest {manifest_path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    return {
+        r["record_id"]: {
+            "frozen_at": str(r.get("frozen_at", "?")),
+            "coverage": r.get("coverage") or {},
+        }
+        for r in data.get("records", [])
+        if isinstance(r, dict) and r.get("split") == "heldout" and r.get("record_id")
+    }
+
+
+def separation_report(coverages: Dict[str, dict]) -> dict:
+    """Is this corpus N papers, or one paper measured N times?
+
+    A held-out corpus earns its denominator by SPANNING designs. Six papers that are all
+    retrospective single-centre CT detection studies are one pattern with six labels: a detector
+    silent across them is silent on that pattern, and "42 detectors clean on 6 papers" reads as
+    six times the evidence it is. This is the corpus-side of the same rule
+    check_panel_diversity applies to reviewers — a majority in one value is concentration, and a
+    repeated full tuple is a duplicate episode, not a second observation.
+    """
+    axes: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    tuples: Dict[tuple, List[str]] = defaultdict(list)
+    declared = {k: v for k, v in coverages.items() if v}
+    for paper, cov in declared.items():
+        for axis, value in sorted(cov.items()):
+            axes[axis][str(value)] += 1
+        tuples[tuple(sorted((k, str(v)) for k, v in cov.items()))].append(paper)
+    n = len(declared)
+    concentrated = [
+        {"axis": axis, "value": val, "n": cnt, "of": n}
+        for axis, vals in axes.items()
+        for val, cnt in vals.items()
+        if n >= 3 and cnt > n / 2
+    ]
+    collapsed = [sorted(v) for v in tuples.values() if len(v) > 1]
+    return {
+        "n_declared": n,
+        "n_undeclared": len(coverages) - n,
+        "axes": {a: dict(v) for a, v in axes.items()},
+        "distinct_profiles": len(tuples),
+        "concentrated": concentrated,
+        "collapsed": collapsed,
+    }
+
+
+def load_dispositions(path: Path) -> Dict[tuple, str]:
+    out: Dict[tuple, str] = {}
+    with path.open(newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            d = (row.get("disposition") or "").strip().lower()
+            if d not in DISPOSITIONS:
+                continue
+            out[((row.get("paper") or "").strip(), (row.get("detector") or "").strip())] = d
+    return out
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    ap.add_argument("--manifest", type=Path)
+    ap.add_argument("--dispositions", type=Path)
+    ap.add_argument("--worksheet", type=Path)
+    ap.add_argument("--ledger", type=Path)
+    ap.add_argument("--only", help="comma-separated detector names")
+    ap.add_argument("--out", type=Path)
+    ap.add_argument("--verbose", action="store_true")
+    a = ap.parse_args(argv)
+
+    if not a.corpus.is_dir():
+        print(
+            f"harness: no held-out corpus at {a.corpus}\n"
+            "  This is expected on a fresh clone: the corpus is real published papers, which are\n"
+            "  gitignored and never committed (reverse_engineer/LICENSING.md). See HELDOUT.md for\n"
+            "  how to build and freeze one.",
+            file=sys.stderr,
+        )
+        return 2
+
+    papers = sorted(p for p in a.corpus.iterdir() if p.suffix.lower() in (".md", ".txt"))
+    unbacked: List[str] = []
+    frozen_at = "unverified"
+    separation = None
+    if a.manifest:
+        heldout = load_heldout(a.manifest)
+        kept = []
+        for p in papers:
+            if p.stem in heldout:
+                kept.append(p)
+            else:
+                unbacked.append(p.name)
+        papers = kept
+        dates = sorted({heldout[p.stem]["frozen_at"] for p in papers})
+        frozen_at = dates[-1] if dates else "unverified"
+        separation = separation_report({p.stem: heldout[p.stem]["coverage"] for p in papers})
+
+    if not papers:
+        print(
+            "harness: zero measurable papers. A run that silently measures nothing is worse than\n"
+            "  no measurement — refusing to emit a rate.",
+            file=sys.stderr,
+        )
+        if unbacked:
+            print(f"  no heldout manifest record for: {', '.join(unbacked)}", file=sys.stderr)
+        return 2
+
+    dets = [d for d in cf.discover() if d.family == "manuscript"]
+    if a.only:
+        want = {s.strip() for s in a.only.split(",") if s.strip()}
+        missing = want - {d.name for d in dets}
+        if missing:
+            print(
+                f"harness: --only named detector(s) that do not exist or take no --manuscript: "
+                f"{', '.join(sorted(missing))}",
+                file=sys.stderr,
+            )
+            return 2
+        dets = [d for d in dets if d.name in want]
+    if not dets:
+        print("harness: found no manuscript-family detectors", file=sys.stderr)
+        return 2
+
+    before = cf.hash_tree(papers)
+    work = Path(tempfile.mkdtemp(prefix="heldout-"))
+    ran: Dict[str, int] = defaultdict(int)
+    fired: Dict[str, int] = defaultdict(int)
+    skipped: Dict[str, str] = {}
+    fires: List[dict] = []
+
+    print("=" * 78)
+    print(f" Held-out crossfire — {len(dets)} detector(s) x {len(papers)} accepted paper(s)")
+    print("=" * 78)
+
+    try:
+        for d in dets:
+            for paper in papers:
+                sandbox = Path(tempfile.mkdtemp(dir=work))  # a default qc/ path lands HERE
+                cmd = ["python3", str(d.path), "--manuscript", str(paper)]  # inputs only, ever
+                try:
+                    r = cf.sh(cmd, cwd=sandbox)
+                except subprocess.TimeoutExpired:
+                    skipped[d.name] = "timed out"
+                    break
+                if r.returncode == 2:
+                    skipped[d.name] = "needs " + cf.missing_flag_from(
+                        r.stderr, r.stdout, ("--manuscript",)
+                    )
+                    break
+                ran[d.name] += 1
+                if r.returncode != 0:
+                    fired[d.name] += 1
+                    fires.append(
+                        {
+                            "paper": paper.stem,
+                            "detector": d.name,
+                            "verdict": verdict_line(r.stdout, r.stderr),
+                        }
+                    )
+                    print(f"  FIRED {d.name} x {paper.stem}")
+                elif a.verbose:
+                    print(f"  ok    {d.name} x {paper.stem}")
+    finally:
+        after = cf.hash_tree(papers)
+        changed = [k for k in before if before[k] != after.get(k)]
+        shutil.rmtree(work, ignore_errors=True)
+
+    if changed:
+        print("\nFAIL: a detector WROTE INTO THE CORPUS. The run is void.", file=sys.stderr)
+        for c in changed:
+            print(f"  modified: {c}", file=sys.stderr)
+        return 2
+
+    ran_pairs = sum(ran.values())
+    fired_pairs = sum(fired.values())
+    if ran_pairs == 0:
+        print("\nharness: zero pairs ran — no measurement taken.", file=sys.stderr)
+        return 2
+    fire_rate = fired_pairs / ran_pairs
+
+    # ---- dispositions: the only path to a false-positive rate -------------------------------
+    labels = load_dispositions(a.dispositions) if a.dispositions else {}
+    lab = [labels.get((f["paper"], f["detector"])) for f in fires]
+    n_spurious = sum(1 for x in lab if x == "spurious")
+    n_real = sum(1 for x in lab if x == "real")
+    n_unsure = sum(1 for x in lab if x == "unsure")
+    n_unlabelled = sum(1 for x in lab if x is None)
+    fp_rate = n_spurious / (n_real + n_spurious) if (n_real + n_spurious) else None
+
+    exercised = sorted(n for n in (d.name for d in dets) if ran.get(n, 0) and not fired.get(n, 0))
+    print("-" * 78)
+    print(f"  papers measured : {len(papers)}   (corpus frozen: {frozen_at})")
+    print(f"  detectors run   : {len(ran)}   skipped: {len(skipped)}")
+    print(f"  pairs           : {ran_pairs}   fired: {fired_pairs}")
+    print(f"  FIRE RATE       : {fire_rate:.3f}  <- the trend to watch across runs")
+    print(f"  silent-when-run : {len(exercised)} detector(s) — OBSERVED clean, not unobserved")
+    if unbacked:
+        print(f"  EXCLUDED (no heldout manifest record): {', '.join(unbacked)}")
+
+    if separation is not None:
+        print("-" * 78)
+        if separation["n_declared"] == 0:
+            print(
+                "  SEPARATION: undeclared. No record carries `coverage`, so this reports "
+                f"{len(papers)} papers\n"
+                "    without knowing whether they are 1 design or 6. Declare coverage axes to make\n"
+                "    the denominator mean something."
+            )
+        else:
+            print(
+                f"  SEPARATION: {separation['distinct_profiles']} distinct design profile(s) "
+                f"across {separation['n_declared']} declared paper(s)"
+                + (f" ({separation['n_undeclared']} undeclared)" if separation["n_undeclared"] else "")
+            )
+            for axis, vals in sorted(separation["axes"].items()):
+                shown = ", ".join(f"{v}={c}" for v, c in sorted(vals.items()))
+                print(f"    {axis}: {shown}")
+            for c in separation["concentrated"]:
+                print(
+                    f"    CONCENTRATED: {c['axis']}={c['value']} holds {c['n']}/{c['of']} papers — "
+                    "silence here is evidence about that value, not about the axis."
+                )
+            for group in separation["collapsed"]:
+                print(
+                    f"    COLLAPSED: {', '.join(group)} share an identical profile — one pattern "
+                    "measured twice, not two observations."
+                )
+    for name, why in sorted(skipped.items()):
+        print(f"  SKIPPED {name} ({why}) — unobserved, NOT evidence of a clean detector")
+
+    if fires:
+        print("-" * 78)
+        if fp_rate is None:
+            print(
+                f"  FALSE-POSITIVE RATE: WITHHELD — {n_unlabelled} fire(s), 0 labelled.\n"
+                "    A fire on an accepted paper may be a real defect reviewers missed. Label the\n"
+                "    worksheet (real / spurious / unsure) before any FP claim is made."
+            )
+        else:
+            cov = (len(fires) - n_unlabelled) / len(fires)
+            print(
+                f"  FALSE-POSITIVE RATE: {fp_rate:.3f}  "
+                f"({n_spurious} spurious / {n_real + n_spurious} decided; "
+                f"{n_unsure} unsure, {n_unlabelled} unlabelled; coverage {cov:.0%})"
+            )
+            if cov < 1.0:
+                print("    Partial coverage — unlabelled fires could move this in either direction.")
+
+    if a.worksheet:
+        todo = [f for f in fires if (f["paper"], f["detector"]) not in labels]
+        with a.worksheet.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh)
+            w.writerow(["paper", "detector", "verdict", "disposition", "note"])
+            for f in todo:
+                w.writerow([f["paper"], f["detector"], f["verdict"], "", ""])
+        print(f"\n  worksheet: {len(todo)} unlabelled fire(s) -> {a.worksheet}")
+
+    payload = {
+        "corpus": str(a.corpus),
+        "frozen_at": frozen_at,
+        "n_papers": len(papers),
+        "n_detectors_run": len(ran),
+        "n_detectors_skipped": len(skipped),
+        "pairs_ran": ran_pairs,
+        "pairs_fired": fired_pairs,
+        "fire_rate": round(fire_rate, 4),
+        "false_positive_rate": None if fp_rate is None else round(fp_rate, 4),
+        "labels": {
+            "spurious": n_spurious,
+            "real": n_real,
+            "unsure": n_unsure,
+            "unlabelled": n_unlabelled,
+        },
+        "per_detector": {
+            d.name: {
+                "ran": ran.get(d.name, 0),
+                "fired": fired.get(d.name, 0),
+                "skipped": skipped.get(d.name),
+            }
+            for d in dets
+        },
+        "excluded_unbacked": unbacked,
+        "separation": separation,
+        "fires": fires,
+    }
+
+    # ---- the trend. A level with no trend says nothing. --------------------------------------
+    if a.ledger and a.only:
+        print(
+            "-" * 78 + "\n"
+            "  LEDGER SKIPPED: --only ran a SUBSET of the detectors. Appending a partial run to the\n"
+            "  trend series would make the next comparison read a filter as a change in the\n"
+            "  detectors — our own behaviour manufacturing our own metric. Run without --only to\n"
+            "  record a trend point."
+        )
+    elif a.ledger:
+        prev = None
+        if a.ledger.is_file():
+            for line in a.ledger.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line:
+                    try:
+                        prev = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+        entry = {k: payload[k] for k in ("frozen_at", "n_papers", "n_detectors_run",
+                                         "pairs_ran", "pairs_fired", "fire_rate",
+                                         "false_positive_rate")}
+        with a.ledger.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        if prev and prev.get("n_papers") == payload["n_papers"]:
+            d_rate = payload["fire_rate"] - prev.get("fire_rate", 0.0)
+            d_det = payload["n_detectors_run"] - prev.get("n_detectors_run", 0)
+            print("-" * 78)
+            print(
+                f"  TREND vs last run: detectors {d_det:+d}, fire rate {d_rate:+.3f}\n"
+                "    Same frozen papers, so a rise is a change in the DETECTORS, not the corpus.\n"
+                "    Detectors up and fire rate up together is the overfitting signature: prune or\n"
+                "    label before adding more."
+            )
+        elif prev:
+            print("-" * 78)
+            print(
+                f"  TREND: not comparable — corpus size changed "
+                f"({prev.get('n_papers')} -> {payload['n_papers']} papers)."
+            )
+
+    if a.out:
+        a.out.parent.mkdir(parents=True, exist_ok=True)
+        a.out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"  json: {a.out}")
+
+    print(
+        "\n  This is an instrument, not a gate: it never fails a build. What it can be wrong about\n"
+        "  is coverage — a detector silent across the corpus is silent ON THESE PAPERS, which is\n"
+        "  evidence only to the extent the corpus spans the designs it reads."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/test_heldout_crossfire.sh
+++ b/reverse_engineer/scripts/test_heldout_crossfire.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Self-test for the held-out measurement instrument and the development firewall that protects it.
+#
+# The real corpus is gitignored published papers, so CI can never run the real measurement. What CI
+# CAN prove is that the instrument is honest about what it measured: that it withholds a
+# false-positive rate it has no labels for, that it names a collapsed corpus instead of counting it,
+# that a partial run cannot enter the trend series, and that a held-out source authorizes nothing.
+#
+# Network-free. Builds its own synthetic corpus in a temp dir.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$HERE/heldout_crossfire.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The instrument needs a detector that reliably fires on a stub paper so the fire / worksheet /
+# disposition paths are exercised. If this detector is ever renamed this test fails loudly, which
+# is the intent: a test that silently stops exercising the fire path is worse than no test.
+DET="check_disclosure_availability"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$TMP/corpus"
+cat > "$TMP/corpus/alpha_2024_ct.md" <<'EOF'
+# Detection on CT
+## Methods
+Patients were split at the patient level; the reference standard was consensus of two readers.
+## Results
+Sensitivity was 0.88 (95% CI 0.83-0.92).
+EOF
+# A deliberate near-duplicate: same declared design profile as alpha. The instrument must call this
+# one pattern measured twice, not two observations.
+cp "$TMP/corpus/alpha_2024_ct.md" "$TMP/corpus/beta_2024_ct.md"
+
+cat > "$TMP/manifest.json" <<'EOF'
+{"schema_version": 1, "records": [
+  {"record_id": "alpha_2024_ct", "split": "heldout", "frozen_at": "2026-07-25",
+   "coverage": {"design": "retrospective_diagnostic", "modality": "ct"}},
+  {"record_id": "beta_2024_ct", "split": "heldout", "frozen_at": "2026-07-25",
+   "coverage": {"design": "retrospective_diagnostic", "modality": "ct"}}
+]}
+EOF
+
+echo "== 1. measurement runs, withholds an unlabelled FP rate, names the collapse =="
+OUT="$(python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only "$DET" \
+        --worksheet "$TMP/ws.csv" --ledger "$TMP/ledger.jsonl" --out "$TMP/run.json" 2>&1)" \
+  || fail "runner exited non-zero (it is an instrument and must never block)"
+
+grep -q "FALSE-POSITIVE RATE: WITHHELD" <<<"$OUT" \
+  || fail "printed a false-positive rate with zero labels — a fire on an accepted paper is not a FP"
+grep -q "COLLAPSED: alpha_2024_ct, beta_2024_ct" <<<"$OUT" \
+  || fail "did not flag two identical design profiles as a collapsed corpus"
+grep -q "LEDGER SKIPPED" <<<"$OUT" \
+  || fail "--only run was not kept out of the trend ledger"
+[ ! -s "$TMP/ledger.jsonl" ] || fail "a partial (--only) run was written into the trend series"
+
+python3 - "$TMP/run.json" <<'PY' || exit 1
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert d["n_papers"] == 2, d["n_papers"]
+assert d["pairs_ran"] == 2, d["pairs_ran"]
+assert d["pairs_fired"] == 2, "the fire path was not exercised: %r" % d["pairs_fired"]
+assert d["false_positive_rate"] is None, "FP rate must be null without labels"
+assert d["separation"]["distinct_profiles"] == 1, d["separation"]
+assert d["separation"]["collapsed"], "collapse not recorded in the artifact"
+v = {f["verdict"] for f in d["fires"]}
+assert v and all(x and not set(x) <= set("=- ") for x in v), \
+    "worksheet verdicts are separator rules, not labelable verdicts: %r" % v
+PY
+
+echo "== 2. labelled dispositions produce a rate =="
+python3 - "$TMP/ws.csv" "$TMP/disp.csv" <<'PY'
+import csv, sys
+rows = list(csv.DictReader(open(sys.argv[1])))
+assert len(rows) == 2, rows
+for r, d in zip(rows, ["spurious", "real"]):
+    r["disposition"] = d
+with open(sys.argv[2], "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=["paper", "detector", "verdict", "disposition", "note"])
+    w.writeheader(); w.writerows(rows)
+PY
+python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only "$DET" \
+    --dispositions "$TMP/disp.csv" 2>&1 | grep -q "FALSE-POSITIVE RATE: 0.500" \
+  || fail "labelled dispositions did not yield the expected 1 spurious / 2 decided rate"
+
+echo "== 3. an unbacked paper is excluded, not silently measured =="
+cp "$TMP/corpus/alpha_2024_ct.md" "$TMP/corpus/gamma_undeclared.md"
+python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only "$DET" 2>&1 \
+  | grep -q "EXCLUDED (no heldout manifest record): gamma_undeclared.md" \
+  || fail "a paper with no heldout manifest record was not excluded and named"
+rm "$TMP/corpus/gamma_undeclared.md"
+
+echo "== 4. an empty corpus refuses to emit a rate =="
+mkdir -p "$TMP/empty"
+if python3 "$RUNNER" --corpus "$TMP/empty" --only "$DET" >/dev/null 2>&1; then
+  fail "a corpus with zero papers produced a measurement instead of refusing"
+fi
+
+echo "== 5. development firewall: a held-out source authorizes nothing =="
+python3 - "$HERE/distill.py" <<'PY' || exit 1
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("distill", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+enums = m.load_schema_enums()
+
+base = dict(record_id="x_2024", source_url="https://e.org/x", source_type="oa_article",
+            license="CC-BY-4.0", license_url="https://creativecommons.org/licenses/by/4.0/",
+            retrieved_at="2026-07-25", verbatim_allowed=False,
+            public_reuse_policy="synthetic_only")
+
+held = dict(base, split="heldout", frozen_at="2026-07-25")
+ok, why = m.authorize(held, "synthetic")
+assert not ok, "a held-out source authorized synthetic reuse — the measurement set can be trained on"
+assert "HELD-OUT" in why, why
+for mode in ("paraphrase", "verbatim"):
+    assert not m.authorize(held, mode)[0], mode
+
+# Negative fixture: the firewall must not block ordinary train-split work.
+assert m.authorize(dict(base, split="train"), "synthetic")[0], "firewall blocked a train source"
+assert m.authorize(base, "synthetic")[0], "firewall blocked a source with no split declared"
+
+# A held-out claim without a freeze date is unverifiable and must not validate.
+errs = m.validate_record(dict(base, split="heldout"), enums)
+assert any("frozen_at" in e for e in errs), errs
+assert not m.validate_record(held, enums), m.validate_record(held, enums)
+assert any("split" in e for e in m.validate_record(dict(base, split="sometimes"), enums))
+PY
+
+echo "PASS: held-out instrument honest about labels, collapse, exclusions, trend; firewall closed."

--- a/reverse_engineer/source_manifest.schema.json
+++ b/reverse_engineer/source_manifest.schema.json
@@ -72,6 +72,22 @@
           "type": "string",
           "description": "Required citation line when public_reuse_policy is cc_by_attribution. Optional otherwise."
         },
+        "split": {
+          "type": "string",
+          "enum": ["train", "heldout"],
+          "default": "train",
+          "description": "Which side of the development firewall this source sits on. train = may inform detectors, probes, exemplars, rubrics (the normal path). heldout = MEASUREMENT ONLY: the source exists to be scored against, and distill.py DENIES every reuse mode for it, including synthetic. A held-out paper that informs a public artifact stops being held out, and the fire-rate measured on it stops meaning anything. Setting this to heldout is one-way in practice: moving a source back to train invalidates every measurement already taken on it."
+        },
+        "frozen_at": {
+          "type": "string",
+          "description": "ISO-8601 date (YYYY-MM-DD) the source was sealed into the held-out split. REQUIRED when split is heldout: the claim a held-out measurement makes is 'no detector was built with knowledge of this paper', and only a freeze date that precedes the detector can support it. A held-out record without one is unverifiable and fails validation."
+        },
+        "coverage": {
+          "type": "object",
+          "additionalProperties": {"type": "string"},
+          "description": "Free-form axis -> value map describing WHAT DESIGN this paper is, so a held-out corpus can be checked for separation rather than merely counted (e.g. {\"design\": \"retrospective_diagnostic\", \"modality\": \"ct\", \"task\": \"detection\", \"venue_tier\": \"specialty\"}). Six papers that are all the same design are one design measured six times: a detector silent across them is silent on ONE pattern, and the fire rate's denominator is inflated. heldout_crossfire.py reports the per-axis distribution and flags concentration. Axes are deliberately unconstrained — declare the ones that distinguish YOUR corpus.",
+          "examples": [{"design": "retrospective_diagnostic", "modality": "ct", "task": "detection"}]
+        },
         "notes": {
           "type": "string",
           "description": "Free-text: why this license was assigned, what was learned, caveats."


### PR DESCRIPTION
## The gap

Every detector here is tested against fixtures authored **alongside it** — a challenge card proving it fires on its own planted defect, and `check_detector_crossfire.py` proving it stays silent on the demo manuscripts. Both are necessary; neither is independent. That is a **training set**, and a detector passing its own challenge card is a training accuracy of 100%: true, and uninformative about the only question that matters as the count climbs — *is the stack getting better, or getting better at satisfying itself?*

`check_detector_crossfire.py` already named this in its closing paragraph:

> A new detector still owes what **no shippable corpus can supply**: two real manuscripts, at least one of them known-good.

No shippable corpus can supply it because published papers cannot be committed here. So the corpus stays **local and gitignored**, and only the number ships.

## What this adds

`reverse_engineer/scripts/heldout_crossfire.py` points that same machinery (imported, never re-implemented — its invocation rules were paid for with 31 clobbered fixtures) at real accepted OA papers marked `split: heldout`. It is an **instrument, not a gate** — it never fails a build — and it refuses to overclaim in three specific ways:

| | |
|---|---|
| **A fire is not a false positive** | A published paper is not a defect-free paper; this project exists because reviewers miss things. The FP rate is **withheld entirely** until a human labels the fires (`real`/`spurious`/`unsure`), then printed with its coverage. Calling every fire an error would manufacture the alarming trend it claims to detect. |
| **"Never fired" ≠ "never ran"** | Exercised silence is evidence; unobserved silence is not. The prune decision turns on exactly that, and harvesting project `qc/` cannot supply it — that only sees detectors somebody happened to run. A frozen corpus observes all of them, every run. |
| **A corpus is checked for separation, not counted** | Six papers sharing one declared `coverage` profile are one pattern measured six times. Concentration and identical profiles are named — the corpus-side of the rule `check_panel_diversity` already applies to reviewers. |

The trend is the signal, so the ledger is protected from us: a `--only` run **cannot** be appended, because letting a filter into the series would make the next comparison read our own behaviour as a change in the detectors.

`distill.py` gains a **development firewall** beside its copyright one: `split: heldout` authorizes *nothing*, including `synthetic`, and `frozen_at` (ISO date) is required. Denying `synthetic` is deliberate — reuse can be non-derivative in copyright terms and total in measurement terms, and reading a held-out paper to author a fresh probe is exactly how a detector comes to know it.

## Verification

Planted the defects rather than watching green. Each fails the self-test; restoring passes:

| planted | result |
|---|---|
| firewall opened (`heldout` authorizes synthetic) | exit 1 |
| FP rate printed with zero labels | exit 1 |
| collapse check blinded | exit 1 |
| restored | exit 0 |

Two bugs the smoke run found in the first draft: the worksheet `verdict` column was a row of `=` (the verdict token goes to **stderr** while the banner goes to stdout), and a `--only` run was polluting the trend ledger.

CI mirror: **211/211** gates pass; the new step ran as `[36/211]` (not skipped).

## Not in scope

`HELDOUT.md` records what a buffer plus a ledger is *not* yet: interleaved replay with **distillation** (promotion that adds one detector per episode is memorisation in the costume of learning — the ratio is measurable), and **associative retrieval** that edits an existing detector instead of appending a new one. Both depend on this split existing first.

No detector added; catalog counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)