### PR TITLE
fix(present-paper): the detector flagged the page numbers its own generator writes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -415,6 +415,9 @@ jobs:
       - name: Run slide-tells challenge (AI-made deck -> all 6 marks; human-made deck -> CLEAN)
         run: bash skills/present-paper/scripts/check_slide_tells_challenge/verify.sh
 
+      - name: "Run present-paper page-number test (the exemption must cover the generator's own form)"
+        run: bash skills/present-paper/tests/test_slide_page_numbers.sh
+
       - name: "Run deck-budget challenge (same deck: fits an oral, too dense for a keynote)"
         run: bash skills/present-paper/scripts/check_deck_budget_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ### Fixed
 
+- **`check_slide_tells` flagged the page numbers its own template generator writes.**
+  `is_page_number` was `re.fullmatch(r"\d{1,3}", ...)` — a bare `12` and nothing else. Its own
+  docstring says a page number "earns its place — someone in Q&A says *go back to 12*", and then it
+  exempted none of the forms a deck actually uses:
+
+  ```
+  '12'          exempt
+  '2 / 57'      FLAGGED   <- what references/generate_pptx_templates.py::_slidenum emits
+  '12 of 57'    FLAGGED
+  'p. 12'       FLAGGED
+  'Page 12'     FLAGGED
+  'Slide 4'     FLAGGED
+  '- 12 -'      FLAGGED
+  ```
+
+  So the detector reported the output of this repo's **own scaffolding** as clutter, under a
+  remediation line that reads "Keep the page number". A tool that fails its own generator is the
+  clearest possible case of a checker validated against its author's assumptions rather than against
+  anything it will meet.
+
+  The exemption now covers `12`, `12.`, `2 / 57`, `2/57`, `12 | 57`, `12 of 57`, `p./pg/Page 12`,
+  `Slide 4`, `Slide 4 of 20` and `- 12 -`, and stays a **full** match: a shape whose entire text is
+  a page number is furniture, while one that merely contains a number
+  (`Confidential — p. 4`, `Study 3 results`) is chrome and still fires.
+
+  `skills/present-paper/tests/test_slide_page_numbers.sh` (wired) pins 23 assertions, and reads the
+  generator's format string **out of the generator's source** rather than restating it — so if the
+  deck builder's page-number format ever changes without the detector following, the test breaks
+  instead of the user's deck. Reverting the exemption turns 12 red.
+
 - **The linter told authors to write "type two diabetes".** `check_small_numbers` flagged any single
   digit followed by a lowercase word. On nine ordinary clinical sentences it was right **twice**;
   the other seven were labels, not counts:

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3788,8 +3788,8 @@
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells.py",
-      "size": 24730,
-      "sha256": "3b91a0f6850b2badaf1657208a779b892931f50ae4962a7c7ccdfc50836a5396"
+      "size": 26077,
+      "sha256": "7f41906b49d38663cc64de2f9dea69208d73f7f45648b4b65c294efbc88de831"
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells_challenge/make_fixtures.py",

--- a/skills/present-paper/scripts/check_slide_tells.py
+++ b/skills/present-paper/scripts/check_slide_tells.py
@@ -247,9 +247,33 @@ def read_deck(path: Path) -> Tuple[List[List[Shape]], List[str], int, int]:
 # ---------------------------------------------------------------------------------------------
 
 
+### Page numbers, in the forms decks actually use ###############################################
+#
+# The exemption used to be `\d{1,3}` and nothing else, so it covered a bare "12" and missed every
+# other way a deck writes the same thing — including `2 / 57`, which is what this repo's OWN
+# template generator emits (`references/generate_pptx_templates.py`, `_slidenum`). The detector
+# therefore flagged the page numbers its own scaffolding produces, under a remediation line that
+# reads "Keep the page number". Every flagged shape on the shipped demo deck was a page number.
+_PAGE_NUMBER_FORMS = (
+    r"\d{1,3}\.?",                        # 12   12.
+    r"\d{1,3}\s*[/|]\s*\d{1,3}",          # 2 / 57   2/57   12 | 57
+    r"\d{1,3}\s+of\s+\d{1,3}",            # 12 of 57
+    r"[-–—]\s*\d{1,3}\s*[-–—]",           # - 12 -
+    r"(?:p|pg|page)\.?\s*\d{1,3}",        # p. 12   pg 12   Page 12
+    r"(?:slide)\.?\s*\d{1,3}"             # Slide 4
+    r"(?:\s*(?:of|/)\s*\d{1,3})?",        # Slide 4 of 20
+)
+PAGE_NUMBER_RE = re.compile(r"(?:%s)" % "|".join(_PAGE_NUMBER_FORMS), re.IGNORECASE)
+
+
 def is_page_number(text: str) -> bool:
-    """A bare page number earns its place — someone in Q&A says "go back to 12"."""
-    return bool(re.fullmatch(r"\d{1,3}", text.strip()))
+    """A page number earns its place — someone in Q&A says "go back to 12".
+
+    Deliberately a full match: a shape whose ENTIRE text is a page number is furniture the audience
+    uses, while a shape that merely contains a number ("Study 3 results", "Confidential — p. 4") is
+    ordinary chrome and stays flagged.
+    """
+    return bool(PAGE_NUMBER_RE.fullmatch(text.strip()))
 
 
 def mark_chrome(slides, h) -> None:

--- a/skills/present-paper/tests/test_slide_page_numbers.sh
+++ b/skills/present-paper/tests/test_slide_page_numbers.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Regression test: the page-number exemption must cover the forms decks actually use — starting with
+# the one this repo's own generator emits.
+#
+# `is_page_number` was `re.fullmatch(r"\d{1,3}", ...)`. Its docstring says a bare page number "earns
+# its place — someone in Q&A says 'go back to 12'", and then it exempted literally nothing else. So
+# `2 / 57` — the string `references/generate_pptx_templates.py::_slidenum` writes onto every slide it
+# builds — was classified as chrome and flagged, under a remediation line reading "Keep the page
+# number". The detector was flagging the output of its own scaffolding.
+#
+# The exemption stays a FULL match on purpose. A shape whose entire text is a page number is
+# furniture the audience uses; a shape that merely contains a number ("Confidential — p. 4") is
+# ordinary chrome and must stay flagged.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+S="$REPO_ROOT/skills/present-paper/scripts/check_slide_tells.py"
+GEN="$REPO_ROOT/skills/present-paper/references/generate_pptx_templates.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-46s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-46s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+isnum() {
+  python3 - "$S" "$1" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("st", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["st"] = m
+spec.loader.exec_module(m)
+print("yes" if m.is_page_number(sys.argv[2]) else "no")
+PY
+}
+
+echo "==== the forms a deck writes a page number in ===="
+for t in "12" "12." "2 / 57" "2/57" "12 | 57" "12 of 57" "p. 12" "pg 12" "Page 12" \
+         "Slide 4" "Slide 4 of 20" "- 12 -"; do
+  ck "exempt: '$t'" yes "$(isnum "$t")"
+done
+
+echo "==== NEGATIVE CONTROLS — real chrome must stay chrome ===="
+for t in "Confidential" "Draft — do not circulate" "Asan Medical Center" "2026-07-30" \
+         "Study 3 results" "Confidential — p. 4" "Background" "1234" "v2.1"; do
+  ck "chrome: '$t'" no "$(isnum "$t")"
+done
+
+echo "==== the repo's own generator must not produce a flagged shape ===="
+# Read the format string out of the generator rather than restating it, so this assertion breaks if
+# the generator's page-number format ever changes without the detector following.
+fmt="$(python3 - "$GEN" <<'PY'
+import re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"f'\{n\}\s*(.*?)\s*\{total\}'", src)
+sys.stdout.write(m.group(1) if m else "MISSING")
+PY
+)"
+ck "generator's separator found in source" "/" "$fmt"
+ck "generator's own output is exempt" yes "$(isnum "3 $fmt 12")"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: a page number in any ordinary form is furniture; everything else is still chrome."


### PR DESCRIPTION
## A checker that fails its own scaffolding

`is_page_number` was `re.fullmatch(r"\d{1,3}", ...)` — a bare `12` and nothing else. Its docstring says a page number *"earns its place — someone in Q&A says go back to 12"*, and then it exempted none of the forms a deck actually uses:

```
'12'          exempt
'2 / 57'      FLAGGED   ← what references/generate_pptx_templates.py::_slidenum emits
'2/57'        FLAGGED
'12 of 57'    FLAGGED
'p. 12'       FLAGGED
'Page 12'     FLAGGED
'Slide 4'     FLAGGED
'- 12 -'      FLAGGED
```

So `/present-paper` built a deck and then reported its own page numbers as clutter — under a remediation line that reads **"Keep the page number"**.

This is the cleanest instance in the batch of the pattern the whole cluster shares: a detector validated against its author's assumptions rather than against anything it will meet. Here it did not even meet the world — it failed the output of the file sitting next to it.

## The fix

Exempt covers `12`, `12.`, `2 / 57`, `2/57`, `12 | 57`, `12 of 57`, `p./pg/Page 12`, `Slide 4`, `Slide 4 of 20`, `- 12 -`.

It stays a **full** match on purpose — a shape whose entire text is a page number is furniture the audience uses; one that merely *contains* a number is chrome and still fires.

## Verification

`skills/present-paper/tests/test_slide_page_numbers.sh` (wired), 23 assertions:

| must be exempt | must stay chrome |
|---|---|
| 12 · 12. · 2 / 57 · 2/57 · 12 \| 57 | Confidential · Draft — do not circulate |
| 12 of 57 · p. 12 · pg 12 · Page 12 | Asan Medical Center · 2026-07-30 |
| Slide 4 · Slide 4 of 20 · - 12 - | **Study 3 results** · **Confidential — p. 4** · 1234 · v2.1 |

And the assertion that keeps this from regressing quietly: the test **reads the generator's format string out of `generate_pptx_templates.py`** instead of restating it, so if the deck builder's page-number format ever changes without the detector following, the test breaks rather than the user's deck.

Reverting the exemption turns **12 red**.

Local mirror **227/227**. `skills 58 / detectors 84` unchanged.