### PR TITLE
feat(manage-refs): --allow-separate-attachments now excuses the MISSING_BODY it cannot check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`--allow-separate-attachments` now downgrades the `MISSING_BODY` it could not check.** When a
+  submission's floats are separate attachment files — the norm in radiology and most of medicine —
+  and `check_xref` runs without a `--docx`, those floats are cited, have no body caption, and there
+  is no rendered artifact to look them up in. Until now that blocked the submission. The flag is the
+  operator's declaration that such floats exist, so it now excuses them.
+
+  **This is an amnesty, and it is priced as one.** In markdown-only mode a caption nobody wrote is
+  indistinguishable from an attachment, and both now pass. So the two downgrades are reported apart,
+  because their evidence differs: `MISSING_DOCX` means a supplied DOCX *proved* the float absent from
+  the rendered output, while `MISSING_BODY` with no DOCX means **nothing was checked**. The second
+  prints as `EXCUSED WITHOUT EVIDENCE`, names every row, and is counted separately in the audit JSON
+  as `summary.downgraded_unchecked` — a consumer cannot read one as the other. The run tells you to
+  come back with `--docx`, which is what converts the excuse into evidence.
+
+  **What the flag still does not excuse**: `MISMATCH`, and a `MISSING_BODY` whose float **is** in the
+  rendered DOCX. There the build pipeline is the only place that knows the caption text, which is SSOT
+  drift; no attachment policy makes that acceptable, and the run says so by name when it blocks.
+
+  Six documentation sites stated the old contract ("`MISSING_BODY` remains FAIL regardless") and all
+  six move together: `manage-refs/SKILL.md`, `check_xref_symptoms.md`, `self-review/SKILL.md`,
+  `phase2_5d_xref_qc.md`, `write-paper/SKILL.md`, `phase7_polish_detail.md`, plus the `--help` text
+  and `pre_submission_gate.sh`. Verified by regression: the 13-case suite fails 7 against the previous
+  behaviour and the 6 it passes are exactly the invariants that must not move — drift still blocks,
+  the flag stays opt-in, and a supplied DOCX still produces an evidenced downgrade.
+
 ### Fixed
 
 - **`check_xref` told a correctly packaged submission it was blocked, and offered no way out.**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2503,8 +2503,8 @@
     },
     {
       "path": "skills/manage-refs/SKILL.md",
-      "size": 19617,
-      "sha256": "e1043b79057e66984de9ab23f73c6d673f95388c0613e37a23536b7011f5c246"
+      "size": 20729,
+      "sha256": "16a7ddf4412580c0797baa52821054114f434b82b302a6d67fec023d56427a8d"
     },
     {
       "path": "skills/manage-refs/citation_styles/README.md",
@@ -2598,8 +2598,8 @@
     },
     {
       "path": "skills/manage-refs/references/check_xref_symptoms.md",
-      "size": 3764,
-      "sha256": "3f2021b641e846714b02633529ceec1e90fe2a45576241f5f515ac48386d1307"
+      "size": 4501,
+      "sha256": "4d0da877aca64367cbf13fa8b1008f39b0f258648a5e2a955ca5b8fc8915236f"
     },
     {
       "path": "skills/manage-refs/scripts/_vendor_citation_writer.py",
@@ -2648,8 +2648,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_xref.py",
-      "size": 26041,
-      "sha256": "27100b43acdc903361693d230cd7cf64a1072bd2dc92c286930c59437bd6f583"
+      "size": 28404,
+      "sha256": "ad5dc74c4c233ba1aedd6ac7b6e025c5db59ad3d729dd7752f102fa3e92742ae"
     },
     {
       "path": "skills/manage-refs/scripts/fill_journal_abbrev.py",
@@ -2668,8 +2668,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/pre_submission_gate.sh",
-      "size": 8932,
-      "sha256": "73ae8e4f32c9fc6d3676d3f4a5b41a74ad7dc2c9f5f5e39d4d5ec7c2e4fcbfb5"
+      "size": 9309,
+      "sha256": "b306abe55ea639cdf2d4044db4af70d9450b8ec2dfa3b5b78e9222966e8bd97a"
     },
     {
       "path": "skills/manage-refs/scripts/render_pandoc.sh",
@@ -4203,8 +4203,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 61915,
-      "sha256": "3ac7b138c1e698e2f818134e8d10849361bb5f60035e885056f949c85729f04a"
+      "size": 62498,
+      "sha256": "891b019237132a910e1157a9f0d6e5ac58bcab2a7077ab969b68e95e3ae5a63b"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",
@@ -4393,8 +4393,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5d_xref_qc.md",
-      "size": 4974,
-      "sha256": "81756d0713842faa1f603a34500dd6aaa699be6526ee6fbbc1ace06467b10143"
+      "size": 5639,
+      "sha256": "5a574035962626a5a758a335906414c709f2d5cb04b3ac5c5e7dfefa7ba6f8b5"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5f_claim_artifact.md",
@@ -5638,8 +5638,8 @@
     },
     {
       "path": "skills/write-paper/SKILL.md",
-      "size": 50027,
-      "sha256": "0ffc727dd59fad870bf6d563478f764e49f17177bed21c35d36679e492b87c81"
+      "size": 50120,
+      "sha256": "6ac3072d67dfabfaeae11a0bf1890e9d616d073cd56b0758669d3b3f4ff59c50"
     },
     {
       "path": "skills/write-paper/references/exemplar_abstract.md",
@@ -6103,8 +6103,8 @@
     },
     {
       "path": "skills/write-paper/references/phase7_polish_detail.md",
-      "size": 18991,
-      "sha256": "5694bfa9da09267b0257e85166607994da1dad1253ed307c0d0da8480cc5868b"
+      "size": 19696,
+      "sha256": "ca5d6c1c900d9ef0b4659d18daabdc3322bba3ecef3ec5955e9dc76de958f7e9"
     },
     {
       "path": "skills/write-paper/references/section_guides/discussion.md",

--- a/skills/manage-refs/SKILL.md
+++ b/skills/manage-refs/SKILL.md
@@ -73,7 +73,9 @@ Validated 2026-05-01 against a 21-reference meta-analysis manuscript
 5. **Cross-reference QC is a submission gate** — `scripts/check_xref.py`
    `--strict` exits 1 on any `MISSING_DOCX` / `MISSING_BODY` / `MISMATCH`,
    blocking pipelines that try to ship a DOCX whose Table/Figure citations
-   don't match captions.
+   don't match captions. `--allow-separate-attachments` downgrades the two
+   rows a separate-attachment submission legitimately produces; it never
+   downgrades a `MISSING_BODY` whose float IS in the rendered DOCX.
 6. **Audit boundary**: this skill writes; bibliographic correctness against
    PubMed/CrossRef stays in `/verify-refs`. Always invoke `/verify-refs`
    after a render before signing off — one read-only audit, one writer.
@@ -187,9 +189,22 @@ User shipped a manuscript and a reviewer flagged a Table/Figure mismatch.
    `MISSING_BODY` / `MISSING_DOCX` / `MISMATCH` triage table.
 4. For journals that accept figures and tables as **separate attachment files**
    (the default in European Radiology, Radiology, AJR, JVIR, KJR, and most
-   medical journals), pass `--allow-separate-attachments`. `MISSING_DOCX` rows
-   are then recorded as WARN rather than FAIL; `MISSING_BODY` and `MISMATCH`
-   remain P0 because they indicate SSOT drift, not attachment policy.
+   medical journals), pass `--allow-separate-attachments`. It downgrades two
+   rows, and the run reports them apart because their evidence differs:
+
+   - `MISSING_DOCX` — a `--docx` was supplied and **proved** the float is not in
+     the rendered main document. That is what a separate attachment looks like.
+   - `MISSING_BODY` with **no `--docx` supplied** — nothing was checked. The float
+     is either separately attached, as you declared, or a caption nobody wrote.
+     Excused on your word, printed as `EXCUSED WITHOUT EVIDENCE`, and counted in
+     `summary.downgraded_unchecked`.
+
+   `MISMATCH` stays P0. So does `MISSING_BODY` when the float **is** in the
+   rendered DOCX — that is SSOT drift, and no attachment policy makes the build
+   pipeline an acceptable single source of truth for a caption.
+
+   **Run once with `--docx` before submitting.** The flag is a declaration, not a
+   verification; supplying the DOCX is what converts an excuse into evidence.
 
 ### D'. v_(N+1) docx regeneration check (build-time companion)
 
