### PR TITLE
fix(polish-language): the linter told authors to write "type two diabetes"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -445,6 +445,9 @@ jobs:
       - name: Run polish-language consistency-linter challenge
         run: bash skills/polish-language/scripts/lint_challenge/verify.sh
 
+      - name: "Run polish-language numeral-designator test (\"type 2 diabetes\" is not \"type two\")"
+        run: bash skills/polish-language/tests/test_numeral_designators.sh
+
       - name: "Run polish-language figure-source locale challenge (UK word in a .pptx/.py label fires; universals stay silent)"
         run: bash skills/polish-language/scripts/lint_figure_locale_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Fixed
 
+- **The linter told authors to write "type two diabetes".** `check_small_numbers` flagged any single
+  digit followed by a lowercase word. On nine ordinary clinical sentences it was right **twice**;
+  the other seven were labels, not counts:
+
+  | sentence | advice given |
+  |---|---|
+  | Patients with **type 2** diabetes | *"2 diabetes" — spell out* |
+  | **Grade 3** adverse events | *"3 adverse" — spell out* |
+  | **Stage 4** disease | *"4 disease" — spell out* |
+  | **Phase 3** trials | *"3 trials" — spell out* |
+  | See **Table 2** for details | *"2 for" — spell out* |
+  | appears in **Figure 1** above | *"1 above" — spell out* |
+  | At **day 7** follow-up | *"7 follow" — spell out* |
+
+  Advice that turns a correct sentence into a wrong one is the fastest way to teach an author to
+  stop running the linter, and "spell out Table 2" additionally breaks `check_figure_citation`,
+  which then cannot find the reference — one detector's output made another one's input invalid.
+
+  A digit that **names** something is now exempt, decided by the word before it: 60-odd document and
+  clinical designators (Figure/Table/Section/Phase/Grade/Stage/Type/Class/Group/Arm/day/week/year…).
+  Keying on the preceding word rather than the following one is the whole point — "8 patients" and
+  "3 deaths" are genuine counts and look identical from the right-hand side. Across this repo's own
+  markdown the change removes **308 of 1,499** flags (21%) and adds none.
+
+  `skills/polish-language/tests/test_numeral_designators.sh` (wired) pins 16 assertions in both
+  directions, including that a designator elsewhere in the line does not excuse a real count later
+  in it. Reverting the rule turns 10 red.
+
 - **A citation that ended a sentence swallowed the full stop, and the tool then accused itself.**
   The key pattern allowed `.` anywhere, but pandoc counts internal punctuation as part of a key only
   when a letter or digit follows it. So `...as previously reported @Smith2023.` parsed as the key

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3623,8 +3623,8 @@
     },
     {
       "path": "skills/polish-language/scripts/lint_consistency.py",
-      "size": 13850,
-      "sha256": "ed6067e9d8968dec7d913aec92be06676d1d250aaee613b390355dcb872392c1"
+      "size": 15665,
+      "sha256": "f380439fae1fd41b966862957ca4232467a1d1701dd5a19c35c1864b3df9aea2"
     },
     {
       "path": "skills/polish-language/scripts/lint_figure_locale.py",

--- a/skills/polish-language/scripts/lint_consistency.py
+++ b/skills/polish-language/scripts/lint_consistency.py
@@ -107,6 +107,29 @@ NUM_RANGE_RE = re.compile(r"(?<![\w/.\-])(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)(?![\w/.
 PVAL_RE = re.compile(r"(?<![A-Za-z])([Pp])\s*([=<>])\s*(0?\.\d+|\d+\.\d+|\.\d+)")
 SMALL_NUM_RE = re.compile(r"(?<![\w.=<>+\-/])([1-9])\s+([a-z]{3,})")
 
+# A single digit that NAMES something is not a counted quantity, and spelling it out is wrong.
+# "type 2 diabetes" is not "type two diabetes" — nor is Grade 3, Stage 4, Phase 3, day 7, Table 2 or
+# Figure 1. The rule fired on every one of those: across nine ordinary clinical sentences it was
+# right twice. Across this repo's own markdown it produced 1,499 flags, 277 of them a digit directly
+# after a designator word. Advice that turns a correct sentence into a wrong one is the fastest way
+# to teach an author to stop running the linter, so the designator — not the digit — decides.
+#
+# Deliberately keyed on the preceding word rather than on what follows: "8 patients" and "3 deaths"
+# are counts and must still be flagged, and they look identical to "type 2 diabetes" from the right.
+DESIGNATOR_WORDS = (
+    # document structure
+    "figure", "figures", "fig", "figs", "table", "tables", "section", "sections", "panel",
+    "appendix", "supplement", "supplementary", "reference", "ref", "equation", "eq", "chapter",
+    "box", "step", "item", "question", "aim", "objective", "part", "page", "line", "row",
+    "column", "note", "phase",
+    # clinical and study designators
+    "type", "grade", "stage", "class", "level", "group", "arm", "cohort", "visit", "cycle",
+    "tier", "category", "version", "model", "site", "center", "centre", "wave", "round",
+    "session", "period", "day", "week", "month", "year", "trimester", "quarter",
+)
+DESIGNATOR_RE = re.compile(
+    r"(?:^|[^\w-])(?:" + "|".join(DESIGNATOR_WORDS) + r")\.?\s*$", re.IGNORECASE)
+
 
 # --------------------------------------------------------------------------- #
 # Checks (each returns list[(line, message)])
@@ -232,6 +255,10 @@ def check_small_numbers(lines):
         for m in SMALL_NUM_RE.finditer(line):
             word = m.group(2)
             if word in UNIT_TOKENS:
+                continue
+            # A digit that names something ("type 2", "Grade 3", "Table 2", "day 7") is a label, not
+            # a count. Spelling it out produces "type two diabetes".
+            if DESIGNATOR_RE.search(line[: m.start(1)]):
                 continue
             out.append((i, f'"{m.group(1)} {word}" — spell out single-digit numbers in prose'))
     return out

--- a/skills/polish-language/tests/test_numeral_designators.sh
+++ b/skills/polish-language/tests/test_numeral_designators.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Regression test: a digit that NAMES something is not a counted quantity.
+#
+# `check_small_numbers` flagged any single digit followed by a lowercase word and told the author to
+# spell it out. On nine ordinary clinical sentences it was right twice. The rest were labels:
+#
+#     "Patients with type 2 diabetes"  ->  "2 diabetes" — spell out   ->  "type two diabetes"
+#     "Grade 3 adverse events"         ->  "3 adverse"
+#     "Stage 4 disease"                ->  "4 disease"
+#     "See Table 2 for details"        ->  "2 for"
+#     "At day 7 follow-up"             ->  "7 follow"
+#
+# Advice that turns a correct sentence into a wrong one is the fastest way to teach an author to stop
+# running the linter — and "spell out Table 2" additionally breaks `check_figure_citation`, which
+# then cannot find the reference. Across this repo's own markdown the rule produced 1,499 flags; 308
+# of them were this.
+#
+# The exemption is keyed on the word BEFORE the digit, not on what follows: "8 patients" and
+# "3 deaths" are genuine counts and look identical from the right-hand side.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+L="$REPO_ROOT/skills/polish-language/scripts/lint_consistency.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-56s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-56s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+flags() {  # flags <sentence> -> number of small-number findings
+  python3 - "$L" "$1" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("lc", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["lc"] = m
+spec.loader.exec_module(m)
+print(len(m.check_small_numbers([sys.argv[2]])))
+PY
+}
+
+echo "==== a designator + digit is a LABEL: must be quiet ===="
+for s in \
+  "Patients with type 2 diabetes were included." \
+  "Grade 3 adverse events occurred in four patients." \
+  "Stage 4 disease was present at baseline." \
+  "Phase 3 trials confirmed this." \
+  "See Table 2 for details." \
+  "The CONSORT diagram appears in Figure 1 above." \
+  "Section 6 describes the audit." \
+  "Group 2 received placebo." \
+  "At day 7 follow-up, the effect persisted." \
+  "In year 3 of follow-up, attrition rose."
+do
+  ck "quiet: ${s:0:44}" 0 "$(flags "$s")"
+done
+
+echo "==== NEGATIVE CONTROLS — a genuine count must still be flagged ===="
+for s in \
+  "We enrolled 8 patients." \
+  "There were 3 deaths." \
+  "A total of 4 centres participated." \
+  "The model used 5 covariates." \
+  "We excluded 2 records after review."
+do
+  ck "flags: ${s:0:44}" 1 "$(flags "$s")"
+done
+
+echo "==== the exemption is anchored to the word, not merely present in the line ===="
+# "type" appears, but the digit belongs to a count later in the sentence.
+ck "designator elsewhere does not excuse a count" 1 \
+   "$(flags "Among patients with type 2 diabetes we excluded 6 records.")"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: labels are left alone, counts are still counted."


### PR DESCRIPTION
## Right twice out of nine

`check_small_numbers` flagged any single digit followed by a lowercase word:

| sentence | advice given | correct? |
|---|---|---|
| Patients with **type 2** diabetes | *"2 diabetes" — spell out* | ✗ → "type two diabetes" |
| **Grade 3** adverse events | *"3 adverse" — spell out* | ✗ |
| **Stage 4** disease | *"4 disease" — spell out* | ✗ |
| **Phase 3** trials | *"3 trials" — spell out* | ✗ |
| See **Table 2** for details | *"2 for" — spell out* | ✗ |
| appears in **Figure 1** above | *"1 above" — spell out* | ✗ |
| At **day 7** follow-up | *"7 follow" — spell out* | ✗ |
| We enrolled **8 patients** | *spell out* | ✓ |
| There were **3 deaths** | *spell out* | ✓ |

Two problems, and the second is the nastier one:

1. Advice that turns a **correct** sentence into a wrong one is the fastest way to teach an author to stop running the linter — and then every other check in this repo goes unrun too.
2. "Spell out Table 2" **breaks `check_figure_citation`**, which can no longer find the reference. One detector's output makes another detector's input invalid.

## The fix

A digit that *names* something is exempt, decided by **the word before it** — 60-odd document and clinical designators (Figure/Table/Section/Panel/Appendix/Equation/Step/Phase/Grade/Stage/Type/Class/Level/Group/Arm/Cohort/Visit/day/week/month/year…).

Keying on the **preceding** word rather than the following one is the whole point: `8 patients` and `type 2 diabetes` are indistinguishable from the right-hand side, and only one of them is a count.

Repo-wide effect on its own markdown: **1,499 → 1,191 flags, removing 308 (21%), adding none.**

## Verification

`skills/polish-language/tests/test_numeral_designators.sh` (wired), 16 assertions in both directions:

- 10 designator sentences must be **quiet**
- 5 genuine counts must still **flag**
- and one that pins the anchoring: *"Among patients with type 2 diabetes we excluded 6 records."* → the designator earlier in the line must **not** excuse the count later in it

Reverting the rule turns **10 red**.

Local mirror **226/226**. `skills 58 / detectors 84` unchanged.