### PR TITLE
test(heldout): a fused heading is invisible to every boundary-anchored finder

### DIFF
--- a/reverse_engineer/scripts/test_render_jats.sh
+++ b/reverse_engineer/scripts/test_render_jats.sh
@@ -167,6 +167,26 @@ python3 "$R" --xml "$TMP/bmc.xml" --out "$TMP/bmc.md" >/dev/null
 must_contain "bmc" "$TMP/bmc.md" \
   "Availability of data and materials" "Datasets are in the repository." \
   "Competing interests" "The Consortium Group"
+# A heading must never be fused to the paragraph that follows it. This is not hypothetical: the
+# throwaway renderer that built the first corpus emitted
+#     Competing interestsThe authors declare that they have no competing interests.
+# and check_disclosure_availability anchors its section match with \b, which cannot fire between
+# "s" and "T". Four of twelve papers were therefore reported as having NO conflict-of-interest
+# statement while plainly carrying one — a false positive manufactured by our own converter and
+# indistinguishable, at the point of reading, from a detector defect (the Class B trap).
+# Found by the metamorphic probe, which is the only thing that ever looked.
+for H in "Competing interests" "Availability of data and materials"; do
+  grep -qE "^#{2,4} ${H}\s*$" "$TMP/bmc.md" \
+    || fail "bmc: \"${H}\" is not a heading on its own line — a fused heading is invisible to a \\b-anchored section finder"
+done
+# And prove the assertion has teeth. Mutating THIS renderer cannot easily produce a fused heading
+# (it joins its parts on newlines), so the check is verified against the defect directly: the exact
+# byte sequence the old converter produced must fail the same grep. An assertion never shown to
+# fail is an assertion nobody has tested.
+printf 'Competing interestsThe authors declare that they have no competing interests.\n' \
+  > "$TMP/fused.md"
+grep -qE "^#{2,4} Competing interests\s*$" "$TMP/fused.md" \
+  && fail "the heading-boundary check passes on a FUSED heading — it detects nothing"
 
 # ---------------------------------------------------------------------------------------------
 # The regression that started it: a <body>-only renderer must FAIL this suite, not squeak through.


### PR DESCRIPTION
The metamorphic probe (#430) moved four verdicts on the held-out corpus, and that PR's description blamed the detector. **It was ours.** The correction is on #430; this PR pins the property so it cannot come back.

## What actually happened

The throwaway renderer that built the corpus — the one `render_jats.py` replaced in #429 — emitted the heading fused to its own paragraph:

```
Competing interestsThe authors declare that they have no competing interests.
```

`check_disclosure_availability` anchors its section match with `\b`, which cannot match between `s` and `T`. So **four of twelve papers were reported as having no conflict-of-interest statement while plainly carrying one.** Swapping the heading for `Conflict of Interest Disclosures`, whose match ends before a space, let the anchor fire and the detector fell silent — which is the movement the probe measured.

Same class as the `author-notes` flattening that manufactured 6 of that corpus's first 12 fires. Worse in one respect: B1–B4 were all found by investigating fires, and **this one cannot be, because the fire it produces is plausible.** A paper that genuinely lacks a COI statement looks exactly like this.

## What this PR adds

`render_jats.py` already emits headings on their own line — verified against the BMC shape, where the detector now reads both the COI and data-availability sections and flags only the funding statement the fixture really lacks. This adds the assertion that pins it, for `Competing interests` and `Availability of data and materials`.

**The assertion is verified against the defect directly, not by mutating the renderer.** Mutating this renderer cannot easily produce a fused heading (it joins its parts on newlines), and a first attempt to mutate it **passed the new check** — an assertion never shown to fail is an assertion nobody has tested. So the test feeds the exact byte sequence the old converter produced and requires the same grep to reject it.

## What this PR deliberately does not do

**No detector change.** Teaching `check_disclosure_availability` to accept a fused heading would be teaching it to tolerate our own corruption.

Local CI mirror: **213/213**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)