### PR TITLE
fix(sync-submission): five false positives that only a corpus outside the fixtures could show

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5263,8 +5263,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/check_credit_integrity.py",
-      "size": 16461,
-      "sha256": "6288efcba7d55d451199f5420affbbf3fceed603defdea09bb04b5ed64155262"
+      "size": 18645,
+      "sha256": "c0ab9a7aa3008af3d23901ee93a764d01ae46786dbedfc287dc6cf031b7248e1"
     },
     {
       "path": "skills/sync-submission/scripts/check_cross_artifact_stale.py",
@@ -5273,8 +5273,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/check_disclosure_availability.py",
-      "size": 10455,
-      "sha256": "f5e195119ec1a24723748049ee6c2ae44418500b1fc6ba525984fa12c7f06aef"
+      "size": 12568,
+      "sha256": "e6576de96a1a217749463e025d5aa35edc6b57efd80093dbfd5b306695b18059"
     },
     {
       "path": "skills/sync-submission/scripts/check_marked_manuscript.py",
@@ -5343,8 +5343,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/credit_integrity_challenge/verify.sh",
-      "size": 5529,
-      "sha256": "9eeacb6730b6025dd04c1b7719014e354ce096e649f47850dadfb78d52d11a6a"
+      "size": 7806,
+      "sha256": "c280d555ba31145ca89c04ae37da3b1b3dfb13f300bf6c4b731ff85658774f10"
     },
     {
       "path": "skills/sync-submission/scripts/cross_document_n_check.py",

--- a/skills/sync-submission/scripts/check_credit_integrity.py
+++ b/skills/sync-submission/scripts/check_credit_integrity.py
@@ -152,7 +152,11 @@ def credit_section(md: str) -> str | None:
 
 
 def norm_term(t: str) -> str:
-    return re.sub(r"\s+", " ", re.sub(r"[^a-z ]", " ", t.lower())).strip()
+    n = re.sub(r"\s+", " ", re.sub(r"[^a-z ]", " ", t.lower())).strip()
+    # "Writing—original draft preparation" is MDPI's rendering of "Writing – original draft", not a
+    # fifteenth term. The trailing noun is house style, so it is normalised away rather than
+    # reported as a near miss.
+    return re.sub(r" preparation$", "", n)
 
 
 def initials_of(name: str) -> str:
@@ -225,7 +229,33 @@ def build_report(manuscript: Path, record_path: Path | None) -> dict | None:
     section_says_credit = bool(re.search(r"CRediT", heading_text + "\n" + body, re.I))
 
     # --- 1. terms outside the fourteen
-    used_raw = re.findall(r"[A-Za-z][A-Za-z–\-&' ]{3,40}", body)
+    #
+    # Only for a section that IS a CRediT block. The docstring above already says so — "a section
+    # that calls itself CRediT" — and the code had drifted from it: the scan ran on any
+    # "Authors' Contributions" heading and merely graded the result `minor`. A minor finding still
+    # exits non-zero, so a free-prose contributions paragraph fired.
+    #
+    # Measured against 12 accepted papers, that is exactly what happened: "analysis" and "writing"
+    # reported as invalid CRediT terms in papers carrying NO CRediT statement at all — zero of the
+    # fourteen present. A journal that never asked for CRediT has not asked its authors to use the
+    # fourteen. A challenge card always contains the block being validated, so no fixture in this
+    # repo could have shown it.
+    #
+    # A block counts as CRediT if it says so, or carries at least three of the official terms.
+    # Three, not one: "Investigation", "Validation" and "Software" are ordinary English words that
+    # turn up in prose by accident; three of them together do not.
+    # Count against the NORMALISED body, because CREDIT_TERMS is keyed normalised: the key is
+    # "writing original draft" and the page says "Writing – original draft". Matching the raw text
+    # undercounts every hyphenated term and lets a real CRediT block fall below the bar.
+    body_norm = norm_term(body)
+    official_present = {t for t in CREDIT_TERMS if t and t in body_norm}
+    is_credit_block = section_says_credit or len(official_present) >= 3
+
+    # The em dash belongs in this class. MDPI renders the taxonomy as "Writing—original draft
+    # preparation"; without U+2014 the term is shredded at the dash and the fragment "writing" is
+    # reported as an invalid CRediT term — against a block that had written the term correctly for
+    # its publisher. Two accepted MDPI papers failed this way.
+    used_raw = re.findall(r"[A-Za-z][A-Za-z—–\-&' ]{3,40}", body) if is_credit_block else []
     seen: set[str] = set()
     for raw in used_raw:
         n = norm_term(raw)

--- a/skills/sync-submission/scripts/check_disclosure_availability.py
+++ b/skills/sync-submission/scripts/check_disclosure_availability.py
@@ -60,16 +60,35 @@ TOKEN_RESPONSIBLE = re.compile(
     r"\bby [A-Z]\.\s?[A-Z]\.|the authors|reviewed by|deployed by|operated by|under the supervision",
     re.IGNORECASE,
 )
+# What separates "this paper discloses that its authors used an AI tool" from "this paper is about
+# AI". Only the first owes the four tokens above.
+AI_AUTHORIAL_USE = re.compile(
+    r"\b(?:we|the authors?|author)\b[^.\n]{0,80}\b(?:used|employed|utili[sz]ed|engaged)\b|"
+    r"\b(?:used|employed|utili[sz]ed)\b[^.\n]{0,60}\b(?:to (?:assist|help|draft|edit|improve|"
+    r"polish|refine)|for (?:language|writing|editing|drafting))|"
+    r"writing assistance|language editing|during the preparation of (?:this|the) manuscript|"
+    r"in (?:the )?preparation of (?:this|the) manuscript|"
+    r"no (?:generative )?ai (?:tools? )?(?:was|were) used",
+    re.IGNORECASE,
+)
 PLACEHOLDER = re.compile(r"\[(?:version|date|tool|name|model|n)\]|\bTODO\b|XXXX|\bTBD\b", re.IGNORECASE)
 
 REASONABLE_REQUEST = re.compile(r"available (?:from the (?:corresponding )?author )?on (?:reasonable )?request", re.IGNORECASE)
 RESOLVABLE = re.compile(r"https?://|doi\.org/|\bgithub\.com\b|\bzenodo\b|\bosf\.io\b|10\.\d{4,}/", re.IGNORECASE)
 
+# House style is not optional vocabulary — it is what the target journal's own author instructions
+# tell the author to write. Measured against 12 accepted papers, this detector reported "no Data
+# Availability statement found" for a JAMA trial carrying "Data Sharing Statement: See Supplement 3"
+# and "no COI statement found" for an Elsevier review carrying "Declaration of competing interest".
+# Both statements were present, correctly worded for their journal, and called missing. A fixture
+# authored beside a detector always uses the phrasing that detector expects, so this class of defect
+# cannot surface until the detector meets a journal that words it differently.
 SECTION_LABELS = {
-    "data_availability": r"data availability|availability of data",
+    "data_availability": r"data availability|availability of data|data sharing",
     "code_availability": r"code availability|availability of code|software availability",
     "funding": r"funding|financial support|grant support",
-    "coi": r"conflicts? of interest|competing interests?|declaration of interests?|disclosure",
+    "coi": (r"conflicts? of interest|competing interests?|"
+            r"declarations? of (?:competing |conflicting )?interests?|disclosure"),
 }
 
 
@@ -113,9 +132,17 @@ def ai_disclosure_block(text: str) -> str | None:
         blk = find_section(text, pat)
         if blk and AI_TRIGGER.search(blk):
             return blk
-    # else: the first paragraph that mentions an AI tool
+    # else: the first paragraph in which the AUTHORS disclose using an AI tool.
+    #
+    # The bar is authorship, not mention. This fallback used to accept any paragraph containing an
+    # AI term, which in a paper whose SUBJECT is AI is the abstract — and then demanded a writing
+    # tool's version, access channel, date and responsible party from it. Measured against an
+    # accepted reader study on AI-assisted pneumothorax detection, that is exactly what happened:
+    # a hard finding, guaranteed, against a paper that never claimed to have used AI to write.
+    # Study-component AI and editorial-writing AI are different disclosures governed by different
+    # rules, and only the second one owes these four tokens.
     for para in re.split(r"\n\s*\n", text):
-        if AI_TRIGGER.search(para):
+        if AI_TRIGGER.search(para) and AI_AUTHORIAL_USE.search(para):
             return para.strip()
     return None
 

--- a/skills/sync-submission/scripts/credit_integrity_challenge/verify.sh
+++ b/skills/sync-submission/scripts/credit_integrity_challenge/verify.sh
@@ -97,6 +97,56 @@ has "and only as a prompt"                        "$OUT" "minor] CREDIT_UNCORROB
 OUT="$(python3 "$DET" --manuscript "$FIX/manuscript_good.md" 2>&1)"
 hasnt "no record -> that half does not run"       "$OUT" "is credited in the manuscript but"
 
+echo "== a contributions paragraph that is not a CRediT block is not graded as one =="
+# Found by running this detector over 12 accepted papers. The docstring says the term check is for
+# "a section that calls itself CRediT"; the code ran it on any Authors' Contributions heading and
+# merely graded the result `minor` — and a minor finding still exits non-zero. So free prose fired:
+# "analysis" and "writing" reported as invalid CRediT terms in papers carrying NO CRediT statement.
+cat > "$TMP/prose_contrib.md" <<'EOF'
+# A manuscript with a plain-prose contributions statement
+
+Jane Doe, Alan Roe
+
+## Author Contributions
+
+Study design, J.D. Data collection, A.R. Statistical analysis, J.D. Manuscript writing, A.R.
+Both authors approved the final version.
+EOF
+OUT="$(python3 "$DET" --manuscript "$TMP/prose_contrib.md" 2>&1)"
+hasnt "prose is not scanned for the fourteen terms" "$OUT" "CREDIT_TERM_INVALID"
+
+echo "== ...but a CRediT block that never says CRediT still is =="
+# Three official terms is evidence enough. One is not: "Investigation", "Validation" and "Software"
+# are ordinary English and turn up in prose by accident.
+cat > "$TMP/unnamed_credit.md" <<'EOF'
+# A manuscript using the taxonomy without naming it
+
+Jane Doe, Alan Roe
+
+## Author Contributions
+
+Conceptualization, J.D.; Methodology, J.D.; Formal analysis, A.R.; Statistical analysis, A.R.
+EOF
+OUT="$(python3 "$DET" --manuscript "$TMP/unnamed_credit.md" 2>&1)"
+has "a real CRediT block is still graded" "$OUT" "CREDIT_TERM_INVALID"
+
+echo "== the em dash belongs inside the term, not between two of them =="
+# MDPI renders the taxonomy as "Writing—original draft preparation". Without U+2014 in the term
+# class the phrase was shredded at the dash and the fragment "writing" reported as invalid — twice,
+# against accepted papers that had written the term correctly for their publisher.
+cat > "$TMP/mdpi.md" <<'EOF'
+# A manuscript in MDPI house style
+
+Jane Doe, Alan Roe
+
+## Author Contributions
+
+Conceptualization, J.D. and A.R.; methodology, J.D.; investigation, A.R.;
+writing—original draft preparation, J.D.; writing—review and editing, A.R.
+EOF
+OUT="$(python3 "$DET" --manuscript "$TMP/mdpi.md" 2>&1)"
+hasnt "MDPI's em-dash rendering is the official term" "$OUT" "CREDIT_TERM_INVALID"
+
 echo "== the artifact names its own author =="
 python3 "$DET" --manuscript "$FIX/manuscript_bad.md" --out "$TMP/r.json" >/dev/null 2>&1
 has "qc JSON carries the detector key" "$(cat "$TMP/r.json")" '"detector": "check_credit_integrity"'

--- a/skills/sync-submission/tests/test_disclosure_availability.sh
+++ b/skills/sync-submission/tests/test_disclosure_availability.sh
@@ -104,6 +104,79 @@ ck "hollow data statement -> blocker under --strict" 1 "$(run --manuscript "$TMP
 # No AI tool mentioned at all -> AI disclosure not required (clean if others present)
 ck "no AI mention -> no ai-disclosure finding" 0 "$(run --manuscript "$TMP/good.md" --journal lancet-digital-health --strict)"
 
+# --- house style is not optional vocabulary (found by measuring 12 accepted papers) -------------
+# Each case below was reported MISSING against a real accepted paper that carried the statement,
+# correctly worded for its own journal. A fixture written beside a detector always uses the
+# phrasing that detector expects, which is exactly why none of this could surface here before.
+
+cat > "$TMP/jama.md" <<'EOF'
+# Trial
+
+## Article Information
+
+Conflict of Interest Disclosures: None reported.
+
+Funding/Support: This trial was funded by a company.
+
+Data Sharing Statement: See Supplement 3.
+EOF
+ck "JAMA 'Data Sharing Statement' counts as data availability" 0 \
+  "$(run --manuscript "$TMP/jama.md" --journal radiology --require data_availability)"
+
+cat > "$TMP/elsevier.md" <<'EOF'
+# Review
+
+## Data availability
+No data were generated.
+
+## Declaration of competing interest
+The authors declare none.
+
+## Funding sources
+None.
+EOF
+ck "Elsevier 'Declaration of competing interest' counts as COI" 0 \
+  "$(run --manuscript "$TMP/elsevier.md" --journal radiology --require coi)"
+
+# A paper whose SUBJECT is AI has not thereby disclosed using AI to write itself. Demanding a
+# writing tool's version / channel / date / responsible party from its abstract is a category error.
+cat > "$TMP/ai_subject.md" <<'EOF'
+# Reader study
+
+## Abstract
+We evaluated whether AI-assisted reading with a large language model improves detection.
+
+## Data Availability
+Data are at https://zenodo.org/record/1.
+
+## Funding
+None.
+
+## Competing Interests
+None.
+EOF
+ck "AI as the study's subject is not an AI-use disclosure" 0 \
+  "$(run --manuscript "$TMP/ai_subject.md" --journal radiology --strict)"
+
+# ...but an actual authorial disclosure still owes its tokens.
+cat > "$TMP/ai_used.md" <<'EOF'
+# Paper
+
+## Data Availability
+Data are at https://zenodo.org/record/1.
+
+## Funding
+None.
+
+## Competing Interests
+None.
+
+## AI Disclosure
+The authors used ChatGPT for language editing.
+EOF
+ck "an authorial AI-use disclosure still owes its tokens" 1 \
+  "$(run --manuscript "$TMP/ai_used.md" --journal radiology)"
+
 echo "----"
 echo "test_disclosure_availability: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
The first consumer of the held-out corpus (#422, #424). Measured against **12 accepted OA papers spanning 12 study designs**, these two detectors fired 6 times. **Four of the six were ours** — and each is a defect a challenge card *structurally cannot* surface, because a fixture written beside a detector uses the phrasing that detector expects.

## `check_disclosure_availability`

| defect | evidence |
|---|---|
| "Data Sharing Statement" unknown | JAMA trial carrying `Data Sharing Statement: See Supplement 3` reported as having none. JAMA/NEJM house style. |
| "Declaration of competing interest" unknown | Elsevier review carrying it reported as having no COI. The pattern had `declaration of interests?`, and the heading does not start with "competing". |
| AI-disclosure fallback accepted **any** paragraph mentioning AI | In a paper whose *subject* is AI that paragraph is the abstract. An accepted reader study on AI-assisted pneumothorax detection was asked for a writing tool's version / channel / date / responsible party and failed by construction. |

Study-component AI and editorial-writing AI are different disclosures under different rules; only the second owes those four tokens. The fallback now requires an authorial-use signal — and an actual *"the authors used ChatGPT for language editing"* still owes them.

## `check_credit_integrity`

| defect | evidence |
|---|---|
| Term scan ran on **any** contributions heading | It graded the result `minor` — but a minor finding still exits non-zero, so free prose fired: "analysis" and "writing" reported as invalid CRediT terms in papers with **no CRediT statement at all**. The docstring already said the check is for *"a section that calls itself CRediT"*; the code had drifted from it. |
| Em dash missing from the term class | MDPI's `Writing—original draft preparation` was shredded at the dash and the fragment "writing" reported as invalid — twice, against papers that had written the term correctly for their publisher. |

A block now qualifies as CRediT by saying so, or by carrying **three** of the official fourteen — three, because "Investigation", "Validation" and "Software" are ordinary English words that turn up in prose by accident.

## Result on the same corpus

| | before | after |
|---|---|---|
| fires | 6 | **2** |
| fire rate | 0.015 | **0.005** |
| labelled false-positive rate | 0.800 | **0.000** |

Both survivors are **real**: a systematic review with no data-availability statement anywhere, and a paper whose contributions section writes `F.G.G` and `J.L` without trailing periods so the tokens resolve to no author (an isolation test with well-formed three-initial names passes, so that one is the paper's defect, not the tokenizer's).

## Verification

Each fix carries a regression case, and each was verified by planting the defect back — 5/5 fail without their fix, pass with it.

⚠️ The first draft of the prose-contributions case **passed without the fix**. It used flowing sentences, where the near-miss terms are never isolated tokens, so it proved nothing. It now uses the shape the real papers had. That is the second time today a green test proved nothing.

CI mirror: 211/211 (distribution manifest regenerated last, after all edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)