### PR TITLE
fix(manage-refs): a full stop is not part of the citation key

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -436,6 +436,9 @@ jobs:
       - name: "Run manage-refs plural-citation test (phrasing must not change the verdict)"
         run: bash skills/manage-refs/tests/test_xref_plural_citations.sh
 
+      - name: "Run manage-refs citation-key boundary test (a full stop is not part of the key)"
+        run: bash skills/manage-refs/tests/test_citation_key_boundaries.sh
+
       - name: Run manage-refs CSL-render hardening test
         run: bash skills/manage-refs/tests/test_csl_render.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ### Fixed
 
+- **A citation that ended a sentence swallowed the full stop, and the tool then accused itself.**
+  The key pattern allowed `.` anywhere, but pandoc counts internal punctuation as part of a key only
+  when a letter or digit follows it. So `...as previously reported @Smith2023.` parsed as the key
+  `Smith2023.` — and `check_citation_keys` reported the **same reference** as `UNDEFINED` (no
+  `Smith2023.` in the .bib) and as `UNUSED` (nothing cited `Smith2023`) in one run, exit 1. A
+  citation ending a sentence is most of them. `;` `,` and `]` already terminated the match; `.`
+  `-` `/` `+` leaked, and `.` is the one that ends English sentences. `@Sec.2a` is still one key,
+  because there the period is followed by an alphanumeric — pandoc's own rule, now encoded rather
+  than approximated.
+
+- **Quarto cross-references were read as bibliography keys.** `@fig-flow`, `@tbl-baseline`,
+  `@sec-methods` and the older `@fig:flow` form resolve against the document's own labels;
+  `quarto render` compiles a manuscript full of them without complaint. This checker called every
+  one an undefined reference and exited 1 — on a manuscript in the shape `scripts/init_project.py`
+  scaffolds itself (`manuscript/index.qmd`). They are now excluded from the verdict and **reported
+  under their own heading**, so nothing is silently dropped; and a .bib entry that genuinely happens
+  to be keyed `fig-...` resolves before the exclusion is ever consulted.
+
+  `skills/manage-refs/tests/test_citation_key_boundaries.sh` (wired) pins 13 assertions including
+  the negative controls: a genuinely undefined key still fails and is named, a real `fig-*` bib key
+  is not diverted, and `--strict-unused` still fails. Reverting the parser turns 6 red.
+
 - **Writing "Figures 1 and 2" turned off the submission blocker.** `check_xref` recognised only the
   singular mention; the plural "s" breaks its `\s+`, so `Figures 1 and 2`, `Tables 1-3` and
   `Figures 2, 4 and 5` matched **nothing**. That is not a missed note — a float cited only that way

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2613,8 +2613,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_citation_keys.py",
-      "size": 4125,
-      "sha256": "b336b661b9d68e42d8829f017d2d55fba22585de6f9d59e2441ffc1c7f5ba3a7"
+      "size": 6593,
+      "sha256": "acf0b653df453ef3d9ed905f09656212ae5f8de6471a19cde52ca415b980fb47"
     },
     {
       "path": "skills/manage-refs/scripts/check_citation_keys_challenge/fixture/manuscript.md",

--- a/skills/manage-refs/scripts/check_citation_keys.py
+++ b/skills/manage-refs/scripts/check_citation_keys.py
@@ -32,9 +32,34 @@ import sys
 from pathlib import Path
 
 # pandoc citation syntax: [@key], [@key, p. 3], [@key1; @key2], [-@key] (suppress author)
-# A key is alnum + : . _ - / +  (per pandoc docs)
-CITE_RE = re.compile(r"(?<![A-Za-z0-9_])-?@([A-Za-z][\w:.\-/+]*)")
+# A key is alnum + : . _ - / + (per pandoc docs) — but pandoc counts internal punctuation as part of
+# the key ONLY when a letter or digit follows it. The old pattern dropped that condition, so a
+# citation ending a sentence — which is most of them — swallowed the full stop:
+#
+#     "...as previously reported @Smith2023."   ->  key "Smith2023."
+#
+# and the tool then reported the SAME reference as UNDEFINED (no `Smith2023.` in the .bib) and as
+# UNUSED (nothing cited `Smith2023`) in a single run. Trailing `;` `,` `]` already terminated the
+# match; `.` `-` `/` `+` leaked, and `.` is the one that ends English sentences. `@Sec.2a` stays one
+# key, because there the period is followed by an alphanumeric — pandoc's own rule, now encoded.
+CITE_RE = re.compile(r"(?<![A-Za-z0-9_])-?@([A-Za-z][\w]*(?:[:.\-/+][\w]+)*)")
 BIB_KEY_RE = re.compile(r"^@\w+\s*\{\s*([^,\s]+)\s*,", re.MULTILINE)
+
+# Quarto / pandoc-crossref cross-references share the `@` sigil but are not bibliography keys:
+# `@fig-flow`, `@tbl-baseline`, `@sec-methods`, `@eq-lik`, and the older `@fig:flow` form. They
+# resolve against the document's own labels, and `quarto render` compiles a manuscript full of them
+# without complaint — while this checker read every one as an undefined reference and exited 1. The
+# repo scaffolds `manuscript/index.qmd` itself (`scripts/init_project.py`), so the toolkit was
+# failing manuscripts in the shape it generates.
+#
+# Excluded from the UNDEFINED verdict, never dropped silently: they are counted and reported. A key
+# with one of these prefixes that IS defined in the .bib resolves normally and never reaches this
+# exclusion, so a real bibliography entry named `fig-...` is unaffected.
+CROSSREF_PREFIXES = (
+    "fig", "tbl", "eq", "sec", "lst", "thm", "lem", "cor", "prp", "cnj",
+    "def", "exm", "exr", "sol", "rem", "alg", "tip", "nte", "wrn", "imp", "cau",
+)
+CROSSREF_RE = re.compile(rf"^(?:{'|'.join(CROSSREF_PREFIXES)})[-:]\w", re.IGNORECASE)
 
 
 def extract_md_keys(md_path: Path) -> set[str]:
@@ -80,10 +105,20 @@ def main() -> int:
     cited = extract_md_keys(args.markdown)
     defined = extract_bib_keys(args.bib)
 
-    undefined = sorted(cited - defined)
+    # Split the unresolved keys before judging them: a Quarto cross-reference resolves against the
+    # document's own labels, not the bibliography, so calling it an undefined citation fails a
+    # manuscript that `quarto render` compiles without complaint. Reported, never silently dropped.
+    unresolved = sorted(cited - defined)
+    crossrefs = [k for k in unresolved if CROSSREF_RE.match(k)]
+    undefined = [k for k in unresolved if not CROSSREF_RE.match(k)]
     unused = sorted(defined - cited)
 
     print(f"[check_citation_keys] cited={len(cited)} defined={len(defined)}")
+    if crossrefs:
+        print(f"\nCROSS-REFERENCES ({len(crossrefs)}) — Quarto/pandoc-crossref labels, not "
+              f"bibliography keys; resolved by the renderer, not checked here:")
+        for k in crossrefs:
+            print(f"  [@{k}]")
     if undefined:
         print(f"\nUNDEFINED ({len(undefined)}) — cited in markdown but not in .bib:")
         for k in undefined:

--- a/skills/manage-refs/tests/test_citation_key_boundaries.sh
+++ b/skills/manage-refs/tests/test_citation_key_boundaries.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression test: where a citation key ENDS, and what an `@` is not.
+#
+# Two defects, both of which made the checker fail correct manuscripts.
+#
+# 1. A citation that ends a sentence swallowed the full stop. The key pattern allowed `.` anywhere,
+#    but pandoc counts internal punctuation as part of a key only when a letter or digit follows it.
+#    So "...as previously reported @Smith2023." parsed as key `Smith2023.` — and the tool then
+#    reported the SAME reference as UNDEFINED (no `Smith2023.` in the .bib) and as UNUSED (nothing
+#    cited `Smith2023`) in one run. A citation ending a sentence is most of them.
+#
+# 2. Quarto / pandoc-crossref cross-references were read as bibliography keys. `@fig-flow`,
+#    `@tbl-baseline`, `@sec-methods` resolve against the document's own labels; `quarto render`
+#    compiles them without complaint. This checker called every one an undefined reference and
+#    exited 1 — on a manuscript in the shape the repo's own `init_project.py` scaffolds.
+#
+# They are excluded from the verdict but REPORTED, so nothing is silently dropped, and a .bib entry
+# that genuinely happens to be named `fig-...` resolves before the exclusion is ever consulted.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+K="$REPO_ROOT/skills/manage-refs/scripts/check_citation_keys.py"
+WORK="$(mktemp -d -t citekey_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+cat > "$WORK/refs.bib" <<'EOF'
+@article{Smith2023,
+  author = {Smith, John},
+  title  = {A title},
+  year   = {2023}
+}
+EOF
+
+cat > "$WORK/figkey.bib" <<'EOF'
+@article{fig-consort,
+  author = {Real, Author},
+  title  = {A paper someone keyed as fig-consort},
+  year   = {2024}
+}
+EOF
+
+run() {  # run <md> <bib> [flags...] -> exit code, output at $WORK/<md>.out
+  local md="$1" bib="$2"; shift 2
+  python3 "$K" "$WORK/$md" "$WORK/$bib" "$@" > "$WORK/$md.out" 2>&1
+  echo $?
+}
+section_count() {  # section_count <md> <SECTION WORD>
+  grep -oE "^$2 \([0-9]+\)" "$WORK/$1.out" | grep -oE '[0-9]+' || echo 0
+}
+
+# --- fixtures ---------------------------------------------------------------------------------
+printf 'Prior work established this [@Smith2023].\n\nAnother sentence cites @Smith2023.\n' \
+  > "$WORK/sentence_end.md"
+
+printf 'A key with internal punctuation: @Sec.2a is one key.\n' > "$WORK/internal_punct.md"
+
+cat > "$WORK/quarto.qmd" <<'EOF'
+---
+title: Example
+---
+
+Prior work established this @Smith2023.
+
+![Study flow](flow.png){#fig-flow}
+
+As shown in @fig-flow, enrolment proceeded. See also @tbl-baseline and @sec-methods.
+EOF
+
+printf 'Cites [@Smith2023] and [@Ghost2024].\n' > "$WORK/undefined.md"
+printf 'Cites [@fig-consort].\n' > "$WORK/figkey.md"
+
+echo "==== 1. a citation ending a sentence is the same citation ===="
+ck "sentence-final @key: exit 0"        0 "$(run sentence_end.md refs.bib)"
+ck "  no UNDEFINED"                     0 "$(section_count sentence_end.md UNDEFINED)"
+ck "  no UNUSED"                        0 "$(section_count sentence_end.md UNUSED)"
+ck "  counted once, not twice"          "cited=1" \
+   "$(grep -oE 'cited=[0-9]+' "$WORK/sentence_end.md.out")"
+
+echo "==== 2. pandoc's actual rule: internal punctuation followed by alphanumeric stays ===="
+run internal_punct.md refs.bib > /dev/null
+ck "@Sec.2a is ONE key, not truncated"  "[@Sec.2a]" \
+   "$(grep -oE '\[@Sec\.2a\]' "$WORK/internal_punct.md.out" | head -1)"
+
+echo "==== 3. Quarto cross-references are not bibliography keys ===="
+ck "Quarto manuscript: exit 0"          0 "$(run quarto.qmd refs.bib)"
+ck "  3 cross-references REPORTED"      3 "$(section_count quarto.qmd CROSS-REFERENCES)"
+ck "  0 undefined"                      0 "$(section_count quarto.qmd UNDEFINED)"
+
+echo "==== NEGATIVE CONTROLS ===="
+ck "a genuinely undefined key still fails" 1 "$(run undefined.md refs.bib)"
+ck "  and it is named"                  "[@Ghost2024]" \
+   "$(grep -oE '\[@Ghost2024\]' "$WORK/undefined.md.out" | head -1)"
+ck "a real .bib key named fig-* resolves" 0 "$(run figkey.md figkey.bib)"
+ck "  not diverted to CROSS-REFERENCES" 0 "$(section_count figkey.md CROSS-REFERENCES)"
+ck "UNUSED detection still works"       1 "$(run undefined.md refs.bib --strict-unused)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || { for f in sentence_end.md quarto.qmd undefined.md figkey.md; do
+    echo "--- $f"; cat "$WORK/$f.out"; done; exit 1; }
+echo "OK: the full stop is punctuation, a cross-reference is not a citation, and a ghost key still fails."


### PR DESCRIPTION
## 1. The tool accused the same reference of two opposite crimes

```markdown
Prior work established this [@Smith2023].

Another sentence cites @Smith2023.
```

```
UNDEFINED (1) — cited in markdown but not in .bib:
  [@Smith2023.]
```

The key pattern allowed `.` anywhere, so a citation ending a sentence parsed as `Smith2023.` — reported **UNDEFINED** (no such bib key) and, in the same run, **UNUSED** (nothing cited `Smith2023`). Exit 1.

A citation ending a sentence is most of them. `;` `,` and `]` already terminated the match; `.` `-` `/` `+` leaked, and `.` is the one that ends English sentences.

Pandoc's actual rule is that internal punctuation belongs to the key **only when a letter or digit follows it**. That is now encoded rather than approximated, so `@Sec.2a` remains one key while `@Smith2023.` does not.

## 2. Quarto cross-references were read as bibliography keys

```
UNDEFINED (4):  [@Smith2023.]  [@fig-flow]  [@sec-methods.]  [@tbl-baseline]
```

`@fig-flow`, `@tbl-baseline`, `@sec-methods` (and the older `@fig:flow`) resolve against the document's own labels. `quarto render` compiles a manuscript full of them without complaint; this checker exited 1 on every one — **on a manuscript in the shape `scripts/init_project.py` scaffolds itself** (`manuscript/index.qmd`).

They now get their own report heading and are excluded from the verdict:

```
CROSS-REFERENCES (3) — Quarto/pandoc-crossref labels, not bibliography keys;
resolved by the renderer, not checked here:
  [@fig-flow]  [@sec-methods]  [@tbl-baseline]
OK: all cited keys defined and all defined keys used.
```

Excluded, **never silently dropped** — and a .bib entry genuinely keyed `fig-...` is `defined`, so it resolves before the exclusion is ever consulted.

## Verification

`skills/manage-refs/tests/test_citation_key_boundaries.sh` (wired), 13 assertions, including the negative controls that matter:

| control | result |
|---|---|
| a genuinely undefined `@Ghost2024` | still exit 1, still named |
| a real .bib key `fig-consort` | resolves; **not** diverted to CROSS-REFERENCES |
| `--strict-unused` | still fails |
| `@Sec.2a` | still one key |

Reverting the parser turns **6 of 13 red**.

Local mirror **225/225**. `skills 58 / detectors 84` unchanged.