### PR TITLE
fix(manage-refs): check_xref blocked a correctly packaged submission and offered no way out

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -415,6 +415,9 @@ jobs:
       - name: Run manage-refs vN-docx cross-reference test
         run: bash skills/manage-refs/tests/test_vN_docx_check.sh
 
+      - name: "Run manage-refs separate-supplement test (a gate red on correct work gets skipped)"
+        run: bash skills/manage-refs/tests/test_xref_separate_supplement.sh
+
       - name: Run manage-refs CSL-render hardening test
         run: bash skills/manage-refs/tests/test_csl_render.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ### Fixed
 
+- **`check_xref` told a correctly packaged submission it was blocked, and offered no way out.**
+  When supplementary tables and figures are separate attachment files — the norm in radiology and
+  most medical journals — and the check runs without `--docx`, those floats are cited, have no body
+  caption, and land on `MISSING_BODY`. `--allow-separate-attachments` does not touch them, because a
+  float only *becomes* the downgradeable `MISSING_DOCX` once a `--docx` has shown it absent from the
+  rendered output. The run printed `SUBMISSION BLOCKED` with nothing to act on.
+
+  `MISSING_BODY` was carrying two situations under one name, and every triage table in this repo
+  describes only one of them. With a DOCX present it means build SSOT drift — the float is rendered
+  but nothing defines its caption — and that stays a P0. With no DOCX there is nothing to have
+  drifted *from*, and the run cannot tell a forgotten caption from a separate supplement file.
+
+  **No verdict changed** — the vocabulary is consumed by `/self-review`, `/write-paper` and
+  `/sync-submission` triage tables, and moving a P0 is a decision for a human, not a side effect.
+  What changed is that the run now names the labels it could not decide and says that supplying
+  `--docx` is what decides them; the `--allow-separate-attachments` downgrades are named rather than
+  counted; and the flag's own help text no longer implies it applies where it cannot reach. A gate
+  that is red on correct work is a gate the operator learns to skip, which costs more than the check.
+
+  Verified by regression: against the unfixed tree the new suite fails exactly the three assertions
+  about the messages and passes all five that pin the verdicts, so the behaviour is provably
+  unchanged.
+
 - **The PII scanner had been reading one file per skill.** `validate_skills.sh` held its
   filename patterns in a bare string and expanded it unquoted into `find`, so `*.md` was
   pathname-expanded against the *caller's* working directory before `find` ever saw it. Run from

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2598,8 +2598,8 @@
     },
     {
       "path": "skills/manage-refs/references/check_xref_symptoms.md",
-      "size": 2426,
-      "sha256": "f3261841492aba9812529419b351cb77e07c49f3da7156773299048f51d9deee"
+      "size": 3764,
+      "sha256": "3f2021b641e846714b02633529ceec1e90fe2a45576241f5f515ac48386d1307"
     },
     {
       "path": "skills/manage-refs/scripts/_vendor_citation_writer.py",
@@ -2648,8 +2648,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_xref.py",
-      "size": 24044,
-      "sha256": "e7f035af887c581eb98b57c865b2ed358b541091c30deeb8e6652145f0929acf"
+      "size": 26041,
+      "sha256": "27100b43acdc903361693d230cd7cf64a1072bd2dc92c286930c59437bd6f583"
     },
     {
       "path": "skills/manage-refs/scripts/fill_journal_abbrev.py",

--- a/skills/manage-refs/references/check_xref_symptoms.md
+++ b/skills/manage-refs/references/check_xref_symptoms.md
@@ -10,10 +10,32 @@ rendered DOCX (via `python-docx`).
 |---|---|---|---|
 | `OK` | cited + body caption + DOCX caption all present, caption text agrees (Jaccard ≥ 0.40) | — | none |
 | `MISSING_DOCX` | cited but no caption with that label in the rendered DOCX | **P0 blocker** | drop the citation if the figure/table was retired, or re-add it to the build pipeline and rebuild DOCX |
-| `MISSING_BODY` | cited but no caption definition in the markdown body sections (build SSOT drift) | **P0 blocker** | add the caption under `## Tables` / `## Figures` in `manuscript.md`, then re-render |
+| `MISSING_BODY` | cited but no caption definition in the markdown body sections | **P0 blocker** | add the caption under `## Tables` / `## Figures` in `manuscript.md`, then re-render — **but if you ran without `--docx`, read the note below first** |
 | `MISMATCH` | label exists in both body and DOCX but caption text disagrees (Jaccard < 0.40) | **P0 blocker** | reconcile body vs build script — body caption is the SSOT, update the build pipeline to match, never the reverse |
 | `UNCITED` | caption defined or rendered but never cited in main text | warn | either delete the caption or add a citation; never ship UNCITED on a clean run |
 | `NOT_CITED_NO_BODY` | label appears only in DOCX (rare; legacy artifact) | warn | clean up the build pipeline; the DOCX is leaking captions from a previous draft |
+
+### `MISSING_BODY` names two different situations
+
+The row above describes the one people mean by it — **build SSOT drift**: the float is rendered in
+the DOCX, but nothing in `manuscript.md` defines its caption, so the build pipeline is the only
+place that knows the text. That is a P0 and stays one.
+
+The same verdict is also returned when **no `--docx` was supplied at all**. Then there is no
+rendered artifact to have drifted *from*, and the run genuinely cannot distinguish
+
+- a caption you forgot to write, from
+- a float that lives in a **separate supplement file** this invocation never saw — the normal
+  packaging for radiology and most medical journals.
+
+`--allow-separate-attachments` does not help here, and that surprises people: the flag downgrades
+`MISSING_DOCX`, and a float only *becomes* `MISSING_DOCX` once a `--docx` has shown it to be absent
+from the rendered output. Without `--docx`, `_classify` never reaches that branch.
+
+**So: pass `--docx <rendered.docx>` to decide it.** The run now says so itself, and names the labels
+it could not decide, rather than printing `SUBMISSION BLOCKED` on a correctly packaged submission
+with no way forward. (A gate that is red on correct work is a gate the operator learns to skip,
+which costs more than the check is worth.)
 
 ## Why this exists
 

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -489,7 +489,11 @@ def main() -> int:
         "--allow-separate-attachments", action="store_true",
         help="Downgrade MISSING_DOCX from FAIL to WARN for figures/tables that are "
              "submitted as separate attachment files (common in radiology and many "
-             "medical journals). MISSING_BODY and MISMATCH remain FAIL regardless.",
+             "medical journals). MISSING_BODY and MISMATCH remain FAIL regardless. "
+             "NOTE: this flag only reaches a float once a --docx has shown it to be "
+             "absent from the rendered output. Without --docx, a cited float with no "
+             "body caption is MISSING_BODY and this flag does not touch it — pass "
+             "--docx to let the run decide which of the two it is.",
     )
     parser.add_argument(
         "--vN-docx-md5",
@@ -603,10 +607,34 @@ def main() -> int:
         if warnings:
             print(
                 f"[check_xref] WARN: {len(warnings)} MISSING_DOCX row(s) downgraded "
-                f"under --allow-separate-attachments."
+                f"under --allow-separate-attachments: "
+                + ", ".join(f.label for f in warnings)
             )
         if not submission_safe:
             print(f"[check_xref] SUBMISSION BLOCKED: {len(blockers)} cross-reference defect(s).")
+            # MISSING_BODY carries two different situations under one name, and only
+            # one of them is the SSOT drift the triage tables describe:
+            #   in_docx True → the float IS rendered but has no body caption. Drift.
+            #   in_docx None → no DOCX was supplied, so there is nothing to have
+            #                  drifted FROM. The float may simply live in a separate
+            #                  supplement file this run never saw.
+            # Without this hint the second case reads as the first, and the operator
+            # is told a correctly packaged submission is blocked with no way out.
+            # A gate that is red on correct work is a gate that gets skipped.
+            undecidable = [f for f in blockers
+                           if f.status == "MISSING_BODY" and f.in_docx is None]
+            if undecidable:
+                labels = ", ".join(f.label for f in undecidable)
+                print(
+                    f"[check_xref] NOTE: {len(undecidable)} of those are MISSING_BODY with no "
+                    f"--docx to compare against ({labels}).\n"
+                    f"           Nothing here can tell a missing caption from a float that "
+                    f"lives in a separate supplement file.\n"
+                    f"           Supply --docx <rendered.docx> to decide it: a float absent "
+                    f"from the DOCX becomes MISSING_DOCX, which\n"
+                    f"           --allow-separate-attachments does downgrade. Adding the flag "
+                    f"alone does not change these rows."
+                )
         if vN_check is not None:
             if vN_check["identical_bytes"]:
                 print(

--- a/skills/manage-refs/tests/test_xref_separate_supplement.sh
+++ b/skills/manage-refs/tests/test_xref_separate_supplement.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Regression test: check_xref must say what would decide a MISSING_BODY it cannot decide.
+#
+# The situation this exists for: a submission whose supplementary tables and figures are
+# separate attachment files — the norm in radiology and most medical journals — checked in
+# markdown-only mode. Those floats are cited, have no caption in the manuscript body, and
+# there is no rendered DOCX to look them up in. `_classify` returns MISSING_BODY, which
+# `--allow-separate-attachments` does not downgrade, so the run prints
+# `SUBMISSION BLOCKED` on a correctly packaged submission and offers no way forward.
+#
+# MISSING_BODY carries two different situations under one name and only one of them is the
+# SSOT drift that every triage table in this repo describes:
+#
+#   in_docx is True  -> the float IS rendered but has no body caption. Real drift. P0.
+#   in_docx is None  -> no DOCX was supplied, so there is nothing to have drifted FROM.
+#
+# This test does not change either verdict — a P0 submission gate's vocabulary is consumed by
+# /self-review, /write-paper and /sync-submission triage tables, and moving it is a decision
+# for a human. It pins the smaller fix: the second case must NAME the labels and say that
+# supplying --docx is what decides them. A gate that is red on correct work with no stated
+# way out is a gate the operator learns to skip, which costs more than the check is worth.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+S="$REPO_ROOT/skills/manage-refs/scripts/check_xref.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+NOTE='no --docx to compare against'
+
+# --- a correctly packaged submission: supplement lives in separate attachment files ---
+cat > "$TMP/sep.md" <<'MD'
+# METHODS
+
+We measured the thing (Table 1). Details are in Supplementary Table S1 and
+Supplementary Figure S1, submitted as separate attachment files.
+
+# TABLES
+
+**Table 1.** Baseline characteristics of the study population.
+MD
+
+# --- genuine SSOT drift: the float IS rendered, but the body defines no caption ---
+cat > "$TMP/drift.md" <<'MD'
+# METHODS
+
+We measured the thing (Table 1) and Supplementary Table S1.
+
+# TABLES
+
+**Table 1.** Baseline characteristics of the study population.
+MD
+
+python3 - "$TMP" <<'PY'
+import sys
+from docx import Document
+tmp = sys.argv[1]
+
+# Renders Table 1 only — the supplement is a separate attachment.
+d = Document()
+for t in ["METHODS",
+          "We measured the thing (Table 1). Details are in Supplementary Table S1 and "
+          "Supplementary Figure S1.",
+          "Table 1. Baseline characteristics of the study population."]:
+    d.add_paragraph(t)
+d.save(f"{tmp}/main.docx")
+
+# Renders Supplementary Table S1 too, while drift.md defines no caption for it.
+d = Document()
+for t in ["METHODS",
+          "We measured the thing (Table 1) and Supplementary Table S1.",
+          "Table 1. Baseline characteristics of the study population.",
+          "Supplementary Table S1. Sensitivity analyses by centre."]:
+    d.add_paragraph(t)
+d.save(f"{tmp}/drift.docx")
+PY
+
+run() { python3 "$S" --md "$1" ${2:+--docx "$2"} --out "$TMP/out.json" \
+          --allow-separate-attachments --strict > "$TMP/log.txt" 2>&1; echo $?; }
+
+# 1) The case the note exists for: undecidable without a DOCX.
+rc=$(run "$TMP/sep.md" "")
+ck "markdown-only separate-supplement still blocks (verdict unchanged)" 1 "$rc"
+grep -q "$NOTE" "$TMP/log.txt"; ck "...and the run says --docx is what decides it" 0 "$?"
+# The labels must appear ON the note line. Grepping the whole log passes vacuously —
+# every label is already printed in the findings table above, so that assertion would
+# have been green against the unfixed code too.
+grep -q "$NOTE.*Table:S-S1" "$TMP/log.txt"; ck "...and the note itself NAMES them" 0 "$?"
+
+# 2) Supplying the DOCX is genuinely the way out — the whole point of the note.
+rc=$(run "$TMP/sep.md" "$TMP/main.docx")
+ck "with --docx the same package PASSES under the flag" 0 "$rc"
+grep -q "$NOTE" "$TMP/log.txt"; ck "...and the note is silent (nothing undecidable)" 1 "$?"
+grep -q "downgraded under --allow-separate-attachments: " "$TMP/log.txt"
+ck "...and the downgraded rows are named, not just counted" 0 "$?"
+
+# 3) Real SSOT drift must be untouched: it blocks, and the note must NOT excuse it.
+rc=$(run "$TMP/drift.md" "$TMP/drift.docx")
+ck "rendered-but-undefined caption still BLOCKS (P0 preserved)" 1 "$rc"
+grep -q "$NOTE" "$TMP/log.txt"; ck "...and the note does not fire on real drift" 1 "$?"
+
+echo "----"
+echo "test_xref_separate_supplement: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## The situation

Supplementary tables and figures submitted as **separate attachment files** — the norm in radiology and most medical journals — checked in markdown-only mode:

```
$ check_xref.py --md manuscript.md --allow-separate-attachments --strict
  Figure:S-S1    MISSING_BODY   ✓  ✗  —  cited but no caption definition in markdown body sections
  Table:S-S1     MISSING_BODY   ✓  ✗  —  cited but no caption definition in markdown body sections
[check_xref] SUBMISSION BLOCKED: 2 cross-reference defect(s).      # exit 1
```

Nothing is wrong with that submission. `--allow-separate-attachments` does not help, and the reason is not obvious: a float only *becomes* the downgradeable `MISSING_DOCX` **once a `--docx` has shown it absent from the rendered output**. Without `--docx`, `_classify` tests `in_docx is False` before `not in_body`, never reaches that branch, and the flag has nothing to act on.

**A gate that is red on correct work is a gate the operator learns to skip** — which costs more than the check is worth.

## The root of it

`MISSING_BODY` carries **two different situations under one name**, and every triage table in this repo (`/self-review`, `/write-paper`, `check_xref_symptoms.md`) describes only one:

| `in_docx` | what it means | is it drift? |
|---|---|---|
| `True` | the float **is** rendered, but nothing in the markdown defines its caption | **yes** — build SSOT drift. P0, unchanged |
| `None` | no DOCX was supplied, so there is nothing to have drifted *from* | **no** — undecidable between a forgotten caption and a supplement file this run never saw |

## What changed — and what deliberately did not

**No verdict moved.** That vocabulary is consumed by three skills' gate tables and `/write-paper` HALTs on it; changing a P0 submission gate is a decision for a human, not a side effect of fixing a message. Six documentation sites state the current contract, and I am not moving them without you.

What did change:

- the run **names the labels it could not decide** and states that `--docx` is what decides them;
- `--allow-separate-attachments` downgrades are **named rather than counted**, so an excused row is visible as a decision rather than a silent pass;
- the flag's `--help` and the symptom triage table no longer imply the flag applies where it cannot reach.

```
[check_xref] SUBMISSION BLOCKED: 2 cross-reference defect(s).
[check_xref] NOTE: 2 of those are MISSING_BODY with no --docx to compare against (Figure:S-S1, Table:S-S1).
           Nothing here can tell a missing caption from a float that lives in a separate supplement file.
           Supply --docx <rendered.docx> to decide it: a float absent from the DOCX becomes MISSING_DOCX, which
           --allow-separate-attachments does downgrade. Adding the flag alone does not change these rows.
```

## Verification

Not "the suite passes" — passing is what the unfixed code already did on the assertions that matter.

| tree | result |
|---|---|
| unfixed `main` | **5 pass / 3 fail** — exactly the three message assertions fail; all five verdict assertions pass, which is what proves behaviour is unchanged |
| this branch | **8 / 8** |

One assertion was tightened before it counted for anything: it grepped the whole log for a label the findings table already prints, so it passed vacuously on both trees. It now requires the label on the note line.

The suite also pins the two cases that must **not** move: the same package **with** `--docx` still passes under the flag (exit 0), and a genuinely rendered-but-undefined caption still blocks (exit 1) with the note silent.

## Provenance — the report this came from was wrong

The originating candidate claimed *"no invocation exists that a correctly packaged main-document + separate-supplement submission can pass"*, reasoning from the help text. Running it showed a passing invocation does exist (`--md … --docx … --allow-separate-attachments` → exit 0). Four sibling candidates bundled with it turned out not to describe this repo at all: `check_xref` **does** handle figures (`CITE_RE`/`CAPTION_RE` both match `Figure|Fig`), it has **no** curated expectation map to skip unmapped floats, and this repo has **no** renumbering utility. Those were observed in project-local tooling and proposed for upstreaming — a much weaker claim than the bundle implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)