### PR TITLE
fix: the Dice-CI claim was wrong in three shipped docs, not just the new one

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -583,8 +583,8 @@
     },
     {
       "path": "skills/calc-sample-size/SKILL.md",
-      "size": 30513,
-      "sha256": "b4c5c8ae6e2f7665846484949bebb28c79593e4d4ed91d99a541021e90aea5fe"
+      "size": 30637,
+      "sha256": "5cdded86ad07224df8dabf6c5ec286df49e9d98b1ccc1c9334b7f422e11dcbbb"
     },
     {
       "path": "skills/calc-sample-size/references/formulas.md",
@@ -618,8 +618,8 @@
     },
     {
       "path": "skills/calc-sample-size/references/segmentation_metric_sample_size.md",
-      "size": 3809,
-      "sha256": "3328647f1fb77f398d137713c0f068f71249dbdad201e9d20318a47c9206d0c2"
+      "size": 3987,
+      "sha256": "0a93b7d19c5183287598ba3a53a51b3f29714d8cff9f35b58c5b1bc1a83d62e5"
     },
     {
       "path": "skills/calc-sample-size/skill.yml",
@@ -2168,8 +2168,8 @@
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/external_validation_comparison.md",
-      "size": 3037,
-      "sha256": "e167bb710d32c618328811b0c883f632e2963fbb29bd9f3571d42192dcf1fd33"
+      "size": 3124,
+      "sha256": "7d905e5b2a75356a23442b222d904bf0381e55168a49e71bce762a6c7d32670d"
     },
     {
       "path": "skills/make-figures/references/exemplar_plots/forest_plot.md",
@@ -4373,8 +4373,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_systematic_check.md",
-      "size": 18988,
-      "sha256": "d78e98cc0eee08b56b13539c9a61836485a7357a2b4b53b6db7d6329d2443da8"
+      "size": 19196,
+      "sha256": "3f9b544f8c588e278d49a69f9ce3800f004229869ed255a50c587d4221addcfa"
     },
     {
       "path": "skills/self-review/references/phases/phase3c_json_output.md",

--- a/skills/calc-sample-size/SKILL.md
+++ b/skills/calc-sample-size/SKILL.md
@@ -402,8 +402,9 @@ overlap/boundary score, not a proportion.
 
 **Approach**: precision sizing `n ≈ (1.96·SD/δ)²` from the **pilot/literature SD of per-case Dice**
 (per structure — size on the **worst** structure you must report, not the average); report the CI by
-**bootstrapping per-case values (BCa)**, since Dice has no closed-form CI and is non-normal near the
-ceiling. A model comparison on the same cases is **paired** (size on the SD of the per-case
+**bootstrapping per-case values (BCa)** — a t-interval is closed-form but Dice is bounded and
+non-normal near the ceiling, so its coverage is not the coverage you asked for, and BCa must resample
+whole **patients**, not structures. A model comparison on the same cases is **paired** (size on the SD of the per-case
 *difference*, or an NI margin). **Size the external cohort too** — a precise external estimate is the
 #1 acceptance lever.
 

--- a/skills/calc-sample-size/references/segmentation_metric_sample_size.md
+++ b/skills/calc-sample-size/references/segmentation_metric_sample_size.md
@@ -50,8 +50,10 @@ margin).
 ## Required parameters + compute
 
 - Pilot/literature **SD of the per-case metric** (per structure), the target **precision δ** or the
-  **NI margin**, the metric itself. There is **no closed-form CI for Dice** → bootstrap per-case
-  values; use the pilot for SD. Report N, the per-structure SD source, and δ / margin.
+  **NI margin**, the metric itself. A t-interval on mean per-case Dice is closed-form, but the metric
+  is **bounded and skewed near the ceiling**, so its nominal coverage is not the real one → **bootstrap
+  per-case values** (BCa, resampling whole patients rather than structures); use the pilot for SD.
+  Report N, the per-structure SD source, and δ / margin.
 
 ## Cross-links
 

--- a/skills/make-figures/references/exemplar_plots/external_validation_comparison.md
+++ b/skills/make-figures/references/exemplar_plots/external_validation_comparison.md
@@ -14,8 +14,8 @@ no real citations.
   **internal as the labelled reference** and each external cohort below it — so the **drop** is read
   at a glance, not buried in a table.
 - **Per-cohort N and a CI on each estimate** — for Dice, a **bootstrap (BCa) CI on per-case values**
-  (there is no closed-form Dice CI); the CI width makes a small external cohort's uncertainty
-  honest.
+  (a t-interval is closed-form but the metric is bounded and bunches near the ceiling, so resample
+  whole patients instead); the CI width makes a small external cohort's uncertainty honest.
 - The **Δ from internal** annotated per external cohort (the generalization gap), and, if the design
   is non-inferiority, the **margin**.
 - **Faceting by structure / subgroup / sequence** where the endpoint demands it, so a per-organ or

--- a/skills/self-review/references/phases/phase2_systematic_check.md
+++ b/skills/self-review/references/phases/phase2_systematic_check.md
@@ -53,7 +53,7 @@ not at all for this manuscript type.
 | Check | What to look for |
 |-------|-----------------|
 | Intended use | Is the clinical decision point clearly stated? (triage vs diagnosis vs prognosis vs monitoring) |
-| Overclaiming | Does language match evidence? ("will improve" -> "may potentially"; "superior" with overlapping CIs?) |
+| Overclaiming | Does language match evidence? ("will improve" -> "may potentially"; "superior" read off two arms' separate CIs rather than a tested difference — note that overlapping CIs neither establish nor refute a difference, so the fix is to report the paired delta and its CI, not to soften a claim the test supports) |
 | Terminology precision | Key terms defined? (e.g., "perioperative" = when exactly?) |
 | Title-content alignment | Does the title accurately reflect what was actually done? |
 | Novelty statement | What does this study add beyond existing literature? Is this explicitly stated? |


### PR DESCRIPTION
## What

Cross-model verification on #421 refuted the absolute claim **"there is no closed-form Dice CI"**. A t-interval on mean per-case Dice *is* closed-form; the real reason to bootstrap is that the metric is **bounded and bunches near the ceiling**, so normal-theory coverage is not the coverage you asked for — and BCa has to resample whole **patients**, not structures.

#421 fixed its own copy. Grepping `main` found the same claim in three documents shipped by **earlier** arcs:

| File | Origin |
|---|---|
| `calc-sample-size/SKILL.md` (Test 15) | already stated the true reason *beside* the false one |
| `calc-sample-size/references/segmentation_metric_sample_size.md` | G73 |
| `make-figures/references/exemplar_plots/external_validation_comparison.md` | G74 |

## Also

The `self-review` overclaiming probe asked whether "superior" appears **"with overlapping CIs"**. Overlapping marginal CIs neither establish nor refute a difference (Schenker & Gentleman 2001) — as written, the probe could tell an author to soften a superiority claim their paired test actually supports. It now asks the question that finds the real defect: was superiority read off two arms' separate CIs instead of a **tested difference**.

## Checked and deliberately left alone

`peer-review/references/exemplar_reviews/ai_overclaiming.md` matched the same grep, but its review body already asks the authors to *"report the difference in AUC with its CI and a test of that difference rather than two separate AUCs"*, and its softening recommendation is conditional on that test, not on the overlap. **Not a defect.**

## Gates

Prose only. Detectors **84** and skills **58** unchanged. Local CI mirror **211/211**. Generated artifacts regenerated last.