### PR TITLE
feat(heldout): metamorphic invariance — a severity probe that needs no labeler

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,9 @@ jobs:
       - name: "Run render_jats fidelity test (a dropped section is not a missing signal, it is a FIRE, biased by publisher)"
         run: bash reverse_engineer/scripts/test_render_jats.sh
 
+      - name: "Run perturbation/invariance self-test (a probe that cannot see a moved verdict is worse than none)"
+        run: bash reverse_engineer/scripts/test_perturb_invariance.sh
+
       - name: Run check_python_floor.py (everything a user runs must parse on the Python we promise)
         run: python3 scripts/check_python_floor.py --strict
 

--- a/reverse_engineer/scripts/invariance_report.py
+++ b/reverse_engineer/scripts/invariance_report.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Q7 — did the verdict survive a rewrite that cannot change what the paper says?
+
+Takes a baseline run of `heldout_crossfire.py` and one run per perturbation from
+`perturb_corpus.py`, and reports the invariance rate: the proportion of (detector, paper) pairs
+whose outcome is unchanged, and of findings whose claim codes are unchanged.
+
+WHY THIS IS THE STRONGEST THING HERE
+    Every other endpoint needs a human to say what the right answer was. This one does not. If the
+    verdict moves under a rewrite that provably preserves the numbers, the citations and the words,
+    then the detector is wrong on one side of the pair — and which side does not matter for the
+    claim being made. That is severity without ground truth.
+
+WHAT A MOVED VERDICT IS NOT
+    For some detectors, order or position IS the subject. `check_citation_order` is supposed to
+    change its mind when floats are reordered. Those detectors are exempt PER PERTURBATION, from an
+    explicit list in perturb_corpus.py, never inferred — an inferred exemption is a place for a real
+    failure to hide. Their movement is reported separately as `expected_change`, and it is a defect
+    of the OPPOSITE kind if they do NOT move: a detector that ignores a reordering it exists to
+    police was not reading the order at all.
+
+READING THE OUTPUT
+    outcome invariance   pairs whose outcome class (fire/clean/not_applicable/...) is unchanged
+    claim invariance     fires whose SET of verdict codes is unchanged. Stricter, and the one that
+                         catches a detector that still fires but for a different reason.
+    per-detector         where the movement is. One detector moving on every paper is a different
+                         finding from every detector moving on one paper.
+
+Usage:
+    invariance_report.py --baseline run.json \\
+        --perturbed house-vocab=run_hv.json --perturbed reorder-sections=run_ro.json \\
+        [--perturb-report house-vocab=report_hv.json] [--out q7.json]
+
+Exit: 0 always (an instrument, not a gate), 2 usage/parse error. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def load(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"invariance: cannot read {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def outcomes(run: dict) -> Dict[tuple, str]:
+    """(detector, paper) -> outcome. Rebuilt from the findings/fires plus per-detector tallies.
+
+    The run artifact records per-detector counts, not per-pair outcomes, so fires are recovered
+    exactly and everything else is 'not-fire'. That is the resolution the comparison needs: the
+    question is whether the stack SPOKE differently, and a clean/not_applicable distinction under
+    perturbation is a separate (and much rarer) event, reported via the pair counts.
+    """
+    out: Dict[tuple, str] = {}
+    for f in run.get("fires", []):
+        out[(f["detector"], f["paper"])] = "fire"
+    return out
+
+
+def claims(run: dict) -> Dict[tuple, frozenset]:
+    by: Dict[tuple, set] = defaultdict(set)
+    for f in run.get("findings", []):
+        if f.get("tier") in ("blocking", "advisory"):
+            by[(f["detector"], f["paper"])].add(f["code"])
+    return {k: frozenset(v) for k, v in by.items()}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--baseline", type=Path, required=True)
+    ap.add_argument("--perturbed", action="append", default=[],
+                    metavar="NAME=PATH", help="repeatable; NAME must match the perturbation")
+    ap.add_argument("--perturb-report", action="append", default=[], metavar="NAME=PATH",
+                    help="repeatable; supplies the exempt-detector list and excluded papers")
+    ap.add_argument("--out", type=Path)
+    a = ap.parse_args(argv)
+
+    base = load(a.baseline)
+    base_out, base_claims = outcomes(base), claims(base)
+
+    exempt: Dict[str, set] = {}
+    excluded: Dict[str, set] = {}
+    for spec in a.perturb_report:
+        if "=" not in spec:
+            print(f"invariance: --perturb-report wants NAME=PATH, got {spec!r}", file=sys.stderr)
+            return 2
+        name, path = spec.split("=", 1)
+        rep = load(Path(path))
+        exempt[name] = set(rep.get("exempt_detectors", ()))
+        excluded[name] = {e["paper"] for e in rep.get("excluded", ())}
+
+    results = []
+    for spec in a.perturbed:
+        if "=" not in spec:
+            print(f"invariance: --perturbed wants NAME=PATH, got {spec!r}", file=sys.stderr)
+            return 2
+        name, path = spec.split("=", 1)
+        run = load(Path(path))
+        p_out, p_claims = outcomes(run), claims(run)
+        ex_det, ex_pap = exempt.get(name, set()), excluded.get(name, set())
+
+        pairs = {k for k in set(base_out) | set(p_out) if k[1] not in ex_pap}
+        judged = {k for k in pairs if k[0] not in ex_det}
+        moved = sorted(k for k in judged if base_out.get(k) != p_out.get(k))
+        expected = sorted(k for k in pairs - judged if base_out.get(k) != p_out.get(k))
+        stuck = sorted(k for k in pairs - judged if base_out.get(k) == p_out.get(k))
+
+        # claim-level: only where both sides fired, so a moved outcome is not counted twice
+        both = {k for k in set(base_claims) & set(p_claims) if k in judged}
+        claim_moved = sorted(k for k in both if base_claims[k] != p_claims[k])
+
+        n_j = len(judged)
+        res = {
+            "perturbation": name,
+            "pairs_judged": n_j,
+            "pairs_moved": len(moved),
+            "outcome_invariance": round(1 - len(moved) / n_j, 4) if n_j else None,
+            "fires_compared": len(both),
+            "claims_moved": len(claim_moved),
+            "claim_invariance": round(1 - len(claim_moved) / len(both), 4) if both else None,
+            "exempt_detectors": sorted(ex_det),
+            "exempt_moved_as_expected": len(expected),
+            "exempt_did_not_move": [f"{d} x {p}" for d, p in stuck],
+            "excluded_papers": sorted(ex_pap),
+            "moved": [{"detector": d, "paper": p,
+                       "baseline": base_out.get((d, p), "not-fire"),
+                       "perturbed": p_out.get((d, p), "not-fire")} for d, p in moved],
+            "claims_changed": [{"detector": d, "paper": p,
+                                "baseline": sorted(base_claims[(d, p)]),
+                                "perturbed": sorted(p_claims[(d, p)])} for d, p in claim_moved],
+        }
+        results.append(res)
+
+        print("=" * 78)
+        print(f" Q7 invariance — {name}")
+        print("=" * 78)
+        print(f"  pairs judged      : {n_j}   moved: {len(moved)}")
+        if res["outcome_invariance"] is not None:
+            print(f"  OUTCOME INVARIANCE: {res['outcome_invariance']:.3f}"
+                  "   <- 1.000 means the rewrite changed nothing the stack noticed")
+        if res["claim_invariance"] is not None:
+            print(f"  CLAIM INVARIANCE  : {res['claim_invariance']:.3f}"
+                  f"   ({len(claim_moved)} of {len(both)} fires changed WHICH claim they made)")
+        by_det: Dict[str, int] = defaultdict(int)
+        for d, _ in moved:
+            by_det[d] += 1
+        for d, n in sorted(by_det.items(), key=lambda x: -x[1]):
+            print(f"    MOVED {d} on {n} paper(s) — read surface form, not content")
+        if ex_det:
+            print(f"  exempt (order/position is their subject): {', '.join(sorted(ex_det))}")
+            print(f"    of these, {len(expected)} moved as expected")
+            for s in res["exempt_did_not_move"]:
+                print(f"    DID NOT MOVE {s} — a detector that polices order ignored a reordering")
+        if ex_pap:
+            print(f"  excluded by the validity guard: {', '.join(sorted(ex_pap))}")
+
+    payload = {"baseline": str(a.baseline), "results": results}
+    if a.out:
+        a.out.parent.mkdir(parents=True, exist_ok=True)
+        a.out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\n  json: {a.out}")
+    print("\n  A moved verdict is a defect on one side of the pair, and which side does not matter\n"
+          "  for this claim. That is why this endpoint needs no labeler.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/perturb_corpus.py
+++ b/reverse_engineer/scripts/perturb_corpus.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Semantics-preserving perturbations of a held-out corpus — the severity probe.
+
+WHAT THIS IS FOR
+    Every other measurement here needs to know the right answer before it can call a detector wrong.
+    This one does not. If a detector's verdict changes when the manuscript is rewritten in a way
+    that cannot change what the manuscript SAYS, then the detector was reading surface form, and it
+    is wrong on one side of the pair regardless of which side. That is a severity test in Mayo's
+    sense: it constructs the case in which the checker would be caught, and it needs no labeler.
+
+    It is also ledger Class C turned into a systematic probe. C1 and C2 were exactly this: a
+    detector that recognised "Data Availability" and not JAMA's "Data Sharing Statement", found by
+    accident on twelve papers. The house-vocabulary perturbation looks for the rest of that class on
+    purpose.
+
+WHY THERE IS NO PARAPHRASE PERTURBATION
+    The obvious fourth perturbation is "reword the prose without changing the claims", and it is
+    omitted deliberately. A machine paraphrase is not verifiably meaning-preserving: certifying that
+    a rewritten sentence still says the same thing is a human judgement, per sentence, at corpus
+    scale. That is a bigger labeling burden than the study this probe was promoted to replace. A
+    perturbation whose validity cannot be checked mechanically cannot support an argument that a
+    changed verdict is the detector's fault.
+
+    So all three perturbations here are ones a script can PROVE it applied correctly, and each run
+    ships a validity report saying so.
+
+THE PERTURBATIONS
+
+  house-vocab       Rewrite section labels and disclosure headings into a different publisher's
+                    house wording ("Data Availability" -> "Data Sharing Statement", "Competing
+                    interests" -> "Declaration of competing interest"). Meaning-preserving because
+                    the pairs are recognised synonyms across journals; a reader loses nothing.
+                    The sharpest probe of the five ledger Class C defects.
+
+  rename-abbrev     Rename in-document abbreviations consistently ("MRI (magnetic resonance
+                    imaging)" everywhere becomes "QZT (magnetic resonance imaging)"). Meaning-
+                    preserving because the abbreviation is DEFINED in the document: the expansion
+                    travels with it. Probes detectors keyed to specific token strings.
+
+  reorder-sections  Permute sibling sections within the body, seeded. Meaning-preserving for every
+                    claim in the paper. NOT meaning-preserving for order itself, so detectors whose
+                    documented job is order or position are exempt (see EXEMPT below) — a changed
+                    verdict there is the detector working, not failing.
+
+VALIDITY GUARD
+    A perturbation that damages the document is not semantics-preserving, and a probe that cannot
+    tell the difference would report our own corruption as a detector defect — which is precisely
+    what happened to the first corpus renderer (ledger B1-B4). So every run asserts, per paper:
+
+      - the multiset of numbers is unchanged
+      - the multiset of citation markers is unchanged
+      - no content is lost: the word count outside the intended edits is unchanged
+      - the intended edit actually happened at least once (a no-op perturbation measures nothing)
+
+    A paper failing any of these is excluded from that perturbation and named in the report.
+
+Usage:
+    perturb_corpus.py --corpus _corpus/heldout --out _corpus/perturbed/house-vocab \\
+        --perturbation house-vocab [--seed 42] [--report path.json]
+
+Exit: 0 written, 1 a paper failed the validity guard (still writes the rest, names the failures),
+      2 usage error. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# --- house vocabulary rings -------------------------------------------------------------------
+# Each ring is a set of wordings that different publishers use for THE SAME THING. Rotating one
+# step around a ring changes the house, never the meaning. Longest-first at match time, so
+# "Conflict of Interest Disclosures" is not eaten by "Conflict of Interest".
+VOCAB_RINGS: Tuple[Tuple[str, ...], ...] = (
+    ("Data Availability Statement", "Data Sharing Statement", "Availability of data and materials",
+     "Data Availability"),
+    ("Conflict of Interest Disclosures", "Declaration of competing interest", "Competing interests",
+     "Conflicts of Interest", "Conflict of Interest"),
+    ("Funding/Support", "Funding Statement", "Funding"),
+    ("CRediT authorship contribution statement", "Author Contributions", "Authors' contributions"),
+    ("Acknowledgements", "Acknowledgments"),
+    ("Ethics approval and consent to participate", "Ethical approval", "Ethics Statement"),
+)
+
+# Detectors exempt from a given perturbation because order or position is their documented subject.
+# A verdict that moves here is the detector doing its job. Named explicitly rather than inferred:
+# an inferred exemption list is a place to hide a real failure.
+EXEMPT: Dict[str, Tuple[str, ...]] = {
+    "reorder-sections": (
+        "check_citation_order",        # float citation order IS the check
+        "check_figure_citation",       # first-citation position
+        "check_perspective_structure",  # section sequence is the subject
+        "check_classical_style",       # heading order / house structure
+        "check_summary_box",           # box placement
+    ),
+    "house-vocab": (),
+    "rename-abbrev": (),
+}
+
+NUM_RE = re.compile(r"\d+(?:[.,]\d+)*")
+CITE_RE = re.compile(r"\[\d+(?:[–\-,;\s]*\d+)*\]")
+# "magnetic resonance imaging (MRI)" — a definition that makes the abbreviation renameable.
+#
+# Two or more capitals, no trailing digit, deliberately. A first version accepted a single capital and so
+# treated figure panel labels "(A)", "(B)" and the statistic "(P)" as abbreviations, then renamed
+# every standalone A and P in the document — 400+ words in some papers. The validity guard caught
+# it and refused to write the corpus, which is what the guard is for; this is the fix behind it.
+ABBREV_DEF_RE = re.compile(r"\(([A-Z]{2,6})\)")
+
+# Capitalised tokens that are not abbreviations of anything, or whose renaming would change meaning.
+ABBREV_STOPLIST = frozenset({
+    "AND", "OR", "NOT", "THE", "ALL", "NEW", "TWO", "ONE", "SD", "SE", "CI", "IQR", "NA", "ID",
+})
+WORD_RE = re.compile(r"[A-Za-z]+")
+
+
+def farthest_in_ring(word: str, ring: Tuple[str, ...]) -> str:
+    """The ring member sharing the FEWEST words with `word`.
+
+    Rotating to the neighbour is a weak probe: "Data Availability" -> "Data Availability Statement"
+    differs by one appended token, and a detector keyed on the substring never notices. The point of
+    this perturbation is to hand the detector a wording it has genuinely never met, so it goes to
+    the most distant member of the ring — "Data Sharing Statement" or "Availability of data and
+    materials". Deterministic: ties break on ring order.
+    """
+    src = set(word.lower().split())
+    return min(
+        (w for w in ring if w != word),
+        key=lambda w: (len(src & set(w.lower().split())), ring.index(w)),
+    )
+
+
+def rotate_vocab(text: str) -> Tuple[str, int]:
+    """Rewrite each house wording as another house's. Longest match first, so a long phrase is not
+    swallowed by a shorter one it contains ("Conflict of Interest Disclosures" vs "Conflict of
+    Interest")."""
+    pairs: List[Tuple[str, str]] = []
+    for ring in VOCAB_RINGS:
+        for word in ring:
+            pairs.append((word, farthest_in_ring(word, ring)))
+    pairs.sort(key=lambda p: -len(p[0]))
+
+    # Two passes with a sentinel, so a rewritten string is not rewritten again by a later rule.
+    n = 0
+    holder: Dict[str, str] = {}
+    for i, (src, dst) in enumerate(pairs):
+        token = f"\x00VOCAB{i}\x00"
+        new, k = re.subn(re.escape(src), token, text)
+        if k:
+            holder[token] = dst
+            text = new
+            n += k
+    for token, dst in holder.items():
+        text = text.replace(token, dst)
+    return text, n
+
+
+def rename_abbreviations(text: str, rng: random.Random) -> Tuple[str, int]:
+    """Rename abbreviations that the document itself defines, consistently, everywhere."""
+    defined = [m.group(1) for m in ABBREV_DEF_RE.finditer(text)]
+    # Only abbreviations that recur — a one-off is not worth perturbing and risks a false rename.
+    counts = Counter(re.findall(r"\b[A-Z]{2,6}\b", text))
+    targets = sorted({a for a in defined if a not in ABBREV_STOPLIST and counts.get(a, 0) >= 2})
+    if not targets:
+        return text, 0
+    n = 0
+    for i, abbr in enumerate(targets):
+        # Deterministic, obviously-synthetic, and LETTERS ONLY. A digit in the replacement token
+        # lands in the document's number multiset, which the validity guard reads as "the numbers
+        # changed" — correctly, and it refused to write the corpus until this was fixed.
+        new = "ZQX" + chr(ord("A") + i // 26) + chr(ord("A") + i % 26)
+        text, k = re.subn(rf"\b{re.escape(abbr)}\b", new, text)
+        n += k
+    return text, n
+
+
+def reorder_sections(text: str, rng: random.Random) -> Tuple[str, int]:
+    """Permute sibling `##` sections, keeping the title block and the first section in place."""
+    lines = text.splitlines(keepends=True)
+    idx = [i for i, ln in enumerate(lines) if re.match(r"^## (?!#)", ln)]
+    if len(idx) < 3:
+        return text, 0
+    head = lines[: idx[0]]
+    blocks: List[List[str]] = []
+    for a, b in zip(idx, idx[1:] + [len(lines)]):
+        blocks.append(lines[a:b])
+    # Keep the first block anchored (usually Abstract) so the document still opens like a paper.
+    first, rest = blocks[0], blocks[1:]
+    order = list(range(len(rest)))
+    rng.shuffle(order)
+    if order == sorted(order) and len(order) > 1:  # a shuffle that changed nothing measures nothing
+        order.reverse()
+    out = head + first + [ln for i in order for ln in rest[i]]
+    return "".join(out), len(order)
+
+
+PERTURBATIONS = {
+    "house-vocab": lambda t, rng: rotate_vocab(t),
+    "rename-abbrev": rename_abbreviations,
+    "reorder-sections": reorder_sections,
+}
+
+
+def validity(before: str, after: str, kind: str, edits: int) -> List[str]:
+    """What must be true for a changed verdict to be the DETECTOR's fault and not ours.
+
+    The word budget is DERIVED from the edits actually made, not a constant. A first version used a
+    flat cap and excluded 6 of 12 pilot papers for the crime of containing many abbreviations —
+    a guard that rejects the perturbation working as designed is a guard that measures nothing.
+    """
+    problems: List[str] = []
+    if Counter(NUM_RE.findall(before)) != Counter(NUM_RE.findall(after)):
+        problems.append("numbers changed")
+    if Counter(CITE_RE.findall(before)) != Counter(CITE_RE.findall(after)):
+        problems.append("citation markers changed")
+    wb, wa = Counter(WORD_RE.findall(before)), Counter(WORD_RE.findall(after))
+    if kind == "reorder-sections" and wb != wa:
+        problems.append("word multiset changed under a pure reordering")
+    delta = sum((wb - wa).values()) + sum((wa - wb).values())
+    if kind == "rename-abbrev":
+        # Each rename removes exactly one token and adds exactly one. Anything else is collateral.
+        if delta != 2 * edits:
+            problems.append(f"rewrote {delta} words for {edits} renames (expected {2 * edits}) — "
+                            "the rename touched something it did not name")
+    elif kind == "house-vocab":
+        # A ring phrase is at most six words, so a swap moves at most twelve.
+        if delta > 12 * edits:
+            problems.append(f"rewrote {delta} words for {edits} swaps — beyond the intended edit")
+    if before == after:
+        problems.append("no-op: nothing was perturbed, so this paper measures nothing")
+    return problems
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--corpus", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--perturbation", choices=sorted(PERTURBATIONS), required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--report", type=Path)
+    a = ap.parse_args(argv)
+
+    if not a.corpus.is_dir():
+        print(f"perturb: no corpus at {a.corpus}", file=sys.stderr)
+        return 2
+    papers = sorted(p for p in a.corpus.iterdir() if p.suffix.lower() in (".md", ".txt"))
+    if not papers:
+        print(f"perturb: no papers in {a.corpus}", file=sys.stderr)
+        return 2
+
+    a.out.mkdir(parents=True, exist_ok=True)
+    fn = PERTURBATIONS[a.perturbation]
+    written, excluded, edits = [], [], 0
+
+    for p in papers:
+        before = p.read_text(encoding="utf-8")
+        rng = random.Random(f"{a.seed}:{p.stem}")  # per paper, so one paper cannot shift another
+        after, n = fn(before, rng)
+        problems = validity(before, after, a.perturbation, n)
+        if problems:
+            excluded.append({"paper": p.stem, "problems": problems})
+            continue
+        (a.out / p.name).write_text(after, encoding="utf-8")
+        written.append({"paper": p.stem, "edits": n})
+        edits += n
+
+    report = {
+        "perturbation": a.perturbation,
+        "seed": a.seed,
+        "source": str(a.corpus),
+        "out": str(a.out),
+        "n_written": len(written),
+        "n_excluded": len(excluded),
+        "total_edits": edits,
+        "exempt_detectors": list(EXEMPT.get(a.perturbation, ())),
+        "written": written,
+        "excluded": excluded,
+    }
+    print(f"perturb {a.perturbation}: {len(written)} paper(s), {edits} edit(s) -> {a.out}")
+    for e in excluded:
+        print(f"  EXCLUDED {e['paper']}: {'; '.join(e['problems'])}")
+    if EXEMPT.get(a.perturbation):
+        print(f"  exempt from invariance (order/position IS their subject): "
+              f"{', '.join(EXEMPT[a.perturbation])}")
+    if a.report:
+        a.report.parent.mkdir(parents=True, exist_ok=True)
+        a.report.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"  report: {a.report}")
+    return 1 if excluded else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reverse_engineer/scripts/test_perturb_invariance.sh
+++ b/reverse_engineer/scripts/test_perturb_invariance.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Self-test for the Q7 severity probe: the perturbation generator and the invariance report.
+#
+# The real corpus is gitignored published papers, so CI can never run the real measurement. What CI
+# CAN prove is that the probe is honest about what it did: that a perturbation which would change
+# the paper's meaning is REFUSED rather than measured, that the exemption list is applied and not
+# quietly ignored, and — the one that matters — that a moved verdict is actually detected and
+# named. A probe that reports 1.000 because it cannot see movement is worse than no probe.
+#
+# Network-free. Builds its own synthetic corpus and its own synthetic run artifacts.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PERTURB="$HERE/perturb_corpus.py"
+REPORT="$HERE/invariance_report.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$TMP/corpus"
+cat > "$TMP/corpus/alpha_2024.md" <<'EOF'
+# A Study of Something
+
+## Abstract
+We enrolled 405 patients with non-small cell lung cancer (NSCLC) and measured 12 outcomes [1].
+
+## Methods
+NSCLC staging followed standard criteria. Computed tomography (CT) was performed in 405 cases.
+CT findings were reviewed by two readers [2].
+
+## Results
+Sensitivity was 0.88 (95% CI 0.83-0.92) across 405 NSCLC cases.
+
+## Discussion
+The CT protocol is described elsewhere [3].
+
+## Data Availability
+All data are available on request.
+
+## Conflict of Interest
+The authors declare none.
+EOF
+
+echo "== 1. each perturbation applies, and proves it preserved the paper =="
+for K in house-vocab rename-abbrev reorder-sections; do
+  python3 "$PERTURB" --corpus "$TMP/corpus" --out "$TMP/$K" --perturbation "$K" \
+      --report "$TMP/rep_$K.json" >"$TMP/out_$K.txt" 2>&1 \
+    || fail "$K: validity guard excluded the fixture — the perturbation damaged the paper"
+  [ -s "$TMP/$K/alpha_2024.md" ] || fail "$K: wrote no paper"
+  python3 - "$TMP/rep_$K.json" "$K" <<'PY' || exit 1
+import json, sys
+rep = json.load(open(sys.argv[1]))
+assert rep["n_excluded"] == 0, rep["excluded"]
+assert rep["total_edits"] > 0, "%s was a no-op: a perturbation that changes nothing measures nothing" % sys.argv[2]
+PY
+done
+
+# The numbers and citations are the paper's content; a perturbation that moves them is not
+# semantics-preserving, and every downstream claim would be about our corruption.
+for K in house-vocab rename-abbrev reorder-sections; do
+  for pat in '405' '0.88' '\[1\]' '\[3\]'; do
+    grep -qE "$pat" "$TMP/$K/alpha_2024.md" || fail "$K: lost $pat from the paper"
+  done
+done
+
+echo "== 2. house-vocab really rewrites the house, and rename-abbrev really renames =="
+# The swap must land on a GENUINELY different wording. Rotating to the ring neighbour once produced
+# "Data Availability" -> "Data Availability Statement", which differs by one appended token and
+# which any substring-keyed detector sails straight through: a probe that measures nothing while
+# reporting perfect invariance. The target is now the most distant member of the ring.
+grep -qE "^## (Data Sharing Statement|Availability of data and materials)$" \
+     "$TMP/house-vocab/alpha_2024.md" \
+  || fail "house-vocab did not rewrite the heading into a distant publisher's wording"
+grep -qE "^## Data Availability" "$TMP/house-vocab/alpha_2024.md" \
+  && fail "house-vocab left the original heading in place — the probe would measure nothing"
+grep -qE "^## (Competing interests|Declaration of competing interest)$" \
+     "$TMP/house-vocab/alpha_2024.md" \
+  || fail "house-vocab did not rewrite the COI heading"
+grep -q "NSCLC" "$TMP/rename-abbrev/alpha_2024.md" \
+  && fail "rename-abbrev left the original abbreviation in place"
+grep -q "non-small cell lung cancer" "$TMP/rename-abbrev/alpha_2024.md" \
+  || fail "rename-abbrev dropped the DEFINITION — the rename is only meaning-preserving with it"
+
+echo "== 3. the validity guard REFUSES a perturbation that changes the paper =="
+# Not a hypothetical: the first rename-abbrev numbered its replacements ZQX00, ZQX01, which put
+# digits into the document's number multiset, and matched single capitals so it renamed every
+# standalone "A" and "P". The guard caught both. This asserts it still would.
+python3 - "$PERTURB" <<'PY' || exit 1
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("perturb", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+before = "We enrolled 405 patients and found 12 events [1]."
+assert "numbers changed" in m.validity(before, "We enrolled 406 patients and found 12 events [1].",
+                                       "house-vocab", 1)
+assert "citation markers changed" in m.validity(before, "We enrolled 405 patients and found 12 events [9].",
+                                                "house-vocab", 1)
+assert any("no-op" in p for p in m.validity(before, before, "house-vocab", 0))
+# A pure reordering may not gain or lose a single word.
+assert any("word multiset" in p for p in
+           m.validity("## A\nx\n## B\ny\n", "## B\ny\n## A\nz\n", "reorder-sections", 1))
+# A rename must move exactly two words per rename; anything else touched something it did not name.
+assert any("did not name" in p for p in
+           m.validity("AA bb cc", "ZZ dd ee", "rename-abbrev", 1))
+assert not m.validity("AA bb AA", "ZZ bb ZZ", "rename-abbrev", 2), \
+    "a correct 2-instance rename was rejected"
+PY
+
+echo "== 4. the invariance report detects a moved verdict and NAMES it =="
+# The test that matters. A probe reporting 1.000 because it cannot see movement is worse than none.
+mk_run() {  # $1 out  $2... "detector:paper:code" triples
+  python3 - "$@" <<'PY'
+import json, sys
+out, triples = sys.argv[1], sys.argv[2:]
+fires, findings = [], []
+for t in triples:
+    det, paper, code = t.split(":")
+    fires.append({"detector": det, "paper": paper, "verdict": code, "bar": "strict"})
+    findings.append({"detector": det, "paper": paper, "code": code, "severity": "major",
+                     "tier": "blocking", "message": code, "parsed": True})
+json.dump({"fires": fires, "findings": findings}, open(out, "w"))
+PY
+}
+mk_run "$TMP/base.json"  d1:p1:CODE_A d1:p2:CODE_A d2:p1:CODE_B
+mk_run "$TMP/same.json"  d1:p1:CODE_A d1:p2:CODE_A d2:p1:CODE_B
+mk_run "$TMP/moved.json" d1:p1:CODE_A               d2:p1:CODE_B   # d1 went silent on p2
+mk_run "$TMP/claim.json" d1:p1:CODE_A d1:p2:CODE_A d2:p1:CODE_Z    # d2 fires for a new reason
+
+OUT="$(python3 "$REPORT" --baseline "$TMP/base.json" --perturbed x="$TMP/same.json" 2>&1)"
+grep -q "OUTCOME INVARIANCE: 1.000" <<<"$OUT" || fail "identical runs did not report full invariance"
+
+OUT="$(python3 "$REPORT" --baseline "$TMP/base.json" --perturbed x="$TMP/moved.json" 2>&1)"
+grep -q "OUTCOME INVARIANCE: 0.667" <<<"$OUT" \
+  || fail "a verdict that moved on 1 of 3 pairs was not reported as 0.667: $OUT"
+grep -q "MOVED d1 on 1 paper" <<<"$OUT" || fail "the moved detector was not named"
+
+OUT="$(python3 "$REPORT" --baseline "$TMP/base.json" --perturbed x="$TMP/claim.json" 2>&1)"
+grep -q "OUTCOME INVARIANCE: 1.000" <<<"$OUT" \
+  || fail "a same-outcome run should keep outcome invariance at 1.000"
+grep -q "CLAIM INVARIANCE  : 0.667" <<<"$OUT" \
+  || fail "a fire that changed WHICH claim it made was not caught by claim invariance: $OUT"
+
+echo "== 5. an exempt detector's movement is expected, and its STILLNESS is a finding =="
+cat > "$TMP/rep_exempt.json" <<'EOF'
+{"exempt_detectors": ["d1"], "excluded": []}
+EOF
+OUT="$(python3 "$REPORT" --baseline "$TMP/base.json" --perturbed x="$TMP/moved.json" \
+        --perturb-report x="$TMP/rep_exempt.json" 2>&1)"
+grep -q "OUTCOME INVARIANCE: 1.000" <<<"$OUT" \
+  || fail "an exempt detector's movement was counted against invariance: $OUT"
+grep -q "of these, 1 moved as expected" <<<"$OUT" || fail "expected movement was not reported"
+grep -q "DID NOT MOVE d1 x p1" <<<"$OUT" \
+  || fail "an order-policing detector that ignored a reordering was not flagged"
+
+echo "== 6. a paper the guard excluded is excluded from the RATE, not silently measured =="
+cat > "$TMP/rep_excl.json" <<'EOF'
+{"exempt_detectors": [], "excluded": [{"paper": "p2", "problems": ["numbers changed"]}]}
+EOF
+OUT="$(python3 "$REPORT" --baseline "$TMP/base.json" --perturbed x="$TMP/moved.json" \
+        --perturb-report x="$TMP/rep_excl.json" 2>&1)"
+grep -q "OUTCOME INVARIANCE: 1.000" <<<"$OUT" \
+  || fail "a paper excluded by the validity guard still entered the invariance rate: $OUT"
+grep -q "excluded by the validity guard: p2" <<<"$OUT" || fail "the excluded paper was not named"
+
+echo "PASS: perturbations preserve numbers/citations/definitions, the guard refuses corruption,"
+echo "      and a moved verdict is detected, named, and correctly exempted or excluded."


### PR DESCRIPTION
Every other measurement in this track needs a human to say what the right answer was before it can call a detector wrong. **This one does not.** If a verdict changes when the manuscript is rewritten in a way that *provably* cannot change what it says, the detector was reading surface form — and it is wrong on one side of the pair regardless of which side.

It is also `HELDOUT.md`'s Class C defect turned into a systematic probe. C1/C2 were exactly this, found by accident on twelve papers: a detector that knew `Data Availability` and not JAMA's `Data Sharing Statement`.

## Three perturbations, all mechanically verifiable

| | |
|---|---|
| `house-vocab` | rewrite a heading into the **most distant** synonym in its ring |
| `rename-abbrev` | rename document-defined abbreviations consistently (the expansion travels with them) |
| `reorder-sections` | permute sibling sections, seeded |

**No paraphrase perturbation, deliberately.** Certifying that a machine-reworded sentence still says the same thing is a per-sentence human judgement at corpus scale — a bigger labeling burden than the study this probe exists to relieve. A perturbation whose validity cannot be checked mechanically cannot support the claim "the changed verdict is the detector's fault".

## The validity guard earned its place twice, before the probe ever ran

Numbers, citation markers and word multisets are compared before/after, with the word budget **derived from the edits actually made**. It refused to write a corpus twice during development:

- `rename-abbrev` numbered its replacements `ZQX00`/`ZQX01`, putting digits into the document's number multiset; and it accepted single capitals, so `(A)` and `(P)` were read as abbreviations and every standalone A and P got renamed — 400+ words in some papers.
- A flat word cap then excluded 6 of 12 papers for the crime of containing many abbreviations. A guard that rejects the perturbation *working as designed* measures nothing. The budget is now exactly 2 words per rename, at most 12 per vocabulary swap.

Without the guard both would have surfaced as detector defects — which is precisely how the first corpus renderer manufactured 6 of 12 fires.

## The probe nearly reported perfect invariance while measuring nothing

The first `house-vocab` rotated each heading to its ring *neighbour*, producing `Data Availability` → `Data Availability **Statement**` — one appended token, which any substring-keyed detector sails through.

> **Invariance: 1.000.** Targeting the least-overlapping ring member instead: **0.911.**

A probe reporting perfect invariance is the first thing to distrust. This was caught only because the self-test asserts the swap must *land somewhere genuinely different*.

## Exemptions are explicit, never inferred

For `check_citation_order` and four others, order **is** the subject; under `reorder-sections` their movement is correct behaviour and is excluded from the rate. Their **stillness** is reported as a finding of the opposite kind — a detector that polices order and ignores a reordering was not reading the order. An inferred exemption list is a place for a real failure to hide.

## Dry run on the (already spent) held-out corpus

| perturbation | outcome invariance | claim invariance | who moved |
|---|---|---|---|
| `house-vocab` | **0.911** | 1.000 | `check_disclosure_availability` on 4 of 12 papers |
| `rename-abbrev` | 0.956 | 0.977 | `check_analysis_definitions` on 2 |
| `reorder-sections` | 0.913 | 0.952 | 3 detectors on 4 pairs; 5 exempt moved 4× as expected |

**All four `house-vocab` movements are fire → not-fire.** The paper carries BMC's `Availability of data and materials`; `check_disclosure_availability` reports the statement missing; rewriting the heading into JAMA's wording — one of the C1 fixes — silences it. The statement is present in both versions.

So C1/C2 fixed the two house wordings that happened to appear in the corpus, and **the class outlived them**. That is a live defect, found with no labeler and no ground truth. Not fixed in this PR: a repair changes the roster the frozen measurement will belong to, and that decision is dated separately.

## Verification

- Self-test asserts a moved verdict is **detected and named**, that the guard refuses corruption (numbers, citations, word multiset, no-op), and that exemptions and guard-exclusions leave the rate alone.
- Local CI mirror: **213/213**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)