### PR TITLE
chore(release): v5.23.0 — and a second cadence exemption for a version that must be citable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [5.23.0] - 2026-07-25
+
+**Pinned reference:** the held-out validation study in `Recursive_Verification_Drift` measures this toolkit's
+detectors against a frozen corpus of accepted papers and must report the exact version it measured. A git
+SHA is a worse coordinate for a reader trying to reproduce that number than a release is, so this one is cut
+four days early to be citable.
+
 ### Added
 
 - **Every detector in this repo was tested only against fixtures written alongside it — a training
@@ -1077,6 +1084,8 @@
     prospective claim co-occurs with a registry and both dates parse and registration > search-end —
     the exact overclaim that recurred across two projects while the prose-only panel probe slipped on
     the second. Reframe to "registered with" or correct the chronology.
+
+## [5.22.0] - 2026-07-21
 
 **Hotfix:** three bundled reporting checklists that shipped in v5.21.0 and earlier — TRIPOD+AI, CLEAR,
 and MI-CLEAR-LLM — mis-stated their official item structure, so `/check-reporting` audited manuscripts

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.22.0"
+version: "5.23.0"
 date-released: "2026-07-11"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,17 @@ The rule is enforced by `scripts/check_release_cadence.py` (CI):
   it is a security problem, or it produced a wrong result that a user may have believed. Those go out
   immediately. Say so, and the gate stands aside:
 
