### PR TITLE
fix(verify-refs): BibTeX `and others` is a declared et-al, not an author mismatch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -330,6 +330,9 @@ jobs:
       - name: Run verify-refs author-normalization test (Unicode dash + BBT brace-protected surname)
         run: bash skills/verify-refs/tests/test_author_normalization.sh
 
+      - name: "Run verify-refs BibTeX and-others test (a declared et-al is not an author mismatch)"
+        run: bash skills/verify-refs/tests/test_bibtex_et_al.sh
+
       - name: "Run verify-refs claim-fidelity challenge (a real citation carrying a claim its source never makes)"
         run: bash skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@
 
 ### Fixed
 
+- **`verify_refs` called BibTeX's own "et al." an author mismatch.** `and others` is what
+  Zotero, Mendeley, JabRef and a hand-written `.bib` all emit for a list the author chose not
+  to type out, and what BibTeX and CSL both render as *et al.* The parser already knew the
+  token — it dropped the literal family `others` from the cited list — but did not read it as
+  a **declaration**, so `cited=6 vs source=53` became `AUTHOR MISMATCH`: the render-aborting
+  verdict, on a correct reference. The escape hatch that existed, `_audit_truncated = N`, is a
+  field this toolkit invented and no reference manager writes. The universal way to declare a
+  truncation failed and the private way succeeded, which is backwards — and it failed hardest
+  on multisociety guidelines and consortium papers, the reference class clinical manuscripts
+  cite most.
+
+  `and others` now sets the same truncation flag, in the trailing position where BibTeX
+  defines it. Declaring a truncation still buys **nothing** else: a cited family that does not
+  match the source, a cited author the source does not have, and an undeclared short list all
+  still fire. `skills/verify-refs/tests/test_bibtex_et_al.sh` (network-free, wired) pins all
+  four, and reverting the one-line fix turns it red.
+
+- **The regression test for the master pre-submission chain had been failing for two months,
+  unseen.** `skills/manage-refs/tests/fixtures/pre_submission_gate/` is the end-to-end test for
+  the chain `manage-refs/SKILL.md` recommends before any submission. Its own `refs.bib` uses
+  `and others`, so it broke the day the author cross-check landed (v1.3.0, #41, 2026-05-31) and
+  stayed broken until today. Three separate things had to be true for that to go unnoticed, and
+  all three are fixed here:
+
+  - `check_test_wiring.py` decides what is a test by its **name**, and this one is called
+    `run.sh`. A gate for finding unrun tests must not have a naming blind spot; anything under
+    a `tests/` directory now counts. The fixture is `EXEMPT` with a stated reason (its stage 2
+    queries live PubMed/CrossRef, so wiring it would make a green build depend on a third-party
+    API) — visible and justified rather than invisible.
+  - That same gate **read its own source**. CI runs it, so its file landed in the one-hop text
+    it searches, and writing a test's path anywhere inside it — a comment, an exemption reason
+    — marked that test wired. Adding one explanatory sentence to `EXEMPT` turned a genuinely
+    unwired test green; removing the sentence turned it red again. The gate no longer reads
+    itself, so `EXEMPT` is the only way to excuse a test.
+  - The fixture's own network-skip guard **could never match**: it grepped the single-line
+    literal `"verify_refs", "status": "FAIL"` against a pretty-printed artifact that writes
+    `"stage"` and `"status"` on separate lines. That it was dead is lucky — alive, it would
+    have skipped on *any* verify_refs failure, hiding exactly the content regression the
+    fixture exists to catch. It now skips on the transport failing, never on the verdict.
+
 - **`CONTRIBUTING.md` promised every detector a challenge directory; 26 of 84 have one.**
   The sentence read *"Each deterministic detector additionally ships a self-contained
   `<detector>_challenge/` directory"* — stated as a property of the codebase, in the document

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5608,8 +5608,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 44683,
-      "sha256": "8b1bfee367b638cd49f5b6f92bfb353edef05ec71b5a9d8b44be9c5aa475b100"
+      "size": 46220,
+      "sha256": "af23fe7bdaa15c78669cbdeb7e990df1239f69b571546a4f129c6934d998256b"
     },
     {
       "path": "skills/verify-refs/skill.yml",

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -52,16 +52,34 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 # Where test assets live and what they are called.
+#
+# The last glob is a naming backstop. This gate reads a test's NAME to decide whether it is
+# a test, so a real regression test that is not called `test_*` or `verify.sh` is invisible
+# to it — and a gate whose job is finding unrun tests must not have a way to be blind. That
+# is not hypothetical: `skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh` is the
+# end-to-end regression for the master pre-submission chain, and it sat unwired and FAILING
+# for two months (2026-05-31 -> 2026-07-29) because it is named `run.sh`. Anything under a
+# `tests/` directory is now claimed as a test regardless of its name.
 ASSET_GLOBS = (
     "skills/**/verify.sh",
     "skills/**/test_*.py",
     "skills/**/test_*.sh",
     "tests/test_*.py",
     "tests/test_*.sh",
+    "skills/**/tests/**/*.sh",
 )
 
 # path -> reason. A test that CI genuinely must not run needs a stated reason, not silence.
-EXEMPT: dict[str, str] = {}
+EXEMPT: dict[str, str] = {
+    "skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh": (
+        "End-to-end chain test whose verify_refs stage queries live PubMed/CrossRef. Wiring it "
+        "into validate.yml would make a green build depend on a third-party API's availability "
+        "and rate limits, so CI would go red for reasons no contributor could act on. Run it by "
+        "hand before any release that touches the manage-refs chain; it exits 77 when the "
+        "network is unreachable. The offline-safe half of its coverage is "
+        "skills/verify-refs/tests/test_bibtex_et_al.sh, which IS wired."
+    ),
+}
 
 
 def _iter_run_commands(root: Path) -> list[str]:
@@ -107,10 +125,19 @@ def collect(root: Path = ROOT) -> dict:
     joined = "\n".join(cmds)
 
     asset_set = set(assets)
+    self_path = Path(__file__).resolve()
     hop_text = []
     for f in _referenced_repo_files(root, cmds):
         if f.relative_to(root).as_posix() in asset_set:
             continue  # a test does not wire another test — see the docstring
+        if f.resolve() == self_path:
+            # This gate must not read ITSELF. CI runs it, so it is a referenced file, so its
+            # own source lands in the one-hop text — and then writing a test's path anywhere
+            # in here, including inside an EXEMPT reason or a comment, marks that test wired.
+            # Observed: adding the sentence "the offline-safe half is <path>, which IS wired"
+            # to an exemption reason turned a genuinely unwired test green. EXEMPT is the one
+            # sanctioned way to excuse a test; prose must not be a second, silent one.
+            continue
         try:
             hop_text.append(f.read_text(encoding="utf-8", errors="replace"))
         except OSError:

--- a/skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh
+++ b/skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh
@@ -67,10 +67,16 @@ bash "$GATE" \
 RC1=$?
 set -e
 
-# If stage 2 failed because of network, skip the entire fixture gracefully.
-if grep -q '"verify_refs", "status": "FAIL"' "$QC_DEFAULT/pre_submission_gate.json" 2>/dev/null \
-   || grep -qiE "network|connection|temporary failure|name resolution" "$WORK_DIR/default.log"; then
-  echo "[SKIP] verify_refs stage failed (likely network-restricted environment)."
+# If stage 2 failed because of NETWORK, skip the fixture gracefully. Only network.
+#
+# This used to also skip whenever the artifact recorded the verify_refs stage as FAIL —
+# which is any failure, including a genuine reference mismatch. That clause could never
+# match (the artifact writes `"stage": "verify_refs"` and `"status": "FAIL"` on separate
+# lines, so the single-line literal found nothing), and it is a mercy that it could not:
+# had it worked it would have skipped this fixture on exactly the content regression the
+# fixture exists to catch. Skip on the transport failing, never on the verdict.
+if grep -qiE "network|connection|temporary failure|name resolution|timed out|urlopen" "$WORK_DIR/default.log"; then
+  echo "[SKIP] verify_refs stage could not reach the network."
   cat "$WORK_DIR/default.log"
   exit 77
 fi

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -48,6 +48,13 @@ class RefRecord:
     # (any non-empty value); when present, count mismatch is downgraded to a note
     # and does not trigger MISMATCH status. Use when CSL renders first-1 or first-5
     # + et al. and the trailing authors are deliberately omitted from the bib.
+    #
+    # It is ALSO set by the standard BibTeX `and others` sentinel. `_audit_truncated`
+    # is a field this toolkit invented; `and others` is the one every reference
+    # manager already writes and BibTeX/CSL already render as "et al.". Treating it
+    # as a count mismatch fired MISMATCH — the render-aborting verdict — on any
+    # consortium or multisociety-guideline reference, which is the class clinical
+    # manuscripts cite most.
     audit_truncated: bool = False
     # Collective / corporate author (EASL, KDIGO, AHA/ACC, WHO, a named working
     # group / consortium). BibTeX convention double-braces these
@@ -192,7 +199,10 @@ def parse_bib(text: str) -> list[RefRecord]:
                 first_author_guess=cited[0] if cited else (parse_first_author(author_field) if author_field else ""),
                 cited_authors=cited,
                 cited_author_count=len(cited),
-                audit_truncated=bool(trunc_match and trunc_match.group(1).strip().lower() not in ("", "false", "0", "no")),
+                audit_truncated=(
+                    bool(trunc_match and trunc_match.group(1).strip().lower() not in ("", "false", "0", "no"))
+                    or has_bibtex_et_al(author_field)
+                ),
                 corporate_author=is_corporate_author_field(author_field),
             )
         )
