### PR TITLE
fix(sync-submission): the heading syntax decided whether you were over the word cap

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -288,6 +288,9 @@ jobs:
       - name: Run sync-submission asset-anonymization gate test (A2)
         run: bash skills/sync-submission/tests/test_asset_anonymization.sh
 
+      - name: "Run word-count heading-form test (setext and ATX must measure the same manuscript alike)"
+        run: bash skills/sync-submission/tests/test_wordcount_heading_forms.sh
+
       - name: Run sync-submission disclosure/availability detector test
         run: bash skills/sync-submission/tests/test_disclosure_availability.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Fixed
 
+- **The heading syntax an author happened to use decided whether they were over a journal's word
+  cap.** Markdown has two heading forms and pandoc accepts both; `check_wordcount_cap` recognised
+  only ATX, and only to depth three. Under setext —
+
+  ```markdown
+  References
+  ==========
+  ```
+
+  — the heading was never seen, `in_skip` never turned on, and the **entire References section was
+  counted as body prose**. Byte-identical prose measured **480 words as ATX and 1,002 as setext**.
+  `#### References` failed the same way for a different reason: `#{1,3}` stops at three.
+
+  This gate blocks a submission against a journal's limit, so the failure is not cosmetic — a
+  conforming manuscript written in setext could be reported over the cap, and an author would cut
+  real content to satisfy it.
+
+  Both forms are now recognised, to all six ATX depths. A setext heading is identified by requiring
+  the line above the underline to be non-blank body text, which is exactly what distinguishes it
+  from a horizontal rule — the negative control the test pins.
+
+  `skills/sync-submission/tests/test_wordcount_heading_forms.sh` (wired) asserts the invariant
+  itself: the same prose measures the same length in either syntax. Reverting the parser turns 3 of
+  its 6 assertions red, at 1,002 against an expected 480.
+
 - **A gate saying "cannot submit" was counted as an optional Minor, and the loop stopped.**
   `_qc_findings._MAJOR` knew two words, `MAJOR` and `FATAL`. Detectors were written independently
   and each picked its own vocabulary, so anything else fell into the `else` branch and became Minor.

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5358,8 +5358,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/check_wordcount_cap.py",
-      "size": 9827,
-      "sha256": "4d1c3403efeb4d891c4558d6e784c4088a0d349aad1625f1c348e50665c17f8d"
+      "size": 11299,
+      "sha256": "93b251185bd2168f4d50161e3d0b3c9d2a8f7b2fa36973b01bc89caf194160ee"
     },
     {
       "path": "skills/sync-submission/scripts/cover_letter_drift_check.py",

--- a/skills/sync-submission/scripts/check_wordcount_cap.py
+++ b/skills/sync-submission/scripts/check_wordcount_cap.py
@@ -51,7 +51,7 @@ from _yaml_frontmatter import split_yaml_front_matter
 # --- measurement (shares the skip set + YAML splitter with cover_letter_drift_check.py) -----
 
 SKIP_SECTION_RE = re.compile(
-    r"^#{1,3}\s+\*{0,2}\s*("
+    r"^#{1,6}\s+\*{0,2}\s*("
     r"Abstract|References?|Table\s+Captions?|Table\s+Legends?|Figure\s+Legends?|"
     r"Tables?|Figures?|Supplementary\s+(Materials?|Tables?|Figures?|Appendix)|"
     r"Acknowled[gd]e?ments?|Funding|Conflicts?\s+of\s+Interest|COI|"
@@ -63,7 +63,19 @@ SKIP_SECTION_RE = re.compile(
 WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'./%\-]*")
 # pandoc inline citations: [@key], [@k1; @k2], [-@k]. Count each @key.
 CITE_RE = re.compile(r"@[A-Za-z0-9_][A-Za-z0-9_:.\-]*")
-HEADER_RE = re.compile(r"^#{1,3}\s")
+# Markdown has two heading syntaxes and pandoc accepts both. This recognised only ATX, and only to
+# depth 3 — so under setext ("References" on one line, "==========" under it) the heading was never
+# seen, `in_skip` never turned on, and the ENTIRE References section was counted as body prose.
+# Byte-identical prose measured 480 words as ATX and 1,002 as setext, and this gate blocks a
+# submission on a journal's word cap.
+HEADER_RE = re.compile(r"^#{1,6}\s")
+# A setext underline: at least two `=` or `-` alone on the line. Two, not one, so a stray "-" is not
+# a heading; and the caller additionally requires the line ABOVE to be non-blank body text, which is
+# what separates a setext heading from a horizontal rule.
+SETEXT_UNDERLINE_RE = re.compile(r"^\s{0,3}(={2,}|-{2,})\s*$")
+# The same section names as SKIP_SECTION_RE, with no leading hashes, for the setext form.
+SETEXT_SKIP_RE = re.compile(
+    SKIP_SECTION_RE.pattern.replace(r"^#{1,6}\s+", "^", 1), re.IGNORECASE)
 
 
 def measure_body(manuscript_path: Path) -> tuple[int, int]:
@@ -74,12 +86,20 @@ def measure_body(manuscript_path: Path) -> tuple[int, int]:
     in_code_fence = False
     words = 0
     cites = 0
-    for line in body_lines:
+    for idx, line in enumerate(body_lines):
         stripped = line.rstrip()
         if stripped.startswith("```"):
             in_code_fence = not in_code_fence
             continue
         if in_code_fence:
+            continue
+        # A setext underline belonging to the line above: consume it, never count it as prose.
+        if SETEXT_UNDERLINE_RE.match(stripped) and idx and body_lines[idx - 1].strip():
+            continue
+        # Setext heading: this line is titled by the underline beneath it.
+        nxt = body_lines[idx + 1].rstrip() if idx + 1 < len(body_lines) else ""
+        if stripped.strip() and SETEXT_UNDERLINE_RE.match(nxt):
+            in_skip = bool(SETEXT_SKIP_RE.match(stripped.strip()))
             continue
         if HEADER_RE.match(stripped):
             in_skip = bool(SKIP_SECTION_RE.match(stripped))

--- a/skills/sync-submission/tests/test_wordcount_heading_forms.sh
+++ b/skills/sync-submission/tests/test_wordcount_heading_forms.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression test: the same manuscript must measure the same length in either heading syntax.
+#
+# Markdown has two heading forms and pandoc accepts both. `check_wordcount_cap` recognised only ATX,
+# and only to depth 3. So under setext —
+#
+#     References
+#     ==========
+#
+# — the heading was never seen, `in_skip` never turned on, and the ENTIRE References section was
+# counted as body prose. Byte-identical prose measured 480 words as ATX and 1,002 as setext. This
+# gate blocks a submission against a journal's word cap, so the syntax an author happened to use
+# decided whether their paper was over the limit.
+#
+# `#### References` had the same problem for a different reason: `#{1,3}` stops at three.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+W="$REPO_ROOT/skills/sync-submission/scripts/check_wordcount_cap.py"
+WORK="$(mktemp -d -t wordcount_heading_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-50s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+words_of() {  # words_of <file> -> body word count as a bare integer
+  python3 "$W" --manuscript "$WORK/$1" --limit 100000 2>/dev/null \
+    | sed -n 's/.*body words (md)  *: *//p' | tr -d ', '
+}
+
+python3 - "$WORK" <<'PY'
+import pathlib, sys
+w = pathlib.Path(sys.argv[1])
+body = "The intervention reduced mortality in the enrolled cohort. " * 60
+refs = "Smith J, Doe A. A representative reference title with several words. Journal. 2023. " * 40
+fm = "---\ntitle: Example\n---\n\n"
+
+(w / "atx.md").write_text(f"{fm}## Introduction\n\n{body}\n\n## References\n\n{refs}\n")
+(w / "setext.md").write_text(
+    f"{fm}Introduction\n============\n\n{body}\n\nReferences\n==========\n\n{refs}\n")
+(w / "setext_dash.md").write_text(
+    f"{fm}Introduction\n------------\n\n{body}\n\nReferences\n----------\n\n{refs}\n")
+(w / "deep.md").write_text(f"{fm}## Introduction\n\n{body}\n\n#### References\n\n{refs}\n")
+# A horizontal rule is NOT a setext underline: it follows a blank line.
+(w / "hrule.md").write_text(f"{fm}## Introduction\n\n{body}\n\n---\n\n{body}\n")
+PY
+
+atx="$(words_of atx.md)"
+
+echo "==== the same prose measures the same length in either syntax ===="
+ck "ATX baseline is a real number"        yes "$([ "${atx:-0}" -gt 100 ] && echo yes || echo no)"
+ck "setext '=' equals ATX"                "$atx" "$(words_of setext.md)"
+ck "setext '-' equals ATX"                "$atx" "$(words_of setext_dash.md)"
+ck "#### References is skipped too"       "$atx" "$(words_of deep.md)"
+
+echo "==== NEGATIVE CONTROLS ===="
+# A horizontal rule after a blank line must not turn the paragraph above it into a heading; both
+# paragraphs stay in the body, so the count is twice the Introduction.
+hr="$(words_of hrule.md)"
+ck "horizontal rule is not a heading"     yes \
+   "$([ "$hr" -gt "$atx" ] && echo yes || echo no)"
+# The References text must genuinely be excluded, not merely equal by coincidence: a manuscript with
+# no References section at all must match too.
+python3 - "$WORK" <<'PY'
+import pathlib, sys
+w = pathlib.Path(sys.argv[1])
+body = "The intervention reduced mortality in the enrolled cohort. " * 60
+(w / "norefs.md").write_text(f"---\ntitle: Example\n---\n\n## Introduction\n\n{body}\n")
+PY
+ck "no-References manuscript matches"     "$atx" "$(words_of norefs.md)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: the heading syntax an author chose no longer decides whether they are over the cap."


### PR DESCRIPTION
## Byte-identical prose, two answers

```
atx.md     ->  body words (md) :   480
setext.md  ->  body words (md) : 1,002
```

Same manuscript. The only difference:

```markdown
## References              References
                    vs     ==========
```

`check_wordcount_cap` recognised only ATX headings, and only to depth three. Under setext the heading was never seen, `in_skip` never turned on, and the **entire References section was counted as body prose**. `#### References` failed the same way for a different reason — `#{1,3}` stops at three. One regex, two separate ways of seeing the world too narrowly.

## Why this one is worse than the rest of the batch

Most of this session's fixes made a **correct manuscript fail**. This one makes the **author damage the manuscript**: the gate blocks submission against a journal's limit, so someone writing in setext near a 3,000-word cap is told they are 500 words over and cuts real content to satisfy an overcount that does not exist.

## The fix

Both heading forms, all six ATX depths. A setext heading is identified by requiring the line **above** the underline to be non-blank body text — which is exactly what separates it from a horizontal rule.

## Verification

`skills/sync-submission/tests/test_wordcount_heading_forms.sh` (wired) asserts the invariant rather than a number: *the same prose measures the same length in either syntax.*

| assertion | |
|---|---|
| setext `=` equals ATX | 480 |
| setext `-` equals ATX | 480 |
| `#### References` skipped too | 480 |
| **horizontal rule is not a heading** | both paragraphs stay in the body |
| **a manuscript with no References at all** | matches, so the equality is not coincidence |

Reverting the parser turns **3 of 6 red**, at 1,002 against an expected 480.

Local mirror **229/229**. `skills 58 / detectors 84` unchanged.