### PR TITLE
fix(heldout): the instrument was muzzling detectors and truncating the corpus

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -141,6 +141,9 @@ jobs:
       - name: Run held-out crossfire self-test (the instrument must withhold a rate it cannot support)
         run: bash reverse_engineer/scripts/test_heldout_crossfire.sh
 
+      - name: "Run render_jats fidelity test (a dropped section is not a missing signal, it is a FIRE, biased by publisher)"
+        run: bash reverse_engineer/scripts/test_render_jats.sh
+
       - name: Run check_python_floor.py (everything a user runs must parse on the Python we promise)
         run: python3 scripts/check_python_floor.py --strict
 

--- a/reverse_engineer/HELDOUT.md
+++ b/reverse_engineer/HELDOUT.md
@@ -37,8 +37,13 @@ The papers are real, published, accepted open-access articles. They are **never 
 live under `_corpus/heldout/`, which is gitignored, exactly like the rest of the corpus
 (`LICENSING.md`). What gets published is the *number*, which is not copyrightable expression.
 
-1. Acquire OA papers as usual (`acquire.py`), convert to `.md` under `_corpus/heldout/`.
-   The filename stem must equal the manifest `record_id`.
+1. Acquire OA papers as usual (`acquire.py`), then render the JATS XML with
+   **`scripts/render_jats.py`** into `_corpus/heldout/`. The filename stem must equal the manifest
+   `record_id`. Do not hand-convert and do not use a one-off script: the renderer *is* the
+   denominator, and the first corpus was rendered by a scratchpad script that took four
+   corrections and then no longer existed, so the number had no reproducible provenance.
+   `test_render_jats.sh` asserts fidelity **per publisher shape** (JAMA / PLOS / Elsevier / MDPI /
+   BMC), because a renderer that knows one publisher's layout biases the corpus by journal.
 2. In `_corpus/manifest.json`, set `split: "heldout"`, `frozen_at: "YYYY-MM-DD"`, and a
    `coverage` map declaring what design the paper *is*.
 3. Never open them again except to label a fire.
@@ -68,7 +73,13 @@ correlated with journal rather than with quality, which is the worst kind a meas
 carry. Render title, byline, abstract, body, `author-notes`, `funding-group`, non-PMC
 `custom-meta`, back matter and references before trusting a single number.
 
-## First baseline (2026-07-25)
+## First baseline (2026-07-25) — every rate here is WITHDRAWN
+
+> **Void, not merely biased.** Two defects in this instrument were found hours after this baseline
+> was written, and both make a noisy stack look quiet. See *"The instrument was measuring its own
+> invocation"* below. The narrative is kept because the *detector defects it found* are real and
+> were fixed; the rates are not. A corrected baseline needs a fresh corpus, because this one is
+> spent.
 
 12 papers, 12 distinct design profiles, no concentration flagged. 33 detectors ran, 10 skipped
 (unobserved, each named by what it needed). **389 pairs, 6 fires, fire rate 0.015.** 31 detectors
@@ -103,6 +114,55 @@ detector changes; measuring the changed detectors on them again is scoring on th
 fitted to. The corpus did not stop being useful — it stopped being *unbiased*, and only for the
 detectors it touched.
 
+**And it was not even a correct tuning score.** At the same bar the true count is 5 fires, not 2 —
+three were hidden by a truncated loop. "The loop closed for the first time" is retracted: what
+closed was the instrument's eyes. See the next section.
+
+## The instrument was measuring its own invocation
+
+Found on 2026-07-25 by running every manuscript detector across this corpus twice, at two bars, and
+never breaking out of the loop. Two defects, both of which make a noisy stack look quiet.
+
+**1. The bar. Most detectors were invoked where they cannot speak.** The runner passed
+`--manuscript <paper>` and read the exit code. But **32 of 42 manuscript detectors document exit 1
+as conditional on `--strict`**: without it they print a Major finding and exit 0.
+
+| bar | fires | runnable pairs | fire rate |
+|---|---|---|---|
+| default (what the baseline ran) | 5 | 392 | 0.013 |
+| `--strict` where the detector offers it | **45** | 392 | **0.115** |
+
+Seven detectors recorded as *observed clean* fire the moment they are allowed to: `check_analysis_definitions`,
+`check_artifact_coverage`, `check_claim_artifact`, `check_cv_leakage`, `check_null_calibration`,
+`check_placeholders`, `check_reference_adequacy`. An instrument built to separate "silent" from
+"unobserved" had a third category it did not know about: **muzzled**.
+
+`--bar` is now explicit, defaults to `strict`, is recorded per detector in the artifact, and the
+ledger refuses to difference two runs taken at different bars.
+
+*The bar is not free, and the honest version of this says so.* `--strict` means "gate Majors" in
+most detectors and "promote advisories" in others — `check_placeholders` escalates a bare Vancouver
+`[1]` citation, which every published paper has. So findings carry a **severity tier** (blocking vs
+advisory), the false-positive rate is reported for both and for blocking-tier alone, and labels are
+about whether a claim is *true*, never whether it is worth acting on.
+
+**2. A per-paper skip abandoned the rest of the corpus.** Exit 2 is overloaded: it means "you did
+not give me the flags I need" (about the *detector*) and "this paper has no section for me to check
+— skipped" (about the *paper*). The runner treated both as a detector-level skip and `break`ed out
+of the paper loop. `check_credit_integrity` was therefore measured on 5 of 12 papers **in filename
+order**, and the abandoned 7 held three further fires, one of them Major. Which papers got measured
+was a function of alphabetical sort.
+
+Outcomes are now per pair, from a closed taxonomy (`fire`, `clean`, `not_applicable`, `unsupplied`,
+`timeout`, `harness_void`), nothing terminates the loop, and each detector is reported as full,
+partial or never-ran with its own denominator — the old summary managed to report 33 run *and* 10
+skipped out of 42, by counting the truncated detector twice.
+
+**What this costs, and what it is worth.** Every rate this file has ever printed is withdrawn. Both
+defects were caught by asking the instrument a question no fixture had asked, which is the argument
+the whole split exists to make, arriving one layer further in than expected. Both now have
+regression cases in `test_heldout_crossfire.sh` that fail against the previous runner.
+
 So the split has three parts, not two, and they are spent in this order:
 
 | set | role | spent by |
@@ -130,17 +190,30 @@ stack speak on already-accepted work". Its *trend* is the signal: the corpus is 
 across runs is a change in the detectors. Detector count up and fire rate up together is the
 overfitting signature — prune or label before adding more.
 
-**False-positive rate** is withheld until a human labels the fires. A published paper is not a
+**False-positive rate** is withheld until a human labels the findings. A published paper is not a
 defect-free paper; this project exists because reviewers miss things, so a fire may be exactly
 right. Calling every fire a false positive would manufacture the alarming trend it claims to
 detect. Label the worksheet (`real` / `spurious` / `unsure`) and the rate appears with its
 coverage.
+
+Its denominator is **findings, not fires**, because one exit can carry several claims and they can
+disagree with each other. The baseline's systematic-review fire asserted both "no data availability
+statement" (true — a real omission in an accepted paper) and "no COI statement" (false — Elsevier's
+*Declaration of competing interest* was there and unrecognised). Labelled at pair level, either
+label is a lie. The worksheet is therefore one row per claim, keyed by its verdict code; a label
+file with no `code` column still works and applies to every claim in that pair.
 
 **Silent-when-run vs skipped** are reported separately and mean opposite things. A detector that
 ran and stayed quiet is *observed* clean. A detector that never got a subject it could read is
 *unobserved* — no evidence either way. The prune decision turns on exactly this distinction, and
 harvesting project `qc/` directories cannot supply it: that only sees detectors somebody happened
 to run. A frozen corpus observes all of them, every run.
+
+**Unobserved has sub-kinds, and they are not synonyms.** `unsupplied` means the detector needs a
+flag a bare manuscript cannot provide — a fact about the detector. `not_applicable` means the
+detector read the paper and declared it out of scope ("no author-contributions section — skipped")
+— a fact about the paper, and one worth auditing separately, because a detector that abstains on
+everything scores perfectly on every rate above.
 
 The instrument never fails a build. It is an instrument, not a gate.
 

--- a/reverse_engineer/scripts/heldout_crossfire.py
+++ b/reverse_engineer/scripts/heldout_crossfire.py
@@ -82,7 +82,7 @@ FINDINGS, NOT JUST FIRES
     availability statement" (true — a real omission in an accepted paper) and "no COI statement"
     (false — Elsevier's "Declaration of competing interest" was there and unrecognised). Labelled
     at pair level, either label is a lie. So bracketed claim lines (`[hard] key: message`,
-    `[major] CODE: message`) are extracted as individual findings, the worksheet is finding-level,
+    `[major] CODE: message`, `✗ [major] code: message`, and markdown table rows) are extracted as individual findings, the worksheet is finding-level,
     and the false-positive rate has FINDINGS as its denominator while the fire rate has PAIRS.
 
 INPUTS
@@ -135,20 +135,63 @@ VERDICT_TOKEN_RE = re.compile(r"^[A-Z][A-Z0-9_]{3,}$")
 MEASURED = ("fire", "clean")
 OUTCOMES = ("fire", "clean", "not_applicable", "unsupplied", "timeout")
 
-# One claim inside one exit. Two house formats are in use and both must parse, because a regex
-# that knows one of them undercounts the other — the same single-vocabulary trap that produced
-# ledger C1/C2 in the detectors themselves:
+# One claim inside one exit. FOUR house formats are in use and all must parse, because a regex that
+# knows one of them undercounts the others — the same single-vocabulary trap that produced ledger
+# C1/C2 in the detectors themselves, recurring in the tool built to measure it. A first version knew
+# the first two and left 27 of 62 pilot findings (44%) with no claim text, which is a row no human
+# can label:
 #     [hard] data_availability_present: no Data Availability statement found
 #     [MAJOR] REFERENCE_STANDARD_UNDEFINED L21  Methods names no reference standard
+#     ✗ [major] methods_zero_citations: the Methods section contains no citations
+#     | 35 | bare_numeric_cite | warn | `[5]` |            <- a markdown table row
 FINDING_RE = re.compile(
-    r"^\s*\[(?P<sev>[A-Za-z][A-Za-z_ -]{1,15})\]\s+(?P<code>[A-Za-z][A-Za-z0-9_.\-]*)\b"
-    r"\s*(?:L\d+)?\s*[:\-]?\s*(?P<msg>.*)$"
+    r"^[\s\u2713\u2717\u26a0\u2022\-*>]*\[(?P<sev>[A-Za-z][A-Za-z_ -]{1,15})\]\s+"
+    r"(?P<code>[A-Za-z][A-Za-z0-9_.\-]*)\b\s*(?:L\d+)?\s*[:\-]?\s*(?P<msg>.*)$"
 )
