### PR TITLE
fix(self-review): a gate saying "cannot submit" was an optional Minor

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -577,6 +577,9 @@ jobs:
       - name: "Run self-review refinement-stop challenge (terminal-state loop controller: zero-edit PASS / stop signal)"
         run: bash skills/self-review/scripts/refinement_stop_challenge/verify.sh
 
+      - name: "Run qc severity-vocabulary test (a blocker must not be an optional Minor)"
+        run: bash skills/self-review/tests/test_qc_severity_vocabulary.sh
+
       - name: "Run self-review baseline-drift challenge (framing drift vs the human-approved baseline; clean reword clears)"
         run: bash skills/self-review/scripts/check_baseline_drift_challenge/verify.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Fixed
 
+- **A gate saying "cannot submit" was counted as an optional Minor, and the loop stopped.**
+  `_qc_findings._MAJOR` knew two words, `MAJOR` and `FATAL`. Detectors were written independently
+  and each picked its own vocabulary, so anything else fell into the `else` branch and became Minor.
+  `check_placeholders` marks a leftover `TODO` as `blocker` and exits 1 on it **unconditionally** —
+  and `refinement_stop`, reading that same artifact, answered:
+
+  ```
+  main :  STOP_MINOR_OPTIONAL — "No required edits ... do not treat them as blocking, do not loop"
+  now  :  CONTINUE            — "Genuine work remains -- resolve these before treating the loop as done"
+  ```
+
+  Six words were affected: `blocker`, `hard` (three detectors), `stale`, `unverifiable`, `FAIL`.
+  Membership is **derived from each detector's own exit contract**, not from what the word sounds
+  like — each one had to make its detector `return 1`. `Flag` is deliberately excluded, and that is
+  the control that makes this a derivation rather than a widening: `check_generated_code` computes
+  `n_flag = len(claims) - n_major` and exits only on `n_major`, so its own contract says `Flag` is
+  advisory.
+
+  The module's docstring already stated the right rule for an unrecognised **schema** — *"make it
+  LOUD, not silent"* — because a controller that quietly skips what it cannot read can report a
+  clean `STOP_ZERO_EDIT` over a held Major. An unrecognised **severity** was the same hazard one
+  level down, defaulting the other way. It now counts as Major and is named in the output: for a
+  stop controller, guessing "major" costs one more loop, while guessing "minor" ends the loop over
+  an unfixed blocker.
+
+  `skills/self-review/tests/test_qc_severity_vocabulary.sh` (wired) pins 17 assertions, and the last
+  one closes the class: **every severity literal shipped anywhere in `skills/*/scripts/*.py` must be
+  classified deliberately**, so a newly invented word fails CI instead of silently becoming
+  optional. It earned its place immediately — it found `unverifiable`
+  (`check_checklist_version.py:119`), which this fix's hand enumeration had missed. Reverting the
+  controller turns 6 assertions red.
+
 - **`check_slide_tells` flagged the page numbers its own template generator writes.**
   `is_page_number` was `re.fullmatch(r"\d{1,3}", ...)` — a bare `12` and nothing else. Its own
   docstring says a page number "earns its place — someone in Q&A says *go back to 12*", and then it

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4433,8 +4433,8 @@
     },
     {
       "path": "skills/self-review/scripts/_qc_findings.py",
-      "size": 3187,
-      "sha256": "eac1b20db8c5c66d12243602e9272d60e1fcc9ef3ed0046d5081a74ef33a9343"
+      "size": 6409,
+      "sha256": "f8426cd3bdfb7c80796956b8d7e85afe5ba77a3b6df5a8f0f1fe92be0446d6b4"
     },
     {
       "path": "skills/self-review/scripts/check_analysis_definitions.py",
@@ -5113,8 +5113,8 @@
     },
     {
       "path": "skills/self-review/scripts/refinement_stop.py",
-      "size": 9006,
-      "sha256": "3da6d19311211c4be42984bd0d0d1a134f770e70a4746a8853bc6409458f9ae6"
+      "size": 9684,
+      "sha256": "ba3f88d4eff6d35bf8d3ca56994ca5f56b060b414918efd5f6ee2343d6f2ec20"
     },
     {
       "path": "skills/self-review/scripts/refinement_stop_challenge/expected/continue.txt",

--- a/skills/self-review/scripts/_qc_findings.py
+++ b/skills/self-review/scripts/_qc_findings.py
@@ -24,7 +24,51 @@ from __future__ import annotations
 _LIST_KEYS = ("claims", "findings")
 _VERDICT_KEYS = ("verdict", "kind", "type")
 _WHERE_KEYS = ("where", "location", "line", "table_line")
-_MAJOR = {"MAJOR", "FATAL"}
+# The severity vocabulary is not one word. Detectors were written independently and each picked its
+# own, and `_MAJOR` knew two of them — so a gate that says a manuscript CANNOT be submitted was
+# counted as an optional Minor. `check_placeholders` marks a leftover `TODO` as `blocker` and exits 1
+# on it unconditionally; the stop controller read that as "no required edits, do not loop".
+#
+# Membership below is derived from each detector's OWN exit contract, not from what the word sounds
+# like — the word had to make its detector return 1:
+#   blocker  check_placeholders            `if s["blocker"]: return 1`        (no --strict needed)
+#   hard     check_disclosure_availability `verdict == "BLOCKER"  -> 1`
+#            check_summary_box             `NONCONFORMANT and --strict -> 1`
+#            build_title_page_affiliations `rc = 1`
+#   stale    check_checklist_version       docstring: "0 = in sync, 1 = stale / unverifiable"
+#   unverif. check_checklist_version       same detector, same `return 0 if safe else 1`; its own
+#                                          output line reads "FAIL: checklist is stale or
+#                                          unverifiable". Found by the repo-wide assertion in
+#                                          test_qc_severity_vocabulary.sh, not by enumeration —
+#                                          which is the point of having that assertion.
+#   FAIL     validate_pptx_mac_compat      `--strict and not ok   -> 1`
+#
+# `Flag` is deliberately NOT here, and that is the control that shows this is a derivation rather
+# than a widening: check_generated_code computes `n_flag = len(claims) - n_major` and exits only on
+# `n_major`, so its own contract says Flag is advisory. `soft` and `warn` likewise.
+_MAJOR = {"MAJOR", "FATAL", "BLOCKER", "HARD", "STALE", "UNVERIFIABLE", "FAIL"}
+
+# Known-advisory. Kept explicit so that a severity belonging to NEITHER set is a novel word rather
+# than an assumption — see `_classify` below.
+_MINOR = {"MINOR", "FLAG", "SOFT", "WARN", "WARNING", "INFO", "NOTE", "OK", "PASS", ""}
+
+
+def _classify(severity: str) -> str:
+    """Return "major" | "minor" | "unknown" for a raw severity string.
+
+    Unknown counts as MAJOR. This module's docstring already states the rule for an unrecognised
+    *schema* — make it loud, never silent, because a controller that quietly skips what it cannot
+    read can report a clean STOP_ZERO_EDIT over a held Major. An unrecognised *severity* is the same
+    hazard one level down, and it defaulted the other way: straight into `minor`, straight into
+    "nothing to do". For a stop controller, guessing "major" costs one more loop; guessing "minor"
+    ends the loop over an unfixed blocker.
+    """
+    s = str(severity).strip().upper()
+    if s in _MAJOR:
+        return "major"
+    if s in _MINOR:
+        return "minor"
+    return "unknown"
 
 
 def parse_gate(obj) -> dict | None:
@@ -51,12 +95,20 @@ def parse_gate(obj) -> dict | None:
     # Prefer an authoritative summary.n_major (claims-schema gates); otherwise count Majors from
     # each item's severity (findings-schema gates carry no such summary).
     n_major_sum = summary.get("n_major")
+    unknown_severities: list[str] = []
     if isinstance(n_major_sum, int):
         major = n_major_sum
         minor = max(0, len(dict_items) - major)
     else:
-        major = sum(1 for it in dict_items if str(it.get("severity", "")).strip().upper() in _MAJOR)
-        minor = len(dict_items) - major
+        major = minor = 0
+        for it in dict_items:
+            verdict = _classify(it.get("severity", ""))
+            if verdict == "minor":
+                minor += 1
+            else:
+                major += 1  # "major", and "unknown" fails toward the loop continuing
+                if verdict == "unknown":
+                    unknown_severities.append(str(it.get("severity", "")).strip())
 
     keys = []
     for it in dict_items:
@@ -64,4 +116,5 @@ def parse_gate(obj) -> dict | None:
         where = next((str(it[w]) for w in _WHERE_KEYS if it.get(w) is not None), "?")
         keys.append(f"{verdict}@{where}")
 
-    return {"name": name, "kind": kind, "major": major, "minor": minor, "keys": keys, "parsed": True}
+    return {"name": name, "kind": kind, "major": major, "minor": minor, "keys": keys,
+            "parsed": True, "unknown_severities": sorted(set(unknown_severities))}

--- a/skills/self-review/scripts/refinement_stop.py
+++ b/skills/self-review/scripts/refinement_stop.py
@@ -99,6 +99,7 @@ def classify(qc_dir: Path) -> dict:
     floor_major = floor_minor = ceiling_findings = 0
     gates: list[str] = []
     unparsed: list[str] = []
+    unknown_sev: list[str] = []
     for path in sorted(qc_dir.glob("*.json")):
         try:
             obj = json.loads(path.read_text(encoding="utf-8"))
@@ -112,6 +113,7 @@ def classify(qc_dir: Path) -> dict:
             # a detector-keyed file with an unrecognised schema -- do NOT count it as clean
             unparsed.append(g["name"])
             continue
+        unknown_sev.extend(g.get("unknown_severities") or [])
         if g["kind"] == "ceiling":
             ceiling_findings += g["major"] + g["minor"]
         else:
@@ -134,6 +136,10 @@ def classify(qc_dir: Path) -> dict:
         floor_minor=floor_minor,
         ceiling_findings=ceiling_findings,
     )