@@ -266,7 +281,9 @@ This skill defines **three submission gates** and **one user approval gate**:
   UNDEFINED keys. The pipeline halts; the user reviews and fixes.
 - **Gate 2 (cross-reference integrity)**: `check_xref.py --strict` exits 1 on
   any `MISSING_DOCX` / `MISSING_BODY` / `MISMATCH` row. The user reviews
-  `qc/xref_audit.json` and resolves before proceeding.
+  `qc/xref_audit.json` and resolves before proceeding. Under
+  `--allow-separate-attachments`, check `summary.downgraded_unchecked` as well as
+  `submission_safe`: a non-zero count means rows passed without being checked.
 - **Gate 3 (audit hand-off)**: before sign-off, the user must run
   `/verify-refs` and confirm `submission_safe: true` in
   `qc/reference_audit.json`. This skill never marks the bibliography

--- a/skills/manage-refs/references/check_xref_symptoms.md
+++ b/skills/manage-refs/references/check_xref_symptoms.md
@@ -10,7 +10,7 @@ rendered DOCX (via `python-docx`).
 |---|---|---|---|
 | `OK` | cited + body caption + DOCX caption all present, caption text agrees (Jaccard ≥ 0.40) | — | none |
 | `MISSING_DOCX` | cited but no caption with that label in the rendered DOCX | **P0 blocker** | drop the citation if the figure/table was retired, or re-add it to the build pipeline and rebuild DOCX |
-| `MISSING_BODY` | cited but no caption definition in the markdown body sections | **P0 blocker** | add the caption under `## Tables` / `## Figures` in `manuscript.md`, then re-render — **but if you ran without `--docx`, read the note below first** |
+| `MISSING_BODY` | cited but no caption definition in the markdown body sections | **P0 blocker**, with one exception — see below | add the caption under `## Tables` / `## Figures` in `manuscript.md`, then re-render |
 | `MISMATCH` | label exists in both body and DOCX but caption text disagrees (Jaccard < 0.40) | **P0 blocker** | reconcile body vs build script — body caption is the SSOT, update the build pipeline to match, never the reverse |
 | `UNCITED` | caption defined or rendered but never cited in main text | warn | either delete the caption or add a citation; never ship UNCITED on a clean run |
 | `NOT_CITED_NO_BODY` | label appears only in DOCX (rare; legacy artifact) | warn | clean up the build pipeline; the DOCX is leaking captions from a previous draft |