@@ -276,6 +286,24 @@ def parse_reference_lines(text: str) -> list[RefRecord]:
 
 
 _NAME_PARTICLES = {"von", "van", "de", "del", "della", "dos", "da", "le", "la", "du", "den", "der", "ten"}
+
+
+def has_bibtex_et_al(author_field: str) -> bool:
+    """True when the author field ends in the BibTeX `and others` sentinel.
+
+    `and others` is BibTeX's own way of saying "et al." — it is what Zotero,
+    Mendeley, JabRef and a hand-written .bib all emit for a list the author chose
+    not to type out, and what BibTeX and CSL both render as an et-al. It is a
+    declaration that the list is deliberately short, so a cited-vs-source count
+    difference is expected and must not be reported as a mismatch.
+
+    Matched only in the trailing position, where BibTeX defines it. A real surname
+    "Others" mid-list (or a first name "Others") is not this sentinel and is left
+    to the ordinary family cross-check.
+    """
+    if not author_field:
+        return False
+    return bool(re.search(r"\s+and\s+others\s*$", re.sub(r"\s+", " ", author_field).strip(), re.I))
 
 
 def parse_bib_authors(author_field: str) -> list:
@@ -699,13 +727,14 @@ def author_cross_check(
             mismatches.append(
                 f"#{i+1} extra cited='{cited_authors[i]}' (source has only {len(actual_authors)} authors)"
             )
-        # source has more authors than cited — count mismatch, suppressed under
-        # `_audit_truncated` marker (intentional CSL et-al truncation).
+        # source has more authors than cited — count mismatch, suppressed when the
+        # bib declares the truncation, either with the `_audit_truncated` marker or
+        # with BibTeX's own `and others` sentinel (intentional CSL et-al truncation).
         if cited_author_count != actual_author_count:
             if audit_truncated and cited_author_count < actual_author_count:
                 notes.append(
                     f"NOTE: intentional truncate ({cited_author_count} of {actual_author_count}; "
-                    f"`_audit_truncated` marker set)"
+                    f"declared by `and others` or `_audit_truncated`)"
                 )
             else:
                 mismatches.append(

--- a/skills/verify-refs/tests/test_bibtex_et_al.sh
+++ b/skills/verify-refs/tests/test_bibtex_et_al.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test: the BibTeX `and others` sentinel is a declared truncation, not a mismatch.
+#
+# `and others` is BibTeX's own et-al.: Zotero, Mendeley, JabRef and a hand-written .bib all
+# emit it for a list the author chose not to type out, and BibTeX and CSL both render it as
+# "et al." verify_refs parsed it (it already dropped the literal family "others" from the
+# cited list) but did not treat it as a declaration, so `cited=6 vs source=53` became
+# AUTHOR MISMATCH — the render-aborting verdict — on the reference class clinical
+# manuscripts cite most: multisociety guidelines and consortium papers.
+#
+# The escape hatch that did exist, `_audit_truncated = N`, is a field this toolkit invented.
+# No reference manager writes it. So the universal way to declare a truncation failed and the
+# private way succeeded, which is the wrong way round.
+#
+# The repo's own fixture proved the cost: skills/manage-refs/tests/fixtures/pre_submission_gate
+# uses `and others`, and its Test 2 invariant broke when the author cross-check landed
+# (v1.3.0, #41, 2026-05-31) and stayed broken because that fixture is not wired into CI.
+#
+# Network-free by construction: every assertion below is against the parser and the
+# cross-check function, never against PubMed or CrossRef.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+V="$REPO_ROOT/skills/verify-refs/scripts/verify_refs.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+run() {
+  python3 - "$V" "$@" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+# @dataclass resolves cls.__module__ through sys.modules; register before exec.
+sys.modules["vr"] = m
+spec.loader.exec_module(m)
+mode = sys.argv[2]
+
+if mode == "sentinel":
+    print("true" if m.has_bibtex_et_al(sys.argv[3]) else "false")
+
+elif mode == "parsed_truncated":
+    bib = (
+        "@article{k,\n  author = {%s},\n  title = {T},\n  year = {2023},\n"
+        "  doi = {10.1/x}\n}\n" % sys.argv[3]
+    )
+    rec = m.parse_bib(bib)[0]
+    print("true" if rec.audit_truncated else "false")
+
+elif mode == "xcheck":
+    # cited families | source families | cited_n | actual_n | truncated
+    cited = [s for s in sys.argv[3].split(",") if s]
+    actual = [s for s in sys.argv[4].split(",") if s]
+    mism, _notes = m.author_cross_check(
+        cited, actual, int(sys.argv[5]), int(sys.argv[6]),
+        corporate=False, soft=False,
+        audit_truncated=(sys.argv[7] == "1"), first_author_guess="",
+    )
+    print("MISMATCH" if mism else "OK")
+PY
+}
+
+echo "==== the sentinel is recognised only where BibTeX defines it ===="
+ck "trailing 'and others'"          true  "$(run sentinel 'Rinella, M and Lazarus, J and others')"
+ck "case-insensitive"               true  "$(run sentinel 'Rinella, M and Others')"
+ck "no sentinel"                    false "$(run sentinel 'Rinella, M and Lazarus, J')"
+ck "surname Others mid-list"        false "$(run sentinel 'Others, A B and Rinella, M')"
+ck "empty field"                    false "$(run sentinel '')"
+
+echo "==== the parser records it as a declared truncation ===="
+ck "and others sets audit_truncated"   true  "$(run parsed_truncated 'Rinella, M and Lazarus, J and others')"
+ck "plain list does not"               false "$(run parsed_truncated 'Rinella, M and Lazarus, J')"
+
+echo "==== NEGATIVE CONTROLS — the check must still bite ===="
+# 2 cited of 53 real authors, truncation declared: a count gap alone is not a finding.
+ck "declared truncation, families agree" OK \
+   "$(run xcheck 'Rinella,Lazarus' 'Rinella,Lazarus,Ratziu' 2 53 1)"
+# Same declaration, but a cited family does not match the source: still a mismatch.
+ck "declared truncation, wrong family"  MISMATCH \
+   "$(run xcheck 'Rinella,Fabricated' 'Rinella,Lazarus,Ratziu' 2 53 1)"
+# Same declaration, but MORE cited authors than the source has: invention, never intentional.
+ck "declared truncation, extra author"  MISMATCH \
+   "$(run xcheck 'Rinella,Lazarus,Ratziu,Ghost' 'Rinella,Lazarus,Ratziu' 4 3 1)"
+# No declaration at all: a silent short list is exactly what the count check exists for.
+ck "undeclared truncation still fires"  MISMATCH \
+   "$(run xcheck 'Rinella,Lazarus' 'Rinella,Lazarus,Ratziu' 2 53 0)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: \`and others\` is a declaration, and declaring it does not buy silence on invention."


### PR DESCRIPTION
## The bug

`and others` is BibTeX's own *et al.* Every reference manager writes it; BibTeX and CSL both render it as "et al."

`verify_refs` already parsed the token — it dropped the literal family `others` from the cited list — but never read it as a **declaration**. So a 53-author multisociety consensus statement cited as six names + `and others` produced:

```
AUTHOR MISMATCH | AUTHOR COUNT: cited=6 vs source=53
```

`MISMATCH` is the render-aborting verdict, fired on a correct reference. The escape hatch that existed, `_audit_truncated = N`, is a field **this toolkit invented** — nothing else writes it. The universal way to declare a truncation failed; the private way succeeded. And it failed hardest on multisociety guidelines and consortium papers: the reference class clinical manuscripts cite most.

## The fix, and what it does *not* excuse

`and others` now sets the same truncation flag, matched only in the trailing position where BibTeX defines it. Declaring a truncation buys silence on the **count and nothing else**:

| case | before | after |
|---|---|---|
| `and others`, families agree | MISMATCH ❌ | **OK** ✅ |
| `and others`, a cited family disagrees with source | MISMATCH | **MISMATCH** ✅ |
| `and others`, a cited author the source does not have | MISMATCH | **MISMATCH** ✅ |
| short list, no marker at all | MISMATCH | **MISMATCH** ✅ |

`skills/verify-refs/tests/test_bibtex_et_al.sh` — network-free, wired into `validate.yml` — pins all four. **Reverting the one-line fix turns it red** (verified, not assumed).

## How it stayed invisible for two months

Found by running `skills/manage-refs/tests/fixtures/pre_submission_gate/run.sh`, the end-to-end test for the chain `manage-refs/SKILL.md` recommends before any submission. Its own `refs.bib` uses `and others`, so it broke the day the cross-check landed (v1.3.0, #41, **2026-05-31**) and nobody saw it. Three independent reasons, all closed here:

1. **`check_test_wiring.py` decides what is a test by its name** — and this one is `run.sh`. A gate for finding unrun tests must not have a naming blind spot. Anything under a `tests/` directory now counts; the fixture is `EXEMPT` with a stated reason (stage 2 queries live PubMed/CrossRef, so wiring it would tie a green build to a third-party API's uptime).

2. **That gate read its own source.** CI runs it → its file entered the one-hop text it searches → writing a test's path anywhere inside it, *including in an exemption reason*, marked that test wired. Adding one explanatory sentence to `EXEMPT` turned a genuinely unwired test green; deleting the sentence turned it red. Demonstrated both directions before fixing. The gate no longer reads itself.

3. **The fixture's network-skip guard could never match.** It grepped the single-line literal `"verify_refs", "status": "FAIL"` against a pretty-printed artifact that writes `"stage"` and `"status"` on separate lines. That it was dead is *lucky* — alive, it would have skipped on **any** verify_refs failure, hiding the exact content regression the fixture exists to catch. It now skips on the transport failing, never on the verdict.

## Verification

- `test_bibtex_et_al.sh` 11/11; reverted fix → red, naming the assertion
- `run.sh` end-to-end: both invariants hold (was failing on `main`)
- Live-API negative controls on 4 hand-built `.bib` variants: OK / MISMATCH / MISMATCH / MISMATCH
- Local mirror **220/220** validate-job gates
- No new detector — `skills 58 / detectors 84` unchanged