### PR TITLE
fix(verify-refs): a BibTeX entry's last field was not a field

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -336,6 +336,9 @@ jobs:
       - name: "Run verify-refs BibTeX and-others test (a declared et-al is not an author mismatch)"
         run: bash skills/verify-refs/tests/test_bibtex_et_al.sh
 
+      - name: "Run verify-refs last-field test (an entry's final field has no trailing comma)"
+        run: bash skills/verify-refs/tests/test_bib_last_field.sh
+
       - name: "Run verify-refs claim-fidelity challenge (a real citation carrying a claim its source never makes)"
         run: bash skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Fixed
 
+- **A BibTeX entry's last field was not a field.** BibTeX makes the comma after an entry's final
+  field optional; the `doi` and `title` regexes both required one. So any entry ending in
+  `doi = {...}` — an extremely common shape — yielded `record.doi == ""`, which **skips the CrossRef
+  check entirely** and drops the record onto the soft-flagged OpenAlex title path where the
+  full-author cross-check is disabled. The anti-fabrication check `/verify-refs` exists to perform
+  was silently off for exactly those references, and it announced nothing: the record simply came
+  back verified by a weaker route. All **three** entries in the repo's own shipped fixture
+  `skills/verify-refs/tests/fixtures/corporate_author.bib` were being read with no DOI, and
+  `detect_duplicates` — which keys on DOI — could not see two entries sharing one.
+
+  `title` had the identical defect needing the opposite remedy: it cannot take an optional comma,
+  because a non-greedy match would then stop at the inner `}` of a brace-protected group and return
+  *"A multisociety {Delphi"*. Both fields are now read by counting braces, which is correct in both
+  positions. An absent DOI still parses as absent — the fix widens what is read, never what is
+  assumed.
+
+  Order mattered here: enabling the author cross-check on this population **before** the `and others`
+  fix below would have converted a silent gap into a wave of false `AUTHOR MISMATCH` verdicts on
+  consortium references, since those are the entries most likely to carry both a trailing DOI and a
+  truncated author list.
+
+  `skills/verify-refs/tests/test_bib_last_field.sh` (network-free, wired) pins ten cases across both
+  field positions, brace-protected and quote-delimited titles, and the absent-DOI negative control.
+  Reverting the parser turns 6 of them red; the mid-entry form that always worked stays green.
+
 - **One error in the release job took out both distribution channels, and there was no way to retry.**
   `gh release create` fails outright when a Release object for the tag already exists. On v5.23.0 it
   did, the step errored, and the job died **before** the npm publish step that follows it. Net effect,

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5608,8 +5608,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 46220,
-      "sha256": "af23fe7bdaa15c78669cbdeb7e990df1239f69b571546a4f129c6934d998256b"
+      "size": 47979,
+      "sha256": "4631625bb9a5bb2514d6c3f910d1f6d1cf443710e8aec554e5d35522ca6deebb"
     },
     {
       "path": "skills/verify-refs/skill.yml",

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -157,6 +157,29 @@ def read_input(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+def brace_field(entry: str, name: str) -> str:
+    """Read a brace-delimited BibTeX field by counting braces, not by regex.
+
+    A non-greedy `{(.+?)}` stops at the first `}`, which truncates any brace-protected inner group
+    (`title = {A multisociety {Delphi} consensus}`). Anchoring the match on a trailing comma avoids
+    that but silently returns nothing when the field is the entry's LAST one, where BibTeX makes the
+    comma optional. Counting depth is correct in both cases. Returns "" when the field is absent or
+    is not brace-delimited.
+    """
+    m = re.search(rf"{name}\s*=\s*\{{", entry, re.I)
+    if not m:
+        return ""
+    start = m.end()
+    depth, j = 1, start
+    while j < len(entry) and depth > 0:
+        if entry[j] == "{":
+            depth += 1
+        elif entry[j] == "}":
+            depth -= 1
+        j += 1
+    return entry[start : j - 1]
+
+
 def parse_bib(text: str) -> list[RefRecord]:
     records: list[RefRecord] = []
     entries = re.split(r"\n(?=@\w+\{)", "\n" + text)
@@ -166,25 +189,30 @@ def parse_bib(text: str) -> list[RefRecord]:
             continue
         key_match = re.match(r"@\w+\{([^,]+),", entry)
         title_match = re.search(r"title\s*=\s*[\{\"](.+?)[\}\"]\s*,", entry, re.I | re.S)
-        doi_match = re.search(r"doi\s*=\s*[\{\"](.+?)[\}\"]\s*,", entry, re.I | re.S)
+        # The trailing comma is OPTIONAL: BibTeX does not require one after an entry's LAST field,
+        # and `doi` is very often that last field. Requiring it left `record.doi` empty for those
+        # entries, which skips the CrossRef check outright and drops the record onto the soft-flagged
+        # OpenAlex title path where the author cross-check is disabled — so the anti-fabrication
+        # check this skill exists for was silently off for exactly those references. Unlike `title`
+        # on the line above, a DOI never carries brace-protected inner groups (`{Delphi}`), so
+        # stopping at the first `}` is correct here and would truncate there.
+        doi_match = re.search(r"doi\s*=\s*[\{\"](.+?)[\}\"]\s*,?", entry, re.I | re.S)
         pmid_match = re.search(r"pmid\s*=\s*[\{\"]?(\d{5,9})", entry, re.I)
         year_match = re.search(r"year\s*=\s*[\{\"]?((?:19|20)\d{2})", entry, re.I)
         raw = normalize_space(entry)
-        # Balanced-brace aware author capture (handles "\~{n}" LaTeX escapes that
-        # would otherwise terminate a non-greedy {.+?} match prematurely).
-        author_field = ""
-        am = re.search(r"author\s*=\s*\{", entry, re.I)
-        if am:
-            start = am.end()
-            depth = 1
-            j = start
-            while j < len(entry) and depth > 0:
-                if entry[j] == "{":
-                    depth += 1
-                elif entry[j] == "}":
-                    depth -= 1
-                j += 1
-            author_field = entry[start : j - 1]
+        author_field = brace_field(entry, "author")
+        # `title` needs the same balanced-brace read, and for the same reason `doi` needed an
+        # optional comma: the regex above requires a trailing comma, so a title that is the entry's
+        # LAST field came back empty. It cannot simply take `,?` — the non-greedy match would then
+        # stop at the inner `}` of a brace-protected group and return "A multisociety {Delphi".
+        # Prefer the balanced read whenever the field is brace-delimited; keep the regex for the
+        # quote-delimited form it already handled.
+        title_braced = brace_field(entry, "title")
+        if title_braced:
+            title_match = None
+            title_text = title_braced
+        else:
+            title_text = title_match.group(1) if title_match else ""
         cited = parse_bib_authors(author_field)
         # v1.3.0: intentional truncate marker (any non-empty `_audit_truncated`)
         trunc_match = re.search(r"_audit_truncated\s*=\s*[\{\"]?([^,}\"]+)", entry, re.I)
@@ -192,7 +220,7 @@ def parse_bib(text: str) -> list[RefRecord]:
             RefRecord(
                 ref_id=key_match.group(1) if key_match else f"ref_{len(records)+1}",
                 raw=raw,
-                title_guess=normalize_space(title_match.group(1)) if title_match else "",
+                title_guess=normalize_space(title_text),
                 doi=clean_doi(doi_match.group(1)) if doi_match else "",
                 pmid=pmid_match.group(1) if pmid_match else "",
                 year_guess=year_match.group(1) if year_match else "",

--- a/skills/verify-refs/tests/test_bib_last_field.sh
+++ b/skills/verify-refs/tests/test_bib_last_field.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Regression test: a BibTeX field that is the entry's LAST one must still be read.
+#
+# BibTeX makes the comma after an entry's final field optional. Both the `doi` and `title` regexes
+# required one, so any entry ending in `doi = {...}` produced `record.doi == ""` — and an empty DOI
+# skips the CrossRef check outright and drops the record onto the soft-flagged OpenAlex title path,
+# where the full-author cross-check is DISABLED. The anti-fabrication check this skill exists for was
+# silently off for exactly those references. All three DOIs in the repo's own shipped fixture
+# `tests/fixtures/corporate_author.bib` were being dropped this way.
+#
+# `title` had the identical defect with a different remedy: it cannot take an optional comma, because
+# a non-greedy match would then stop at the inner `}` of a brace-protected group and return
+# "A multisociety {Delphi". Both fields are now read by counting braces.
+#
+# Network-free: every assertion is against the parser.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+V="$REPO_ROOT/skills/verify-refs/scripts/verify_refs.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-46s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-46s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+field() {  # field <which> <bib-body>
+  python3 - "$V" "$1" "$2" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["vr"] = m
+spec.loader.exec_module(m)
+recs = m.parse_bib(sys.argv[3])
+r = recs[0]
+print(r.doi if sys.argv[2] == "doi" else r.title_guess)
+PY
+}
+
+DOI_LAST='@article{k,
+  author = {Smith, John},
+  title  = {A title},
+  doi    = {10.1000/xyz789}
+}'
+TITLE_LAST='@article{k,
+  author = {Smith, John},
+  doi    = {10.1000/xyz789},
+  title  = {A plain title}
+}'
+BRACED='@article{k,
+  author = {Smith, John},
+  title  = {A multisociety {Delphi} consensus statement},
+  doi    = {10.1000/xyz789}
+}'
+BRACED_LAST='@article{k,
+  author = {Smith, John},
+  doi    = {10.1000/xyz789},
+  title  = {A multisociety {Delphi} consensus statement}
+}'
+QUOTED='@article{k,
+  author = {Smith, John},
+  title  = "A quoted title",
+  doi    = {10.1000/xyz789}
+}'
+NO_DOI='@article{k,
+  author = {Smith, John},
+  title  = {A title}
+}'
+# doi genuinely mid-entry, with a trailing comma: the form that already worked and must keep working.
+DOI_MID='@article{k,
+  author = {Smith, John},
+  doi    = {10.1000/xyz789},
+  year   = {2024}
+}'
+
+echo "==== the last field is still a field ===="
+ck "doi last"                     "10.1000/xyz789"  "$(field doi "$DOI_LAST")"
+ck "doi mid-entry, trailing comma" "10.1000/xyz789" "$(field doi "$DOI_MID")"
+ck "title last"                   "A plain title"   "$(field title "$TITLE_LAST")"
+
+echo "==== brace-protected groups are not truncated (either position) ===="
+ck "braced title, comma after"    "A multisociety {Delphi} consensus statement" "$(field title "$BRACED")"
+ck "braced title, last field"     "A multisociety {Delphi} consensus statement" "$(field title "$BRACED_LAST")"
+ck "quote-delimited title"        "A quoted title"  "$(field title "$QUOTED")"
+
+echo "==== NEGATIVE CONTROLS — absent stays absent ===="
+ck "no doi field: empty, not invented"  ""  "$(field doi "$NO_DOI")"
+ck "title still read when doi absent"   "A title"  "$(field title "$NO_DOI")"
+
+echo "==== the shipped fixture that was silently DOI-less ===="
+n_empty="$(python3 - "$V" "$REPO_ROOT/skills/verify-refs/tests/fixtures/corporate_author.bib" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["vr"] = m
+spec.loader.exec_module(m)
+recs = m.parse_bib(open(sys.argv[2], encoding="utf-8").read())
+print(sum(1 for r in recs if not r.doi))
+PY
+)"
+ck "entries with no parsed DOI"   0  "$n_empty"
+
+echo "==== duplicate detection needs the DOI it was not getting ===="
+dup="$(python3 - "$V" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["vr"] = m
+spec.loader.exec_module(m)
+bib = """@article{a,
+  author = {Smith, John},
+  title  = {First},
+  doi    = {10.1000/same}
+}
+
+@article{b,
+  author = {Doe, Jane},
+  title  = {Second},
+  doi    = {10.1000/same}
+}
+"""
+print(len(m.detect_duplicates(m.parse_bib(bib))))
+PY
+)"
+ck "two DOI-last entries sharing a DOI"  1  "$dup"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: the last field parses, brace groups survive, and an absent DOI stays absent."