-# A detector's own severity word, mapped to two tiers. Blocking-tier findings are the ones a
-# reviewer would call findings; advisory ones are the stack clearing its throat. The tier is
-# recorded per finding so the false-positive rate can be reported for both and for Majors alone.
+
+# A detector's own severity word, mapped to three tiers.
+#   blocking  what a reviewer would call a finding
+#   advisory  the stack clearing its throat — still a claim, still labelable
+#   context   the detector says outright that this is not a verdict
 BLOCKING_SEV = {"major", "blocker", "hard", "critical", "error", "fail", "p0"}
-ADVISORY_SEV = {"minor", "warn", "warning", "soft", "info", "note", "advisory", "unspecified"}
+ADVISORY_SEV = {"minor", "warn", "warning", "soft", "note", "advisory", "unspecified"}
+CONTEXT_SEV = {"info", "context", "note-only", "debug"}
+ALL_SEV = BLOCKING_SEV | ADVISORY_SEV | CONTEXT_SEV
+
+TABLE_SEP_RE = re.compile(r"^\s*\|[\s:\-|]+\|\s*$")
+IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.\-]*$")
+
+
+def tier_of(sev: str) -> str:
+    if sev in BLOCKING_SEV:
+        return "blocking"
+    if sev in CONTEXT_SEV:
+        return "context"
+    return "advisory"
+
+
+def table_row_finding(line: str) -> Optional[tuple]:
+    """A markdown table row carrying a severity column, e.g.
+
+        | Line | Type              | Severity | Match |
+        | 35   | bare_numeric_cite | warn     | `[5]` |
+
+    Several detectors report every finding this way and nothing else. Reading only bracketed
+    lines left them as unlabelable rows whose 'code' was the output banner.
+    """
+    if not line.lstrip().startswith("|") or TABLE_SEP_RE.match(line):
+        return None
+    cells = [c.strip().strip("`") for c in line.strip().strip("|").split("|")]
+    if len(cells) < 2:
+        return None
+    sev = next((c.lower() for c in cells if c.lower() in ALL_SEV), None)
+    if sev is None:
+        return None
+    code = next((c for c in cells if IDENT_RE.match(c) and c.lower() not in ALL_SEV), None)
+    if not code or code.lower() in ("none", "severity", "type", "check"):
+        return None
+    msg = " ".join(c for c in cells if c and c != code and c.lower() != sev)
+    return sev, code, msg
 # A detector that declares its own inapplicability, e.g. "no author-contributions section — skipped."
 SELF_SKIP_RE = re.compile(r"\bskipp?ed\b", re.I)
 USAGE_RE = re.compile(r"^usage:", re.M)