@@ -19,7 +19,9 @@ rendered DOCX (via `python-docx`).
 
 The row above describes the one people mean by it — **build SSOT drift**: the float is rendered in
 the DOCX, but nothing in `manuscript.md` defines its caption, so the build pipeline is the only
-place that knows the text. That is a P0 and stays one.
+place that knows the text. That is a P0 under every policy, including
+`--allow-separate-attachments`. No attachment style makes a build script an acceptable single
+source of truth for a caption.
 
 The same verdict is also returned when **no `--docx` was supplied at all**. Then there is no
 rendered artifact to have drifted *from*, and the run genuinely cannot distinguish
@@ -28,14 +30,29 @@ rendered artifact to have drifted *from*, and the run genuinely cannot distingui
 - a float that lives in a **separate supplement file** this invocation never saw — the normal
   packaging for radiology and most medical journals.
 
-`--allow-separate-attachments` does not help here, and that surprises people: the flag downgrades
-`MISSING_DOCX`, and a float only *becomes* `MISSING_DOCX` once a `--docx` has shown it to be absent
-from the rendered output. Without `--docx`, `_classify` never reaches that branch.
+**`--allow-separate-attachments` downgrades that second case**, because the flag is exactly the
+declaration that some floats live outside the main document. But it is an *excuse*, not a check:
+the run prints
 
-**So: pass `--docx <rendered.docx>` to decide it.** The run now says so itself, and names the labels
-it could not decide, rather than printing `SUBMISSION BLOCKED` on a correctly packaged submission
-with no way forward. (A gate that is red on correct work is a gate the operator learns to skip,
-which costs more than the check is worth.)
+```
+[check_xref] WARN: 2 MISSING_BODY row(s) EXCUSED WITHOUT EVIDENCE under --allow-separate-attachments:
+           Figure:S-S1, Table:S-S1
+           No --docx was supplied, so nothing here was actually checked.
+```
+
+and records the count in `summary.downgraded_unchecked`, separately from
+`summary.downgraded_proven_absent` — the `MISSING_DOCX` rows a supplied DOCX actually proved absent
+from the rendered output.
+
+**Run once with `--docx` before submitting.** That is what converts the excuse into evidence: a
+float genuinely absent from the rendered output becomes `MISSING_DOCX` (still downgraded, now
+proven), and a caption nobody wrote becomes visible again.
+
+| invocation | separate-supplement float | forgotten caption |
+|---|---|---|
+| no flag | **blocks** | **blocks** |
+| flag, no `--docx` | passes — excused without evidence | passes — **this is the cost of the flag** |
+| flag + `--docx` | passes — proven absent from the DOCX | **blocks** as `MISSING_BODY` (in DOCX) or surfaces as `MISSING_DOCX` you must explain |
 
 ## Why this exists
 

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -487,13 +487,16 @@ def main() -> int:
     parser.add_argument("--quiet", action="store_true")
     parser.add_argument(
         "--allow-separate-attachments", action="store_true",
-        help="Downgrade MISSING_DOCX from FAIL to WARN for figures/tables that are "
-             "submitted as separate attachment files (common in radiology and many "
-             "medical journals). MISSING_BODY and MISMATCH remain FAIL regardless. "
-             "NOTE: this flag only reaches a float once a --docx has shown it to be "
-             "absent from the rendered output. Without --docx, a cited float with no "
-             "body caption is MISSING_BODY and this flag does not touch it — pass "
-             "--docx to let the run decide which of the two it is.",
+        help="Declare that some figures/tables are submitted as separate attachment "
+             "files rather than inline (the norm in radiology and most medical "
+             "journals). Downgrades two things from FAIL to WARN: MISSING_DOCX, where "
+             "a supplied --docx proved the float is not in the rendered main document; "
+             "and MISSING_BODY where NO --docx was supplied, so nothing was checked and "
+             "the float is excused on your word. Those two are reported separately "
+             "because only the first has evidence behind it. Still FAIL regardless: "
+             "MISMATCH, and MISSING_BODY where the float IS in the rendered DOCX but "
+             "nothing in the markdown defines its caption — that is SSOT drift, which "
+             "no attachment policy makes acceptable. Run with --docx before submitting.",
     )
     parser.add_argument(
         "--vN-docx-md5",
@@ -538,18 +541,41 @@ def main() -> int:
     findings = reconcile(citations, body_captions, docx_captions)
 
     # Submission safety: any cited label whose status is not OK or UNCITED is a blocker.
-    # With --allow-separate-attachments, MISSING_DOCX is downgraded to a warning;
-    # MISSING_BODY and MISMATCH remain FAIL regardless because they indicate SSOT
-    # drift rather than journal-policy attachment style.
+    #
+    # --allow-separate-attachments is a declaration by the operator: "some of this
+    # manuscript's floats are submitted as separate attachment files, not inline."
+    # That is the normal packaging for radiology and most medical journals. Under it,
+    # two situations are downgraded to warnings — and they are NOT equally well
+    # evidenced, so they are reported apart:
+    #
+    #   MISSING_DOCX                    a DOCX was supplied and PROVED the float is not
+    #                                   in the rendered main document. Evidence exists.
+    #   MISSING_BODY with in_docx None  no DOCX was supplied, so nothing was checked.
+    #                                   The float may equally be a caption someone
+    #                                   forgot to write. Excused on the operator's word.
+    #
+    # MISSING_BODY with in_docx True stays a blocker under every policy: the float IS
+    # rendered and nothing in the markdown defines its caption, so the build pipeline
+    # is the only place that knows the text. That is SSOT drift, and no attachment
+    # policy makes it acceptable. MISMATCH likewise.
     if args.allow_separate_attachments:
-        blocking_statuses = {"MISSING_BODY", "MISMATCH"}
+        blockers = [
+            f for f in findings
+            if f.status == "MISMATCH"
+            or (f.status == "MISSING_BODY" and f.in_docx is True)
+        ]
+        proven_absent = [f for f in findings if f.status == "MISSING_DOCX"]
+        unchecked = [
+            f for f in findings
+            if f.status == "MISSING_BODY" and f.in_docx is None
+        ]
+        warnings = proven_absent + unchecked
     else:
         blocking_statuses = {"MISSING_DOCX", "MISSING_BODY", "MISMATCH"}
-    blockers = [f for f in findings if f.status in blocking_statuses]
-    warnings = [
-        f for f in findings
-        if args.allow_separate_attachments and f.status == "MISSING_DOCX"
-    ]
+        blockers = [f for f in findings if f.status in blocking_statuses]
+        proven_absent = []
+        unchecked = []
+        warnings = []
     submission_safe = len(blockers) == 0
 
     vN_check: dict | None = None
@@ -592,7 +618,12 @@ def main() -> int:
             "uncited": sum(1 for f in findings if f.status == "UNCITED"),
             "blockers": len(blockers),
             "warnings": len(warnings),
+            # The two downgrades kept apart, because a consumer that treats them alike
+            # cannot tell a float the DOCX proved absent from one nothing ever checked.
+            "downgraded_proven_absent": len(proven_absent),
+            "downgraded_unchecked": len(unchecked),
         },
