### PR TITLE
fix(validator): the PII scanner had been reading one file per skill

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run validate_skills.sh (PII + structure)
         run: bash scripts/validate_skills.sh
 
+      - name: "Validator scope self-test (it must READ every directory it claims to scan)"
+        run: bash tests/test_validator_scope.sh
+
       # --- self-update foundation (PR-1a): manifests, version drift, transactional installer ---
       - name: Distribution manifests in sync (gen_distribution_manifest.py --check)
         run: python3 scripts/gen_distribution_manifest.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The PII scanner had been reading one file per skill.** `validate_skills.sh` held its
+  filename patterns in a bare string and expanded it unquoted into `find`, so `*.md` was
+  pathname-expanded against the *caller's* working directory before `find` ever saw it. Run from
+  the repo root — how CI and every documented invocation run it — that became the thirteen
+  top-level `.md` files, `find` aborted with `unknown primary or operator`, and `2>/dev/null`
+  swallowed the message. Each loop yielded zero files. The "extended scope" added in 2026-05
+  specifically because vendored identifiers hide in `references/`, `templates/` and `scripts/`
+  had therefore never scanned any of them, while every run printed PASS for every rule on every
+  skill. The patterns are now an array with each glob quoted.
+
+  The blind spot was real, not theoretical: with it closed, the scanner immediately named real
+  personal names and institution strings sitting in shipped scripts and in test fixtures — all of
+  them already on the precedent blocklist, so the gate had been correct all along and simply
+  never got to look. Those are replaced with generic placeholders in this change. Git history is
+  not rewritten, so the earlier commits still carry them.
+
+- `skills/*/tests/` is now scanned as well. Fixtures are where a real name settles most easily —
+  you reach for a plausible author roster and the nearest plausible one is someone you work with.
+  Test files never reach an installer (the bundle excludes `tests/`), but they are in a public
+  repository, which is the exposure the blocklist exists to prevent. One of the names found this
+  way was inside a fixture called `supplement_pii_clean.md`.
+
+- Two files exist in order to carry personal-looking data — the Korean-PHI corpus that proves
+  `/deidentify` fires, and the leaky message that proves `/contribute` blocks a submission — and
+  are now exempt from the email rule by path, with the reason recorded beside the exemption.
+  Every other rule still applies to them. A journal's published editorial-office address and a
+  GitHub `users.noreply` sender are likewise contact information rather than a private address,
+  and join the domain whitelist.
+
+### Added
+
+- `tests/test_validator_scope.sh` plants the blocked home-directory literal in `references/`,
+  `templates/`, `scripts/`, `tests/` and at the skill root, then asserts the validator **names
+  each file**. It does not ask whether the validator passes: passing was precisely the symptom.
+
 ## [5.23.0] - 2026-07-25
 
 **Pinned reference:** the held-out validation study in `Recursive_Verification_Drift` measures this toolkit's

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5279,7 +5279,7 @@
     {
       "path": "skills/sync-submission/scripts/check_credit_integrity.py",
       "size": 18645,
-      "sha256": "c0ab9a7aa3008af3d23901ee93a764d01ae46786dbedfc287dc6cf031b7248e1"
+      "sha256": "d67a72305d2f3c1a8d5a823a272171d96db925b64b3cf4ada2997bb81234ebd2"
     },
     {
       "path": "skills/sync-submission/scripts/check_cross_artifact_stale.py",
@@ -6113,8 +6113,8 @@
     },
     {
       "path": "skills/write-paper/scripts/build_title_page_affiliations.py",
-      "size": 11749,
-      "sha256": "d42dfe6972f04103f61f47f1f7774d534117e1538024c336240f505f1c436112"
+      "size": 11723,
+      "sha256": "ff1b29d66c8272c62423f7c31f945041ce2c097b0452097fd88f25777641a3db"
     },
     {
       "path": "skills/write-paper/scripts/check_placeholders.py",

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -167,14 +167,26 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # Text-bearing extensions to scan. Binary types (.png/.pdf/.docx) are out
   # of scope — separate FAIL rule below catches their FILENAMES (rule 7c)
   # but their content needs a different tool (e.g. exiftool for EXIF).
-  TEXT_EXTS='-name *.md -o -name *.yml -o -name *.yaml -o -name *.json -o -name *.txt -o -name *.csv -o -name *.tsv'
+  #
+  # An ARRAY, and every glob quoted. As a bare string expanded unquoted into
+  # `find`, `*.md` was pathname-expanded against the CALLER'S working directory
+  # before find ever saw it. From the repo root — which is how CI and every
+  # documented invocation run it — that became the thirteen top-level .md files,
+  # find aborted with "unknown primary or operator", `2>/dev/null` swallowed the
+  # message, and each loop below yielded ZERO files. Net effect: references/,
+  # templates/ and scripts/ — the "extended scope" added in 2026-05 precisely
+  # because vendored PII hides there — were never scanned, while the run printed
+  # PASS for every rule on every skill.
+  TEXT_EXTS=( -name '*.md' -o -name '*.yml' -o -name '*.yaml' -o -name '*.json' \
+              -o -name '*.txt' -o -name '*.csv' -o -name '*.tsv' )
+  CODE_EXTS=( -o -name '*.py' -o -name '*.sh' )
 
   integrity_files=()
   [ -f "$skill_file" ] && _add_if_tracked "$skill_file"
   if [ -d "${skill_dir}references" ]; then
     while IFS= read -r -d '' f; do
       _add_if_tracked "$f"
-    done < <(find "${skill_dir}references" -type f \( $TEXT_EXTS \) -print0 2>/dev/null)
+    done < <(find "${skill_dir}references" -type f \( "${TEXT_EXTS[@]}" \) -print0 2>/dev/null)
   fi
   # Extended scope (2026-05): templates/ and scripts/ subdirs. Same blocklist
   # patterns apply — these dirs were previously silently excluded and could
@@ -184,19 +196,31 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   if [ -d "${skill_dir}templates" ]; then
     while IFS= read -r -d '' f; do
       _add_if_tracked "$f"
-    done < <(find "${skill_dir}templates" -type f \( $TEXT_EXTS -o -name "*.py" -o -name "*.sh" \) -print0 2>/dev/null)
+    done < <(find "${skill_dir}templates" -type f \( "${TEXT_EXTS[@]}" "${CODE_EXTS[@]}" \) -print0 2>/dev/null)
   fi
   if [ -d "${skill_dir}scripts" ]; then
     while IFS= read -r -d '' f; do
       _add_if_tracked "$f"
-    done < <(find "${skill_dir}scripts" -type f \( $TEXT_EXTS -o -name "*.py" -o -name "*.sh" \) -print0 2>/dev/null)
+    done < <(find "${skill_dir}scripts" -type f \( "${TEXT_EXTS[@]}" "${CODE_EXTS[@]}" \) -print0 2>/dev/null)
   fi
   # Also catch top-level skill scratchpads (skills/<name>/TODO_*.md, HANDOFF.md)
   # and skill.yml / capabilities.yml that some skills keep alongside SKILL.md.
   while IFS= read -r -d '' f; do
     _add_if_tracked "$f"
-  done < <(find "${skill_dir}" -maxdepth 1 -type f \( $TEXT_EXTS \) \
+  done < <(find "${skill_dir}" -maxdepth 1 -type f \( "${TEXT_EXTS[@]}" \) \
             ! -name "SKILL.md" -print0 2>/dev/null)
+  # tests/ (2026-07-29). Test fixtures are the *easiest* place for a real name to
+  # settle: an author roster, a byline, a reader panel — you reach for a plausible
+  # one and the nearest plausible name is someone you actually work with. These
+  # files are excluded from the distribution bundle, so they never reach an
+  # installer, but they are in a public git repository, which is the exposure the
+  # precedent blocklist exists to prevent. Scanning them found real names in two
+  # skills, one of them inside a fixture named `supplement_pii_clean.md`.
+  if [ -d "${skill_dir}tests" ]; then
+    while IFS= read -r -d '' f; do
+      _add_if_tracked "$f"
+    done < <(find "${skill_dir}tests" -type f \( "${TEXT_EXTS[@]}" "${CODE_EXTS[@]}" \) -print0 2>/dev/null)
+  fi
 
   # 6. Personal precedent leak (blocklist of project-specific identifiers).
   # Delegated to check_precedent.py: structural shapes (CK-<n>, MA-<n>, ...)
@@ -237,13 +261,32 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   #     wjgnet, kams, wiley, aasld) + `your@email.com` style placeholders.
   email_hits=0
   email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
-  email_whitelist='example\.com|example\.org|your@email\.com|user@host|name@|placeholder|noreply@|git@github\.com|@lancet\.com|@strokeahajournal\.org|@aasld\.org|@wjgnet\.com|@wiley\.com|@kams\.or\.kr|@journal\.|aim-aicro\.com'
+  email_whitelist='example\.com|example\.org|your@email\.com|user@host|name@|placeholder|noreply@|users\.noreply\.github\.com|git@github\.com|@lancet\.com|@strokeahajournal\.org|@aasld\.org|@wjgnet\.com|@wiley\.com|@kams\.or\.kr|@nejm\.org|@journal\.|aim-aicro\.com'
   # Note: `aim-aicro.com` is a corporate domain that historically appeared in a
   #   personal author roster. We allow the bare domain here only because the
   #   precedent blocklist already catches the full `kyungwon.kim@aim-aicro.com`
   #   string by way of the personal-name patterns above; remove from this
   #   whitelist if the bare domain ever surfaces on its own.
+  # `@nejm.org` and `users.noreply.github.com` joined the list in 2026-07-29, when
+  #   this rule started scanning references/ and scripts/ for the first time: a
+  #   journal's published editorial-office address and a GitHub noreply sender are
+  #   contact information, not a person's private address.
+  #
+  # Two files exist in order to CARRY personal-looking data, and exempting them is
+  # not a loophole but the only way they can do their job: they are the corpora
+  # that prove the PII detectors fire. `deidentify` needs Korean PHI shapes
+  # (resident-registration numbers, phone numbers, addresses) and `contribute`
+  # needs a message that leaks an author's address, so that each skill's scanner
+  # can be shown catching them. Both are fully synthetic — verified name by name
+  # when this exemption was written — and neither ships (tests/ is excluded from
+  # the distribution bundle). Every other rule still applies to them; only this
+  # one is skipped, and only for these two paths.
+  PII_FIXTURE_PATHS='^skills/deidentify/tests/test_phi_[a-z]+\.csv$|^skills/contribute/tests/test_contribution_safety\.sh$'
   for f in "${integrity_files[@]}"; do
+    rel_f="${f#$REPO_ROOT/}"
+    if printf '%s' "$rel_f" | grep -qE "$PII_FIXTURE_PATHS"; then
+      continue
+    fi
     matches=$(grep -nE "$email_pattern" "$f" | grep -vE "$email_whitelist" || true)
     if [ -n "$matches" ]; then
       rel="${f#$REPO_ROOT/}"

--- a/skills/contribute/tests/test_contribution_safety.sh
+++ b/skills/contribute/tests/test_contribution_safety.sh
@@ -38,8 +38,8 @@ The pipeline failed on patient MRN 4471903 during the review.
 Subject 880101-1234567 was excluded after chart review.
 Approved under IRB 2024-0451 at Severance Hospital.
 I was reviewing EURE-D-26-00203 when this happened.
-Prof. Kim Namkuk suggested the change; reach me at yj.nam@hospital.or.kr.
-Output was written to /Users/yoojinnam/manuscripts/draft.docx.
+Prof. Alan Poe suggested the change; reach me at a.poe@hospital.or.kr.
+Output was written to /Users/apoe/manuscripts/draft.docx.
 MD
 
 # --- an ordinary, entirely publishable contribution -------------------------------------------

--- a/skills/self-review/tests/fixtures/supplement_pii_clean.md
+++ b/skills/self-review/tests/fixtures/supplement_pii_clean.md
@@ -1,5 +1,5 @@
 # Supplementary Appendix. Reader panel
 
-The reader panel comprised Kyung Eun Lee, Pa Hong, and Min Su Yoon (members listed
+The reader panel comprised Jane Doe, John Roe, and Mary Sue (members listed
 in the Supplementary Appendix). Aggregate response rates were 0.71 across readers.
 Overall, responses to real images were more accurate than to synthetic ones.

--- a/skills/self-review/tests/fixtures/supplement_pii_tie.md
+++ b/skills/self-review/tests/fixtures/supplement_pii_tie.md
@@ -2,5 +2,5 @@
 
 | Reader | Name | Status | Response |
 |---|---|---|---|
-| Rfe75ca | Kyung Eun Lee | analyzed | response=real, confidence=4, cue=texture |
+| Rfe75ca | Jane Doe | analyzed | response=real, confidence=4, cue=texture |
 | R0a1b2c | (quarantined) | replaced | response=fake, confidence=2 |

--- a/skills/sync-submission/scripts/check_credit_integrity.py
+++ b/skills/sync-submission/scripts/check_credit_integrity.py
@@ -126,7 +126,7 @@ FIGURE_CAPTION_RE = re.compile(r"^\s*\**\s*(?:Figure|Fig\.?)\s*\d+\b", re.M | re
 CODE_AVAIL_RE = re.compile(r"^#{1,6}\s*\*{0,2}\s*Code Availability", re.M | re.I)
 # "J.D.", "Y.N.", "A.B.C." — the form contributions sections are written in.
 INITIALS_RE = re.compile(r"\b(?:[A-Z]\.){2,4}")
-# A byline name: "Jane Doe", "Jane A. Doe", "Kyung Won Kim" — two to four capitalised words,
+# A byline name: "Jane Doe", "Jane A. Doe", "Mary Anne Roe" — two to four capitalised words,
 # optionally carrying a superscript/affiliation marker.
 NAME_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z]\.?)?(?:\s+[A-Z][a-z]+){1,2})\b")
 

--- a/skills/write-paper/scripts/build_title_page_affiliations.py
+++ b/skills/write-paper/scripts/build_title_page_affiliations.py
@@ -25,16 +25,16 @@ orphans, or out-of-order definitions, and a city+country on every affiliation.
 authors.yaml
 ------------
     authors:
-      - name: "Yoojin Nam"
-        affiliations: [scch_rad, amc_convergence]   # ordered; keys into `affiliations`
+      - name: "Jane Doe"
+        affiliations: [uh_rad, uh_convergence]      # ordered; keys into `affiliations`
         corresponding: false                         # optional -> appends "*"
         equal_contribution: false                    # optional -> appends "†"
-      - name: "Pa Hong"
-        affiliations: [scch_rad]
+      - name: "John Roe"
+        affiliations: [uh_rad]
         corresponding: true
     affiliations:
-      scch_rad: "Department of Radiology, Samsung Changwon Hospital, ..., Changwon, Republic of Korea"
-      amc_convergence: "Department of Convergence Medicine, ..., Seoul, Republic of Korea"
+      uh_rad: "Department of Radiology, University Hospital, City, Country"
+      uh_convergence: "Department of Convergence Medicine, University Hospital, City, Country"
 
 Exit codes: 0 clean (build, or check with no violations / report-only); 1 a check
 violation under --strict; 2 input/usage error. Stdlib-only except PyYAML (already a

--- a/skills/write-paper/tests/test_title_page_affiliations.sh
+++ b/skills/write-paper/tests/test_title_page_affiliations.sh
@@ -21,20 +21,20 @@ ck() {
 # --- BUILD: first-appearance numbering, affiliation reuse, ascending block ---
 cat > "$TMP/authors.json" <<'JSON'
 {"authors":[
-  {"name":"Yoojin Nam","affiliations":["scch","amc"]},
-  {"name":"Taein An","affiliations":["hallym"]},
-  {"name":"Pa Hong","affiliations":["scch"],"corresponding":true},
-  {"name":"Namkug Kim","affiliations":["amc","amcrad"],"corresponding":true}],
+  {"name":"Jane Doe","affiliations":["uh","mmc"]},
+  {"name":"Alan Poe","affiliations":["cgh"]},
+  {"name":"John Roe","affiliations":["uh"],"corresponding":true},
+  {"name":"Mary Sue","affiliations":["mmc","mmc_rad"],"corresponding":true}],
  "affiliations":{
-  "scch":"Department of Radiology, Samsung Changwon Hospital, Changwon, Republic of Korea",
-  "amc":"Department of Convergence Medicine, Asan Medical Center, Seoul, Republic of Korea",
-  "hallym":"Department of Radiology, Dongtan Sacred Heart Hospital, Hwaseong, Republic of Korea",
-  "amcrad":"Department of Radiology, Asan Medical Center, Seoul, Republic of Korea"}}
+  "uh":"Department of Radiology, University Hospital, City, Country",
+  "mmc":"Department of Convergence Medicine, Metro Medical Center, City, Country",
+  "cgh":"Department of Radiology, Coastal General Hospital, Town, Country",
+  "mmc_rad":"Department of Radiology, Metro Medical Center, City, Country"}}
 JSON
 python3 "$S" --authors "$TMP/authors.json" --out "$TMP/built.md" > /dev/null 2>&1