+    if unknown_sev:
+        rec += (f" (WARNING: severity word(s) no controller knows: "
+                f"{', '.join(sorted(set(unknown_sev)))} — counted as Major so the loop continues "
+                f"rather than stopping over a verdict nobody classified)")
     if unparsed:
         rec += (f" (WARNING: {len(unparsed)} gate artifact(s) had an unrecognised schema and were "
                 f"NOT counted -- this verdict may understate the floor: "
@@ -147,6 +153,7 @@ def classify(qc_dir: Path) -> dict:
         "ceiling_findings": ceiling_findings,
         "gates_read": sorted(set(gates)),
         "gates_unparsed": sorted(set(unparsed)),
+        "unknown_severities": sorted(set(unknown_sev)),
         "recommendation": rec,
     }
 
@@ -160,6 +167,9 @@ def render(result: dict, qc_dir_display: str) -> str:
         f"  Ceiling pass:  {result['ceiling_findings']} finding(s)",
         f"  Gates read:    {gates}",
     ]
+    if result.get("unknown_severities"):
+        lines.append(f"  Unknown sev:   {', '.join(result['unknown_severities'])}  "
+                     f"(counted as Major — the loop continues rather than stopping on a guess)")
     if result.get("gates_unparsed"):
         lines.append(f"  Unparsed:      {', '.join(result['gates_unparsed'])}  (unrecognised schema — NOT counted)")
     lines.append(f"  qc dir:        {qc_dir_display}")