+        "downgraded_unchecked_labels": [f.label for f in unchecked],
         "submission_safe": submission_safe and not vN_check_failed,
         "findings": [asdict(f) for f in findings],
         "vN_docx_check": vN_check,
@@ -604,36 +635,44 @@ def main() -> int:
     if not args.quiet:
         print(render_summary(findings, len(citations)))
         print(f"\n[check_xref] wrote {args.out}")
-        if warnings:
+        # The two downgrades are printed apart because their evidence differs, and the
+        # weaker one has to stay visible. Merging them into one count is how an excused
+        # row starts reading like a checked one.
+        if proven_absent:
             print(
-                f"[check_xref] WARN: {len(warnings)} MISSING_DOCX row(s) downgraded "
-                f"under --allow-separate-attachments: "
-                + ", ".join(f.label for f in warnings)
+                f"[check_xref] WARN: {len(proven_absent)} MISSING_DOCX row(s) downgraded under "
+                f"--allow-separate-attachments: " + ", ".join(f.label for f in proven_absent) + "\n"
+                f"           The DOCX was read and does not contain them, which is what a "
+                f"separate attachment looks like."
+            )
+        if unchecked:
+            print(
+                f"[check_xref] WARN: {len(unchecked)} MISSING_BODY row(s) EXCUSED WITHOUT "
+                f"EVIDENCE under --allow-separate-attachments:\n"
+                f"           " + ", ".join(f.label for f in unchecked) + "\n"
+                f"           No --docx was supplied, so nothing here was actually checked. Each "
+                f"of these is either a float in a\n"
+                f"           separate supplement file — which is what you declared — or a caption "
+                f"nobody wrote. This run cannot\n"
+                f"           tell them apart, and passed them on your word.\n"
+                f"           Run again with --docx <rendered.docx> before submitting: a float "
+                f"genuinely absent from the rendered\n"
+                f"           output becomes MISSING_DOCX (still downgraded, but now proven), and "
+                f"a caption you forgot becomes visible."
             )
         if not submission_safe:
             print(f"[check_xref] SUBMISSION BLOCKED: {len(blockers)} cross-reference defect(s).")