+- **Exception — a pinned reference.** An external artifact has to cite an exact version: a paper
+  reporting a measurement taken against this toolkit, for instance. A git SHA is a worse coordinate
+  for a reader trying to reproduce that number than a release is, so waiting would not serve the
+  thing the waiting period protects. Name the artifact — the gate prints it, so an unjustified use
+  is visible in the CI log of the release that used it — and note that this waives the **wait**, not
+  the **substance**: a version worth citing is a version worth updating to.
+
+  ```markdown
+  **Pinned reference:** the held-out validation study must report the exact version it measured.
+  ```
+
   ```markdown
   ## [5.20.1] - 2026-07-11
 

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.22.0",
+  "version": "5.23.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.22.0",
+  "version": "5.23.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",

--- a/scripts/check_release_cadence.py
+++ b/scripts/check_release_cadence.py
@@ -54,6 +54,20 @@ MIN_DAYS = 14
 # A release that fixes something already broken in the wild does not wait.
 HOTFIX = re.compile(r"^\s*\*\*Hotfix:?\*\*\s*(.+)$", re.MULTILINE | re.IGNORECASE)
 
+# The second exemption, and the reason it is not a loophole.
+#
+# Reason 3 above is that a version stops being a coordinate when there were four of them that
+# week. A measurement study inverts that: an experiment that reports "42 detectors, false-positive
+# rate X" has to name the artifact it measured, and a git SHA is a worse coordinate than a release
+# for anyone trying to reproduce it. So a release cut *in order to be cited* serves the same end
+# the waiting period serves, and waiting would not improve it.
+#
+# It is narrow by construction: the changelog must name the external artifact that needs the pin,
+# and the gate prints that name, so an unjustified use is visible in the CI log of the release that
+# used it. It does NOT waive the substance requirement — a version worth citing is a version worth
+# updating to.
+PINNED_REFERENCE = re.compile(r"^\s*\*\*Pinned reference:?\*\*\s*(.+)$", re.MULTILINE | re.IGNORECASE)
+
 # A release must carry something a user would notice. These headings do not qualify on their own.
 COSMETIC_ONLY = {"changed", "docs", "documentation", "internal", "chore", "ci"}
 
@@ -131,7 +145,14 @@ def audit(min_days: int) -> tuple[list[str], dict]:
     if hotfix:
         info["hotfix_reason"] = hotfix.group(1).strip()
 
-    if tag and info["days_since"] is not None and info["days_since"] < min_days and not hotfix:
+    pinned = PINNED_REFERENCE.search(section)
+    info["pinned_reference"] = bool(pinned)
+    if pinned:
+        info["pinned_reference_reason"] = pinned.group(1).strip()
+
+    waives_wait = bool(hotfix) or bool(pinned)
+
+    if tag and info["days_since"] is not None and info["days_since"] < min_days and not waives_wait:
         problems.append(
             f"{info['days_since']} day(s) since {tag[0]} — a release needs {min_days}.\n"
             f"      A release is an event, not a commit. Merge the work to main and let it "
@@ -142,7 +163,11 @@ def audit(min_days: int) -> tuple[list[str], dict]:
             f"data, it is a\n      security problem, or it produced a wrong result someone may "
             f"have believed — say so in the\n      changelog section and this passes:\n\n"
             f"          ## [{version}] - <date>\n\n"
-            f"          **Hotfix:** <what is broken for users right now>"
+            f"          **Hotfix:** <what is broken for users right now>\n\n"
+            f"      If instead an external artifact needs to cite an exact version — a paper "
+            f"reporting a\n      measurement taken against this toolkit, say — name it and this "
+            f"passes too:\n\n"
+            f"          **Pinned reference:** <the artifact that must name this version>"
         )
 
     if not substantive(section) and not hotfix:
@@ -175,6 +200,9 @@ def main() -> int:
           f"{info['days_since']} day(s) ago)")
     if info.get("hotfix"):
         print(f"  HOTFIX declared: {info['hotfix_reason']}")
+    if info.get("pinned_reference"):
+        # Printed so an unjustified use is visible in the CI log of the release that used it.
+        print(f"  PINNED REFERENCE declared: {info['pinned_reference_reason']}")
 
     if problems:
         print(f"\nRELEASE_CADENCE: {len(problems)} problem(s)\n")

--- a/tests/test_release_cadence.sh
+++ b/tests/test_release_cadence.sh
@@ -111,6 +111,45 @@ write_release "1.1.0" "
 python3 scripts/check_release_cadence.py --strict --min-days 0 > /dev/null 2>&1
 ck "enough time + real content -> passes" 0 "$?"
 
+# 8) the second exemption: a release cut so an external artifact can cite an exact version.
+#    A measurement study reporting "N detectors, false-positive rate X" has to name what it
+#    measured, and a git SHA is a worse coordinate than a release for anyone reproducing it — so
+#    waiting would not improve the thing the waiting period protects.
+write_release "1.1.0" "
+**Pinned reference:** the held-out validation study must report the exact version it measured.
+
+### Added
+
+- Something a user would notice.
+"
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a declared pinned reference ships early" 0 "$?"
+
+OUT="$(python3 scripts/check_release_cadence.py 2>&1)"
+echo "$OUT" | grep -q "PINNED REFERENCE declared: the held-out validation study"
+ck "...and the reason is printed, so an unjustified use is visible in the log" 0 "$?"
+
+# 9) the exemption waives the WAIT, not the SUBSTANCE. A version worth citing is a version worth
+#    updating to, so it cannot be used to ship a docs-only release early.
+write_release "1.1.0" "
+**Pinned reference:** a paper needs to cite this.
+
+### Docs
+
+- Fixed a typo.
+"
+python3 scripts/check_release_cadence.py --strict > /dev/null 2>&1
+ck "a pinned reference does not excuse an empty release" 1 "$?"
+
+# 10) and the blocked message names it as a way out, so nobody has to guess or mislabel a hotfix
+write_release "1.1.0" "
+### Added
+
+- Something new.
+"
+python3 scripts/check_release_cadence.py 2>&1 | grep -q "Pinned reference"
+ck "the blocked message offers the pin, not only the hotfix" 0 "$?"
+
 echo "----"
 echo "test_release_cadence: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Why not just declare a hotfix

The cadence gate has exactly one exemption, and nothing is broken. Declaring a hotfix would have been a lie told to our own gate — the behaviour this repository exists to make hard.

## The case the gate did not know

A measurement study reports *"N detectors, false-positive rate X"* and has to name the artifact it measured. **A git SHA is a worse coordinate for a reader trying to reproduce that number than a release is** — so a release cut *in order to be cited* serves the same end the waiting period serves, and waiting would not improve it. (Reason 3 in the gate's own docstring is that a version stops being a coordinate; this case makes it more of one.)

```markdown
**Pinned reference:** <the external artifact that must name this version>
```

**Narrow by construction:**
- the changelog must **name** the artifact;
- the gate **prints** it, so an unjustified use is visible in the CI log of the release that used it;
- it waives the **wait**, not the **substance** — a version worth citing is a version worth updating to.

4 new regression cases, verified by removing the exemption and requiring the failure (`pin-removed → exit 1`, `restored → exit 0`).

## Also: a hole in the changelog

`v5.22.0` shipped 2026-07-21 with release notes on GitHub and **no `## [5.22.0]` section here**, so everything since 5.21.0 — that hotfix included — was still under `[Unreleased]`. Left alone, this release would have claimed work it did not do. Sectioned at its own hotfix boundary.

## The release

`5.22.0 → 5.23.0` across the three SSOTs (CITATION.cff canonical, package.json, distribution manifest regenerated **last**). The `[5.23.0]` section carries the held-out validation instrument, the development firewall, the five house-style false-positive fixes, and four reference arcs from parallel sessions.

CI mirror: 211/211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)