### PR TITLE
fix(manage-refs): writing "Figures 1 and 2" turned off the submission blocker

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -433,6 +433,9 @@ jobs:
       - name: "Run manage-refs separate-supplement test (a gate red on correct work gets skipped)"
         run: bash skills/manage-refs/tests/test_xref_separate_supplement.sh
 
+      - name: "Run manage-refs plural-citation test (phrasing must not change the verdict)"
+        run: bash skills/manage-refs/tests/test_xref_plural_citations.sh
+
       - name: Run manage-refs CSL-render hardening test
         run: bash skills/manage-refs/tests/test_csl_render.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Fixed
 
+- **Writing "Figures 1 and 2" turned off the submission blocker.** `check_xref` recognised only the
+  singular mention; the plural "s" breaks its `\s+`, so `Figures 1 and 2`, `Tables 1-3` and
+  `Figures 2, 4 and 5` matched **nothing**. That is not a missed note — a float cited only that way
+  scored `UNCITED` instead of `MISSING_DOCX`, and `UNCITED` is not in `blocking_statuses`. Two
+  manuscripts identical in meaning got opposite verdicts on the same DOCX:
+
+  ```
+  "As shown in Figures 1 and 2"        -> exit 0, submission_safe: true
+  "As shown in Figure 1 and Figure 2"  -> exit 1, SUBMISSION BLOCKED (Figure 2 missing from the DOCX)
+  ```
+
+  Ordinary English disabled the gate; the repetitive phrasing this tool's own examples happen to use
+  kept it on. `skill.yml` calls this detector a hard submission blocker, and for anyone who writes
+  the way journals ask them to, it was not one.
+
+  Plural mentions are now read, and their number lists **expanded**: `Figures 1-3` is three floats,
+  not two, because an endpoint-only read drops Figure 2 — the same missing-blocker outcome, one
+  number further in. `to` and `through` are expanded as ranges too, since the list pattern already
+  accepted them as joins and would otherwise have dropped the interior of `Figures 3 to 5`. A
+  descending pair (`Figures 5-2`) is read as two endpoints rather than an invented range, and a
+  lettered panel range (`Figure 2A-2C`) is left alone.
+
+  `skills/manage-refs/tests/test_xref_plural_citations.sh` (wired) pins the equivalence itself — the
+  same package must get the same verdict however the citation is phrased — plus the negative
+  controls: a genuinely uncited figure still reports `UNCITED`, a complete package still exits 0,
+  and the singular is not double-counted inside the plural. Reverting the parser turns 6 of its 11
+  assertions red, including `submission_safe expected=False actual=True`.
+
 - **`check_table_percentages` invented a denominator, then reported false arithmetic as a MAJOR.**
   The most common table in clinical research is a Table 1 of independent binary characteristics with
   N stated in the **caption**. It declares no column `n = N` and has no Total row, so the checker

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2648,8 +2648,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_xref.py",
-      "size": 28404,
-      "sha256": "ad5dc74c4c233ba1aedd6ac7b6e025c5db59ad3d729dd7752f102fa3e92742ae"
+      "size": 31099,
+      "sha256": "13d89487a740fdac9b55f6f92d8228fea2c7ae4b8d1c32f96bab3616be8a5b32"
     },
     {
       "path": "skills/manage-refs/scripts/fill_journal_abbrev.py",

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -81,6 +81,30 @@ CITE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# The same mention written the way people actually write it: a PLURAL kind word carrying a list of
+# numbers — "Figures 1 and 2", "Tables 1-3", "Figures 2, 4 and 5". CITE_RE cannot see any of these
+# (the plural "s" breaks its `\s+`), and the consequence was not a missed note but a DISABLED GATE:
+# a float cited only this way scored UNCITED rather than MISSING_DOCX, and UNCITED is not in
+# `blocking_statuses`. Two manuscripts identical in meaning got opposite verdicts —
+#   "Figures 1 and 2"       -> exit 0, submission_safe
+#   "Figure 1 and Figure 2" -> exit 1, SUBMISSION BLOCKED
+# — so writing ordinary English turned the blocker off, while the repetitive form this tool's own
+# examples happen to use kept it on.
+CITE_LIST_RE = re.compile(
+    r"(?<![A-Za-z])(Supplementary\s+|Supp\s+|Supp\.\s+|S\.\s*)?"
+    r"(Tables|Figures|Figs\.|Figs)\s+"
+    r"(S?\d+[A-Za-z]?(?:\s*(?:,|&|–|—|-|and|to|through)\s*S?\d+[A-Za-z]?)*)",
+    re.IGNORECASE,
+)
+
+# One token inside a numlist, with an optional "A-B" range tail. A range must be EXPANDED: reading
+# "Figures 1-3" as {1, 3} silently drops Figure 2 — the same missing-blocker outcome, one number in.
+# The separators must match what CITE_LIST_RE accepts as a JOIN, or a form it lets through gets read
+# as two endpoints and the interior is dropped: "Figures 3 to 5" scoring {3, 5} loses Figure 4 exactly
+# as an unexpanded "3-5" would.
+CITE_TOKEN_RE = re.compile(
+    r"(S?)(\d+)([A-Za-z]?)(?:\s*(?:[–—-]|to|through)\s*(S?)(\d+)([A-Za-z]?))?", re.IGNORECASE)
+
 # Caption definition (start of line, optional bold markdown). Matches:
 #   Table 1. Caption text...
 #   **Table 1.** Caption...
@@ -181,6 +205,22 @@ def extract_citations(md_text: str, body_caption_offsets: list[tuple[int, int]])
     labels: list[Label] = []
     for m in CITE_RE.finditer(text):
         labels.append(_normalize(m.group(2), m.group(1), m.group(3)))
+    # Plural mentions carrying a numlist. Singular "Figure" is a prefix of plural "Figures", so the
+    # two patterns cannot both match the same span and no citation is double-counted.
+    for m in CITE_LIST_RE.finditer(text):
+        supp, kind, numlist = m.group(1), m.group(2), m.group(3)
+        # Normalise the plural kind word to the singular the label vocabulary uses.
+        singular = "Table" if kind.lower().startswith("table") else "Figure"
+        for supp_a, num_a, suf_a, supp_b, num_b, suf_b in CITE_TOKEN_RE.findall(numlist):
+            if num_b and not suf_a and not suf_b and int(num_b) >= int(num_a):
+                # A true range: expand it. A lettered endpoint ("2A-2C") is a panel range, not a
+                # float range, so it is left to its endpoints rather than invented over.
+                for n in range(int(num_a), int(num_b) + 1):
+                    labels.append(_normalize(singular, supp, f"{supp_a}{n}"))
+            else:
+                labels.append(_normalize(singular, supp, f"{supp_a}{num_a}{suf_a}"))
+                if num_b:
+                    labels.append(_normalize(singular, supp, f"{supp_b}{num_b}{suf_b}"))
     return labels
 
 

--- a/skills/manage-refs/tests/test_xref_plural_citations.sh
+++ b/skills/manage-refs/tests/test_xref_plural_citations.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Regression test: a plural float mention is a citation.
+#
+# `check_xref` recognised only the singular "Figure 1". The plural "s" breaks its `\s+`, so
+# "Figures 1 and 2" — the way people actually write it — matched NOTHING. The consequence was not a
+# missed note, it was a disabled gate: a float cited only that way scored UNCITED instead of
+# MISSING_DOCX, and UNCITED is not in `blocking_statuses`. Two manuscripts identical in meaning got
+# opposite verdicts:
+#
+#     "Figures 1 and 2"        -> exit 0, submission_safe: true   <- Figure 2 absent from the DOCX
+#     "Figure 1 and Figure 2"  -> exit 1, SUBMISSION BLOCKED
+#
+# So ordinary English turned the submission blocker off, while the repetitive form this tool's own
+# examples happen to use kept it on. The invariant this test pins is that equivalence: the same
+# package must get the same verdict however the citation is phrased.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+X="$REPO_ROOT/skills/manage-refs/scripts/check_xref.py"
+WORK="$(mktemp -d -t xref_plural_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# A DOCX containing ONLY Figure 1's caption, so Figure 2 is genuinely absent from the rendered file.
+mk_docx() {  # mk_docx <path> <caption text...>
+  python3 - "$@" <<'PY'
+import sys, zipfile
+out, caps = sys.argv[1], sys.argv[2:]
+body = "".join(f"<w:p><w:r><w:t>{c}</w:t></w:r></w:p>" for c in caps)
+with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("[Content_Types].xml", '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        '<Default Extension="xml" ContentType="application/xml"/>'
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>')
+    z.writestr("_rels/.rels", '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>')
+    z.writestr("word/document.xml", '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>'
+        + body + '</w:body></w:document>')
+PY
+}
+
+mk_md() {  # mk_md <path> <citation sentence> [extra legend lines...]
+  local path="$1" cite="$2"; shift 2
+  {
+    echo "## Results"; echo
+    echo "$cite"; echo
+    echo "## Figure Legends"; echo
+    echo "**Figure 1.** Study flow diagram."; echo
+    echo "**Figure 2.** Kaplan-Meier survival curves."
+    for extra in "$@"; do echo; echo "$extra"; done
+  } > "$path"
+}
+
+run() {  # run <md> <docx> -> exit code; JSON at $WORK/<md>.json
+  python3 "$X" --md "$WORK/$1" --docx "$WORK/$2" --strict --out "$WORK/$1.json" \
+    > "$WORK/$1.out" 2>&1
+  echo $?
+}
+safe() { python3 -c "import json;print(json.load(open('$WORK/$1.json'))['submission_safe'])"; }
+status_of() {  # status_of <md> <label>   e.g. status_of plural.md Figure:2
+  python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+for f in d['findings']:
+    if f['label'] == sys.argv[2]:
+        print(f['status']); break
+else:
+    print('ABSENT')" "$WORK/$1.json" "$2"
+}
+
+mk_docx "$WORK/partial.docx" "Figure 1. Study flow diagram."
+mk_docx "$WORK/full.docx" "Figure 1. Study flow diagram." "Figure 2. Kaplan-Meier survival curves."
+
+mk_md "$WORK/plural.md"     "As shown in Figures 1 and 2, the effect held."
+mk_md "$WORK/repeated.md"   "As shown in Figure 1 and Figure 2, the effect held."
+mk_md "$WORK/range.md"      "As shown in Figures 1-2, the effect held."
+mk_md "$WORK/wordrange.md"  "As shown in Figures 1 to 2, the effect held."
+mk_md "$WORK/uncited.md"    "The analysis is described in the Methods."
+
+echo "==== the equivalence: phrasing must not change the verdict ===="
+rc_plural="$(run plural.md partial.docx)"
+rc_repeat="$(run repeated.md partial.docx)"
+ck "plural 'Figures 1 and 2' blocks"        1 "$rc_plural"
+ck "repetitive form blocks (unchanged)"     1 "$rc_repeat"
+ck "same verdict either way"                "$rc_repeat" "$rc_plural"
+ck "plural: submission_safe false"          False "$(safe plural.md)"
+ck "plural: Figure 2 is MISSING_DOCX"       MISSING_DOCX "$(status_of plural.md Figure:2)"
+
+echo "==== ranges expand; an endpoint-only read would drop the interior ===="
+ck "'Figures 1-2' blocks"                   1 "$(run range.md partial.docx)"
+ck "'Figures 1 to 2' blocks"                1 "$(run wordrange.md partial.docx)"
+
+echo "==== NEGATIVE CONTROLS ===="
+ck "a genuinely uncited figure stays UNCITED" UNCITED "$(run uncited.md full.docx >/dev/null; status_of uncited.md Figure:2)"
+rc_ok="$(run plural.md full.docx)"
+ck "complete package: exit 0"               0 "$rc_ok"
+ck "complete package: submission_safe true" True "$(safe plural.md)"
+ck "no double count (singular is a prefix of plural)" 2 \
+   "$(run repeated.md full.docx >/dev/null; grep -o 'in-text citations: [0-9]*' "$WORK/repeated.md.out" | grep -o '[0-9]*')"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || { for f in plural repeated uncited; do echo "--- $f"; cat "$WORK/$f.md.out"; done; exit 1; }
+echo "OK: 'Figures 1 and 2' and 'Figure 1 and Figure 2' are the same claim, and both block."


### PR DESCRIPTION
## Two manuscripts, same meaning, same DOCX, opposite verdicts

```
"As shown in Figures 1 and 2, the effect held."        →  exit 0, submission_safe: true
"As shown in Figure 1 and Figure 2, the effect held."  →  exit 1, SUBMISSION BLOCKED
```

Figure 2 is absent from the DOCX in **both** runs. `check_xref` recognised only the singular mention — the plural "s" breaks its `\s+` — so `Figures 1 and 2` matched **nothing**:

```
"As shown in Figures 1 and 2, the effect held."  ->  []
"See Figures 1-3 for details."                   ->  []
"See Tables 1 and 2."                            ->  []
"See Figure 1 and Figure 2."                     ->  [Figure:1, Figure:2]
```

And a float nobody cites scores `UNCITED`, which is **not in `blocking_statuses`**. So the gate `skill.yml:56` calls a hard submission blocker was, for anyone writing the way journals ask them to, not one. The repetitive phrasing this tool's own examples happen to use is what kept it on.

## The fix

Plural mentions are read, and their number lists **expanded**:

| written | before | after |
|---|---|---|
| `Figures 1 and 2` | — | 1, 2 |
| `Figures 1-3` | — | 1, **2**, 3 |
| `Figures 3 to 5` | — | 3, **4**, 5 |
| `Figures 2, 4 and 5` | — | 2, 4, 5 |
| `Supplementary Figures S1 and S2` | — | S1, S2 |
| `Figure 1` | 1 | 1 |
| `Figure 2A-2C` (panels) | 2A | 2A |
| `Figures 5-2` (descending) | — | 5, 2 — endpoints, not an invented range |

Expansion is the point, not a nicety: reading `Figures 1-3` as {1, 3} drops Figure 2 — the same missing-blocker outcome, one number further in. `to`/`through` are expanded because the list pattern already accepted them as joins and would otherwise have lost the interior.

## Verification

`skills/manage-refs/tests/test_xref_plural_citations.sh` (wired, 11 assertions) pins the **equivalence** — the same package must get the same verdict however the citation is phrased — plus negative controls: a genuinely uncited figure still reports `UNCITED`, a complete package still exits 0, and the singular is not double-counted inside the plural.

Reverting the parser turns **6 of 11 red**, including `submission_safe expected=False actual=True`.

Local mirror **224/224**. `skills 58 / detectors 84` unchanged.