-            # MISSING_BODY carries two different situations under one name, and only
-            # one of them is the SSOT drift the triage tables describe:
-            #   in_docx True → the float IS rendered but has no body caption. Drift.
-            #   in_docx None → no DOCX was supplied, so there is nothing to have
-            #                  drifted FROM. The float may simply live in a separate
-            #                  supplement file this run never saw.
-            # Without this hint the second case reads as the first, and the operator
-            # is told a correctly packaged submission is blocked with no way out.
-            # A gate that is red on correct work is a gate that gets skipped.
-            undecidable = [f for f in blockers
-                           if f.status == "MISSING_BODY" and f.in_docx is None]
-            if undecidable:
-                labels = ", ".join(f.label for f in undecidable)
+            drift = [f for f in blockers
+                     if f.status == "MISSING_BODY" and f.in_docx is True]
+            if drift and args.allow_separate_attachments:
                 print(
-                    f"[check_xref] NOTE: {len(undecidable)} of those are MISSING_BODY with no "
-                    f"--docx to compare against ({labels}).\n"
-                    f"           Nothing here can tell a missing caption from a float that "
-                    f"lives in a separate supplement file.\n"
-                    f"           Supply --docx <rendered.docx> to decide it: a float absent "
-                    f"from the DOCX becomes MISSING_DOCX, which\n"
-                    f"           --allow-separate-attachments does downgrade. Adding the flag "
-                    f"alone does not change these rows."
+                    f"[check_xref] NOTE: {len(drift)} of those are MISSING_BODY that "
+                    f"--allow-separate-attachments does NOT excuse "
+                    f"({', '.join(f.label for f in drift)}).\n"
+                    f"           These floats ARE in the rendered DOCX while nothing in the "
+                    f"markdown defines their caption, so the\n"
+                    f"           build pipeline is the only place that knows the text. That is "
+                    f"SSOT drift, not attachment style."
                 )
         if vN_check is not None:
             if vN_check["identical_bytes"]:

--- a/skills/manage-refs/scripts/pre_submission_gate.sh
+++ b/skills/manage-refs/scripts/pre_submission_gate.sh
@@ -42,8 +42,12 @@ Optional:
   --docx PATH                 Pre-built DOCX. If omitted, render via render_pandoc.sh.
   --journal CSL_KEY           Journal CSL key (default: vancouver)
   --allow-separate-attachments
-                              Forwarded to check_xref.py; downgrades MISSING_DOCX
-                              from FAIL to WARN.
+                              Forwarded to check_xref.py. Declares that some floats
+                              are submitted as separate attachment files. Downgrades
+                              MISSING_DOCX (proven absent from a supplied --docx) and,
+                              when no --docx was supplied, MISSING_BODY (excused
+                              without evidence — see summary.downgraded_unchecked).
+                              A MISSING_BODY whose float IS in the DOCX still fails.
   --qc-dir PATH               Output artifact directory (default: qc/)
   -h, --help                  Show this help
 

--- a/skills/manage-refs/tests/test_xref_separate_supplement.sh
+++ b/skills/manage-refs/tests/test_xref_separate_supplement.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-# Regression test: check_xref must say what would decide a MISSING_BODY it cannot decide.
+# Regression test: --allow-separate-attachments, and the exact shape of the amnesty it grants.
 #
 # The situation this exists for: a submission whose supplementary tables and figures are
 # separate attachment files — the norm in radiology and most medical journals — checked in
 # markdown-only mode. Those floats are cited, have no caption in the manuscript body, and
-# there is no rendered DOCX to look them up in. `_classify` returns MISSING_BODY, which
-# `--allow-separate-attachments` does not downgrade, so the run prints
-# `SUBMISSION BLOCKED` on a correctly packaged submission and offers no way forward.
+# there is no rendered DOCX to look them up in, so `_classify` returns MISSING_BODY and the
+# run once printed SUBMISSION BLOCKED on a correctly packaged submission.
 #
 # MISSING_BODY carries two different situations under one name and only one of them is the
 # SSOT drift that every triage table in this repo describes:
@@ -14,11 +13,18 @@
 #   in_docx is True  -> the float IS rendered but has no body caption. Real drift. P0.
 #   in_docx is None  -> no DOCX was supplied, so there is nothing to have drifted FROM.
 #
-# This test does not change either verdict — a P0 submission gate's vocabulary is consumed by
-# /self-review, /write-paper and /sync-submission triage tables, and moving it is a decision
-# for a human. It pins the smaller fix: the second case must NAME the labels and say that
-# supplying --docx is what decides them. A gate that is red on correct work with no stated
-# way out is a gate the operator learns to skip, which costs more than the check is worth.
+# The maintainer's decision (2026-07-29) is that --allow-separate-attachments downgrades the
+# second case: with the flag set the operator has declared those floats live outside the main
+# document, and a gate that is red on correct work is a gate that gets skipped.
+#
+# The cost of that decision is a real amnesty — in markdown-only mode a caption nobody wrote is
+# indistinguishable from an attachment, and both now pass. So what this suite pins is not just
+# "it passes" but that the amnesty stays VISIBLE and BOUNDED:
+#   - the excused rows are named, and labelled EXCUSED WITHOUT EVIDENCE, apart from the
+#     MISSING_DOCX rows that a supplied DOCX actually proved absent;
+#   - the JSON separates the two counts, so a consumer cannot read one as the other;
+#   - MISSING_BODY with the float present in the DOCX still BLOCKS. That is SSOT drift, and no
+#     attachment policy makes it acceptable.
 set -u
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
@@ -39,7 +45,7 @@ ck() {
   fi
 }
 
-NOTE='no --docx to compare against'
+EXCUSED='EXCUSED WITHOUT EVIDENCE'
 
 # --- a correctly packaged submission: supplement lives in separate attachment files ---
 cat > "$TMP/sep.md" <<'MD'
@@ -91,26 +97,43 @@ PY
 run() { python3 "$S" --md "$1" ${2:+--docx "$2"} --out "$TMP/out.json" \
           --allow-separate-attachments --strict > "$TMP/log.txt" 2>&1; echo $?; }
 
-# 1) The case the note exists for: undecidable without a DOCX.
+# 1) The declared case: markdown-only, floats live in separate attachment files.
 rc=$(run "$TMP/sep.md" "")
