### PR TITLE
fix(manage-refs): fill_journal_abbrev.py had never run

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -445,6 +445,9 @@ jobs:
       - name: "Run manage-refs citation-key boundary test (a full stop is not part of the key)"
         run: bash skills/manage-refs/tests/test_citation_key_boundaries.sh
 
+      - name: "Run manage-refs journal-abbrev parsing test (a tool that cannot start is advertised)"
+        run: bash skills/manage-refs/tests/test_journal_abbrev_parsing.sh
+
       - name: Run manage-refs CSL-render hardening test
         run: bash skills/manage-refs/tests/test_csl_render.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ### Fixed
 
+- **`fill_journal_abbrev.py` had never run.** `parse_entries` returned the `Match` objects from
+  `re.finditer` while every caller treats the result as the entry **text**, so the first line of work
+  raised `TypeError: expected string or bytes-like object, got 're.Match'` — on the first entry, for
+  every input. Meanwhile `check_csl_render.py` names this script to the user as the remedy when a
+  journal spec needs `shortjournal`, and `manage-refs/SKILL.md` lists it in the tool table. **A tool
+  that cannot start is worse than a missing one: it is advertised.**
+
+  A second defect was hidden behind the first and only became reachable once it was fixed: `field()`
+  required a trailing comma after the value, and BibTeX makes that comma optional on an entry's
+  **last** field — which `doi` very often is. The DOI would have returned None, no PMID lookup would
+  happen, and the run would have reported *"0/1 entries"* while exiting 0. Same defect class as the
+  reference parser fixed in #445, in a different file.
+
+  Verified end to end against live PubMed: a real entry with a trailing `doi` now resolves and gets
+  `shortjournal = {Hepatology}` written back.
+
+  `skills/manage-refs/tests/test_journal_abbrev_parsing.sh` (wired, network-free) pins the parsing
+  contract — including the caller's exact first line, where the crash happened — plus the
+  absent-DOI negative control. Reverting turns 6 of its 7 assertions red.
+
 - **The heading syntax an author happened to use decided whether they were over a journal's word
   cap.** Markdown has two heading forms and pandoc accepts both; `check_wordcount_cap` recognised
   only ATX, and only to depth three. Under setext —

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -2653,8 +2653,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/fill_journal_abbrev.py",
-      "size": 4533,
-      "sha256": "2782190044944526e1f27572062192466b34e116a4a50c9f3aecc59117b06e6e"
+      "size": 5370,
+      "sha256": "a9d6ceab5a12832c3cbf9a329afef4afa9ed4964ad0e2a34dc5fa7ced5646bd1"
     },
     {
       "path": "skills/manage-refs/scripts/inject_zotero_cwyw.py",

--- a/skills/manage-refs/scripts/fill_journal_abbrev.py
+++ b/skills/manage-refs/scripts/fill_journal_abbrev.py
@@ -45,10 +45,19 @@ def pmids_summary(pmids):
     return {p: {"source": res.get(p, {}).get("source")} for p in pmids}
 
 def parse_entries(bib):
-    return [m for m in re.finditer(r"@\w+\{[^@]*?\n\}", bib, re.S)]
+    # `finditer` yields Match objects, and every caller treats these as the entry TEXT. Returning the
+    # matches meant `re.match(..., b)` received a Match where it wanted a string, and the script died
+    # with `TypeError: expected string or bytes-like object, got 're.Match'` on the FIRST entry — so
+    # it had never run at all, while `check_csl_render.py` names it to the user as the remedy for a
+    # missing `shortjournal`.
+    return [m.group(0) for m in re.finditer(r"@\w+\{[^@]*?\n\}", bib, re.S)]
 
 def field(block, name):
-    m = re.search(rf"{name}\s*=\s*\{{(.+?)\}},", block, re.S)
+    # The trailing comma is optional: BibTeX does not require one after an entry's LAST field, and
+    # `doi` is very often exactly that. Requiring it returned None for those entries, which here
+    # means the DOI is never resolved and the abbreviation is never filled — silently, on the
+    # entries most likely to need it. Same defect class as the reference parser fixed in #445.
+    m = re.search(rf"{name}\s*=\s*\{{(.+?)\}}\s*,?", block, re.S)
     return m.group(1).strip() if m else None
 
 def main():

--- a/skills/manage-refs/tests/test_journal_abbrev_parsing.sh
+++ b/skills/manage-refs/tests/test_journal_abbrev_parsing.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression test: fill_journal_abbrev.py must survive its own first entry.
+#
+# `parse_entries` returned the Match objects from `re.finditer`, while every caller treats the result
+# as the entry TEXT. So the first line of work —
+#
+#     key = re.match(r"@\w+\{([^,]+),", b).group(1)
+#
+# — raised `TypeError: expected string or bytes-like object, got 're.Match'`, on the FIRST entry, for
+# every input. The script had never run. Meanwhile `check_csl_render.py` names it to the user as the
+# remedy when a journal spec needs `shortjournal`, and `manage-refs/SKILL.md` lists it in the tool
+# table. A tool that cannot start is worse than a missing one: it is advertised.
+#
+# The second defect only becomes visible once the first is fixed. `field()` required a trailing comma
+# after the value, and BibTeX makes that comma optional on an entry's LAST field — which `doi` very
+# often is. The DOI would have come back None, no PMID lookup would happen, and the run would report
+# "0/1 entries" while exiting 0. Same defect class as the reference parser fixed in #445.
+#
+# Network-free: asserts the parsing contract, never PubMed.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+F="$REPO_ROOT/skills/manage-refs/scripts/fill_journal_abbrev.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+probe() {  # probe <mode> -> one line of output
+  python3 - "$F" "$1" <<'PY'
+import importlib.util, re, sys
+spec = importlib.util.spec_from_file_location("fja", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["fja"] = m
+spec.loader.exec_module(m)
+mode = sys.argv[2]
+
+DOI_LAST = """@article{Rinella2023,
+\tauthor = {Rinella, Mary E.},
+\tjournal = {Hepatology},
+\tyear = {2023},
+\tdoi = {10.1097/HEP.0000000000000520}
+}
+"""
+DOI_MID = """@article{Smith2023,
+\tauthor = {Smith, John},
+\tdoi = {10.1000/xyz789},
+\tjournal = {Radiology},
+\tyear = {2023}
+}
+"""
+NO_DOI = """@article{Doe2023,
+\tauthor = {Doe, Jane},
+\tjournal = {Radiology},
+\tyear = {2023}
+}
+"""
+TWO = DOI_LAST + "\n" + DOI_MID
+
+if mode == "type":
+    print(type(m.parse_entries(DOI_LAST)[0]).__name__)
+elif mode == "caller":
+    # exactly what main() does first; this is where it used to raise TypeError
+    try:
+        b = m.parse_entries(DOI_LAST)[0]
+        print(re.match(r"@\w+\{([^,]+),", b).group(1).strip())
+    except TypeError as e:
+        print(f"TypeError: {e}")
+elif mode == "count":
+    print(len(m.parse_entries(TWO)))
+elif mode == "doi_last":
+    print(m.field(m.parse_entries(DOI_LAST)[0], "doi") or "None")
+elif mode == "doi_mid":
+    print(m.field(m.parse_entries(DOI_MID)[0], "doi") or "None")
+elif mode == "doi_absent":
+    print(m.field(m.parse_entries(NO_DOI)[0], "doi") or "None")
+elif mode == "journal_mid":
+    print(m.field(m.parse_entries(DOI_MID)[0], "journal") or "None")
+PY
+}
+
+echo "==== the script must survive its own first entry ===="
+ck "parse_entries yields text, not Match"  str        "$(probe type)"
+ck "the caller's first line does not raise" Rinella2023 "$(probe caller)"
+ck "two entries parse as two"              2          "$(probe count)"
+
+echo "==== a value in the LAST field is still a value ===="
+ck "doi as the entry's last field"  "10.1097/HEP.0000000000000520" "$(probe doi_last)"
+ck "doi mid-entry, trailing comma"  "10.1000/xyz789"               "$(probe doi_mid)"
+ck "journal mid-entry"              "Radiology"                    "$(probe journal_mid)"
+
+echo "==== NEGATIVE CONTROL — absent stays absent ===="
+ck "no doi field: None, not invented" None "$(probe doi_absent)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: the tool starts, reads its last field, and does not invent a DOI it was not given."


### PR DESCRIPTION
## The script died on its own first entry, for every input

```
$ python3 skills/manage-refs/scripts/fill_journal_abbrev.py --bib mini.bib --out out.bib
TypeError: expected string or bytes-like object, got 're.Match'
```

`parse_entries` returned the `Match` objects from `re.finditer`; every caller treats the result as the entry **text**. So the very first line of work —

```python
key = re.match(r"@\w+\{([^,]+),", b).group(1)
```

— raised, on the first entry, always.

Meanwhile `check_csl_render.py:158` names this script to the user as the remedy when a journal spec needs `shortjournal`, and `manage-refs/SKILL.md` lists it in the tool table. **A tool that cannot start is worse than a missing one: it is advertised.**

## A second defect was hidden behind the first

Only reachable once the crash was fixed: `field()` required a trailing comma after the value, and BibTeX makes that comma optional on an entry's **last** field — which `doi` very often is. The DOI would have returned `None`, no PMID lookup would happen, and the run would have printed *"0/1 entries"* while exiting **0**.

Same defect class as the reference parser fixed in #445, in a different file. Both fixes were needed for the tool to do anything:

```
$ python3 ... --bib real.bib --out real_out.bib
shortjournal injected: 1/1 entries (DOIs resolved to PMID: 1)

  journal = {Hepatology},
  shortjournal = {Hepatology},     ← from PubMed, live
  year = {2023},
  doi = {10.1097/HEP.0000000000000520}
```

## Verification

`skills/manage-refs/tests/test_journal_abbrev_parsing.sh` (wired, **network-free**) pins the parsing contract, including the caller's exact first line where the crash happened, and the absent-DOI negative control (`None`, not invented).

Reverting turns **6 of 7 red**, the second assertion reading:

```
FAIL  the caller's first line does not raise
      expected=Rinella2023  actual=TypeError: expected string or bytes-like object, got 're.Match'
```

Local mirror **230/230**. `skills 58 / detectors 84` unchanged.