### PR TITLE
fix(reverse-engineer): the held-out instrument was inventing skip reasons for files it failed to hand over

### DIFF
--- a/reverse_engineer/HELDOUT.md
+++ b/reverse_engineer/HELDOUT.md
@@ -48,6 +48,48 @@ detection studies are one pattern measured six times: a detector silent across t
 that pattern, and the denominator is inflated sixfold. That is what `coverage` is for, and the
 instrument reports concentration and identical profiles rather than trusting the count.
 
+## Rendering the corpus faithfully (where the first measurement went wrong)
+
+The corpus is the denominator. A converter that drops a section the detectors read does not produce
+a missing signal — it produces a **fire**, and that fire is indistinguishable from a detector
+defect. The first real run reported 12 fires; three rendering fixes later it reported 6, and **every
+one of those removals was the parser, not the detectors**:
+
+| what the renderer dropped | what fired | fire rate |
+|---|---|---|
+| everything but `<body>` | `check_disclosure_availability` on **12 of 12** papers | 0.031 |
+| `<author-notes>`, `<back>` | JAMA / Elsevier put disclosures there | 0.018 |
+| `<funding-group>`, `<custom-meta id="data-availability">` | PLOS puts them there and nowhere else | 0.015 |
+| `<contrib-group>` (the byline) | `check_credit_integrity` cannot resolve initials without it | 0.015 |
+
+The trap worth naming: **publishers disagree about where a disclosure lives**, so a renderer that
+knows one publisher's location manufactures fires *for the other publishers' papers only* — a bias
+correlated with journal rather than with quality, which is the worst kind a measurement corpus can
+carry. Render title, byline, abstract, body, `author-notes`, `funding-group`, non-PMC
+`custom-meta`, back matter and references before trusting a single number.
+
+## First baseline (2026-07-25)
+
+12 papers, 12 distinct design profiles, no concentration flagged. 33 detectors ran, 10 skipped
+(unobserved, each named by what it needed). **389 pairs, 6 fires, fire rate 0.015.** 31 detectors
+observed clean.
+
+Labelled: **false-positive rate 0.800** (4 spurious / 5 decided, 1 unsure, coverage 100%). Two
+causes, both structurally invisible to a fixture authored alongside its detector:
+
+- **House-style vocabulary.** JAMA's "Data Sharing Statement" / "Funding/Support" / "Conflict of
+  Interest Disclosures" and Elsevier's "Declaration of competing interest" all went unrecognised.
+  A fixture uses the phrasing its detector expects, so the detector had never met a journal that
+  words it differently.
+- **Firing on prose when the target section is absent.** `check_credit_integrity` flagged the
+  ordinary words "analysis" and "writing" as invalid CRediT terms in papers carrying **no CRediT
+  statement at all**. A fixture always contains the block being validated; a real corpus does not.
+
+One fire was real — a systematic review with no data-availability statement anywhere — which is
+exactly why the rate is withheld until a human looks. The instrument found a genuine omission in an
+accepted paper and three vocabulary bugs in our own stack, and could not have told them apart by
+itself.
+
 ## Reading the output
 
 ```bash

--- a/reverse_engineer/HELDOUT.md
+++ b/reverse_engineer/HELDOUT.md
@@ -90,6 +90,32 @@ exactly why the rate is withheld until a human looks. The instrument found a gen
 accepted paper and three vocabulary bugs in our own stack, and could not have told them apart by
 itself.
 
+## A fire you act on spends the paper
+
+This is the rule the first cycle produced, and it is the one most easily skipped.
+
+The six fires above were investigated, and four turned out to be ours: house-style vocabulary and
+a term scan running on sections that were never CRediT blocks. Fixing them dropped the same corpus
+to **2 fires, fire rate 0.005, false-positive rate 0.000** — the loop closed for the first time.
+
+That number is a **tuning score, not a held-out estimate.** Those twelve papers have now informed
+detector changes; measuring the changed detectors on them again is scoring on the set they were
+fitted to. The corpus did not stop being useful — it stopped being *unbiased*, and only for the
+detectors it touched.
+
+So the split has three parts, not two, and they are spent in this order:
+
+| set | role | spent by |
+|---|---|---|
+| challenge-card fixtures | train | authored with the detector |
+| **this corpus** | validation — find defects, fix them, re-measure | acting on a fire |
+| a **fresh** frozen corpus | test — one unbiased number | reading it |
+
+Acquiring the next freeze is cheap: the same PMC route, different DOIs, `frozen_at` on the day it
+is sealed. Do that before quoting a false-positive rate as evidence of anything, and do not quote
+this one as unbiased — it is the score of a fix on the cases that motivated it, which is exactly
+the reading a reviewer would catch.
+
 ## Reading the output
 
 ```bash

--- a/reverse_engineer/scripts/heldout_crossfire.py
+++ b/reverse_engineer/scripts/heldout_crossfire.py
@@ -180,6 +180,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--verbose", action="store_true")
     a = ap.parse_args(argv)
 