@@ -190,6 +200,7 @@ def main(argv=None) -> int:
             "ceiling_findings": 0,
             "gates_read": [],
             "gates_unparsed": [],
+            "unknown_severities": [],
             "recommendation": RECOMMENDATIONS["INDETERMINATE"],
         }
     else:

--- a/skills/self-review/tests/test_qc_severity_vocabulary.sh
+++ b/skills/self-review/tests/test_qc_severity_vocabulary.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression test: a gate that says "cannot submit" must not be counted as an optional Minor.
+#
+# `_qc_findings._MAJOR` knew two words, `MAJOR` and `FATAL`. The detectors were written
+# independently and each picked its own vocabulary, so a severity outside those two fell into the
+# `else` branch and was counted Minor. `check_placeholders` marks a leftover `TODO` as `blocker` and
+# exits 1 on it unconditionally — and the stop controller read the same artifact and answered:
+#
+#     STOP_MINOR_OPTIONAL — "No required edits ... do not treat them as blocking and do not loop"
+#
+# Membership in the Major set is derived from each detector's own exit contract, so this test asserts
+# behaviour per word, and — the part that closes the class — asserts that EVERY severity literal
+# shipped anywhere in skills/*/scripts/*.py is classified deliberately. A newly invented word must
+# fail this test rather than silently become an optional Minor.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+R="$REPO_ROOT/skills/self-review/scripts/refinement_stop.py"
+Q="$REPO_ROOT/skills/self-review/scripts/_qc_findings.py"
+WORK="$(mktemp -d -t qc_severity_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-50s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+verdict_for() {  # verdict_for <severity> -> the controller's terminal-state word
+  local sev="$1" d="$WORK/qc_$RANDOM"
+  mkdir -p "$d"
+  python3 - "$d/gate.json" "$sev" <<'PY'
+import json, sys
+json.dump({"detector": "check_placeholders",
+           "findings": [{"verdict": "PLACEHOLDER_LEFT", "severity": sys.argv[2], "line": 42}]},
+          open(sys.argv[1], "w"), indent=1)
+PY
+  python3 "$R" --qc-dir "$d" 2>/dev/null | sed -n '1s/.*: //p'
+}
+
+echo "==== words whose own detector exits 1: the loop must CONTINUE ===="
+for sev in blocker hard stale FAIL MAJOR FATAL Major major; do
+  ck "severity '$sev' -> CONTINUE" CONTINUE "$(verdict_for "$sev")"
+done
+
+echo "==== NEGATIVE CONTROLS — advisory words must stay optional ===="
+# check_generated_code computes n_flag = len(claims) - n_major and exits only on n_major, so its own
+# contract says Flag is advisory. Widening indiscriminately would break this.
+for sev in Flag Minor minor soft warn INFO; do
+  ck "severity '$sev' -> STOP_MINOR_OPTIONAL" STOP_MINOR_OPTIONAL "$(verdict_for "$sev")"
+done
+
+echo "==== an unrecognised word fails toward the loop CONTINUING, and is named ===="
+ck "unknown 'urgent' -> CONTINUE" CONTINUE "$(verdict_for urgent)"
+d="$WORK/qc_unknown"; mkdir -p "$d"
+python3 - "$d/gate.json" <<'PY'
+import json, sys
+json.dump({"detector": "check_x",
+           "findings": [{"verdict": "V", "severity": "urgent", "line": 1}]},
+          open(sys.argv[1], "w"), indent=1)
+PY
+ck "  and reported by name" "urgent" \
+   "$(python3 "$R" --qc-dir "$d" --out "$d/stop.json" >/dev/null 2>&1; \
+      python3 -c 'import json,sys; print(",".join(json.load(open(sys.argv[1])).get("unknown_severities",[])))' "$d/stop.json" 2>/dev/null || echo MISSING)"
+
+echo "==== the class-closing assertion: every shipped severity word is classified ===="
+unclassified="$(python3 - "$REPO_ROOT" "$Q" <<'PY'
+import importlib.util, pathlib, re, sys
+root = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("q", sys.argv[2])
+m = importlib.util.module_from_spec(spec)
+sys.modules["q"] = m
+spec.loader.exec_module(m)
+pat = re.compile(r'"severity"\s*:\s*"([A-Za-z_][A-Za-z_ ]*)"')
+words = set()
+for p in root.glob("skills/*/scripts/*.py"):
+    words |= set(pat.findall(p.read_text(encoding="utf-8", errors="replace")))
+bad = sorted(w for w in words if m._classify(w) == "unknown")
+print(",".join(bad))
+PY
+)"
+ck "severity words no controller classifies" "" "$unclassified"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: a blocker blocks, an advisory stays advisory, and a new word cannot join silently."