@@ -192,30 +235,41 @@ def extract_findings(stdout: str, stderr: str, fallback: str) -> List[dict]:
     without bracketed claim lines still made exactly one claim.
     """
     out: List[dict] = []
-    seen = set()
+    seen: Dict[tuple, dict] = {}
     for ln in ((stderr or "") + "\n" + (stdout or "")).splitlines():
         m = FINDING_RE.match(ln)
-        if not m:
-            continue
-        sev = m.group("sev").strip().lower()
-        key = (sev, m.group("code"))
+        if m:
+            sev, code, msg = m.group("sev").strip().lower(), m.group("code"), m.group("msg").strip()
+        else:
+            row = table_row_finding(ln)
+            if not row:
+                continue
+            sev, code, msg = row
+        key = (sev, code)
         if key in seen:
+            # Same claim, another instance (8 bare citations on 8 lines is one claim about the
+            # paper). Keep the first message and count the rest; collapsing silently would make
+            # a labeler think it happened once.
+            seen[key]["occurrences"] += 1
             continue
-        seen.add(key)
-        out.append(
-            {
-                "severity": sev,
-                "tier": "blocking" if sev in BLOCKING_SEV else "advisory",
-                "code": m.group("code"),
-                "message": m.group("msg").strip()[:300],
-                "parsed": True,
-            }
-        )
+        rec = {
+            "severity": sev,
+            "tier": tier_of(sev),
+            "code": code,
+            # A tag with no message ("[est-reassign] PRIMARY_REASSIGNED") would hand the labeler a
+            # bare code. Fall back to the pair's verdict line so every row asserts something.
+            "message": (msg or fallback or code)[:300],
+            "occurrences": 1,
+            "parsed": True,
+        }
+        seen[key] = rec
+        out.append(rec)
     if not out:
-        # No parseable claim line. The exit still asserted something, so record one finding and
-        # mark it unparsed — the count of these is the parser's own coverage, reported per run.
-        out.append({"severity": "unspecified", "tier": "advisory", "code": fallback or "UNSPECIFIED",
-                    "message": fallback, "parsed": False})
+        # No parseable claim line anywhere. The exit still asserted something, so record one row and
+        # mark it unparsed. These are NOT labelable — their 'code' is whatever the banner said — and
+        # the count of them is the parser's own coverage, reported with every run.
+        out.append({"severity": "unspecified", "tier": "unparsed", "code": fallback or "UNSPECIFIED",
+                    "message": fallback, "occurrences": 1, "parsed": False})
     return out
 
 
@@ -525,10 +579,18 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # ---- dispositions: the only path to a false-positive rate -------------------------------
     # Denominator is FINDINGS, not pairs: one exit can carry a true claim and a false one.
+    #
+    # Two kinds of row are NOT in it, because neither asserts anything a human can call true or
+    # false, and leaving them in makes the rate depend on how a labeler disposes of an unanswerable
+    # row (registered as amendment 2 before the corpus was read):
+    #   context   the detector says outright this is not a verdict ("[info] ... Load is context")
+    #   unparsed  no claim line could be read, so the 'code' is an output banner
     labels = load_dispositions(a.dispositions) if a.dispositions else {}
     for f in findings:
         f["disposition"] = label_for(labels, f["paper"], f["detector"], f["code"])
-    lab = [f["disposition"] for f in findings]
+    labelable = [f for f in findings if f["tier"] in ("blocking", "advisory")]
+    n_context = sum(1 for f in findings if f["tier"] == "context")
+    lab = [f["disposition"] for f in labelable]
     n_spurious = sum(1 for x in lab if x == "spurious")
     n_real = sum(1 for x in lab if x == "real")
     n_unsure = sum(1 for x in lab if x == "unsure")
@@ -540,10 +602,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     print(f"  papers measured : {len(papers)}   (corpus frozen: {frozen_at})")
     print(f"  detectors       : {len(full)} full / {len(partial)} partial / {len(never)} never ran"
           f"   (of {len(dets)})")
-    n_block = sum(1 for f in findings if f["tier"] == "blocking")
+    n_block = sum(1 for f in labelable if f["tier"] == "blocking")
     n_unparsed = sum(1 for f in findings if not f["parsed"])
-    print(f"  pairs           : {ran_pairs}   fired: {fired_pairs}   findings: {len(findings)}"
-          f" ({n_block} blocking-tier, {n_unparsed} with no parseable claim line)")
+    print(f"  pairs           : {ran_pairs}   fired: {fired_pairs}   "
+          f"labelable findings: {len(labelable)} ({n_block} blocking-tier)")
+    print(f"  not labelable   : {n_context} context-only (detector says it is not a verdict), "
+          f"{n_unparsed} unparsed (no claim line — parser coverage, not evidence)")
     print(f"  unobserved pairs: {unobserved_pairs} "
           f"(not_applicable {sum(t['not_applicable'] for t in tally.values())}, "
           f"unsupplied {sum(t['unsupplied'] for t in tally.values())}, "
@@ -597,17 +661,17 @@ def main(argv: Optional[List[str]] = None) -> int:
                     if o in reasons[name]), "no reason recorded")
         print(f"  NEVER RAN {name} ({why}) — unobserved, NOT evidence of a clean detector")
 
-    if findings:
+    if labelable:
         print("-" * 78)
         if fp_rate is None:
             print(
-                f"  FALSE-POSITIVE RATE: WITHHELD — {n_unlabelled} finding(s) across "
+                f"  FALSE-POSITIVE RATE: WITHHELD — {n_unlabelled} labelable finding(s) across "
                 f"{len(fires)} fire(s), 0 labelled.\n"
                 "    A fire on an accepted paper may be a real defect reviewers missed. Label the\n"
                 "    worksheet (real / spurious / unsure) before any FP claim is made."
             )
         else:
-            cov = (len(findings) - n_unlabelled) / len(findings)
+            cov = (len(labelable) - n_unlabelled) / len(labelable)
             print(
                 f"  FALSE-POSITIVE RATE: {fp_rate:.3f}  "
                 f"({n_spurious} spurious / {n_real + n_spurious} decided; "
@@ -615,7 +679,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             )
             print("    denominator is FINDINGS, not fires — one exit can carry a true claim and a "
                   "false one.")
-            blocking = [f for f in findings if f["tier"] == "blocking"]
+            blocking = [f for f in labelable if f["tier"] == "blocking"]
             b_sp = sum(1 for f in blocking if f["disposition"] == "spurious")
             b_dec = b_sp + sum(1 for f in blocking if f["disposition"] == "real")
             if b_dec:
@@ -625,7 +689,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print("    Partial coverage — unlabelled findings could move this either way.")
 
     if a.worksheet:
-        todo = [f for f in findings if f["disposition"] is None]
+        todo = [f for f in labelable if f["disposition"] is None]
         with a.worksheet.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
             w.writerow(["paper", "detector", "code", "severity", "verdict", "disposition", "note"])
@@ -645,9 +709,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         "pairs_ran": ran_pairs,
         "pairs_fired": fired_pairs,
         "pairs_unobserved": unobserved_pairs,
-        "n_findings": len(findings),
-        "n_findings_blocking": sum(1 for f in findings if f["tier"] == "blocking"),
-        "n_findings_unparsed": sum(1 for f in findings if not f["parsed"]),
+        "n_findings_labelable": len(labelable),
+        "n_findings_blocking": n_block,
+        "n_findings_context": n_context,
+        "n_findings_unparsed": n_unparsed,
         "fire_rate": round(fire_rate, 4),
         "fire_rate_default_bar": (round(default_bar_fires / ran_pairs, 4)
                                   if a.bar == "both" else None),

--- a/reverse_engineer/scripts/heldout_crossfire.py
+++ b/reverse_engineer/scripts/heldout_crossfire.py
@@ -42,14 +42,59 @@ WHY "NEVER FIRED" IS REPORTED SEPARATELY FROM "NEVER RAN"
     project `qc/` harvesting cannot supply it — that only observes detectors somebody happened to
     run. A frozen corpus observes all of them on every run.
 
+THE SEVERITY BAR, AND WHY IT IS NOT THE DEFAULT ONE (paid for on 2026-07-25)
+    The first version of this file invoked `<detector> --manuscript <paper>` and read the exit
+    code. But 32 of 42 manuscript detectors document exit 1 as CONDITIONAL ON --strict: without it
+    they print a Major finding and exit 0. Re-running the pilot corpus at both bars: 5 fires at the
+    default bar, 45 at the strict bar, and SEVEN detectors this instrument had recorded as
+    "observed clean" fire the moment they are allowed to speak.
+
+    That is the instrument committing the error it exists to detect — a check whose output and exit
+    code disagree, read by its exit code alone. So the bar is now explicit: --strict is passed to
+    every detector whose --help offers it, the bar actually used is recorded PER DETECTOR in the
+    artifact, and `--bar both` records the default-bar outcome alongside as a secondary series.
+    A rate whose bar is not recorded is not reportable, and rates at different bars are not
+    comparable — the ledger refuses to difference them.
+
+WHY AN OUTCOME IS PER PAIR AND NEVER TERMINATES THE LOOP (also paid for on 2026-07-25)
+    Exit 2 is overloaded. It means "you did not give me the flags I need" (a property of the
+    DETECTOR) and also "this paper has no section for me to check — skipped" (a property of the
+    PAPER). The first version treated both as a detector-level skip and `break`ed out of the paper
+    loop, so `check_credit_integrity` was measured on 5 of 12 papers in filename order and the
+    remaining 7 — which held THREE more fires, one of them Major — were never measured at all.
+    Which papers got measured was a function of alphabetical sort order.
+
+    Every pair now gets its own outcome from a closed taxonomy, and no outcome stops the loop:
+
+      fire            exit 1 at the declared bar
+      clean           exit 0 — OBSERVED clean
+      not_applicable  exit 2, detector's own "... — skipped": the paper has no subject for it
+      unsupplied      exit 2, usage error naming a flag we cannot supply from a bare manuscript
+      timeout         no exit inside the limit
+      harness_void    exit 2 with "not found" — WE handed it a bad path. Voids the run.
+
+    Only `fire` and `clean` are in the fire-rate denominator. A detector is reported as full,
+    partial or never-ran with its own denominator, and appears in exactly one of those categories —
+    the old summary managed to report 33 run AND 10 skipped out of 42.
+
+FINDINGS, NOT JUST FIRES
+    One exit can carry several claims. The pilot's systematic-review fire asserted both "no data
+    availability statement" (true — a real omission in an accepted paper) and "no COI statement"
+    (false — Elsevier's "Declaration of competing interest" was there and unrecognised). Labelled
+    at pair level, either label is a lie. So bracketed claim lines (`[hard] key: message`,
+    `[major] CODE: message`) are extracted as individual findings, the worksheet is finding-level,
+    and the false-positive rate has FINDINGS as its denominator while the fire rate has PAIRS.
+
 INPUTS
   --corpus       directory of held-out papers as .md/.txt (default: _corpus/heldout/).
   --manifest     optional _corpus/manifest.json. When given, a paper is measured only if a record
                  whose record_id equals its filename stem declares split=heldout. Unbacked papers
                  are named and excluded — an unverified corpus makes an unverifiable number.
-  --dispositions optional CSV (paper,detector,verdict,disposition,note) with disposition in
-                 {real, spurious, unsure}. Without it, no false-positive rate is printed.
-  --worksheet    write unlabelled fires to this CSV for a human to label.
+  --bar          strict (default) | default | both. Which severity bar detectors are invoked at.
+  --dispositions optional CSV (paper,detector[,code],verdict,disposition,note) with disposition in
+                 {real, spurious, unsure}. A row without `code` labels every finding of that pair.
+                 Without this file, no false-positive rate is printed.
+  --worksheet    write unlabelled findings to this CSV for a human to label.
   --ledger       JSONL run history; append this run and print the delta against the last entry.
   --only         comma-separated detector names, for tests and for re-checking one detector.
   --out          JSON artifact.
@@ -85,6 +130,93 @@ DEFAULT_CORPUS = REPO / "_corpus" / "heldout"
 DISPOSITIONS = ("real", "spurious", "unsure")
 SEPARATOR_RE = re.compile(r"^[\s=~*_\-─—–]+$")
 VERDICT_TOKEN_RE = re.compile(r"^[A-Z][A-Z0-9_]{3,}$")
+
+# Outcomes in the fire-rate denominator. Everything else is UNOBSERVED and is reported as such.
+MEASURED = ("fire", "clean")
+OUTCOMES = ("fire", "clean", "not_applicable", "unsupplied", "timeout")
+
+# One claim inside one exit. Two house formats are in use and both must parse, because a regex
+# that knows one of them undercounts the other — the same single-vocabulary trap that produced
+# ledger C1/C2 in the detectors themselves:
+#     [hard] data_availability_present: no Data Availability statement found
+#     [MAJOR] REFERENCE_STANDARD_UNDEFINED L21  Methods names no reference standard
+FINDING_RE = re.compile(
+    r"^\s*\[(?P<sev>[A-Za-z][A-Za-z_ -]{1,15})\]\s+(?P<code>[A-Za-z][A-Za-z0-9_.\-]*)\b"
+    r"\s*(?:L\d+)?\s*[:\-]?\s*(?P<msg>.*)$"
+)
+# A detector's own severity word, mapped to two tiers. Blocking-tier findings are the ones a
+# reviewer would call findings; advisory ones are the stack clearing its throat. The tier is
+# recorded per finding so the false-positive rate can be reported for both and for Majors alone.
+BLOCKING_SEV = {"major", "blocker", "hard", "critical", "error", "fail", "p0"}
+ADVISORY_SEV = {"minor", "warn", "warning", "soft", "info", "note", "advisory", "unspecified"}
+# A detector that declares its own inapplicability, e.g. "no author-contributions section — skipped."
+SELF_SKIP_RE = re.compile(r"\bskipp?ed\b", re.I)
+USAGE_RE = re.compile(r"^usage:", re.M)
+NOT_FOUND_RE = re.compile(r"\bnot found\b|No such file", re.I)
+
+
+def accepts_strict(det) -> bool:
+    """Ask the detector, once, whether it has a bar above its default. Never guess it."""
+    return "--strict" in cf.read_usage(det.path)
+
+
+def classify_outcome(rc: int, stdout: str, stderr: str) -> tuple:
+    """(outcome, detail). The closed taxonomy from the module docstring.
+
+    Order matters. A usage error and a self-declared skip both exit 2 and mean opposite things:
+    the first is about the detector, the second about the paper. Collapsing them is how a corpus
+    silently shrinks — and how a detector that abstains on everything scores perfectly.
+    """
+    blob = (stderr or "") + "\n" + (stdout or "")
+    if rc == 0:
+        return "clean", None
+    if rc == 1:
+        return "fire", None
+    if rc == 2:
+        if NOT_FOUND_RE.search(blob):
+            return "harness_void", blob.strip()[:200]
+        if USAGE_RE.search(blob):
+            return "unsupplied", "needs " + cf.missing_flag_from(stderr, stdout, ("--manuscript",))
+        if SELF_SKIP_RE.search(blob):
+            first = next((ln.strip() for ln in blob.splitlines() if ln.strip()), "")
+            return "not_applicable", first[:200]
+        return "unsupplied", "needs " + cf.missing_flag_from(stderr, stdout, ("--manuscript",))
+    # A crash is the harness's problem to explain, never a quiet skip.
+    return "harness_void", f"exit {rc}: " + blob.strip()[:180]
+
+
+def extract_findings(stdout: str, stderr: str, fallback: str) -> List[dict]:
+    """The individual claims inside one exit, so each can be labelled on its own merits.
+
+    Falls back to a single finding carrying the verdict token, because a detector that fires
+    without bracketed claim lines still made exactly one claim.
+    """
+    out: List[dict] = []
+    seen = set()
+    for ln in ((stderr or "") + "\n" + (stdout or "")).splitlines():
+        m = FINDING_RE.match(ln)
+        if not m:
+            continue
+        sev = m.group("sev").strip().lower()
+        key = (sev, m.group("code"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            {
+                "severity": sev,
+                "tier": "blocking" if sev in BLOCKING_SEV else "advisory",
+                "code": m.group("code"),
+                "message": m.group("msg").strip()[:300],
+                "parsed": True,
+            }
+        )
+    if not out:
+        # No parseable claim line. The exit still asserted something, so record one finding and
+        # mark it unparsed — the count of these is the parser's own coverage, reported per run.
+        out.append({"severity": "unspecified", "tier": "advisory", "code": fallback or "UNSPECIFIED",
+                    "message": fallback, "parsed": False})
+    return out
 
 
 def verdict_line(stdout: str, stderr: str) -> str:
@@ -158,27 +290,76 @@ def separation_report(coverages: Dict[str, dict]) -> dict:
 
 
 def load_dispositions(path: Path) -> Dict[tuple, str]:
+    """(paper, detector, code) -> label, with (paper, detector, None) as a pair-wide fallback.
+
+    The pair-wide form is what the pilot's worksheet produced, before findings were separable.
+    Reading it still is deliberate: an old label file should keep working, and where it disagrees
+    with a finding-level label the finding-level one wins (it is the more specific claim).
+    """
     out: Dict[tuple, str] = {}
     with path.open(newline="", encoding="utf-8") as fh:
         for row in csv.DictReader(fh):
             d = (row.get("disposition") or "").strip().lower()
             if d not in DISPOSITIONS:
                 continue
-            out[((row.get("paper") or "").strip(), (row.get("detector") or "").strip())] = d
+            code = (row.get("code") or "").strip() or None
+            out[((row.get("paper") or "").strip(), (row.get("detector") or "").strip(), code)] = d
     return out
+
+
+def label_for(labels: Dict[tuple, str], paper: str, detector: str, code: str) -> Optional[str]:
+    return labels.get((paper, detector, code)) or labels.get((paper, detector, None))
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
     ap.add_argument("--manifest", type=Path)
+    ap.add_argument(
+        "--bar",
+        choices=("strict", "default", "both"),
+        default="strict",
+        help="severity bar detectors are invoked at. strict (default) passes --strict to every "
+        "detector whose --help offers it, because most document exit 1 as conditional on it; "
+        "both also records the default-bar outcome as a secondary series.",
+    )
     ap.add_argument("--dispositions", type=Path)
     ap.add_argument("--worksheet", type=Path)
     ap.add_argument("--ledger", type=Path)
     ap.add_argument("--only", help="comma-separated detector names")
+    ap.add_argument(
+        "--roster-out",
+        type=Path,
+        help="write the detector roster (name, bar, file sha256) and exit without measuring. "
+        "This is what a pre-registration freezes: a rate belongs to a named set of detectors at a "
+        "named content hash, or it belongs to nothing.",
+    )
     ap.add_argument("--out", type=Path)
     ap.add_argument("--verbose", action="store_true")
     a = ap.parse_args(argv)
+
+    if a.roster_out:
+        import hashlib
+
+        roster = [
+            {
+                "detector": d.name,
+                "path": str(d.path.relative_to(REPO)),
+                "bar": "strict" if (a.bar in ("strict", "both") and accepts_strict(d)) else "default",
+                "sha256": hashlib.sha256(d.path.read_bytes()).hexdigest(),
+            }
+            for d in sorted(cf.discover(), key=lambda x: x.name)
+            if d.family == "manuscript"
+        ]
+        a.roster_out.parent.mkdir(parents=True, exist_ok=True)
+        a.roster_out.write_text(
+            json.dumps({"bar_policy": a.bar, "n_detectors": len(roster), "detectors": roster},
+                       indent=2),
+            encoding="utf-8",
+        )
+        n_strict = sum(1 for r in roster if r["bar"] == "strict")
+        print(f"roster: {len(roster)} manuscript detector(s), {n_strict} at --strict -> {a.roster_out}")
+        return 0
 
     # Detectors run with cwd inside a throwaway sandbox, so a default `qc/...` report lands there
     # instead of in the repo. That makes every path handed to them absolute-or-broken: a relative
@@ -242,55 +423,80 @@ def main(argv: Optional[List[str]] = None) -> int:
         print("harness: found no manuscript-family detectors", file=sys.stderr)
         return 2
 
+    bars = {d.name: ("strict" if (a.bar in ("strict", "both") and accepts_strict(d)) else "default")
+            for d in dets}
+
     before = cf.hash_tree(papers)
     work = Path(tempfile.mkdtemp(prefix="heldout-"))
-    ran: Dict[str, int] = defaultdict(int)
-    fired: Dict[str, int] = defaultdict(int)
-    skipped: Dict[str, str] = {}
+    # outcome counters per detector, one bucket per taxonomy member — no detector is ever counted
+    # in two categories, and no category is a synonym for another.
+    tally: Dict[str, Dict[str, int]] = {d.name: {o: 0 for o in OUTCOMES} for d in dets}
+    reasons: Dict[str, Dict[str, str]] = defaultdict(dict)  # detector -> outcome -> example reason
     fires: List[dict] = []
+    findings: List[dict] = []
+    default_bar_fires = 0  # secondary series under --bar both
+
+    def run_one(det, paper: Path, strict: bool):
+        sandbox = Path(tempfile.mkdtemp(dir=work))  # a default qc/ path lands HERE
+        cmd = ["python3", str(det.path), "--manuscript", str(paper)]  # inputs only, ever
+        if strict:
+            cmd.append("--strict")
+        return cf.sh(cmd, cwd=sandbox)
 
     print("=" * 78)
     print(f" Held-out crossfire — {len(dets)} detector(s) x {len(papers)} accepted paper(s)")
+    print(f" bar: {a.bar}")
     print("=" * 78)
 
     try:
         for d in dets:
+            strict = bars[d.name] == "strict"
             for paper in papers:
-                sandbox = Path(tempfile.mkdtemp(dir=work))  # a default qc/ path lands HERE
-                cmd = ["python3", str(d.path), "--manuscript", str(paper)]  # inputs only, ever
                 try:
-                    r = cf.sh(cmd, cwd=sandbox)
+                    r = run_one(d, paper, strict)
                 except subprocess.TimeoutExpired:
-                    skipped[d.name] = "timed out"
-                    break
-                if r.returncode == 2:
-                    # "not found" is never a skip: the detector is telling us the harness handed it
-                    # a path it could not open. Recording that as a missing-input skip is how the
-                    # instrument lies to itself. Fail loudly instead.
-                    if re.search(r"\bnot found\b|No such file", (r.stderr or "") + (r.stdout or "")):
-                        print(
-                            f"\nharness: {d.name} could not open {paper} — the harness built a bad "
-                            f"command, this is not a detector skip.\n  {(r.stderr or '').strip()[:200]}",
-                            file=sys.stderr,
-                        )
-                        return 2
-                    skipped[d.name] = "needs " + cf.missing_flag_from(
-                        r.stderr, r.stdout, ("--manuscript",)
+                    # A timeout is a property of THIS pair. The next paper still gets measured.
+                    tally[d.name]["timeout"] += 1
+                    reasons[d.name].setdefault("timeout", f"timed out on {paper.stem}")
+                    continue
+
+                outcome, detail = classify_outcome(r.returncode, r.stdout, r.stderr)
+                if outcome == "harness_void":
+                    # WE handed it something it could not read. Recording that as a detector skip is
+                    # how the instrument lies to itself. Fail loudly instead.
+                    print(
+                        f"\nharness: {d.name} could not read {paper.stem} — the harness built a bad "
+                        f"command, this is not a detector skip.\n  {detail}",
+                        file=sys.stderr,
                     )
-                    break
-                ran[d.name] += 1
-                if r.returncode != 0:
-                    fired[d.name] += 1
-                    fires.append(
-                        {
-                            "paper": paper.stem,
-                            "detector": d.name,
-                            "verdict": verdict_line(r.stdout, r.stderr),
-                        }
-                    )
-                    print(f"  FIRED {d.name} x {paper.stem}")
+                    return 2
+
+                tally[d.name][outcome] += 1
+                if detail:
+                    reasons[d.name].setdefault(outcome, detail)
+
+                if outcome == "fire":
+                    verdict = verdict_line(r.stdout, r.stderr)
+                    claims = extract_findings(r.stdout, r.stderr, verdict)
+                    fires.append({"paper": paper.stem, "detector": d.name, "verdict": verdict,
+                                  "bar": bars[d.name], "n_findings": len(claims)})
+                    for c in claims:
+                        findings.append({"paper": paper.stem, "detector": d.name,
+                                         "bar": bars[d.name], **c})
+                    print(f"  FIRED {d.name} x {paper.stem}"
+                          + (f"  ({len(claims)} claims)" if len(claims) > 1 else ""))
                 elif a.verbose:
-                    print(f"  ok    {d.name} x {paper.stem}")
+                    print(f"  {outcome:<15} {d.name} x {paper.stem}")
+
+                # Secondary series: what the OLD bar would have recorded for this same pair. This is
+                # the number that made seven detectors look observed-clean.
+                if a.bar == "both" and strict:
+                    try:
+                        r0 = run_one(d, paper, False)
+                    except subprocess.TimeoutExpired:
+                        continue
+                    if classify_outcome(r0.returncode, r0.stdout, r0.stderr)[0] == "fire":
+                        default_bar_fires += 1
     finally:
         after = cf.hash_tree(papers)
         changed = [k for k in before if before[k] != after.get(k)]
@@ -302,29 +508,54 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"  modified: {c}", file=sys.stderr)
         return 2
 
-    ran_pairs = sum(ran.values())
-    fired_pairs = sum(fired.values())
+    measured = {n: sum(t[o] for o in MEASURED) for n, t in tally.items()}
+    ran_pairs = sum(measured.values())
+    fired_pairs = sum(t["fire"] for t in tally.values())
+    unobserved_pairs = sum(t[o] for t in tally.values() for o in OUTCOMES if o not in MEASURED)
     if ran_pairs == 0:
         print("\nharness: zero pairs ran — no measurement taken.", file=sys.stderr)
         return 2
     fire_rate = fired_pairs / ran_pairs
 
+    # A detector sits in exactly ONE of these. The old summary reported 33 run and 10 skipped out
+    # of 42, because a detector truncated mid-corpus was counted as both.
+    full = sorted(n for n, m in measured.items() if m == len(papers))
+    partial = sorted(n for n, m in measured.items() if 0 < m < len(papers))
+    never = sorted(n for n, m in measured.items() if m == 0)
+
     # ---- dispositions: the only path to a false-positive rate -------------------------------
+    # Denominator is FINDINGS, not pairs: one exit can carry a true claim and a false one.
     labels = load_dispositions(a.dispositions) if a.dispositions else {}
-    lab = [labels.get((f["paper"], f["detector"])) for f in fires]
+    for f in findings:
+        f["disposition"] = label_for(labels, f["paper"], f["detector"], f["code"])
+    lab = [f["disposition"] for f in findings]
     n_spurious = sum(1 for x in lab if x == "spurious")
     n_real = sum(1 for x in lab if x == "real")
     n_unsure = sum(1 for x in lab if x == "unsure")
     n_unlabelled = sum(1 for x in lab if x is None)
     fp_rate = n_spurious / (n_real + n_spurious) if (n_real + n_spurious) else None
 
-    exercised = sorted(n for n in (d.name for d in dets) if ran.get(n, 0) and not fired.get(n, 0))
+    exercised = sorted(n for n, t in tally.items() if measured[n] and not t["fire"])
     print("-" * 78)
     print(f"  papers measured : {len(papers)}   (corpus frozen: {frozen_at})")
-    print(f"  detectors run   : {len(ran)}   skipped: {len(skipped)}")
-    print(f"  pairs           : {ran_pairs}   fired: {fired_pairs}")
+    print(f"  detectors       : {len(full)} full / {len(partial)} partial / {len(never)} never ran"
+          f"   (of {len(dets)})")
+    n_block = sum(1 for f in findings if f["tier"] == "blocking")
+    n_unparsed = sum(1 for f in findings if not f["parsed"])
+    print(f"  pairs           : {ran_pairs}   fired: {fired_pairs}   findings: {len(findings)}"
+          f" ({n_block} blocking-tier, {n_unparsed} with no parseable claim line)")
+    print(f"  unobserved pairs: {unobserved_pairs} "
+          f"(not_applicable {sum(t['not_applicable'] for t in tally.values())}, "
+          f"unsupplied {sum(t['unsupplied'] for t in tally.values())}, "
+          f"timeout {sum(t['timeout'] for t in tally.values())}) — no evidence either way")
     print(f"  FIRE RATE       : {fire_rate:.3f}  <- the trend to watch across runs")
+    if a.bar == "both":
+        print(f"  default-bar fires: {default_bar_fires} of the same {ran_pairs} pairs "
+              f"(rate {default_bar_fires / ran_pairs:.3f}) — secondary series, not comparable")
     print(f"  silent-when-run : {len(exercised)} detector(s) — OBSERVED clean, not unobserved")
+    n_strict = sum(1 for v in bars.values() if v == "strict")
+    print(f"  bar             : {n_strict} detector(s) at --strict, {len(dets) - n_strict} at their "
+          f"default exit code")
     if unbacked:
         print(f"  EXCLUDED (no heldout manifest record): {', '.join(unbacked)}")
 
@@ -356,45 +587,70 @@ def main(argv: Optional[List[str]] = None) -> int:
                     f"    COLLAPSED: {', '.join(group)} share an identical profile — one pattern "
                     "measured twice, not two observations."
                 )
-    for name, why in sorted(skipped.items()):
-        print(f"  SKIPPED {name} ({why}) — unobserved, NOT evidence of a clean detector")
+    for name in partial:
+        t = tally[name]
+        print(f"  PARTIAL {name}: measured {measured[name]}/{len(papers)} papers "
+              f"(not_applicable {t['not_applicable']}, unsupplied {t['unsupplied']}, "
+              f"timeout {t['timeout']}) — the rest are unobserved, not clean")
+    for name in never:
+        why = next((reasons[name][o] for o in ("unsupplied", "not_applicable", "timeout")
+                    if o in reasons[name]), "no reason recorded")
+        print(f"  NEVER RAN {name} ({why}) — unobserved, NOT evidence of a clean detector")
 
-    if fires:
+    if findings:
         print("-" * 78)
         if fp_rate is None:
             print(
-                f"  FALSE-POSITIVE RATE: WITHHELD — {n_unlabelled} fire(s), 0 labelled.\n"
+                f"  FALSE-POSITIVE RATE: WITHHELD — {n_unlabelled} finding(s) across "
+                f"{len(fires)} fire(s), 0 labelled.\n"
                 "    A fire on an accepted paper may be a real defect reviewers missed. Label the\n"
                 "    worksheet (real / spurious / unsure) before any FP claim is made."
             )
         else:
-            cov = (len(fires) - n_unlabelled) / len(fires)
+            cov = (len(findings) - n_unlabelled) / len(findings)
             print(
                 f"  FALSE-POSITIVE RATE: {fp_rate:.3f}  "
                 f"({n_spurious} spurious / {n_real + n_spurious} decided; "
                 f"{n_unsure} unsure, {n_unlabelled} unlabelled; coverage {cov:.0%})"
             )
+            print("    denominator is FINDINGS, not fires — one exit can carry a true claim and a "
+                  "false one.")
+            blocking = [f for f in findings if f["tier"] == "blocking"]
+            b_sp = sum(1 for f in blocking if f["disposition"] == "spurious")
+            b_dec = b_sp + sum(1 for f in blocking if f["disposition"] == "real")
+            if b_dec:
+                print(f"    blocking-tier only: {b_sp / b_dec:.3f} ({b_sp}/{b_dec} decided) — the "
+                      "rate for claims the stack calls Major")
             if cov < 1.0:
-                print("    Partial coverage — unlabelled fires could move this in either direction.")
+                print("    Partial coverage — unlabelled findings could move this either way.")
 
     if a.worksheet:
-        todo = [f for f in fires if (f["paper"], f["detector"]) not in labels]
+        todo = [f for f in findings if f["disposition"] is None]
         with a.worksheet.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["paper", "detector", "verdict", "disposition", "note"])
+            w.writerow(["paper", "detector", "code", "severity", "verdict", "disposition", "note"])
             for f in todo:
-                w.writerow([f["paper"], f["detector"], f["verdict"], "", ""])
-        print(f"\n  worksheet: {len(todo)} unlabelled fire(s) -> {a.worksheet}")
+                w.writerow([f["paper"], f["detector"], f["code"], f["severity"],
+                            f["message"], "", ""])
+        print(f"\n  worksheet: {len(todo)} unlabelled finding(s) -> {a.worksheet}")
 
     payload = {
         "corpus": str(a.corpus),
         "frozen_at": frozen_at,
+        "bar": a.bar,
         "n_papers": len(papers),
-        "n_detectors_run": len(ran),
-        "n_detectors_skipped": len(skipped),
+        "n_detectors_full": len(full),
+        "n_detectors_partial": len(partial),
+        "n_detectors_never_ran": len(never),
         "pairs_ran": ran_pairs,
         "pairs_fired": fired_pairs,
+        "pairs_unobserved": unobserved_pairs,
+        "n_findings": len(findings),
+        "n_findings_blocking": sum(1 for f in findings if f["tier"] == "blocking"),
+        "n_findings_unparsed": sum(1 for f in findings if not f["parsed"]),
         "fire_rate": round(fire_rate, 4),
+        "fire_rate_default_bar": (round(default_bar_fires / ran_pairs, 4)
+                                  if a.bar == "both" else None),
         "false_positive_rate": None if fp_rate is None else round(fp_rate, 4),
         "labels": {
             "spurious": n_spurious,
@@ -404,15 +660,19 @@ def main(argv: Optional[List[str]] = None) -> int:
         },
         "per_detector": {
             d.name: {
-                "ran": ran.get(d.name, 0),
-                "fired": fired.get(d.name, 0),
-                "skipped": skipped.get(d.name),
+                "bar": bars[d.name],
+                "measured": measured[d.name],
+                "status": ("full" if d.name in full else
+                           "partial" if d.name in partial else "never_ran"),
+                **tally[d.name],
+                "reasons": dict(reasons[d.name]),
             }
             for d in dets
         },
         "excluded_unbacked": unbacked,
         "separation": separation,
         "fires": fires,
+        "findings": findings,
     }
 
     # ---- the trend. A level with no trend says nothing. --------------------------------------
@@ -434,14 +694,23 @@ def main(argv: Optional[List[str]] = None) -> int:
                         prev = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-        entry = {k: payload[k] for k in ("frozen_at", "n_papers", "n_detectors_run",
+        entry = {k: payload[k] for k in ("frozen_at", "bar", "n_papers", "n_detectors_full",
                                          "pairs_ran", "pairs_fired", "fire_rate",
                                          "false_positive_rate")}
         with a.ledger.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
-        if prev and prev.get("n_papers") == payload["n_papers"]:
+        if prev and prev.get("bar", "default") != payload["bar"]:
+            # Differencing two bars would read an invocation change as a change in the detectors.
+            # The pilot series was recorded at the default bar and cannot be continued.
+            print("-" * 78)
+            print(
+                f"  TREND: not comparable — severity bar changed "
+                f"({prev.get('bar', 'default')} -> {payload['bar']}). A rate measured at a bar where\n"
+                "    most detectors cannot exit non-zero is not the same quantity. Series restarts."
+            )
+        elif prev and prev.get("n_papers") == payload["n_papers"]:
             d_rate = payload["fire_rate"] - prev.get("fire_rate", 0.0)
-            d_det = payload["n_detectors_run"] - prev.get("n_detectors_run", 0)
+            d_det = payload["n_detectors_full"] - prev.get("n_detectors_full", 0)
             print("-" * 78)
             print(
                 f"  TREND vs last run: detectors {d_det:+d}, fire rate {d_rate:+.3f}\n"

--- a/reverse_engineer/scripts/render_jats.py
+++ b/reverse_engineer/scripts/render_jats.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""JATS XML -> Markdown, for the held-out corpus. The renderer IS the denominator.
+
+WHY THIS EXISTS AS A COMMITTED SCRIPT
+    The first held-out corpus was rendered by a throwaway script in a session scratchpad. That
+    script took four corrections, each of which moved the measured fire rate, and then it was gone
+    — so the corpus could not be rebuilt, the corrections could not be re-run, and the number had
+    no reproducible provenance. For a measurement instrument that is a hole, not an inconvenience.
+
+WHAT A DROPPED SECTION DOES TO A MEASUREMENT
+    A converter that loses a section the detectors read does not produce a missing signal. It
+    produces a FIRE, and that fire is indistinguishable from a detector defect at the point of
+    reading. The four corrections, in order, and the fire rate after each:
+
+      <body> only                                    disclosure detector fired on 12 of 12   0.031
+      + <author-notes>, <back>                       JAMA / Elsevier keep disclosures there   0.018
+      + <funding-group>, <custom-meta>               PLOS keeps them there and nowhere else   0.015
+      + <contrib-group> (the byline)                 CRediT cannot resolve initials without it 0.015
+
+    And a fifth, subtler one: <author-notes> flattened into a single paragraph puts every JAMA
+    label ("Funding/Support:", "Data Sharing Statement:") mid-line, where a line-anchored section
+    finder cannot see it. Structure is part of the content.
+
+THE BIAS THIS GUARDS AGAINST
+    Publishers disagree about WHERE a disclosure lives in the XML. A renderer that knows one
+    publisher's location manufactures fires for the other publishers' papers only — a bias
+    correlated with journal rather than with quality, which for a benchmark corpus is worse than
+    noise: it is systematic, and it aligns with a variable nobody thought to control. So the
+    fidelity test is PER PUBLISHER SHAPE, not overall (test_render_jats.sh).
+
+Usage:
+    render_jats.py --xml a.nxml --out _corpus/heldout/record_id.md
+    render_jats.py --xml-dir raw/ --out-dir _corpus/heldout/   # stem is preserved as record_id
+
+Exit: 0 rendered, 1 a required element was absent (named), 2 usage/parse error. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import List, Optional
+
+# PMC writes housekeeping into custom-meta too. These are not article content and a detector that
+# reads them is reading our pipeline, not the paper.
+PMC_INTERNAL_META = {"pmc-simple-viewer", "pmc-article-type", "processing-meta", "dtd-version"}
+
+# Elements whose text is never article prose.
+DROP_TAGS = {"xref", "graphic", "inline-graphic", "media", "table-wrap-foot", "label"}
+
+
+def text_of(el: Optional[ET.Element]) -> str:
+    """All descendant text, minus cross-reference furniture, whitespace-normalised.
+
+    itertext() would happily inline every <xref> number into the sentence, turning
+    "as shown previously" into "as shown previously 12 13 14" — which is how a citation-density
+    detector comes to measure our converter.
+    """
+    if el is None:
+        return ""
+    parts: List[str] = []
+
+    def walk(node: ET.Element) -> None:
+        tag = node.tag.split("}")[-1]
+        if tag in DROP_TAGS:
+            if node.tail:
+                parts.append(node.tail)
+            return
+        if node.text:
+            parts.append(node.text)
+        for child in node:
+            walk(child)
+        if node.tail:
+            parts.append(node.tail)
+
+    walk(el)
+    return re.sub(r"\s+", " ", "".join(parts)).strip()
+
+
+def find(el: ET.Element, path: str) -> Optional[ET.Element]:
+    return el.find(path)
+
+
+def byline(article_meta: ET.Element) -> str:
+    """Author names in order. Without this the CRediT check cannot resolve a single initial."""
+    names: List[str] = []
+    for group in article_meta.findall("contrib-group"):
+        for contrib in group.findall("contrib"):
+            if contrib.get("contrib-type") not in (None, "author"):
+                continue
+            name = contrib.find("name")
+            if name is not None:
+                given = text_of(name.find("given-names"))
+                sur = text_of(name.find("surname"))
+                full = " ".join(x for x in (given, sur) if x)
+                if full:
+                    names.append(full)
+                continue
+            coll = contrib.find("collab")
+            if coll is not None and text_of(coll):
+                names.append(text_of(coll))
+    return ", ".join(names)
+
+
+def render_sections(parent: ET.Element, level: int, out: List[str]) -> None:
+    """Sections recursively, heading level tracking depth. Paragraphs stay paragraphs."""
+    for child in parent:
+        tag = child.tag.split("}")[-1]
+        if tag == "sec":
+            title = text_of(child.find("title"))
+            if title:
+                out.append(f"\n{'#' * min(level, 6)} {title}\n")
+            render_sections(child, level + 1, out)
+        elif tag in ("p", "disp-quote", "statement"):
+            t = text_of(child)
+            if t:
+                out.append(t + "\n")
+        elif tag == "list":
+            for item in child.findall("list-item"):
+                t = text_of(item)
+                if t:
+                    out.append(f"- {t}")
+            out.append("")
+        elif tag in ("table-wrap", "fig"):
+            cap = text_of(child.find("caption"))
+            lab = text_of(child.find("label"))
+            if cap or lab:
+                out.append(f"**{lab}** {cap}".strip() + "\n")
+        elif tag == "title":
+            continue
+
+
+def render_author_notes(article_meta: ET.Element, out: List[str]) -> None:
+    """Author notes, ONE PARAGRAPH PER CHILD.
+
+    Flattening these was the fourth correction. JAMA puts "Funding/Support:", "Data Sharing
+    Statement:" and "Conflict of Interest Disclosures:" in sibling <fn> blocks; joined into one
+    paragraph, every label lands mid-line and a line-anchored section finder sees none of them.
+    """
+    notes = article_meta.find("author-notes")
+    if notes is None:
+        return
+    blocks: List[str] = []
+    for child in notes:
+        tag = child.tag.split("}")[-1]
+        if tag == "corresp":
+            t = text_of(child)
+            if t:
+                blocks.append(t)
+        elif tag == "fn":
+            for p in child.findall("p") or [child]:
+                t = text_of(p)
+                if t:
+                    blocks.append(t)
+        else:
+            t = text_of(child)
+            if t:
+                blocks.append(t)
+    if blocks:
+        out.append("\n## Article Information\n")
+        out.extend(b + "\n" for b in blocks)
+
+
+def render_funding(article_meta: ET.Element, out: List[str]) -> None:
+    """PLOS keeps funding in <funding-group> and nowhere a body-only renderer would look."""
+    fg = article_meta.find("funding-group")
+    if fg is None:
+        return
+    lines: List[str] = []
+    stmt = fg.find("funding-statement")
+    if stmt is not None and text_of(stmt):
+        lines.append(text_of(stmt))
+    for award in fg.findall("award-group"):
+        t = text_of(award)
+        if t:
+            lines.append(t)
+    if lines:
+        out.append("\n## Funding\n")
+        out.extend(x + "\n" for x in lines)
+
+
+def render_custom_meta(article_meta: ET.Element, out: List[str]) -> None:
+    """Non-PMC custom-meta. PLOS puts data availability here — as a <custom-meta>, not a section.
+
+    Rendered as `**name:** value` on its own line so a label-anchored finder can see it, which is
+    the same lesson as author-notes: the label has to start a line.
+    """
+    for group in article_meta.findall("custom-meta-group"):
+        for meta in group.findall("custom-meta"):
+            name = text_of(meta.find("meta-name"))
+            value = text_of(meta.find("meta-value"))
+            if not name or not value:
+                continue
+            if name.strip().lower() in PMC_INTERNAL_META:
+                continue
+            label = name.replace("-", " ").strip().title()
+            out.append(f"\n**{label}:** {value}\n")
+
+
+def render_back(back: Optional[ET.Element], out: List[str]) -> None:
+    """Acknowledgements, notes, footnote groups, back sections, then references.
+
+    Elsevier's "Declaration of competing interest" is a back <sec>; MDPI's contributions live in a
+    back <fn-group>. Both are invisible to a <body>-only renderer.
+    """
+    if back is None:
+        return
+    for child in back:
+        tag = child.tag.split("}")[-1]
+        if tag == "ack":
+            out.append("\n## Acknowledgements\n")
+            render_sections(child, 3, out)
+        elif tag == "fn-group":
+            out.append("\n## Notes\n")
+            for fn in child.findall("fn"):
+                for p in fn.findall("p") or [fn]:
+                    t = text_of(p)
+                    if t:
+                        out.append(t + "\n")
+        elif tag == "notes":
+            title = text_of(child.find("title")) or "Notes"
+            out.append(f"\n## {title}\n")
+            render_sections(child, 3, out)
+        elif tag == "sec":
+            title = text_of(child.find("title")) or "Section"
+            out.append(f"\n## {title}\n")
+            render_sections(child, 3, out)
+        elif tag == "ref-list":
+            out.append("\n## References\n")
+            for i, ref in enumerate(child.findall("ref"), 1):
+                t = text_of(ref)
+                if t:
+                    out.append(f"{i}. {t}")
+            out.append("")
+
+
+def render(xml_path: Path) -> str:
+    try:
+        root = ET.parse(str(xml_path)).getroot()
+    except ET.ParseError as exc:
+        raise SystemExit(f"render_jats: cannot parse {xml_path}: {exc}")
+
+    article = root if root.tag.split("}")[-1] == "article" else root.find(".//article")
+    if article is None:
+        raise SystemExit(f"render_jats: no <article> element in {xml_path}")
+
+    front = article.find("front")
+    article_meta = front.find("article-meta") if front is not None else None
+    if article_meta is None:
+        raise SystemExit(f"render_jats: no front/article-meta in {xml_path}")
+
+    out: List[str] = []
+    title = text_of(article_meta.find("title-group/article-title"))
+    out.append(f"# {title}\n" if title else "# (untitled)\n")
+
+    names = byline(article_meta)
+    if names:
+        out.append(names + "\n")
+
+    for abstract in article_meta.findall("abstract"):
+        kind = abstract.get("abstract-type")
+        out.append(f"\n## {'Abstract' if not kind else kind.title() + ' Abstract'}\n")
+        render_sections(abstract, 3, out)
+        # An unsectioned abstract is a bare <p> run, which render_sections already emits.
+
+    body = article.find("body")
+    if body is not None:
+        render_sections(body, 2, out)
+
+    render_author_notes(article_meta, out)
+    render_funding(article_meta, out)
+    render_custom_meta(article_meta, out)
+    render_back(article.find("back"), out)
+
+    text = "\n".join(out)
+    return re.sub(r"\n{3,}", "\n\n", text).strip() + "\n"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--xml", type=Path)
+    ap.add_argument("--out", type=Path)
+    ap.add_argument("--xml-dir", type=Path)
+    ap.add_argument("--out-dir", type=Path)
+    a = ap.parse_args(argv)
+
+    if a.xml_dir:
+        if not a.out_dir:
+            ap.error("--xml-dir requires --out-dir")
+        a.out_dir.mkdir(parents=True, exist_ok=True)
+        n = 0
+        for x in sorted(a.xml_dir.iterdir()):
+            if x.suffix.lower() not in (".xml", ".nxml"):
+                continue
+            (a.out_dir / f"{x.stem}.md").write_text(render(x), encoding="utf-8")
+            n += 1
+        print(f"render_jats: {n} file(s) -> {a.out_dir}")
+        return 0
+
+    if not a.xml or not a.out:
+        ap.error("pass --xml and --out, or --xml-dir and --out-dir")
+    a.out.parent.mkdir(parents=True, exist_ok=True)
+    a.out.write_text(render(a.xml), encoding="utf-8")
+    print(f"render_jats: {a.xml} -> {a.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/test_heldout_crossfire.sh
+++ b/reverse_engineer/scripts/test_heldout_crossfire.sh
@@ -67,22 +67,55 @@ assert d["separation"]["collapsed"], "collapse not recorded in the artifact"
 v = {f["verdict"] for f in d["fires"]}
 assert v and all(x and not set(x) <= set("=- ") for x in v), \
     "worksheet verdicts are separator rules, not labelable verdicts: %r" % v
+# One exit carries several claims, and each must be labelable on its own merits: the pilot's
+# systematic-review fire asserted a true omission AND a false one inside a single exit.
+assert d["n_findings"] > d["pairs_fired"], \
+    "findings not split out of fires: %r findings, %r fires" % (d["n_findings"], d["pairs_fired"])
+assert all(f.get("code") for f in d["findings"]), "a finding with no code cannot be labelled"
+# The bar is part of the measurement. A rate whose bar is not recorded is not reportable.
+assert d["bar"] == "strict", d["bar"]
+assert all(v["bar"] in ("strict", "default") for v in d["per_detector"].values())
+# Every detector sits in exactly ONE status bucket. The old summary managed to report 33 run AND
+# 10 skipped out of 42, by counting a truncated detector in both.
+assert d["n_detectors_full"] + d["n_detectors_partial"] + d["n_detectors_never_ran"] \
+    == len(d["per_detector"]), d
 PY
 
-echo "== 2. labelled dispositions produce a rate =="
+echo "== 2. labelled dispositions produce a rate, at FINDING level =="
 python3 - "$TMP/ws.csv" "$TMP/disp.csv" <<'PY'
 import csv, sys
 rows = list(csv.DictReader(open(sys.argv[1])))
-assert len(rows) == 2, rows
-for r, d in zip(rows, ["spurious", "real"]):
-    r["disposition"] = d
+assert len(rows) >= 4, "expected finding-level rows (>=2 claims x 2 papers), got %r" % len(rows)
+assert "code" in rows[0], "worksheet is not finding-level: %r" % list(rows[0])
+# Same claims on both papers, labelled oppositely, so the rate is not degenerate either way.
+for r in rows:
+    r["disposition"] = "spurious" if r["paper"] == "alpha_2024_ct" else "real"
 with open(sys.argv[2], "w", newline="") as fh:
-    w = csv.DictWriter(fh, fieldnames=["paper", "detector", "verdict", "disposition", "note"])
+    w = csv.DictWriter(fh, fieldnames=["paper", "detector", "code", "severity", "verdict",
+                                       "disposition", "note"])
     w.writeheader(); w.writerows(rows)
 PY
 python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only "$DET" \
     --dispositions "$TMP/disp.csv" 2>&1 | grep -q "FALSE-POSITIVE RATE: 0.500" \
-  || fail "labelled dispositions did not yield the expected 1 spurious / 2 decided rate"
+  || fail "finding-level dispositions did not yield the expected half-spurious rate"
+
+echo "== 2b. a pair-level label file (no code column) still labels every finding =="
+python3 - "$TMP/ws.csv" "$TMP/disp_pairlevel.csv" <<'PY'
+import csv, sys
+seen, out = set(), []
+for r in csv.DictReader(open(sys.argv[1])):
+    if r["paper"] in seen:
+        continue
+    seen.add(r["paper"])
+    out.append({"paper": r["paper"], "detector": r["detector"], "verdict": "", "note": "",
+                "disposition": "spurious" if r["paper"] == "alpha_2024_ct" else "real"})
+with open(sys.argv[2], "w", newline="") as fh:
+    w = csv.DictWriter(fh, fieldnames=["paper", "detector", "verdict", "disposition", "note"])
+    w.writeheader(); w.writerows(out)
+PY
+python3 "$RUNNER" --corpus "$TMP/corpus" --manifest "$TMP/manifest.json" --only "$DET" \
+    --dispositions "$TMP/disp_pairlevel.csv" 2>&1 | grep -q "coverage 100%" \
+  || fail "a pre-findings (pair-level) label file no longer covers the findings it labelled"
 
 echo "== 3. an unbacked paper is excluded, not silently measured =="
 cp "$TMP/corpus/alpha_2024_ct.md" "$TMP/corpus/gamma_undeclared.md"
@@ -101,6 +134,87 @@ REL_OUT="$(cd "$TMP" && python3 "$RUNNER" --corpus ./corpus --only "$DET" 2>&1)"
   || fail "relative --corpus made the runner exit non-zero"
 grep -qE "pairs +: 2 " <<<"$REL_OUT" \
   || fail "relative --corpus ran 0 pairs — detectors were handed a path they cannot resolve"
+
+echo "== 3c. the SEVERITY BAR: a detector that exits 0 on its own blocker must not read as clean =="
+# Paid for on 2026-07-25. 32 of 42 manuscript detectors document exit 1 as conditional on --strict:
+# without it they PRINT a Major finding and exit 0, and the first version of this instrument read
+# only the exit code. Re-running the pilot corpus at both bars gave 5 fires vs 45, and seven
+# detectors recorded as "observed clean" fired the moment they were allowed to speak.
+# check_placeholders is the demonstration: it prints a warn-severity finding for a bare numeric
+# citation and exits 0, and only escalates to exit 1 under --strict. Note what this fixture also
+# shows — that the strict bar is not free. `--strict` means "gate Majors" in most detectors and
+# "promote advisories" in some, so a published paper using Vancouver citations fires at the strict
+# bar for a claim that is perfectly TRUE. That is why findings carry a severity tier and why the
+# labelling rule is correctness, not usefulness.
+mkdir -p "$TMP/bar"
+cat > "$TMP/bar/paper_with_marker.md" <<'EOF'
+# A study
+## Methods
+We enrolled patients consecutively, as described previously [1].
+EOF
+cat > "$TMP/bar_manifest.json" <<'EOF'
+{"schema_version": 1, "records": [
+  {"record_id": "paper_with_marker", "split": "heldout", "frozen_at": "2026-07-25",
+   "coverage": {"design": "unspecified"}}
+]}
+EOF
+python3 "$RUNNER" --corpus "$TMP/bar" --manifest "$TMP/bar_manifest.json" \
+  --only check_placeholders --bar default --out "$TMP/bar_default.json" >/dev/null 2>&1 \
+  || fail "runner exited non-zero on the bar fixture"
+python3 "$RUNNER" --corpus "$TMP/bar" --manifest "$TMP/bar_manifest.json" \
+  --only check_placeholders --bar strict --out "$TMP/bar_strict.json" >/dev/null 2>&1 \
+  || fail "runner exited non-zero on the bar fixture"
+python3 - "$TMP/bar_default.json" "$TMP/bar_strict.json" <<'PY' || exit 1
+import json, sys
+lo, hi = (json.load(open(p)) for p in sys.argv[1:3])
+assert lo["pairs_fired"] == 0, "fixture no longer demonstrates the bar: %r" % lo["pairs_fired"]
+assert hi["pairs_fired"] == 1, \
+    "the strict bar did not surface a finding the default bar swallowed: %r" % hi["pairs_fired"]
+assert hi["per_detector"]["check_placeholders"]["bar"] == "strict", hi["per_detector"]
+PY
+
+echo "== 3d. a per-paper skip must NOT abandon the rest of the corpus =="
+# Also paid for on 2026-07-25. Exit 2 means both "you did not give me the flags I need" (about the
+# DETECTOR) and "this paper has no section for me" (about the PAPER). The first version treated
+# both as a detector-level skip and broke out of the paper loop, so check_credit_integrity was
+# measured on 5 of 12 papers in FILENAME ORDER and the remaining 7 — holding three more fires —
+# were never measured. The first paper here is the one that makes it exit 2, on purpose.
+mkdir -p "$TMP/skip"
+cat > "$TMP/skip/aaa_no_credit_section.md" <<'EOF'
+# A study
+## Methods
+Patients were enrolled consecutively.
+EOF
+cat > "$TMP/skip/zzz_unresolvable_initials.md" <<'EOF'
+# A study
+
+Jane A. Doe, Robert B. Smith
+
+## Author contributions
+J.A.D.: Conceptualization; Methodology. R.B.S.: Writing – original draft. Q.Z.T.: Supervision.
+EOF
+cat > "$TMP/skip_manifest.json" <<'EOF'
+{"schema_version": 1, "records": [
+  {"record_id": "aaa_no_credit_section", "split": "heldout", "frozen_at": "2026-07-25",
+   "coverage": {"design": "a"}},
+  {"record_id": "zzz_unresolvable_initials", "split": "heldout", "frozen_at": "2026-07-25",
+   "coverage": {"design": "b"}}
+]}
+EOF
+python3 "$RUNNER" --corpus "$TMP/skip" --manifest "$TMP/skip_manifest.json" \
+  --only check_credit_integrity --out "$TMP/skip.json" >/dev/null 2>&1 \
+  || fail "runner exited non-zero on the truncation fixture"
+python3 - "$TMP/skip.json" <<'PY' || exit 1
+import json, sys
+d = json.load(open(sys.argv[1]))
+pd = d["per_detector"]["check_credit_integrity"]
+assert pd["not_applicable"] == 1, "the self-declared skip was not classified per paper: %r" % pd
+assert d["pairs_fired"] == 1, \
+    "a skip on the FIRST paper swallowed the fire on the second: %r" % d["pairs_fired"]
+assert pd["status"] == "partial", pd["status"]
+assert pd["measured"] == 1, pd
+assert d["pairs_unobserved"] == 1, d["pairs_unobserved"]
+PY
 
 echo "== 4. an empty corpus refuses to emit a rate =="
 mkdir -p "$TMP/empty"

--- a/reverse_engineer/scripts/test_heldout_crossfire.sh
+++ b/reverse_engineer/scripts/test_heldout_crossfire.sh
@@ -69,9 +69,18 @@ assert v and all(x and not set(x) <= set("=- ") for x in v), \
     "worksheet verdicts are separator rules, not labelable verdicts: %r" % v
 # One exit carries several claims, and each must be labelable on its own merits: the pilot's
 # systematic-review fire asserted a true omission AND a false one inside a single exit.
-assert d["n_findings"] > d["pairs_fired"], \
-    "findings not split out of fires: %r findings, %r fires" % (d["n_findings"], d["pairs_fired"])
-assert all(f.get("code") for f in d["findings"]), "a finding with no code cannot be labelled"
+assert d["n_findings_labelable"] > d["pairs_fired"], \
+    "findings not split out of fires: %r findings, %r fires" % (
+        d["n_findings_labelable"], d["pairs_fired"])
+assert all(f.get("code") and f.get("message") for f in d["findings"]), \
+    "a finding with no code or no message cannot be labelled"
+# The parser's own coverage is part of the measurement: a row whose claim could not be read is not
+# evidence about a detector, and a row the detector calls context is not a claim at all. Both are
+# counted and both stay out of the labelable denominator (amendment 2).
+for k in ("n_findings_context", "n_findings_unparsed", "n_findings_blocking"):
+    assert k in d, "missing %s — the finding denominator is not accountable" % k
+assert d["n_findings_unparsed"] == 0, \
+    "the stub detector's claims did not parse: %r unparsed" % d["n_findings_unparsed"]
 # The bar is part of the measurement. A rate whose bar is not recorded is not reportable.
 assert d["bar"] == "strict", d["bar"]
 assert all(v["bar"] in ("strict", "default") for v in d["per_detector"].values())

--- a/reverse_engineer/scripts/test_render_jats.sh
+++ b/reverse_engineer/scripts/test_render_jats.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Per-publisher fidelity test for the held-out corpus renderer.
+#
+# WHY PER PUBLISHER AND NOT OVERALL
+#   Publishers disagree about WHERE a disclosure lives in JATS. A renderer that knows one
+#   publisher's location drops the others' — and a dropped section does not read as a missing
+#   signal, it reads as a FIRE. So the corpus acquires a bias correlated with JOURNAL rather than
+#   with quality, which for a benchmark is worse than noise: it is systematic, and it aligns with
+#   a variable nobody thought to control.
+#
+#   An "overall" fidelity check passes as soon as one shape works. This one asserts each shape
+#   separately, so the failure names the publisher.
+#
+# Every fixture below is a synthetic JATS document written for this test. Network-free.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R="$HERE/render_jats.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# $1 name, $2 rendered file, $3.. required strings
+must_contain() {
+  local who="$1" f="$2"; shift 2
+  for needle in "$@"; do
+    grep -qF -- "$needle" "$f" || fail "$who: renderer dropped \"$needle\""
+  done
+}
+# A label that a line-anchored section finder must be able to see: it has to START a line.
+must_start_line() {
+  local who="$1" f="$2"; shift 2
+  for needle in "$@"; do
+    grep -qE "^[*]{0,2}${needle}" "$f" \
+      || fail "$who: \"$needle\" exists but not at line start — a line-anchored finder cannot see it"
+  done
+}
+
+# ---------------------------------------------------------------------------------------------
+# JAMA shape: everything lives in <author-notes> as sibling <fn> blocks. Flattening them into one
+# paragraph is what put every label mid-line in the first corpus.
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/jama.xml" <<'EOF'
+<article><front><article-meta>
+<title-group><article-title>A Randomized Trial of Something</article-title></title-group>
+<contrib-group>
+  <contrib contrib-type="author"><name><surname>Guo</surname><given-names>Lixin</given-names></name></contrib>
+  <contrib contrib-type="author"><name><surname>Xi</surname><given-names>Yue</given-names></name></contrib>
+</contrib-group>
+<abstract><sec><title>Question</title><p>Does it work?</p></sec></abstract>
+<author-notes>
+  <fn><p>Funding/Support: Supported by grant 12345.</p></fn>
+  <fn><p>Data Sharing Statement: See Supplement 3.</p></fn>
+  <fn><p>Conflict of Interest Disclosures: None reported.</p></fn>
+</author-notes>
+</article-meta></front>
+<body><sec><title>Methods</title><p>We randomized 405 adults<xref ref-type="bibr">12</xref>.</p></sec></body>
+<back><ref-list><ref><mixed-citation>Smith J. A paper. J Med. 2024;1:1-9.</mixed-citation></ref></ref-list></back>
+</article>
+EOF
+python3 "$R" --xml "$TMP/jama.xml" --out "$TMP/jama.md" >/dev/null
+must_contain "jama" "$TMP/jama.md" \
+  "A Randomized Trial of Something" "Lixin Guo, Yue Xi" \
+  "Funding/Support:" "Data Sharing Statement:" "Conflict of Interest Disclosures:" \
+  "We randomized 405 adults" "Smith J. A paper."
+must_start_line "jama" "$TMP/jama.md" \
+  "Funding/Support:" "Data Sharing Statement:" "Conflict of Interest Disclosures:"
+# The xref number must NOT be inlined into the sentence — that is our converter writing citations.
+grep -qF "405 adults12" "$TMP/jama.md" \
+  && fail "jama: an <xref> was inlined into the prose — a citation-density check would measure us"
+
+# ---------------------------------------------------------------------------------------------
+# PLOS shape: funding in <funding-group>, data availability in <custom-meta>. Neither is a section
+# and neither is in <body>, so a body-only renderer reports both as absent.
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/plos.xml" <<'EOF'
+<article><front><article-meta>
+<title-group><article-title>An Open Access Study</article-title></title-group>
+<contrib-group><contrib contrib-type="author"><name><surname>Doe</surname><given-names>Jane</given-names></name></contrib></contrib-group>
+<abstract><p>Unsectioned abstract text.</p></abstract>
+<funding-group><funding-statement>This work was funded by NIH R01.</funding-statement></funding-group>
+<custom-meta-group>
+  <custom-meta><meta-name>data-availability</meta-name><meta-value>All data are within the manuscript.</meta-value></custom-meta>
+  <custom-meta><meta-name>pmc-simple-viewer</meta-name><meta-value>true</meta-value></custom-meta>
+</custom-meta-group>
+</article-meta></front>
+<body><sec><title>Results</title><p>Everything worked.</p></sec></body>
+</article>
+EOF
+python3 "$R" --xml "$TMP/plos.xml" --out "$TMP/plos.md" >/dev/null
+must_contain "plos" "$TMP/plos.md" \
+  "An Open Access Study" "Jane Doe" "Unsectioned abstract text." \
+  "This work was funded by NIH R01." "All data are within the manuscript."
+must_start_line "plos" "$TMP/plos.md" "Data Availability:"
+grep -qF "pmc-simple-viewer" "$TMP/plos.md" \
+  && fail "plos: PMC housekeeping metadata leaked into the corpus — detectors would read our pipeline"
+
+# ---------------------------------------------------------------------------------------------
+# Elsevier shape: "Declaration of competing interest" is a BACK SECTION, not author-notes.
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/elsevier.xml" <<'EOF'
+<article><front><article-meta>
+<title-group><article-title>A Systematic Review</article-title></title-group>
+<contrib-group><contrib contrib-type="author"><name><surname>Roe</surname><given-names>Richard</given-names></name></contrib></contrib-group>
+</article-meta></front>
+<body><sec><title>Introduction</title><p>Background prose.</p></sec></body>
+<back>
+  <sec><title>Declaration of competing interest</title><p>The authors declare none.</p></sec>
+  <ack><p>We thank the librarians.</p></ack>
+  <ref-list><ref><mixed-citation>Roe R. Prior work. 2023.</mixed-citation></ref></ref-list>
+</back>
+</article>
+EOF
+python3 "$R" --xml "$TMP/elsevier.xml" --out "$TMP/elsevier.md" >/dev/null
+must_contain "elsevier" "$TMP/elsevier.md" \
+  "Declaration of competing interest" "The authors declare none." "We thank the librarians." \
+  "Roe R. Prior work."
+must_start_line "elsevier" "$TMP/elsevier.md" "## Declaration of competing interest"
+
+# ---------------------------------------------------------------------------------------------
+# MDPI shape: contributions in a back <fn-group>, with an EM DASH inside the CRediT term.
+# The dash is ledger C5 — the term scan shredded "Writing—original draft" at the dash.
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/mdpi.xml" <<'EOF'
+<article><front><article-meta>
+<title-group><article-title>A Radiomics Study</article-title></title-group>
+<contrib-group>
+  <contrib contrib-type="author"><name><surname>Rossi</surname><given-names>Paolo</given-names></name></contrib>
+</contrib-group>
+</article-meta></front>
+<body><sec><title>Methods</title><p>Features were extracted.</p></sec></body>
+<back>
+  <fn-group>
+    <fn><p>Author Contributions: Conceptualization, P.R.; Writing—original draft preparation, P.R.</p></fn>
+    <fn><p>Data Availability Statement: Data are available on request.</p></fn>
+  </fn-group>
+</back>
+</article>
+EOF
+python3 "$R" --xml "$TMP/mdpi.xml" --out "$TMP/mdpi.md" >/dev/null
+must_contain "mdpi" "$TMP/mdpi.md" \
+  "Author Contributions:" "Writing—original draft preparation" "Data Availability Statement:"
+must_start_line "mdpi" "$TMP/mdpi.md" "Author Contributions:" "Data Availability Statement:"
+grep -qF "Writing—original draft" "$TMP/mdpi.md" \
+  || fail "mdpi: the em dash inside a CRediT term did not survive rendering"
+
+# ---------------------------------------------------------------------------------------------
+# BMC / Springer shape: declarations as nested back sections under one parent.
+# ---------------------------------------------------------------------------------------------
+cat > "$TMP/bmc.xml" <<'EOF'
+<article><front><article-meta>
+<title-group><article-title>A Cohort Study</article-title></title-group>
+<contrib-group>
+  <contrib contrib-type="author"><name><surname>Kim</surname><given-names>Minji</given-names></name></contrib>
+  <contrib contrib-type="author"><collab>The Consortium Group</collab></contrib>
+</contrib-group>
+</article-meta></front>
+<body><sec><title>Discussion</title><p>Interpretation.</p></sec></body>
+<back><sec><title>Declarations</title>
+  <sec><title>Availability of data and materials</title><p>Datasets are in the repository.</p></sec>
+  <sec><title>Competing interests</title><p>The authors declare no competing interests.</p></sec>
+</sec></back>
+</article>
+EOF
+python3 "$R" --xml "$TMP/bmc.xml" --out "$TMP/bmc.md" >/dev/null
+must_contain "bmc" "$TMP/bmc.md" \
+  "Availability of data and materials" "Datasets are in the repository." \
+  "Competing interests" "The Consortium Group"
+
+# ---------------------------------------------------------------------------------------------
+# The regression that started it: a <body>-only renderer must FAIL this suite, not squeak through.
+# Proven by rendering a JAMA fixture and asserting the disclosure block is what carries the labels
+# — if a future refactor drops <author-notes>, every assertion above fires, naming the publisher.
+# ---------------------------------------------------------------------------------------------
+python3 - "$TMP/jama.md" <<'PY' || exit 1
+import sys
+md = open(sys.argv[1]).read()
+labels = ["Funding/Support:", "Data Sharing Statement:", "Conflict of Interest Disclosures:"]
+lines = [ln for ln in md.splitlines() if any(ln.startswith(x) for x in labels)]
+assert len(lines) == 3, \
+    "author-notes were flattened: %d of 3 labels start their own line" % len(lines)
+PY
+
+echo "PASS: renderer preserves byline, abstract, body, author-notes (unflattened), funding-group,"
+echo "      custom-meta, back sections, fn-groups and references across 5 publisher shapes."


### PR DESCRIPTION
Two defects in `heldout_crossfire.py`, found by running every manuscript detector across the held-out corpus twice at two invocation bars and never breaking out of the loop. Both make a noisy stack look quiet. Between them they void every rate this instrument has printed, including the "fire rate 0.005, false-positive rate 0.000" line that read as the loop closing.

### 1. The bar — most detectors were invoked where they cannot speak

The runner passed `--manuscript <paper>` and read the exit code. But **32 of 42 manuscript detectors document exit 1 as conditional on `--strict`**: without it they print a Major finding and exit 0.

| bar | fires | runnable pairs | fire rate |
|---|---|---|---|
| default (what every run so far used) | 5 | 392 | 0.013 |
| `--strict` where the detector offers it | **45** | 392 | **0.115** |

Seven detectors recorded as *observed clean* fire the moment they are allowed to: `check_analysis_definitions`, `check_artifact_coverage`, `check_claim_artifact`, `check_cv_leakage`, `check_null_calibration`, `check_placeholders`, `check_reference_adequacy`.

This is the A2 signature — output and exit code disagree, only the exit code is read — occurring inside the tool written to catch it. An instrument built to separate *silent* from *unobserved* had a third category it did not know about: **muzzled**.

`--bar {strict,default,both}` now defaults to `strict`, is recorded per detector in the artifact, and the ledger refuses to difference two runs taken at different bars.

The bar is not free and the code says so: `--strict` means "gate Majors" in most detectors and "promote advisories" in others (`check_placeholders` escalates a bare Vancouver `[1]`, which every published paper has). So findings carry a severity tier and the FP rate is reported for blocking-tier alone as well as overall.

### 2. A per-paper skip abandoned the rest of the corpus

Exit 2 is overloaded: "you did not give me the flags I need" (about the *detector*) and "this paper has no section for me to check — skipped" (about the *paper*). The runner treated both as a detector-level skip and `break`ed out of the paper loop. `check_credit_integrity` was measured on 5 of 12 papers **in filename order**; the abandoned 7 held three more fires, one of them Major. Which papers got measured was a function of alphabetical sort.

Outcomes are now per pair from a closed taxonomy (`fire` / `clean` / `not_applicable` / `unsupplied` / `timeout` / `harness_void`), nothing terminates the loop, and each detector is reported as full, partial or never-ran with its own denominator — the old summary managed to report 33 run *and* 10 skipped out of 42 by counting the truncated detector in both.

### Also in this PR

- **Findings, not fires.** One exit can carry several claims that disagree: a fire on a systematic review asserted both a true omission (no data availability) and a false one (no COI — Elsevier's *Declaration of competing interest* was present and unrecognised). Labelled at pair level, either label is a lie. Claim lines are extracted per finding with a severity tier; the worksheet is finding-level; the false-positive rate takes findings as its denominator while the fire rate keeps pairs. Existing pair-level label files still work.
- **`--roster-out`** writes the detector roster with each detector's bar and file sha256. A rate belongs to a named set of detectors at a named content hash, or it belongs to nothing.
- **`render_jats.py`, committed.** The corpus renderer existed only as a throwaway script that took four corrections and then no longer existed, so the denominator had no reproducible provenance. `test_render_jats.sh` asserts fidelity **per publisher shape** — JAMA `author-notes`, PLOS `funding-group` + `custom-meta`, Elsevier back-section, MDPI `fn-group` with an em dash, BMC nested declarations — plus line-start assertions, because a label flattened mid-line is invisible to a line-anchored finder. A renderer that knows one publisher's layout drops the others', and a dropped section does not read as a missing signal: it reads as a **fire**, biased by journal rather than by quality.

### Verification

- Regression cases for both defects **fail against the previous runner**: the bar fixture reports 0 fires where it should report 1; the truncation fixture refuses to emit a measurement at all after abandoning the corpus.
- Six planted mutants of the renderer (drop author-notes, flatten them, drop custom-meta, drop byline, drop back matter, inline xrefs) are each caught by name.
- Full local CI mirror: **212/212 gates pass**.

`HELDOUT.md` withdraws every rate it has published and records why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)