-ck "markdown-only separate-supplement still blocks (verdict unchanged)" 1 "$rc"
-grep -q "$NOTE" "$TMP/log.txt"; ck "...and the run says --docx is what decides it" 0 "$?"
-# The labels must appear ON the note line. Grepping the whole log passes vacuously —
-# every label is already printed in the findings table above, so that assertion would
-# have been green against the unfixed code too.
-grep -q "$NOTE.*Table:S-S1" "$TMP/log.txt"; ck "...and the note itself NAMES them" 0 "$?"
+ck "markdown-only separate-supplement PASSES under the flag" 0 "$rc"
+grep -q "$EXCUSED" "$TMP/log.txt"; ck "...and the amnesty is stated, not silent" 0 "$?"
+# The labels must appear in the EXCUSED block. Grepping the whole log passes vacuously —
+# every label is already printed in the findings table above.
+awk "/$EXCUSED/,/Run again with --docx/" "$TMP/log.txt" | grep -q 'Table:S-S1'
+ck "...and the excused rows are NAMED in that block" 0 "$?"
+grep -q 'nothing here was actually checked' "$TMP/log.txt"
+ck "...and it says nothing was checked, not that it verified them" 0 "$?"
+python3 -c "
+import json,sys
+s=json.load(open('$TMP/out.json'))['summary']
+sys.exit(0 if s.get('downgraded_unchecked')==2 and s.get('downgraded_proven_absent')==0 else 1)" 2>/dev/null
+ck "...and the JSON counts it as unchecked, not as proven-absent" 0 "$?"
 
-# 2) Supplying the DOCX is genuinely the way out — the whole point of the note.
+# 2) A supplied DOCX turns the same rows into an EVIDENCED downgrade, not an excuse.
 rc=$(run "$TMP/sep.md" "$TMP/main.docx")
-ck "with --docx the same package PASSES under the flag" 0 "$rc"
-grep -q "$NOTE" "$TMP/log.txt"; ck "...and the note is silent (nothing undecidable)" 1 "$?"
-grep -q "downgraded under --allow-separate-attachments: " "$TMP/log.txt"
-ck "...and the downgraded rows are named, not just counted" 0 "$?"
+ck "with --docx the same package PASSES too" 0 "$rc"
+grep -q "$EXCUSED" "$TMP/log.txt"; ck "...and nothing is excused without evidence" 1 "$?"
+grep -q 'MISSING_DOCX row(s) downgraded' "$TMP/log.txt"
+ck "...it is reported as a proven-absent downgrade instead" 0 "$?"
+python3 -c "
+import json,sys
+s=json.load(open('$TMP/out.json'))['summary']
+sys.exit(0 if s.get('downgraded_proven_absent')==2 and s.get('downgraded_unchecked')==0 else 1)" 2>/dev/null
+ck "...and the JSON keeps the two apart" 0 "$?"
 
-# 3) Real SSOT drift must be untouched: it blocks, and the note must NOT excuse it.
+# 3) The bound on the amnesty: real SSOT drift still blocks WITH the flag set.
 rc=$(run "$TMP/drift.md" "$TMP/drift.docx")
-ck "rendered-but-undefined caption still BLOCKS (P0 preserved)" 1 "$rc"
-grep -q "$NOTE" "$TMP/log.txt"; ck "...and the note does not fire on real drift" 1 "$?"
+ck "rendered-but-undefined caption still BLOCKS under the flag" 1 "$rc"
+grep -q "$EXCUSED" "$TMP/log.txt"; ck "...and is not excused" 1 "$?"
+grep -q 'does NOT excuse' "$TMP/log.txt"; ck "...and the run says why it is different" 0 "$?"
+
+# 4) Without the flag nothing is downgraded at all — the declaration has to be made.
+rc=$(python3 "$S" --md "$TMP/sep.md" --out "$TMP/out.json" --strict > "$TMP/log.txt" 2>&1; echo $?)
+ck "no flag: the same package still blocks (opt-in preserved)" 1 "$rc"
 
 echo "----"
 echo "test_xref_separate_supplement: $pass passed, $fail failed"

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -454,11 +454,16 @@ attachment style is not read as a blocker.
 | Status | Default policy | With `--allow-separate-attachments` |
 |---|---|---|
 | `MISSING_DOCX` | **Major (P0)** — cited Table/Figure absent from rendered output | **Minor** — separately attached per journal policy |
-| `MISSING_BODY` | **Major (P0)** — build SSOT drift; rendered caption has no body definition | **Major (P0)** (no change) |
+| `MISSING_BODY` | **Major (P0)** — no body caption definition | **Major (P0)** when the float IS in the rendered DOCX (SSOT drift). **Minor** when no `--docx` was supplied — excused without evidence, and reported as such |
 | `MISMATCH` | **Major (P0)** — caption text disagrees between body and rendered DOCX | **Major (P0)** (no change) |
 | `UNCITED` | Minor — orphan caption; cite it or remove it | Minor (no change) |
 
