### PR TITLE
fix(self-review): a manuscript's own changelog is not a confession

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,12 @@ jobs:
       - name: "Validator scope self-test (it must READ every directory it claims to scan)"
         run: bash tests/test_validator_scope.sh
 
+      - name: "Run check_frontmatter_scope.py (a manuscript detector must not read YAML front matter as prose)"
+        run: python3 scripts/check_frontmatter_scope.py --strict
+
+      - name: "Front-matter scope gate self-test (a new detector cannot join silently)"
+        run: bash tests/test_frontmatter_scope.sh
+
       - name: "Unshipped-rule gate self-test (an instruction we do not ship is not an instruction)"
         run: bash tests/test_personal_rule_refs.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`check_claim_artifact` read a manuscript's own changelog as a confession.** A pandoc
+  manuscript opens with a `---`-fenced YAML block, and projects keep real sentences in it. A
+  `changelog:` entry saying *"the primary endpoint was changed from 30-day to 90-day mortality"*
+  was scanned as body prose and returned `PRIMARY_REASSIGNED` — a **P0** — so a project was
+  penalised for keeping an honest record. A Major that fires harder the more openly a project
+  documents itself is the Major most likely to get waved through, and estimand provenance is
+  exactly the gate that must not be. The detector now strips front matter first; the same
+  sentence in the body still fires, which is what makes the fix meaningful rather than a mute.
+
+### Added
+
+- **`scripts/check_frontmatter_scope.py` — the gap was never the fix, it was the visibility.**
+  `_frontmatter.py` has existed for months and had reached **4 of the 41** detectors that take
+  `--manuscript`; the other 37 read YAML front matter as prose, and three of them had already
+  fired on it in production. Nothing made that countable, so nothing got swept.
+
+  The gate requires every `--manuscript` detector to strip front matter — directly or through a
+  same-directory helper it imports, so the two that strip via `_prose.py` are correctly counted
+  as compliant rather than invented as debt — or to appear in an **ALLOWLIST that names it**.
+  The list is seeded with the 35 that did not, and it exists to be emptied: a name leaves it when
+  that detector is fixed, and a **stale entry is itself a failure**, so the list cannot quietly
+  overstate the debt either. New detectors get no grace period.
+
+  Deliberately a list rather than a count: "37 detectors do not strip front matter" is a number
+  nobody acts on; a name is a piece of work. Repo-CI validator under `scripts/`, so
+  `integrity_detectors` stays **84**.
+
 ### Changed
 
 - **`--allow-separate-attachments` now downgrades the `MISSING_BODY` it could not check.** When a

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4548,8 +4548,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_claim_artifact.py",
-      "size": 22106,
-      "sha256": "890ba1834c86d864e40c4ad3c9afb7db6824ffb5f50c2b8896b2a9bbea611ab0"
+      "size": 22558,
+      "sha256": "98e7fa5cc5539d753e5cdd429d9640a63ab149606c85f57f51c4fbe5b128bbcf"
     },
     {
       "path": "skills/self-review/scripts/check_classical_style.py",

--- a/scripts/check_frontmatter_scope.py
+++ b/scripts/check_frontmatter_scope.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""A manuscript detector that reads YAML front matter as body prose.
+
+A pandoc manuscript opens with a `---`-fenced YAML block, and projects keep real sentences
+in it: `status:` notes, `changelog:` entries, build annotations. Every detector in this repo
+that scans `--manuscript` rolls its own body extractor, and those extractors filter lines
+starting with `#`, `|`, `>`, `!`, list markers and code fences. **A YAML front-matter block
+matches none of those**, so its prose is read as the manuscript's own text.
+
+This is not hypothetical. Three shipped detectors have fired on it:
+
+  check_citation_order      reported floats "cited out of order" from a `status:` block
+                            narrating a display-item renumber
+  check_aphorism_density    listed build notes among the manuscript's short declaratives
+  check_claim_artifact      returned PRIMARY_REASSIGNED — a **P0** — when a `changelog:`
+                            entry said the primary endpoint was changed. A Major that fires
+                            harder the more openly a project records its own history is the
+                            Major most likely to get waved through, and estimand provenance
+                            is precisely the gate that must not be.
+
+`skills/self-review/scripts/_frontmatter.py` (and `sync-submission`'s `_yaml_frontmatter.py`)
+solve it. The problem was never the fix; it was that nothing made the gap visible, so the fix
+reached 4 of 41 detectors over several months.
+
+WHAT THIS GATE DOES
+
+Every `skills/*/scripts/check_*.py` that accepts `--manuscript` must either strip front matter
+-- directly, or through a same-directory helper it imports -- or appear in ALLOWLIST below with
+a reason. The allowlist is seeded with the detectors that did not strip it on the day this gate
+landed, and it exists to be **emptied**: a name leaves it when that detector is fixed, and
+nothing may be added without a reason. New detectors get no grace period.
+
+This is deliberately a list rather than a count. "37 detectors do not strip front matter" is a
+number nobody acts on; a name is a piece of work. It is the same reason a scanner that skips
+unmapped items has to print what it skipped.
+
+Repo-CI validator, so it lives in scripts/ and is NOT an analysis-integrity detector: the
+catalog glob is `skills/*/scripts/{check_,detect_,derive_,verify_refs}*.py`, and this file is
+outside it. `integrity_detectors` is unchanged.
+
+Usage:  python3 scripts/check_frontmatter_scope.py [--strict]
+Exit:   0 clean (or advisory without --strict); 1 a detector strips nothing and is not listed.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+TAKES_MANUSCRIPT = re.compile(r'["\']--manuscript["\']')
+# Direct evidence that the module removes front matter before analysing prose.
+STRIPS = re.compile(
+    r"from\s+_(?:yaml_)?frontmatter\s+import"
+    r"|import\s+_(?:yaml_)?frontmatter\b"
+    r"|strip_frontmatter\s*\("
+    r"|strip_yaml_frontmatter\s*\("
+)
+# A same-directory private helper import: `from _prose import ...`. Resolved one level,
+# because check_aphorism_density and check_rhetorical_density strip through _prose, and a
+# gate that called those two "debt" would be inventing work.
+SIBLING_IMPORT = re.compile(r"^\s*(?:from|import)\s+(_\w+)", re.M)
+
+# path -> why it does not strip yet. EMPTY THIS LIST. Every entry is a detector that will
+# read a `status:` or `changelog:` block as manuscript prose the first time a project puts
+# one there. They are listed rather than counted so each is a piece of work with a name.
+ALLOWLIST: dict[str, str] = {
+    # -- self-review: the largest family, and where the P0s live -------------------------
+    "skills/self-review/scripts/check_analysis_definitions.py": "not yet swept",
+    "skills/self-review/scripts/check_artifact_coverage.py": "not yet swept",
+    "skills/self-review/scripts/check_baseline_drift.py": "not yet swept",
+    "skills/self-review/scripts/check_classical_style.py": "not yet swept",
+    "skills/self-review/scripts/check_cohort_arithmetic.py": "not yet swept",
+    "skills/self-review/scripts/check_cv_leakage.py": "not yet swept",
+    "skills/self-review/scripts/check_dta_denominators.py": "not yet swept",
+    "skills/self-review/scripts/check_editorial_impression.py": "not yet swept",
+    "skills/self-review/scripts/check_effect_stability.py": "not yet swept",
+    "skills/self-review/scripts/check_emphasis_density.py": "not yet swept",
+    "skills/self-review/scripts/check_figure_citation.py": "not yet swept",
+    "skills/self-review/scripts/check_incorporation_bias.py": "not yet swept",
+    "skills/self-review/scripts/check_nested_group_comparison.py": "not yet swept",
+    "skills/self-review/scripts/check_null_calibration.py": "not yet swept",
+    "skills/self-review/scripts/check_paired_difference_estimator.py": "not yet swept",
+    "skills/self-review/scripts/check_paren_spans.py": "not yet swept",
+    "skills/self-review/scripts/check_reference_adequacy.py": "not yet swept",
+    "skills/self-review/scripts/check_reported_p_from_counts.py": "not yet swept",
+    "skills/self-review/scripts/check_reviewer_team_consistency.py": "not yet swept",
+    "skills/self-review/scripts/check_rounded_delta.py": "not yet swept",
+    "skills/self-review/scripts/check_scope_coherence.py": "not yet swept",
+    "skills/self-review/scripts/check_supplement_hygiene.py": "not yet swept",
+    "skills/self-review/scripts/check_table_percentages.py": "not yet swept",
+    # -- other skills: each needs its own helper, since skills are self-contained --------
+    "skills/academic-aio/scripts/check_summary_box.py": "not yet swept",
+    "skills/check-reporting/scripts/check_checklist_version.py": "not yet swept",
+    "skills/check-reporting/scripts/check_framework_naming.py": "not yet swept",
+    "skills/humanize/scripts/check_sentence_variety.py": "not yet swept",
+    "skills/peer-review/scripts/check_self_improvement_claims.py": "not yet swept",
+    "skills/revise/scripts/check_response_claims.py": "not yet swept",
+    "skills/sync-submission/scripts/check_credit_integrity.py": "not yet swept",
+    "skills/sync-submission/scripts/check_cross_artifact_stale.py": "not yet swept",
+    "skills/sync-submission/scripts/check_disclosure_availability.py": "not yet swept",
+    "skills/sync-submission/scripts/check_portal_mirror.py": "not yet swept",
+    "skills/verify-refs/scripts/check_claim_fidelity.py": "not yet swept",
+    "skills/write-paper/scripts/check_placeholders.py": "not yet swept",
+}
+
+
+def _strips(path: Path, seen: set[Path] | None = None) -> bool:
+    """True if `path`, or a same-directory `_helper` it imports, removes front matter."""
+    seen = seen if seen is not None else set()
+    if path in seen or not path.is_file():
+        return False
+    seen.add(path)
+    src = path.read_text(encoding="utf-8", errors="replace")
+    if STRIPS.search(src):
+        return True
+    return any(
+        _strips(path.parent / f"{name}.py", seen)
+        for name in SIBLING_IMPORT.findall(src)
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on any unlisted detector (CI uses this)")
+    a = ap.parse_args()
+
+    detectors, stripping, unlisted, listed = [], [], [], []
+    for p in sorted(ROOT.glob("skills/*/scripts/check_*.py")):
+        rel = p.relative_to(ROOT).as_posix()
+        if not TAKES_MANUSCRIPT.search(p.read_text(encoding="utf-8", errors="replace")):
+            continue
+        detectors.append(rel)
+        if _strips(p):
+            stripping.append(rel)
+        elif rel in ALLOWLIST:
+            listed.append(rel)
+        else:
+            unlisted.append(rel)
+
+    stale = sorted(set(ALLOWLIST) - set(detectors) - set(stripping) | (set(ALLOWLIST) & set(stripping)))
+
+    print(f"--manuscript detectors: {len(detectors)} | strip front matter: {len(stripping)} "
+          f"| known debt: {len(listed)} | unlisted: {len(unlisted)}")
+
+    if stale:
+        print("\nSTALE ALLOWLIST -- these now strip front matter (or no longer exist). "
+              "Delete them from ALLOWLIST:")
+        for rel in stale:
+            print(f"  {rel}")
+
+    if unlisted:
+        print("\nFRONTMATTER_SCOPE: a --manuscript detector that does not strip YAML front matter\n"
+              "and is not listed as known debt. A `status:` or `changelog:` block in the manuscript\n"
+              "will be read as body prose:\n")
+        for rel in unlisted:
+            print(f"  {rel}")
+        print("\n  Fix: `from _frontmatter import strip_frontmatter` (a same-directory helper --\n"
+              "  skills are self-contained, so each skill needs its own copy) and apply it to the\n"
+              "  manuscript text before any pattern runs. Add a regression fixture whose front\n"
+              "  matter contains the phrase the detector looks for, and assert it stays silent\n"
+              "  while the same phrase in the body still fires.")
+
+    if listed and not unlisted and not stale:
+        print(f"\nOK: no unlisted detector. {len(listed)} known-debt entries remain -- this list\n"
+              "exists to be emptied; see ALLOWLIST in this file.")
+
+    failed = bool(unlisted) or bool(stale)
+    if failed and a.strict:
+        return 1
+    if failed:
+        print("\n(advisory: re-run with --strict to fail)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/self-review/scripts/check_claim_artifact.py
+++ b/skills/self-review/scripts/check_claim_artifact.py
@@ -53,6 +53,8 @@ import re
 import sys
 from pathlib import Path
 
+from _frontmatter import strip_frontmatter
+
 EVALUE_TOL = 0.15  # relative tolerance for E-value recompute
 
 PRIMARY_RE = re.compile(
@@ -410,7 +412,12 @@ def main() -> int:
     def _unwrap(t: str) -> str:
         return re.sub(r"\s*\n\s*", " ", t)
 
-    manuscript = _unwrap(mp.read_text(encoding="utf-8"))
+    # Strip the YAML front matter before any estimand pattern runs. A project that
+    # honestly logs "the primary endpoint was changed ..." in a `changelog:` block was
+    # read as a body self-admission and given PRIMARY_REASSIGNED — a Major that fires
+    # harder the more openly a project records its own history, which is exactly the
+    # Major most likely to get waved through.
+    manuscript = _unwrap(strip_frontmatter(mp.read_text(encoding="utf-8")))
     prereg = None
     prereg_raw = None
     if args.prereg:

--- a/skills/self-review/tests/fixtures/claim_body_reassign.md
+++ b/skills/self-review/tests/fixtures/claim_body_reassign.md
@@ -1,0 +1,3 @@
+# METHODS
+
+The primary endpoint was changed from 30-day to 90-day mortality after the DSMB review.

--- a/skills/self-review/tests/fixtures/claim_frontmatter_changelog.md
+++ b/skills/self-review/tests/fixtures/claim_frontmatter_changelog.md
@@ -1,0 +1,15 @@
+---
+title: "Effect of X on ninety-day mortality"
+version: v4
+changelog:
+  - "v2: added the pre-specified sensitivity analyses"
+  - "v3: the primary endpoint was changed from 30-day to 90-day mortality after the DSMB review, before unblinding"
+---
+
+# METHODS
+
+The primary outcome was 90-day all-cause mortality, pre-specified in the registered protocol.
+
+# RESULTS
+
+Ninety-day mortality was 12.1% in the intervention arm versus 15.8% in the control arm.

--- a/skills/self-review/tests/test_claim_artifact.sh
+++ b/skills/self-review/tests/test_claim_artifact.sh
@@ -113,5 +113,22 @@ RC="$HERE/fixtures/claim_registration_clean.md"
 python3 "$SCRIPT" --manuscript "$RC" --strict >/dev/null 2>&1
 check "exit 0 on genuinely-prospective + no-prospective-claim registrations" test "$?" -eq 0
 
+# YAML front matter is not body prose. A project that honestly records "the primary
+# endpoint was changed ..." in a `changelog:` block was handed PRIMARY_REASSIGNED — a P0 —
+# for keeping a good record. The same sentence in the BODY is a real self-admission and
+# must still fire, which is what makes the first assertion mean something.
+FM="$HERE/fixtures/claim_frontmatter_changelog.md"
+python3 "$SCRIPT" --manuscript "$FM" --out "$OUT" --strict >/dev/null 2>&1
+check "a changelog in YAML front matter is not a self-admission" test "$?" -eq 0
+check "...and no PRIMARY_REASSIGNED is recorded" python3 -c "
+import json
+d=json.load(open('$OUT'))
+raise SystemExit(0 if not any(c['verdict']=='PRIMARY_REASSIGNED' for c in d['claims']) else 1)
+"
+BR="$HERE/fixtures/claim_body_reassign.md"
+python3 "$SCRIPT" --manuscript "$BR" --out "$OUT" --strict >/dev/null 2>&1
+check "the same sentence in the body still fires (P0 preserved)" test "$?" -eq 1
+check "PRIMARY_REASSIGNED detected in body" has_verdict PRIMARY_REASSIGNED
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/tests/test_frontmatter_scope.sh
+++ b/tests/test_frontmatter_scope.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check_frontmatter_scope.py.
+#
+# The gate exists because a pandoc manuscript opens with a `---`-fenced YAML block that
+# projects fill with real sentences — `status:` notes, `changelog:` entries — and every
+# `--manuscript` detector's hand-rolled body extractor filters `#`, `|`, `>`, `!`, list
+# markers and code fences, none of which a YAML block matches. Three shipped detectors
+# fired on it, one of them returning a P0 (`PRIMARY_REASSIGNED`) because a changelog said
+# the primary endpoint had been changed — a Major that fires harder the more openly a
+# project records its own history.
+#
+# The fix existed the whole time (`_frontmatter.py`); nothing made the gap visible, so it
+# reached 4 of 41 detectors over months. So what this suite pins is not the fix but the
+# VISIBILITY: a new detector cannot join silently, and an entry cannot rot on the list
+# after its detector is fixed.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+G="$REPO_ROOT/scripts/check_frontmatter_scope.py"
+PROBE="$REPO_ROOT/skills/self-review/scripts/check_zz_frontmatter_probe_$$.py"
+LISTED="$REPO_ROOT/skills/self-review/scripts/check_paren_spans.py"
+BACKUP="$(mktemp)"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+cleanup() {
+  rm -f "$PROBE"
+  # cp, never `git checkout -- <file>`: that reverts to HEAD and would destroy any
+  # uncommitted work on this file, which has cost this repo a session before.
+  [ -s "$BACKUP" ] && cp "$BACKUP" "$LISTED"
+  rm -f "$BACKUP"
+}
+trap cleanup EXIT
+cp "$LISTED" "$BACKUP"
+
+# Never pipe between the gate and $? — a pipeline's status is the LAST command's, and
+# reading `head`'s 0 as the gate's verdict is a mistake this repo has made more than once.
+run() { python3 "$G" --strict > /dev/null 2>&1; echo $?; }
+
+# 1) The tree as committed must be clean, or the gate cannot land.
+ck "the repository as committed passes" 0 "$(run)"
+
+# 2) A NEW --manuscript detector that strips nothing must fail. No grace period: the
+#    allowlist is a record of what was already there, not a door.
+cat > "$PROBE" <<'PY'
+#!/usr/bin/env python3
+"""Throwaway probe created and deleted by tests/test_frontmatter_scope.sh."""
+import argparse
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manuscript", required=True)
+    ap.parse_args()
+    return 0
+PY
+ck "a new unlisted --manuscript detector FAILS" 1 "$(run)"
+
+# 3) ...and passes as soon as it strips.
+printf 'from _frontmatter import strip_frontmatter\n' >> "$PROBE"
+ck "...and passes once it strips front matter" 0 "$(run)"
+rm -f "$PROBE"
+
+# 4) An entry that has been fixed must be REMOVED from the list, not left to rot. A stale
+#    allowlist overstates the debt and quietly re-permits a regression on that file.
+printf 'from _frontmatter import strip_frontmatter\n' | cat - "$LISTED" > "$LISTED.tmp" && mv "$LISTED.tmp" "$LISTED"
+ck "a listed detector that now strips is reported STALE" 1 "$(run)"
+python3 "$G" --strict 2>&1 | grep -q "STALE ALLOWLIST"
+ck "...and the stale entry is named" 0 "$?"
+cp "$BACKUP" "$LISTED"
+
+# 5) Transitive stripping counts. check_aphorism_density and check_rhetorical_density strip
+#    through _prose.py; a gate that could not see one level of same-directory import would
+#    call those two debt, which is inventing work rather than finding it.
+python3 "$G" 2>&1 | grep -qE 'strip front matter: [6-9]|strip front matter: [1-9][0-9]'
+ck "same-directory helper imports are resolved (not counted as debt)" 0 "$?"
+
+# 6) The advisory path must not be silently green: without --strict it still reports.
+rm -f "$PROBE"; cat > "$PROBE" <<'PY'
+import argparse
+argparse.ArgumentParser().add_argument("--manuscript")
+PY
+python3 "$G" 2>&1 | grep -q "FRONTMATTER_SCOPE"
+ck "without --strict the violation is still printed" 0 "$?"
+python3 "$G" > /dev/null 2>&1
+ck "...but does not fail the build" 0 "$?"
+
+cleanup
+
+echo "----"
+echo "test_frontmatter_scope: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## The defect

A pandoc manuscript opens with a `---`-fenced YAML block, and projects keep real sentences in it. Every `--manuscript` detector in this repo rolls its own body extractor, and those filter lines starting with `#`, `|`, `>`, `!`, list markers and code fences — **a YAML block matches none of them.**

So this manuscript:

```yaml
---
title: "Effect of X on ninety-day mortality"
changelog:
  - "v3: the primary endpoint was changed from 30-day to 90-day mortality after the DSMB review, before unblinding"
---
```

came back from `check_claim_artifact` as `PRIMARY_REASSIGNED` — a **P0**. The project was penalised for keeping an honest record.

**A Major that fires harder the more openly a project documents itself is the Major most likely to get waved through**, and estimand provenance is exactly the gate that must not be.

Reproduced against `main` before writing anything; the first fixture I wrote did *not* fire, and running it showed why — `REASSIGN_RE`'s first alternative needs `primary` *before* the verb, and I had written "changed the primary". The fixture was wrong, not the claim.

## What is actually interesting

`_frontmatter.py` has existed for months. **Its own docstring names two detectors that fired on this in production.** It had reached **4 of the 41** detectors that take `--manuscript`.

The fix was never missing. What was missing was anything that made the other 37 countable — so nobody swept them, for months, while the helper sat next to them.

## The gate

`scripts/check_frontmatter_scope.py` requires every `--manuscript` detector to strip front matter — directly, **or through a same-directory helper it imports**, so `check_aphorism_density` and `check_rhetorical_density` (which strip via `_prose.py`) are counted as compliant rather than invented as debt — or to appear in an **ALLOWLIST that names it**.

```
--manuscript detectors: 41 | strip front matter: 6 | known debt: 35 | unlisted: 0
```

It is seeded with the 35 that do not, and it exists to be **emptied**. A name leaves when that detector is fixed, and **a stale entry is itself a failure**, so the list cannot quietly overstate the debt either. New detectors get no grace period.

Deliberately a list, not a count: *"37 detectors do not strip front matter"* is a number nobody acts on; a name is a piece of work. Same reason a scanner that skips unmapped items has to print what it skipped.

## Verification

Not "the suite passes". Four directions, each of which would be green on a gate that did nothing:

| assertion | why it matters |
|---|---|
| a new unlisted `--manuscript` detector **fails** | the allowlist is a record, not a door |
| ...and passes once it strips | the fix is what clears it, not the listing |
| a listed detector that now strips is reported **STALE** and fails | a rotted list overstates debt and re-permits regression |
| transitive stripping through a sibling import is recognised | otherwise the gate invents two entries of work |

Plus, on the detector itself: the changelog fixture is silent **and** the same sentence in the body still fires. Without the second, the fix would be indistinguishable from a mute.

## Counts

Repo-CI validator under `scripts/`, outside the `skills/*/scripts/{check_,detect_,derive_,verify_refs}*.py` catalog glob — `integrity_detectors` stays **84**, `skills` **58**.

## Not done here

The 35 allowlisted detectors. Each needs its own fix plus a fixture whose front matter carries the phrase that detector looks for, asserted silent while the body still fires — which is the work the list now makes visible one name at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)