### PR TITLE
docs(contributing): the challenge-card promise was false (26 of 84 detectors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Fixed
 
+- **`CONTRIBUTING.md` promised every detector a challenge directory; 26 of 84 have one.**
+  The sentence read *"Each deterministic detector additionally ships a self-contained
+  `<detector>_challenge/` directory"* — stated as a property of the codebase, in the document
+  whose whole job is telling an outside contributor what is true here. It was wrong twice:
+  the directories are named after the **feature** under test, not always a single script, and
+  48 of them cover 84 detectors. A contributor who went looking for the one belonging to the
+  detector they were extending would have found nothing and had to guess whether they had
+  misread the repo or the repo had misread itself. The text now states the coverage as a
+  number and hands over the loop that prints the 58 detectors still without one — turning a
+  false claim into an entry point for the contribution this project is actually short of.
+  No gate: the count moves with every merge, and a gate here would only pin a promise nobody
+  made.
+
 - **`check_claim_artifact` read a manuscript's own changelog as a confession.** A pandoc
   manuscript opens with a `---`-fenced YAML block, and projects keep real sentences in it. A
   `changelog:` entry saying *"the primary endpoint was changed from 30-day to 90-day mortality"*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,13 +106,26 @@ Do not maintain a shorter list by hand: a gate added to the workflow, or a `--st
 flag, silently drifts out of a copied list and is only caught by a red CI after you
 push. `run_ci_mirror.sh` reads the workflow, so it stays exact.
 
-Each deterministic detector additionally ships a self-contained
-`<detector>_challenge/` directory — a positive case, a negative control, and a
-`verify.sh` — so any single detector can be exercised offline in isolation, for
-example:
+Deterministic work additionally ships a self-contained `<feature>_challenge/`
+directory — a positive case, a negative control, and a `verify.sh` — so it can be
+exercised offline in isolation:
 
 ```bash
 bash skills/self-review/scripts/check_reported_p_from_counts_challenge/verify.sh
+```
+
+New deterministic scripts are expected to add one. Coverage of what already exists
+is **partial, and deliberately stated rather than implied**: 48 challenge directories
+exist against 84 detectors, and they are named after the feature under test — which
+is not always one script — so 26 detectors have a directory bearing their own name.
+A pull request that adds a challenge directory for a detector that lacks one is a
+welcome contribution on its own. To see which those are:
+
+```bash
+for d in skills/*/scripts/{check_,detect_,derive_,verify_refs}*.py; do
+  s=$(basename "$d" .py)
+  find skills -type d -name "${s}_challenge" | grep -q . || echo "$s"
+done
 ```
 
 A green run of `.github/workflows/validate.yml` is required before any release is


### PR DESCRIPTION
## What

`CONTRIBUTING.md` stated, as a property of the codebase:

> Each deterministic detector additionally ships a self-contained `<detector>_challenge/` directory

It does not. Measured on `main` (`e1aeee1`):

| | |
|---|---|
| detectors (`skills/*/scripts/{check_,detect_,derive_,verify_refs}*.py`) | **84** |
| challenge directories (`find skills -type d -name '*_challenge'`) | **48** |
| detectors with a directory named after them | **26** |

Wrong twice over: the directories are named for the **feature** under test — which is not always a single script — and coverage is partial either way.

## Why it matters here specifically

This document exists to tell someone who has never seen the repo what is true about it. A contributor extending a detector goes looking for the challenge directory the guide promises, finds nothing, and cannot tell whether the repo is inconsistent or they misread it. This project has had **two** externally-authored PRs in its life; that is not a place to spend goodwill on a guessing game.

## What changed

The paragraph now states coverage as a number and hands over the loop that prints the 58 detectors still lacking one, framed as a self-contained first contribution:

```bash
for d in skills/*/scripts/{check_,detect_,derive_,verify_refs}*.py; do
  s=$(basename "$d" .py)
  find skills -type d -name "${s}_challenge" | grep -q . || echo "$s"
done
```

Verified to print exactly 58, matching an independent Python count.

## Deliberately no gate

The number moves with every merge, and pinning it would enforce a promise that was never the valuable part. The fix is making the claim true, not making it checkable.

Docs only — no skill, detector, or count changes (`skills 58 / detectors 84` unchanged). Local mirror: **219/219 validate-job gates pass**.