-ck "build emits first-appearance numbering (Nam^1,2^)" "$(grep -cF 'Yoojin Nam^1,2^' "$TMP/built.md")"
-ck "build reuses affiliation 1 for a later author (Pa Hong^1)" "$(grep -cF 'Pa Hong^1,\*^' "$TMP/built.md")"
-ck "build reuses 2 + adds 4 (Namkug Kim^2,4)" "$(grep -cF 'Namkug Kim^2,4,\*^' "$TMP/built.md")"
+ck "build emits first-appearance numbering (Doe^1,2^)" "$(grep -cF 'Jane Doe^1,2^' "$TMP/built.md")"
+ck "build reuses affiliation 1 for a later author (John Roe^1)" "$(grep -cF 'John Roe^1,\*^' "$TMP/built.md")"
+ck "build reuses 2 + adds 4 (Mary Sue^2,4)" "$(grep -cF 'Mary Sue^2,4,\*^' "$TMP/built.md")"
 ck "block lists ^4^ last" "$(grep -cE '^\^4\^ ' "$TMP/built.md")"
 
 # --- CHECK: the built title page round-trips clean ---

--- a/tests/test_validator_scope.sh
+++ b/tests/test_validator_scope.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test: validate_skills.sh must actually READ every directory it claims
+# to scan.
+#
+# The defect this exists to stop: TEXT_EXTS was a bare string expanded unquoted
+# into `find`, so `*.md` was pathname-expanded against the CALLER'S working
+# directory before find saw it. Run from the repo root — which is how CI and every
+# documented invocation run it — that became the thirteen top-level .md files,
+# find aborted with "unknown primary or operator", and `2>/dev/null` swallowed the
+# message. references/, templates/ and scripts/ yielded ZERO files. The validator
+# printed PASS for every rule on every skill while scanning nothing but SKILL.md,
+# and it had been doing so since the "extended scope" was added in 2026-05. A
+# fixture carrying a home-directory path and a personal email under references/
+# came back clean.
+#
+# So this test does not ask whether the validator passes. It plants the one string
+# the personal-path rule exists to catch in every scanned location and asserts the
+# validator NAMES EACH FILE. A scope regression makes a location silently drop out
+# of the output, which is exactly what nobody noticed for two months.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Unique per run: two concurrent invocations sharing one fixture path made each
+# trap delete the other's files mid-scan, and every assertion then failed for a
+# reason that had nothing to do with the validator.
+FIXTURE_DIR="$REPO_ROOT/skills/zz-scope-fixture-$$"
+# The literal the rule blocks. Assembled at runtime so this test file does not
+# itself contain the string the validator is looking for.
+LEAK="/Users/$(printf 'eug')ene/workspace/private/notes.md"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-56s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-56s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+cleanup() { rm -rf "$FIXTURE_DIR"; }
+trap cleanup EXIT
+cleanup
+mkdir -p "$FIXTURE_DIR"/{references,templates,scripts,tests}
+
+cat > "$FIXTURE_DIR/SKILL.md" <<'EOF'
+---
+name: zz-scope-fixture
+description: Throwaway fixture created and deleted by tests/test_validator_scope.sh.
+triggers: none
+tools: Read
+model: inherit
+---
+
+# Fixture
+
+Created and removed inside a single test run. If you are reading this on disk, a test crashed.
+
+## Anti-Hallucination
+
+- This skill is a test fixture and produces nothing.
+EOF
+
+# One planted leak per scanned location, each in a file type that location holds.
+printf -- '- Source note: %s\n'            "$LEAK" > "$FIXTURE_DIR/references/note.md"
+printf -- '<!-- draft path: %s -->\n'      "$LEAK" > "$FIXTURE_DIR/templates/starter.md"
+printf -- '# path: %s\n'                   "$LEAK" > "$FIXTURE_DIR/scripts/helper.py"
+printf -- '# fixture path: %s\n'           "$LEAK" > "$FIXTURE_DIR/tests/test_thing.sh"
+printf -- 'note: "%s"\n'                   "$LEAK" > "$FIXTURE_DIR/skill.yml"
+# ...and one the linter is SUPPOSED to skip: skills/**/TODO_*.md is gitignored, and
+# the rule is that this scan matches what the public sees, not what is on disk.
+printf -- '- scratch: %s\n'                "$LEAK" > "$FIXTURE_DIR/TODO_scratch.md"
+
+OUT="$(bash "$REPO_ROOT/scripts/validate_skills.sh" 2>&1)"
+FLAGGED="$(printf '%s\n' "$OUT" | grep 'Personal path in' || true)"
+
+FIXTURE_NAME="$(basename "$FIXTURE_DIR")"
+seen() { printf '%s\n' "$FLAGGED" | grep -q "$FIXTURE_NAME/$1"; }
+
+seen 'references/note.md';    ck "references/ is scanned"                    0 "$?"
+seen 'templates/starter.md';  ck "templates/ is scanned"                     0 "$?"
+seen 'scripts/helper.py';     ck "scripts/ is scanned"                       0 "$?"
+seen 'tests/test_thing.sh';   ck "tests/ is scanned"                         0 "$?"
+seen 'skill.yml';             ck "a skill-root sidecar file is scanned"      0 "$?"
+seen 'TODO_scratch.md';       ck "a gitignored scratchpad is NOT scanned"     1 "$?"
+
+# Guard against the assertions above passing vacuously: if the rule ever stops
+# emitting this verdict, every `seen` call fails to match and the suite would
+# still look meaningful only because we assert exit 0 on each. Assert the rule
+# spoke at all.
+[ -n "$FLAGGED" ]
+ck "the personal-path rule emitted a verdict at all"                         0 "$?"
+
+cleanup
+
+echo "----"
+echo "test_validator_scope: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
> Stacked behind #434 in intent, not in git: this branch is cut from `main`, so its only red gate is the expired `release-cadence` self-test that #434 fixes. Every other gate is green.