+    # Detectors run with cwd inside a throwaway sandbox, so a default `qc/...` report lands there
+    # instead of in the repo. That makes every path handed to them absolute-or-broken: a relative
+    # --corpus resolves against the CALLER's cwd, which the subprocess does not share. The first
+    # real run was invoked as `--corpus _corpus/heldout`; every detector answered "manuscript not
+    # found", and this harness relabelled that as "needs an input this fixture cannot supply" —
+    # a skip reason it invented for a file it had failed to hand over, on 34 of 42 detectors, in
+    # an instrument whose whole job is honest accounting.
+    a.corpus = a.corpus.resolve()
+
     if not a.corpus.is_dir():
         print(
             f"harness: no held-out corpus at {a.corpus}\n"
@@ -255,6 +264,16 @@ def main(argv: Optional[List[str]] = None) -> int:
                     skipped[d.name] = "timed out"
                     break
                 if r.returncode == 2:
+                    # "not found" is never a skip: the detector is telling us the harness handed it
+                    # a path it could not open. Recording that as a missing-input skip is how the
+                    # instrument lies to itself. Fail loudly instead.
+                    if re.search(r"\bnot found\b|No such file", (r.stderr or "") + (r.stdout or "")):
+                        print(
+                            f"\nharness: {d.name} could not open {paper} — the harness built a bad "
+                            f"command, this is not a detector skip.\n  {(r.stderr or '').strip()[:200]}",
+                            file=sys.stderr,
+                        )
+                        return 2
                     skipped[d.name] = "needs " + cf.missing_flag_from(
                         r.stderr, r.stdout, ("--manuscript",)
                     )

--- a/reverse_engineer/scripts/test_heldout_crossfire.sh
+++ b/reverse_engineer/scripts/test_heldout_crossfire.sh
@@ -91,6 +91,17 @@ python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only 
   || fail "a paper with no heldout manifest record was not excluded and named"
 rm "$TMP/corpus/gamma_undeclared.md"
 
+echo "== 3b. a RELATIVE --corpus still reaches the detectors =="
+# Detectors run with cwd inside a sandbox, so a relative corpus path resolves against a directory
+# they do not share. The first real run was invoked exactly this way: every detector answered
+# "manuscript not found", and the harness relabelled that as a missing-input skip — 34 of 42
+# detectors silently unmeasured. Every synthetic fixture used absolute paths, so nothing caught it.
+# This case runs from inside $TMP on purpose.
+REL_OUT="$(cd "$TMP" && python3 "$RUNNER" --corpus ./corpus --only "$DET" 2>&1)" \
+  || fail "relative --corpus made the runner exit non-zero"
+grep -qE "pairs +: 2 " <<<"$REL_OUT" \
+  || fail "relative --corpus ran 0 pairs — detectors were handed a path they cannot resolve"
+
 echo "== 4. an empty corpus refuses to emit a rate =="
 mkdir -p "$TMP/empty"
 if python3 "$RUNNER" --corpus "$TMP/empty" --only "$DET" >/dev/null 2>&1; then


### PR DESCRIPTION
Follow-up to #422, found by actually running it on a real corpus.

## The bug

The first real run was invoked as `--corpus _corpus/heldout`. Detectors run with cwd inside a throwaway sandbox (so a default `qc/...` report cannot land in the repo), which makes a **relative** corpus path resolve against a directory the subprocess does not share. Every detector answered `manuscript not found` — and the harness relabelled that as:

> needs an input this fixture cannot supply

on **34 of 42 detectors**, in an instrument whose entire job is honest accounting. It then returned *before* printing the skip list, so the reason was invisible. Every synthetic fixture passed absolute paths, which is exactly why the self-test was green.

**Fixes**
- resolve `--corpus` (root cause)
- `not found` is now a **harness error, not a skip** — if a detector cannot open what we handed it, we built a bad command and must fail loudly
- the self-test runs one case from inside the temp dir with a **relative** path; removing the resolve makes it fail

## What the first measurement cost to learn (HELDOUT.md)

The corpus is the denominator, and a renderer that drops a section the detectors read does not produce a *missing signal* — it produces a **fire**, indistinguishable from a detector defect. Twelve fires became six across three rendering fixes, and **all six removals were the parser, not the detectors**:

| renderer dropped | what fired | fire rate |
|---|---|---|
| everything but `<body>` | disclosure detector on **12 of 12** | 0.031 |
| `<author-notes>`, `<back>` | JAMA / Elsevier put disclosures there | 0.018 |
| `<funding-group>`, `<custom-meta id="data-availability">` | PLOS puts them there and nowhere else | 0.015 |
| `<contrib-group>` | no byline → no initials to resolve | 0.015 |

Publishers disagree about *where* a disclosure lives, so a renderer that knows one publisher's location manufactures fires **for the other publishers' papers only** — a bias correlated with journal rather than with quality.

## First baseline (recorded in HELDOUT.md)

12 papers, 12 distinct design profiles, no concentration. 33 detectors ran, 10 skipped (each named). **389 pairs, 6 fires, fire rate 0.015.** 31 detectors observed clean.

Labelled: **false-positive rate 0.800** (4 spurious / 5 decided, 1 unsure, coverage 100%). Both causes are structurally invisible to a fixture authored alongside its detector:

- **House-style vocabulary** — JAMA's "Data Sharing Statement" / "Funding/Support" / "Conflict of Interest Disclosures", Elsevier's "Declaration of competing interest": all unrecognised. A fixture uses the phrasing its detector expects, so the detector had never met a journal that words it differently.
- **Firing on prose when the target section is absent** — `check_credit_integrity` flagged the ordinary words "analysis" and "writing" as invalid CRediT terms in papers carrying **no CRediT statement at all**.

One fire was **real** (a systematic review with no data-availability statement anywhere), which is precisely why the rate is withheld until a human looks: the instrument found a genuine omission in an accepted paper *and* three vocabulary bugs in our own stack, and could not have told them apart by itself.

Those detector fixes are deliberately **not** in this PR — they are the next batch, and they now have evidence behind them.

CI mirror: 211/211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)