### PR TITLE
fix(release): one error killed both distribution channels, and a pushed tag left no way to retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,21 @@ on:
   push:
     tags:
       - "v*"
+  # Recovery path. A tag can only ever be pushed once, so before this existed a release job that
+  # failed after the tag landed could not be retried at all — which is exactly what happened to
+  # v5.23.0: the release step errored, the job died before the npm step, and the ZIPs the README
+  # sends non-programmers to (releases/latest/download/...) 404'd with no way to republish.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing version tag to (re)publish, e.g. v5.23.0"
+        required: true
+        type: string
+
+# Resolved once so a dispatch run targets the tag it was given and a push run targets the tag that
+# triggered it. Every step below reads this, never github.ref_name directly.
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 # Least privilege: contents:write to publish the release; id-token + attestations for the build
 # provenance attestation. Nothing else.
@@ -50,6 +65,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # On a dispatch run the default ref is the branch, not the tag, and the version gate below
+          # compares the tag against the CHECKED-OUT manifest — so a republish must check out the tag
+          # or it would validate the wrong tree.
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -64,7 +83,7 @@ jobs:
           # ...and the tracked distribution_files.json inventory still matches the on-disk tree, so
           # the inventory the ZIP bundles (which the updater trusts) is anchored to the real source.
           python3 scripts/gen_distribution_manifest.py --check
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           VER="${TAG#v}"
           MAN="$(python3 -c 'import json;print(json.load(open("metadata/distribution_manifest.json"))["version"])')"
           if [ "$VER" != "$MAN" ]; then
@@ -78,7 +97,7 @@ jobs:
           set -euo pipefail
           BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python3 scripts/build_classroom_release.py \
-            --tag "${GITHUB_REF_NAME}" \
+            --tag "${RELEASE_TAG}" \
             --git-sha "${GITHUB_SHA}" \
             --built-at "${BUILT_AT}"
 
@@ -87,7 +106,7 @@ jobs:
           set -euo pipefail
           for zip in dist/medsci-skills-classroom-*.zip; do
             python3 scripts/check_release_zip.py --zip "$zip" \
-              --expect-tag "${GITHUB_REF_NAME}" --require-provenance
+              --expect-tag "${RELEASE_TAG}" --require-provenance
           done
 
       - name: List built artifacts
@@ -108,7 +127,7 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         id: notes
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${RELEASE_TAG}"
           # Tags are "vX.Y.Z" but CHANGELOG headers are "## [X.Y.Z]" (no leading v).
           # Strip the v so the section is actually found (else notes fall back).
           VER="${TAG#v}"
@@ -141,11 +160,34 @@ jobs:
         # Nothing modifies dist/ between those steps and this upload, so the API sha256 the updater
         # later checks covers exactly the verified bytes.
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          gh release create "$TAG" \
-            --title "MedSci Skills ${TAG}" \
-            --notes-file /tmp/release_notes.md \
-            dist/medsci-skills-classroom-*.zip
+          set -euo pipefail
+          TAG="${RELEASE_TAG}"
+          # Create-or-update, never create-or-die. `gh release create` fails outright when a Release
+          # object for the tag already exists — which it can, from a partial earlier run or from the
+          # tag itself — and that failure killed the whole job BEFORE the npm publish step, leaving
+          # the GitHub assets missing AND npm a version behind from one error. Both symptoms, one
+          # cause. Uploading with --clobber keeps the invariant the comment above depends on: the
+          # bytes attached are the ZIPs that were verified and attested in this same run.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — updating notes and (re)uploading assets."
+            gh release edit "$TAG" \
+              --title "MedSci Skills ${TAG}" \
+              --notes-file /tmp/release_notes.md
+            gh release upload "$TAG" dist/medsci-skills-classroom-*.zip --clobber
+          else
+            gh release create "$TAG" \
+              --title "MedSci Skills ${TAG}" \
+              --notes-file /tmp/release_notes.md \
+              dist/medsci-skills-classroom-*.zip
+          fi
+          # Assert the outcome rather than the command's exit code: a release that ends with no
+          # assets is the exact failure this step exists to prevent, and it looked like success.
+          n="$(gh release view "$TAG" --json assets --jq '.assets | length')"
+          echo "assets attached to $TAG: $n"
+          if [ "$n" -lt 2 ]; then
+            echo "::error::release $TAG ended with $n asset(s); expected the 2 classroom ZIPs." >&2
+            exit 1
+          fi
 
       # --- npm publish (last, gated on NPM_TOKEN, idempotent) so a npm issue never blocks the release ---
       - name: Set up Node for npm publish