### PR DESCRIPTION
## Same artifact, opposite instruction

A manuscript with a leftover `TODO`. `check_placeholders` marks it `"severity": "blocker"` and exits 1 on it **unconditionally**. `refinement_stop` reads that artifact:

```
main :  STOP_MINOR_OPTIONAL
        "No required edits -- present the Minor items as an optional menu;
         do not treat them as blocking and do not loop for them."

now  :  CONTINUE
        "Genuine work remains -- resolve these before treating the loop as done."
```

`_qc_findings._MAJOR` was `{"MAJOR", "FATAL"}`. Detectors were written independently and each picked its own vocabulary; anything else fell into the `else` branch and became Minor.

## Membership is derived, not guessed

Each word had to make its own detector `return 1`:

| severity | detector | its own exit contract |
|---|---|---|
| `blocker` | `check_placeholders` | `if s["blocker"]: return 1` — no `--strict` needed |
| `hard` | `check_disclosure_availability` | `verdict == "BLOCKER"` → 1 |
| | `check_summary_box` | `NONCONFORMANT and --strict` → 1 |
| | `build_title_page_affiliations` | `rc = 1` |
| `stale`, `unverifiable` | `check_checklist_version` | *"Exit: 0 = in sync, 1 = stale / unverifiable"* |
| `FAIL` | `validate_pptx_mac_compat` | `--strict and not ok` → 1 |
| **`Flag`** | `check_generated_code` | `n_flag = len(claims) - n_major`; exits only on `n_major` → **stays Minor** |

`Flag` is the control that makes this a derivation rather than a widening.

## Unknown now fails toward the loop continuing

The module's docstring already states the rule for an unrecognised **schema** — *"make an unreadable one LOUD, not silent: a controller that quietly skips a detector whose schema it does not recognise can report a clean STOP_ZERO_EDIT while a findings-schema gate held a Major."*

An unrecognised **severity** was the same hazard one level down, and defaulted the other way. It now counts as Major and is named in the output. For a stop controller the asymmetry is decisive: guessing "major" costs one more loop; guessing "minor" ends the loop over an unfixed blocker.

## The assertion that closes the class — and caught me

`skills/self-review/tests/test_qc_severity_vocabulary.sh` (wired), 17 assertions. The last one requires that **every severity literal shipped anywhere in `skills/*/scripts/*.py` is classified deliberately**, so a newly invented word fails CI rather than silently becoming optional.

It earned its place on first run: I derived the list by reading exit contracts and got five words. The assertion found a sixth — **`unverifiable`** (`check_checklist_version.py:119`) — which the same detector's `return 0 if safe else 1` makes blocking and whose own output line reads *"FAIL: checklist is stale or unverifiable"*.

Reverting the controller turns **6 of 17 red**.

Local mirror **228/228**. `skills 58 / detectors 84` unchanged.