### PR DESCRIPTION
## The bug

BibTeX makes the comma after an entry's **final** field optional. Both field regexes required one:

```python
doi_match = re.search(r"doi\s*=\s*[\{\"](.+?)[\}\"]\s*,", entry, ...)   # ← mandatory comma
```

So an entry ending in `doi = {10.1097/...}` — an extremely common shape — parsed with **no DOI**:

```
doi last          -> doi=''
doi + comma       -> doi='10.1097/hep.0000000000000520'
```

And an empty DOI is not a small loss. It **skips the CrossRef check entirely** and drops the record onto the soft-flagged OpenAlex title path, **where the full-author cross-check is disabled**. The anti-fabrication check `/verify-refs` exists to perform was silently off for those references — and it announced nothing, because the record came back verified by a weaker route.

The repo's own shipped fixture proves the reach: all **3** entries in `skills/verify-refs/tests/fixtures/corporate_author.bib` were being read with no DOI. `detect_duplicates`, which keys on DOI, could not see two entries sharing one.

## `title` had the same defect and needed the opposite remedy

`title` cannot take an optional comma — a non-greedy match would then stop at the inner `}` of a brace-protected group and return *"A multisociety {Delphi"*. Both fields are now read by **counting braces**, which is correct in either position:

| | before | after |
|---|---|---|
| `doi` last | `''` | `10.1000/xyz789` |
| `title` last | `''` | `A plain title` |
| `title = {A multisociety {Delphi} consensus}`, comma after | full | full |
| `title` braced **and** last | `''` | full |
| quote-delimited title | works | works |
| **no `doi` field at all** | `''` | **`''`** |

The last row is the point: this widens what is *read*, never what is *assumed*.

## Order mattered

Enabling the author cross-check on this population **before** #443 would have converted a silent gap into a wave of false `AUTHOR MISMATCH` verdicts — consortium papers are precisely the entries most likely to carry both a trailing DOI and an `and others` author list. #443 landing first is what makes this safe.

## Verification

`skills/verify-refs/tests/test_bib_last_field.sh` — network-free, wired into `validate.yml`, 10 assertions. Reverting the parser turns **6 red**; the mid-entry form that always worked stays green (so the test is not merely asserting "the new code runs").

Local mirror **222/222**. `skills 58 / detectors 84` unchanged.