@@ -161,7 +203,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          VER="${GITHUB_REF_NAME#v}"
+          VER="${RELEASE_TAG#v}"
           # Idempotent: re-running a tag must not fail on "version already published".
           if npm view "medsci-skills@${VER}" version >/dev/null 2>&1; then
             echo "medsci-skills@${VER} is already on npm — skipping publish."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -180,6 +180,9 @@ jobs:
       - name: Run release-cadence gate self-test
         run: bash tests/test_release_cadence.sh
 
+      - name: "Run release publish-step test (create-or-update; a release with no assets is red)"
+        run: bash tests/test_release_publish_step.sh
+
       - name: Run check_locale_inventory.py (Korean-bearing files must be inventory-justified)
         run: python3 scripts/check_locale_inventory.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@
 
 ### Fixed
 
+- **One error in the release job took out both distribution channels, and there was no way to retry.**
+  `gh release create` fails outright when a Release object for the tag already exists. On v5.23.0 it
+  did, the step errored, and the job died **before** the npm publish step that follows it. Net effect,
+  live until now: the v5.23.0 Release carried **0 assets**, so the ZIP links `README.md` gives
+  non-programmers (`releases/latest/download/medsci-skills-classroom-*.zip`, and v5.23.0 *is* latest)
+  returned 404; and npm stayed on **5.22.0** while `package.json` said 5.23.0, so
+  `npx medsci-skills@latest install` silently installed the previous release. For scale, v5.22.0's two
+  ZIPs were downloaded 8 and 7 times — a real path for roughly fifteen people per release, sitting at
+  zero.
+
+  Three changes, all repair:
+
+  - The publish step is now **create-or-update**: it edits the notes and re-uploads with `--clobber`
+    when the Release exists. The invariant the original comment relied on is preserved — the bytes
+    attached are still the ZIPs verified and attested earlier in the same run.
+  - It now **asserts the outcome instead of the command's exit code**. A release finishing with fewer
+    than two assets fails the step. That is the shape this class hides behind: the command that
+    mattered did not run, and the step looked successful.
+  - `workflow_dispatch(tag)` gives the job a **recovery path**. A version tag can only be pushed once,
+    so a release that failed after the tag landed could not be re-run at all. Every step now reads a
+    resolved `RELEASE_TAG`, and the checkout takes the tag, so a dispatch republishes the tagged tree
+    rather than a branch.
+
+  `tests/test_release_publish_step.sh` executes the **actual `run:` block extracted from the shipped
+  workflow** — not a copy — against a stubbed `gh` whose `release create` errors on an existing
+  release exactly as the real one does. Reverting the step turns 4 of its 7 assertions red.
+
+  Writing that test surfaced a latent one next door: `check_test_wiring._referenced_repo_files` built
+  each candidate as `root / token`, and an **absolute** token discards `root` entirely. `release.yml`
+  has always named `/tmp/release_notes.md`, so the moment that file existed on the runner the gate
+  crashed on `relative_to`. Crashing was the good outcome — had it not, the gate would have read a
+  file from **outside the repository** into the one-hop text it searches, where any test path inside
+  it would have counted as wiring. Absolute and `../` escaping tokens are now dropped. This is the
+  same shape as the self-read fixed in #443: the gate's notion of "a file that runs this test" was
+  wider than the set of files it can vouch for.
+
 - **`verify_refs` called BibTeX's own "et al." an author mismatch.** `and others` is what
   Zotero, Mendeley, JabRef and a hand-written `.bib` all emit for a list the author chose not
   to type out, and what BibTeX and CSL both render as *et al.* The parser already knew the

--- a/scripts/check_test_wiring.py
+++ b/scripts/check_test_wiring.py
@@ -104,14 +104,26 @@ def _iter_run_commands(root: Path) -> list[str]:
 
 
 def _referenced_repo_files(root: Path, cmds: list[str]) -> list[Path]:
-    """Repo files named by a run: command — the one-hop frontier."""
+    """**Repo** files named by a run: command — the one-hop frontier.
+
+    A run: command may name an absolute path (`--notes-file /tmp/release_notes.md`). `root / token`
+    on an absolute token discards `root` entirely, so such a token used to escape the repo: if the
+    file happened to exist on the runner, `collect` crashed on `relative_to` — and if it had not
+    crashed it would have read a file from outside the repository into the one-hop text, where any
+    test path inside it would silently count as wiring. Anchor to the repo and drop anything that
+    resolves outside it.
+    """
     out: list[Path] = []
     for cmd in cmds:
         for token in cmd.replace("&&", " ").replace("|", " ").replace(";", " ").split():
             token = token.strip("\"'()")
-            if "/" not in token or token.startswith("-"):
+            if "/" not in token or token.startswith("-") or token.startswith("/"):
                 continue
             candidate = root / token
+            try:
+                candidate.resolve().relative_to(root)
+            except ValueError:
+                continue  # ../.. escape
             if candidate.is_file():
                 out.append(candidate)
     return out

--- a/tests/test_release_publish_step.sh
+++ b/tests/test_release_publish_step.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression test for the release job's publish step.
+#
+# A version tag can only be pushed once. So when the v5.23.0 run failed at
+# `gh release create` — the Release object for the tag already existed, and `create` errors rather
+# than updates — the job died there, BEFORE the npm publish step that follows it. One error produced
+# both live symptoms: the GitHub Release carried zero assets (so the ZIP links README sends
+# non-programmers to, `releases/latest/download/...`, 404'd) and npm sat a version behind. There was
+# no way to retry, because the tag was already pushed.
+#
+# This test executes the ACTUAL `run:` block from .github/workflows/release.yml — extracted from the
+# shipped YAML, not a copy of it — against a stubbed `gh`, so it cannot drift from what CI runs.
+#
+# Three properties, the third being the one that turns a silent bad outcome into a red build:
+#   1. Release absent  -> `gh release create` with the ZIPs.
+#   2. Release present -> `gh release edit` + `gh release upload --clobber` (no failure).
+#   3. Either path, but the release ends with fewer than 2 assets -> the step FAILS.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t release_publish_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- extract the step's run block from the shipped workflow -------------------------------------
+python3 - "$REPO_ROOT/.github/workflows/release.yml" "$WORK/step.sh" <<'PY'
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+steps = wf["jobs"]["release"]["steps"]
+hits = [s for s in steps if "Create GitHub Release" in (s.get("name") or "")]
+if len(hits) != 1:
+    sys.exit(f"expected exactly one publish step, found {len(hits)}")
+run = hits[0].get("run")
+if not run:
+    sys.exit("publish step has no run: block")
+open(sys.argv[2], "w", encoding="utf-8").write(run)
+PY
+[ -s "$WORK/step.sh" ] || { echo "FAIL: could not extract the run block" >&2; exit 1; }
+
+# --- stub gh ------------------------------------------------------------------------------------
+# RELEASE_EXISTS controls whether `gh release view <tag>` succeeds; ASSET_COUNT is what the final
+# assertion reads back. Every invocation is appended to $WORK/calls so we can assert on the verbs.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$CALLS"
+case "$1 $2" in
+  "release view")
+    if [[ "$*" == *"--json assets"* ]]; then echo "${ASSET_COUNT}"; exit 0; fi
+    [ "${RELEASE_EXISTS}" = "1" ] && exit 0 || exit 1 ;;
+  "release create")
+    # Faithful to the real gh: creating a Release for a tag that already has one is an ERROR.
+    # This is the exact failure that killed the v5.23.0 job. A stub that returned 0 here would
+    # make the regression untestable — the old code would look fine.
+    if [ "${RELEASE_EXISTS}" = "1" ]; then
+      echo "HTTP 422: Validation Failed (a release with the same tag name already exists)" >&2
+      exit 1
+    fi
+    exit 0 ;;
+  "release edit"|"release upload") exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$WORK/bin/gh"
+
+run_step() {  # run_step <exists> <asset_count> ; echoes exit code, writes $WORK/calls
+  local exists="$1" assets="$2"
+  : > "$WORK/calls"
+  mkdir -p "$WORK/dist"
+  : > "$WORK/dist/medsci-skills-classroom-macos.zip"
+  : > "$WORK/dist/medsci-skills-classroom-windows.zip"
+  # Deliberately do NOT create /tmp/release_notes.md: the stub never reads it, and creating it made
+  # check_test_wiring crash by pulling an absolute path out of the workflow (fixed separately).
+  ( cd "$WORK" \
+    && PATH="$WORK/bin:$PATH" CALLS="$WORK/calls" RELEASE_EXISTS="$exists" ASSET_COUNT="$assets" \
+       RELEASE_TAG="v9.9.9" bash "$WORK/step.sh" >"$WORK/out" 2>&1 )
+  echo $?
+}
+
+echo "==== 1. no Release object yet: create ===="
+rc="$(run_step 0 2)"
+ck "exit 0" 0 "$rc"
+ck "used 'release create'" yes "$(grep -q '^release create' "$WORK/calls" && echo yes || echo no)"
+
+echo "==== 2. Release already exists (the v5.23.0 case): update, do not die ===="
+rc="$(run_step 1 2)"
+ck "exit 0 instead of failing" 0 "$rc"
+ck "used 'release upload' with --clobber" yes \
+   "$(grep '^release upload' "$WORK/calls" | grep -q -- '--clobber' && echo yes || echo no)"
+ck "did NOT call 'release create'" yes \
+   "$(grep -q '^release create' "$WORK/calls" && echo no || echo yes)"
+
+echo "==== 3. NEGATIVE CONTROL — a release that ends with no assets must FAIL ===="
+rc="$(run_step 1 0)"
+ck "exit 1 when 0 assets attached" 1 "$rc"
+rc="$(run_step 0 1)"
+ck "exit 1 when only 1 of 2 attached" 1 "$rc"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || { echo "--- last step output ---"; cat "$WORK/out"; exit 1; }
+echo "OK: publish step is create-or-update, and a release with missing assets is a red build."