-`MISSING_BODY` and `MISMATCH` stay P0 under every policy: they are SSOT drift, not a style choice.
+`MISMATCH` stays P0 under every policy. So does `MISSING_BODY` **when the float is present in the
+rendered DOCX** — the build pipeline is then the only place that knows the caption text, which is SSOT
+drift and not a style choice. `MISSING_BODY` with **no `--docx` supplied** is different: nothing was
+checked, so under `--allow-separate-attachments` it is excused on the author's declaration and the run
+says so in those words. Treat those rows as unverified, not as verified — re-run with `--docx` before
+submission and read `summary.downgraded_unchecked` in the audit JSON.
 
 **Do NOT auto-fix cross-reference defects in `--fix` mode.** Rewriting a caption in the body
 without re-running the DOCX build merely moves the mismatch. Emit each P0 row as its own

--- a/skills/self-review/references/phases/phase2_5d_xref_qc.md
+++ b/skills/self-review/references/phases/phase2_5d_xref_qc.md
@@ -62,15 +62,24 @@ DOCX build has occurred yet (early drafts).
    the journal's figure/table submission policy. Many radiology and medical
    journals (e.g., European Radiology, Radiology, AJR) accept figures and tables
    as separate attachment files rather than inline in the manuscript DOCX; for
-   those workflows pass `--allow-separate-attachments` so MISSING_DOCX is not
-   treated as a P0 blocker. `MISSING_BODY` and `MISMATCH` remain P0 regardless,
-   because they indicate SSOT drift between body markdown and rendered DOCX
-   rather than a legitimate attachment style.
+   those workflows pass `--allow-separate-attachments`. That flag downgrades two
+   things, and they are not equally well evidenced — the audit JSON and the console
+   output keep them apart, and so should you:
+
+   - `MISSING_DOCX` — a `--docx` was supplied and PROVED the float is not in the
+     rendered main document. That is what a separate attachment looks like.
+   - `MISSING_BODY` where **no `--docx` was supplied** — nothing was checked. The
+     float is either separately attached, as declared, or a caption nobody wrote.
+     Excused on the author's word; counted in `summary.downgraded_unchecked`.
+
+   `MISMATCH` remains P0 regardless. So does `MISSING_BODY` when the float IS in the
+   rendered DOCX: the build pipeline is then the only place that knows the caption
+   text, which is SSOT drift and not an attachment style.
 
    | Status | Default policy | With `--allow-separate-attachments` |
    |---|---|---|
    | `MISSING_DOCX` | **Major (P0)** — cited Table/Figure absent from rendered output | **Minor** — figure/table is separately attached per journal policy |
-   | `MISSING_BODY` | **Major (P0)** — build SSOT drift; rendered caption has no body definition | **Major (P0)** (no change) |
+   | `MISSING_BODY` | **Major (P0)** — no body caption definition | **Major (P0)** when the float IS in the rendered DOCX (SSOT drift). **Minor** when no `--docx` was supplied — excused without evidence, and reported as such |
    | `MISMATCH` | **Major (P0)** — caption text disagrees between body and rendered DOCX | **Major (P0)** (no change) |
    | `UNCITED` | Minor — orphan caption that should be cited or removed | Minor (no change) |
 