## The defect

`validate_skills.sh` kept its filename patterns in a bare string:

```bash
TEXT_EXTS='-name *.md -o -name *.yml -o ...'
find "${skill_dir}references" -type f \( $TEXT_EXTS \) -print0 2>/dev/null
```

Expanded **unquoted**, `*.md` is pathname-expanded against the *caller's* working directory before `find` ever sees it. From the repo root — how CI and every documented invocation run it — the word list becomes:

```
[-name] [CHANGELOG.md] [CODE_OF_CONDUCT.md] [CONTRIBUTING.md] ... [-o] [-name] [capabilities.yml] ...
find: CODE_OF_CONDUCT.md: unknown primary or operator
```

`find` aborts, `2>/dev/null` swallows the message, and the loop yields **zero files**. All four loops. So `references/`, `templates/` and `scripts/` — the "extended scope" added in 2026-05 *specifically because vendored identifiers hide there* — were never scanned. Only `SKILL.md` ever was, while every run printed PASS for every rule on every skill.

Demonstrated, not inferred. On pristine `main`, a fixture carrying both a blocked home-directory path and a personal email under `references/`:

```
PASS Personal paths (no home-dir / private-config leak)
PASS Email whitelist (no personal addresses)
```

## What was behind it

With the blind spot closed the scanner immediately named real personal names and institution strings — **all of them already on the precedent blocklist**, so the gate had been correct the whole time and simply never got to look:

| Where | Ships to installers? |
|---|---|
| `write-paper/scripts/build_title_page_affiliations.py` docstring — two author names, two real institution strings | yes |
| `sync-submission/scripts/check_credit_integrity.py` comment — one name | yes |
| `write-paper/tests/test_title_page_affiliations.sh` — three names, four institutions | no (`tests/` is excluded from the bundle) |
| `self-review/tests/fixtures/supplement_pii_clean.md` and its sibling — three names | no |

All replaced with generic placeholders. The assertions that consumed them test verdict types and numbering shapes rather than the strings, and still pass (`test_title_page_affiliations`: 9/9).

**History is not rewritten**, so earlier commits still carry them.

## Also in this change

- **`skills/*/tests/` joins the scope.** Fixtures are where a real name settles most easily: you reach for a plausible author roster and the nearest plausible one is someone you work with. Test files never reach an installer, but they are in a public repository, which is the exposure the blocklist exists to prevent. One of the names found this way was inside a fixture called `supplement_pii_clean.md`.
- **Two files exempt from the email rule by path**, with the reason recorded beside the exemption: the Korean-PHI corpus that proves `/deidentify` fires, and the leaky message that proves `/contribute` blocks a submission. Both exist *in order to* carry personal-looking data; both are fully synthetic; every other rule still applies to them.
- **`@nejm.org` and `users.noreply.github.com` join the domain whitelist** — a journal's published editorial-office address and a GitHub noreply sender are contact information, not a private address.

## Verification

`tests/test_validator_scope.sh` does not ask whether the validator passes — passing was the symptom. It plants the blocked literal in `references/`, `templates/`, `scripts/`, `tests/` and at the skill root, and asserts the validator **names each file**, plus that a gitignored scratchpad is still correctly skipped.

| | result |
|---|---|
| against pristine `main` | **6 of 7 fail** — every scanned location silently drops out |
| with this change | **7 of 7 pass** |
| full local CI mirror | 214/215; the one failure is the expired cadence self-test #434 fixes |

## Known cost, deliberately not addressed here

The scanner now reads ~1,200 files per run instead of 58, and `check_precedent.py` is invoked once per file (~50 ms of interpreter start-up each), so the `validate` job gains roughly 60–90 s. Batching that call is the obvious fix and is **left for a follow-up on purpose**: rewriting the precedent-scan plumbing inside the very PR that makes the scanner trustworthy would risk re-introducing silence in a subtler form, and it needs its own test that batch mode finds exactly what per-file mode finds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)