### PR DESCRIPTION
## Live right now, on `main`

```
$ gh release view v5.23.0 --json assets --jq '.assets|length'   →  0
$ npm view medsci-skills version                                →  5.22.0
$ python3 -c "import json;print(json.load(open('package.json'))['version'])"  →  5.23.0
```

`README.md` sends non-programmers to `releases/latest/download/medsci-skills-classroom-*.zip`. v5.23.0 **is** latest and has no assets, so that link 404s. And `npx medsci-skills@latest install` quietly installs the previous release.

**One cause.** `gh release create` fails outright when a Release object for the tag already exists. It did, the step errored, and the job died **before** the npm publish step that follows it — which is itself already idempotent and would have worked.

For scale: v5.22.0's two ZIPs were downloaded **8 and 7** times. This is a real path for ~15 people per release, currently at zero.

## Three repairs

| | |
|---|---|
| **Create-or-update** | `gh release edit` + `gh release upload --clobber` when the Release exists. The attested-bytes invariant the original comment relies on is untouched — what gets attached is still the ZIPs verified and attested in the same run. |
| **Assert the outcome** | A release finishing with fewer than 2 assets now fails the step. This is what the whole class hides behind: the command that mattered did not run, and the step looked successful. |
| **`workflow_dispatch(tag)`** | A version tag can only be pushed once, so a release that failed after the tag landed **could not be retried at all**. Every step now reads a resolved `RELEASE_TAG`; the checkout takes the tag, so a dispatch republishes the tagged tree, not a branch. |

## The test runs the shipped YAML, not a copy

`tests/test_release_publish_step.sh` extracts the actual `run:` block from `.github/workflows/release.yml` and executes it against a stubbed `gh`. The stub's `release create` **errors on an existing release exactly as the real one does** — a permissive stub made the regression untestable on the first attempt, and the old code passed.

Reverting the step: **4 of 7 assertions go red**, including `exit 0 instead of failing → actual=1`, which is literally the v5.23.0 job dying.

## A latent bug this surfaced

`check_test_wiring._referenced_repo_files` built candidates as `root / token`; an **absolute** token discards `root`. `release.yml` has always named `/tmp/release_notes.md`, so the gate crashed on `relative_to` the moment that file existed on the runner.

Crashing was the lucky outcome. Had it not crashed, the gate would have read a file from **outside the repository** into the one-hop text it searches — where any test path inside would have counted as wiring. Same shape as the self-read fixed in #443. Absolute and `../`-escaping tokens are now dropped.

## After merge

The release itself is **not** part of this PR. Once merged, `workflow_dispatch` with `tag=v5.23.0` republishes: it rebuilds and re-attests the ZIPs, attaches them to the existing Release, and lets the npm step run. That is a publish action and is yours to trigger.

Local mirror **221/221**. `skills 58 / detectors 84` unchanged.