--- a/skills/write-paper/SKILL.md
+++ b/skills/write-paper/SKILL.md
@@ -734,7 +734,7 @@ Severity levels: **ENFORCED** = pipeline halts on failure (cannot proceed to nex
 | 7.5 | Humanize density (`/humanize`) | ADVISORY | AI patterns > 2.0 / 1000 words | Sweep + flag remaining; user reviews |
 | 7.5a | AIO checklist (`/academic-aio --aio`) | OPT-IN | user supplies `--aio` flag | PASS/PARTIAL/FAIL report; never auto-applies |
 | 7.6 | DOCX build (delegate `/manage-refs scripts/render_pandoc.sh`) | ENFORCED | render exits non-zero | Halt; report stderr to user |
-| 7.6a | Cross-reference QC (delegate `/manage-refs scripts/check_xref.py --strict`) | ENFORCED — submission gate | MISSING_DOCX / MISSING_BODY / MISMATCH > 0 | Halt; route fixes per `references/phase7_polish_detail.md` |
+| 7.6a | Cross-reference QC (delegate `/manage-refs scripts/check_xref.py --strict`) | ENFORCED — submission gate | MISSING_DOCX / MISSING_BODY / MISMATCH > 0 (under `--allow-separate-attachments`: MISMATCH, or MISSING_BODY whose float is in the DOCX) | Halt; route fixes per `references/phase7_polish_detail.md` |
 | 7.7 | Final submission gate | ENFORCED | any of 7.0–7.6a above failed | Refuse to mark `submission_safe: true` |
 | 8+ | Cover letter generation | OPT-IN | user invokes `--cover-letter` | Renders against journal profile |
 

--- a/skills/write-paper/references/phase7_polish_detail.md
+++ b/skills/write-paper/references/phase7_polish_detail.md
@@ -243,7 +243,7 @@ emits a 3-way matrix to `qc/xref_audit.json`:
 |---|---|---|
 | `OK` | cited + body caption + DOCX caption all present and caption text agrees (Jaccard ≥ 0.40) | — |
 | `MISSING_DOCX` | cited but no caption with that label in the rendered DOCX | **P0 blocker** |
-| `MISSING_BODY` | cited but no caption definition in the markdown body sections (build SSOT drift) | **P0 blocker** |
+| `MISSING_BODY` | cited but no caption definition in the markdown body sections | **P0 blocker** — except under `--allow-separate-attachments` with no `--docx` supplied, where nothing was checked and the row is excused without evidence |
 | `MISMATCH` | label exists in both body and DOCX but caption text disagrees | **P0 blocker** |
 | `UNCITED` | caption defined or rendered but never cited in main text | warn |
 | `NOT_CITED_NO_BODY` | label appears only in DOCX (rare; legacy artifact) | warn |
@@ -251,6 +251,14 @@ emits a 3-way matrix to `qc/xref_audit.json`:
 **Submission gate:** if any `MISSING_DOCX` / `MISSING_BODY` / `MISMATCH` row is
 present, `submission_safe: false` and the script exits 1 under `--strict`.
 HALT pipeline. Do NOT proceed to Step 7.7. Route fixes by symptom:
+
+> **Under `--allow-separate-attachments`** (the normal invocation for journals that take
+> figures and tables as separate files) two of those downgrade to WARN: `MISSING_DOCX`,
+> which a supplied `--docx` proved absent from the rendered output, and `MISSING_BODY`
+> where no `--docx` was supplied at all. The second is an excuse rather than a check —
+> the run prints `EXCUSED WITHOUT EVIDENCE` and counts it in
+> `summary.downgraded_unchecked`. Run once with `--docx` before Step 7.7 so those rows
+> become evidenced. A `MISSING_BODY` whose float **is** in the DOCX still halts.
 
 - `MISSING_BODY` → add caption definition under `## Tables` / `## Figures` in
   `manuscript.md`, then re-run Step 7.6 + 7.6a. If the build script


### PR DESCRIPTION
Follow-up to #438, which deliberately left this decision to you. You chose the downgrade, and this ships it with the six documentation sites moved together.

## What changes

`--allow-separate-attachments` is the operator's declaration that some floats are submitted as separate attachment files. It now downgrades the `MISSING_BODY` rows produced by that packaging in markdown-only mode, instead of blocking a correct submission.

## This is an amnesty, and it is priced as one

In markdown-only mode a caption nobody wrote is **indistinguishable** from a separate attachment. Both now pass. So the two downgrades are reported apart, because their evidence differs:

| downgrade | evidence |
|---|---|
| `MISSING_DOCX` | a supplied `--docx` **proved** the float absent from the rendered main document |
| `MISSING_BODY`, no `--docx` | **nothing was checked** — excused on your word |

```
[check_xref] WARN: 2 MISSING_BODY row(s) EXCUSED WITHOUT EVIDENCE under --allow-separate-attachments:
           Figure:S-S1, Table:S-S1
           No --docx was supplied, so nothing here was actually checked. Each of these is either a float in a
           separate supplement file — which is what you declared — or a caption nobody wrote. This run cannot
           tell them apart, and passed them on your word.
           Run again with --docx <rendered.docx> before submitting: a float genuinely absent from the rendered
           output becomes MISSING_DOCX (still downgraded, but now proven), and a caption you forgot becomes visible.
```

The audit JSON keeps them apart too — `summary.downgraded_unchecked` vs `summary.downgraded_proven_absent`, plus `downgraded_unchecked_labels` — so a downstream consumer cannot read an excuse as a check.

## What the flag still does not excuse

`MISMATCH`, and a `MISSING_BODY` whose float **is** in the rendered DOCX. There the build pipeline is the only place that knows the caption text — SSOT drift, which no attachment policy makes acceptable. When that blocks, the run now names those rows and says why they are different, so the distinction is visible rather than inferred.

| invocation | separate-supplement float | forgotten caption |
|---|---|---|
| no flag | **blocks** | **blocks** |
| flag, no `--docx` | passes — excused without evidence | passes — **this is the cost** |
| flag + `--docx` | passes — proven absent | **blocks**, or surfaces as a `MISSING_DOCX` you must explain |

## Six sites moved together

`manage-refs/SKILL.md` (3 passages) · `check_xref_symptoms.md` · `self-review/SKILL.md` · `phase2_5d_xref_qc.md` · `write-paper/SKILL.md` (2 passages) · `phase7_polish_detail.md` — plus the `--help` text and `pre_submission_gate.sh`. All of them said *"`MISSING_BODY` remains FAIL regardless"*. Leaving any behind would have left a triage table telling a reader the opposite of what the tool does.

## Verification

Not "the suite passes". The 13-case suite was run against the **previous** behaviour first:

| tree | result |
|---|---|
| `main` (post-#438) | **6 pass / 7 fail** |
| this branch | **13 / 13** |

The 6 that pass on `main` are exactly the invariants that must not move: SSOT drift still blocks, the flag stays opt-in (no flag → still blocks), and a supplied DOCX still yields an evidenced downgrade. That is what makes the 7 failures meaningful rather than noise.

## Found while doing this, not fixed here

`skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh` is a five-stage runnable gate test that appears **nowhere in `validate.yml`** and currently fails (stage 3 `verify_refs.py --strict` → `MISMATCH: 1` against the live APIs). Pre-existing — it fails identically with all local changes stashed. `check_test_wiring.py` reports `0 unwired` because its `ASSET_GLOBS` match `verify.sh` and `test_*`, and this file is named `run.sh`. Captured for the next batch; the network dependency is a legitimate reason to keep it out of CI, but it should be a stated `EXEMPT` entry rather than an accident of filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)