### PR TITLE
fix(self-review): an inferred table denominator must reconcile something

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -535,6 +535,9 @@ jobs:
       - name: Run self-review table-percentage challenge (n (%) recompute vs denominator)
         run: bash skills/self-review/scripts/check_table_percentages_challenge/verify.sh
 
+      - name: "Run table-percentage denominator test (an inferred denominator must reconcile something)"
+        run: bash skills/self-review/tests/test_table_percent_denominator.sh
+
       - name: Run self-review nested-group-comparison challenge (subset vs parent cohort)
         run: bash skills/self-review/scripts/check_nested_group_comparison_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 ### Fixed
 
+- **`check_table_percentages` invented a denominator, then reported false arithmetic as a MAJOR.**
+  The most common table in clinical research is a Table 1 of independent binary characteristics with
+  N stated in the **caption**. It declares no column `n = N` and has no Total row, so the checker
+  fell through to summing the column's own counts — 79 + 53 + 40 + 26 = **198** for a study of 132 —
+  and accused all four correct cells, each with a specific wrong replacement percentage, at MAJOR,
+  exit 1 under `--strict`. Telling an author to change a right number to a wrong one is worse than
+  saying nothing: it is the fastest way to teach someone to stop running the checks.
+
+  **Gating on `is_partition` would have been the wrong fix, and the test pins that too.** That flag
+  is derived from the printed percentages summing to ~100, so a partition containing a wrong
+  percentage stops looking like a partition — the check would have gone silent on exactly the error
+  it exists to catch. (Tried it; the negative control caught it.)
+
+  The rule instead distinguishes a **declared** denominator from an **inferred** one. A header
+  `n = N` or a Total row is the author's own statement and is taken at its word: if the arithmetic
+  disagrees, that is the finding. A count-sum is the checker's guess, and a guess that reconciles
+  **none** of the cells is not evidence that every cell is wrong — it is evidence that the guess is
+  wrong. That column now reports `PERCENT_DENOM_UNKNOWN` (INFO) naming the sum it tried and asking
+  for a declared N, instead of four accusations.
+
+  Coverage cost, stated rather than hidden: a caption-N table whose percentages are *genuinely*
+  wrong is now INFO rather than MAJOR, because nothing in the table distinguishes it from a correct
+  one. Recovering N from the caption would close that and is not attempted here.
+
+  `skills/self-review/tests/test_table_percent_denominator.sh` (wired) pins 11 assertions. The
+  original code fails 3; the `is_partition` version fails 2 different ones.
+
 - **A BibTeX entry's last field was not a field.** BibTeX makes the comma after an entry's final
   field optional; the `doi` and `title` regexes both required one. So any entry ending in
   `doi = {...}` — an extremely common shape — yielded `record.doi == ""`, which **skips the CrossRef

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4918,8 +4918,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_table_percentages.py",
-      "size": 8760,
-      "sha256": "32405faecca4b8c28a38a90d272d8849c0451c048938440301bfe9a732d99a37"
+      "size": 11061,
+      "sha256": "faeed0132193a9bc3ca90d061d6e2d185a2e29d50b46165154e76d43edd90d5f"
     },
     {
       "path": "skills/self-review/scripts/check_table_percentages_challenge/expected/bad.txt",

--- a/skills/self-review/scripts/check_table_percentages.py
+++ b/skills/self-review/scripts/check_table_percentages.py
@@ -141,23 +141,55 @@ def audit(text: str, source: str, tol: float = DEFAULT_TOL) -> Report:
                         if tc:
                             denom, src = int(tc.group(1).replace(",", "")), "Total row"
                             break
+            # Summing a column's counts is a denominator only for a partition — mutually exclusive
+            # categories accounting for everyone. For the most common table in clinical research, a
+            # Table 1 of independent binary characteristics with N declared in the CAPTION, the sum
+            # is a meaningless number larger than N, and using it accused every correct cell of bad
+            # arithmetic while printing a specific wrong replacement percentage.
+            #
+            # Gating on `is_partition` is NOT the fix: that flag is computed from the printed
+            # percentages summing to ~100, so a partition with a wrong percentage stops looking like
+            # a partition — the check would go silent on exactly the error it exists to catch.
+            #
+            # The denominator is INFERRED here, unlike a header `n =` or a Total row, which the
+            # author declared. So it must earn its use: keep it only if it explains at least one
+            # cell. A denominator that reconciles nothing is not evidence that every cell is wrong,
+            # it is evidence that it is the wrong denominator. Verified below, after recomputation.
+            inferred = False
             if denom is None:
-                denom, src = sum(p[2] for p in parsed), "column count-sum"
+                denom, src, inferred = sum(p[2] for p in parsed), "column count-sum", True
 
             if not denom:
                 rep.findings.append(Finding("PERCENT_DENOM_UNKNOWN", "INFO", lineno,
                                             f"column {col}", "percentage column with no recoverable denominator"))
                 continue
 
+            column_findings: list[Finding] = []
+            reconciled = 0
             for label, raw, count, pct, _hp in parsed:
                 if count > denom:
                     continue  # not a proportion of this denominator
                 recomputed = 100.0 * count / denom
                 if abs(recomputed - pct) > tol:
-                    rep.findings.append(Finding(
+                    column_findings.append(Finding(
                         "PERCENT_MISMATCH", "MAJOR", lineno, f"{label}: {raw}",
                         f"printed {pct:g}% but {count}/{denom} ({src}) = {recomputed:.1f}% "
                         f"(Δ{abs(recomputed - pct):.1f}pp)"))
+                else:
+                    reconciled += 1
+
+            # An inferred denominator that reconciles NOTHING is the wrong denominator, not proof
+            # that every cell is wrong. Report the gap rather than the accusation. A declared
+            # denominator (header `n =`, Total row) is never second-guessed this way: if the author
+            # states N and the arithmetic disagrees, that is the finding.
+            if inferred and column_findings and reconciled == 0:
+                rep.findings.append(Finding(
+                    "PERCENT_DENOM_UNKNOWN", "INFO", lineno, f"column {col}",
+                    f"percentage column with no declared denominator; the column count-sum "
+                    f"({denom}) reconciles none of {len(column_findings)} cell(s), so it is not the "
+                    f"denominator — declare N in the column header (n = N) or a Total row to check"))
+            else:
+                rep.findings.extend(column_findings)
     return rep
 
 

--- a/skills/self-review/tests/test_table_percent_denominator.sh
+++ b/skills/self-review/tests/test_table_percent_denominator.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression test: an INFERRED denominator must earn its use.
+#
+# The most common table in clinical research is a Table 1 of independent binary characteristics with
+# N stated in the CAPTION. It declares no column `n = N` and has no Total row, so the checker fell
+# through to summing the column's counts — 79 + 53 + 40 + 26 = 198 for a study of 132 — and then
+# accused all four correct cells of bad arithmetic, each with a specific wrong replacement
+# percentage, at MAJOR, exit 1 under --strict. A gate that reds a correct submission and tells the
+# author to change a right number to a wrong one is worse than one that stays quiet.
+#
+# Gating on `is_partition` is NOT the fix and this test pins that: that flag is derived from the
+# printed percentages summing to ~100, so a partition containing a wrong percentage stops looking
+# like a partition and the check would go silent on the very error it exists to catch. The rule is
+# instead that an inferred denominator reconciling NOTHING is the wrong denominator, while a
+# denominator the author DECLARED is never second-guessed.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+D="$REPO_ROOT/skills/self-review/scripts/check_table_percentages.py"
+WORK="$(mktemp -d -t table_percent_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-50s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+rc_of() {  # rc_of <file> -> exit code, no pipe between the command and $?
+  python3 "$D" --manuscript "$WORK/$1" --strict > "$WORK/$1.out" 2>&1
+  echo $?
+}
+majors() { grep -c '^\[MAJOR\]' "$WORK/$1.out" || true; }
+has_info() { grep -q 'PERCENT_DENOM_UNKNOWN' "$WORK/$1.out" && echo yes || echo no; }
+
+# 1. The real-world false positive: caption N, independent binary rows, every percentage correct.
+cat > "$WORK/caption_n.md" <<'EOF'
+## Results
+
+**Table 1.** Baseline characteristics of the 132 enrolled patients.
+
+| Characteristic | Value |
+|---|---|
+| Male sex | 79 (59.8%) |
+| Hypertension | 53 (40.2%) |
+| Diabetes | 40 (30.3%) |
+| Current smoker | 26 (19.7%) |
+EOF
+
+# 2. A genuine partition with one wrong percentage. The count-sum IS the denominator here and
+#    reconciles 2 of 3 rows, so the wrong one must still be caught.
+cat > "$WORK/partition_bad.md" <<'EOF'
+## Results
+
+**Table 2.** Tumour stage distribution.
+
+| Stage | n (%) |
+|---|---|
+| I | 40 (99.0%) |
+| II | 30 (30.0%) |
+| III | 30 (30.0%) |
+EOF
+
+# 3. A correct partition: silent.
+cat > "$WORK/partition_ok.md" <<'EOF'
+## Results
+
+**Table 3.** Tumour stage distribution.
+
+| Stage | n (%) |
+|---|---|
+| I | 40 (40.0%) |
+| II | 30 (30.0%) |
+| III | 30 (30.0%) |
+EOF
+
+# 4. A DECLARED denominator that the arithmetic contradicts. Never second-guessed.
+cat > "$WORK/declared_bad.md" <<'EOF'
+## Results
+
+**Table 4.** Characteristics.
+
+| Characteristic | Value (n = 132) |
+|---|---|
+| Male sex | 79 (75.0%) |
+EOF
+
+echo "==== the false positive this fixes ===="
+ck "caption-N Table 1: exit 0"            0   "$(rc_of caption_n.md)"
+ck "caption-N Table 1: zero MAJOR"        0   "$(majors caption_n.md)"
+ck "caption-N Table 1: says why (INFO)"   yes "$(has_info caption_n.md)"
+
+echo "==== NEGATIVE CONTROLS — the check must still bite ===="
+ck "partition with a wrong %: exit 1"     1   "$(rc_of partition_bad.md)"
+ck "partition with a wrong %: 1 MAJOR"    1   "$(majors partition_bad.md)"
+ck "declared n= contradicted: exit 1"     1   "$(rc_of declared_bad.md)"
+ck "declared n= contradicted: 1 MAJOR"    1   "$(majors declared_bad.md)"
+ck "declared n= is never downgraded"      no  "$(has_info declared_bad.md)"
+
+echo "==== a correct partition stays silent ===="
+ck "correct partition: exit 0"            0   "$(rc_of partition_ok.md)"
+ck "correct partition: no findings at all" 0  "$(majors partition_ok.md)"
+ck "correct partition: no INFO either"    no  "$(has_info partition_ok.md)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || { for f in caption_n partition_bad declared_bad partition_ok; do
+    echo "--- $f"; cat "$WORK/$f.md.out"; done; exit 1; }
+echo "OK: an inferred denominator must reconcile something; a declared one is taken at its word."


### PR DESCRIPTION
## The false positive

The most common table in clinical research — a Table 1 of independent binary characteristics, N in the **caption**:

```
**Table 1.** Baseline characteristics of the 132 enrolled patients.

| Male sex       | 79 (59.8%) |   79/132 = 59.8%  ✓
| Hypertension   | 53 (40.2%) |   53/132 = 40.2%  ✓
| Diabetes       | 40 (30.3%) |   40/132 = 30.3%  ✓
| Current smoker | 26 (19.7%) |   26/132 = 19.7%  ✓
```

Every cell correct. The checker's verdict, before this PR:

```
[MAJOR] printed 59.8% but 79/198 (column count-sum) = 39.9% (Δ19.9pp)
[MAJOR] printed 40.2% but 53/198 (column count-sum) = 26.8% (Δ13.4pp)
[MAJOR] printed 30.3% but 40/198 (column count-sum) = 20.2% (Δ10.1pp)
[MAJOR] printed 19.7% but 26/198 (column count-sum) = 13.1% (Δ6.6pp)
--strict → exit 1
```

79 + 53 + 40 + 26 = **198**, which is not a denominator for anything. Telling an author to change a right number to a wrong one is worse than saying nothing — it is the fastest way to teach someone to stop running the checks.

## The obvious fix is wrong, and the test pins that

`is_partition` is already computed two lines above, so gating on it looks right. It is not: that flag is derived from **the printed percentages summing to ~100**, so a partition containing a wrong percentage stops looking like a partition — and the check goes silent on exactly the error it exists to catch. I tried it; the negative control caught it, and the test now keeps it caught.

## The rule that works: declared vs inferred

| denominator | source | treatment |
|---|---|---|
| header `n = N`, Total row | the **author** stated it | taken at its word — if the arithmetic disagrees, that is the finding |
| column count-sum | the **checker** guessed it | must reconcile at least one cell, or it is the wrong guess |

A guess that reconciles **none** of the cells is not evidence that every cell is wrong. That column now reports `PERCENT_DENOM_UNKNOWN` (INFO), naming the sum it tried and asking for a declared N.

## Coverage cost, stated not hidden

A caption-N table whose percentages are *genuinely* wrong is now INFO rather than MAJOR — nothing in the table distinguishes it from a correct one. Recovering N from the caption would close that gap; it is not attempted here.

## Verification

`skills/self-review/tests/test_table_percent_denominator.sh`, wired, 11 assertions:

- original code → **3 fail** (the caption-N table reds with 4 MAJORs)
- `is_partition` version → **2 different fail** (partition with a wrong % goes silent)
- this PR → 11/11

Existing challenge card unaffected. Local mirror **223/223**. `skills 58 / detectors 84` unchanged.