### PR TITLE
docs: move the held-out corpus fence out of a prompt and into the repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`CLAUDE.md` — the held-out corpus fence, moved out of a prompt and into the repository.**
+  `_corpus/heldout/` exists to be material no detector was written knowing about, and its protocol
+  spends a *fresh* corpus by the act of **reading it**. That rule lived in `reverse_engineer/HELDOUT.md`
+  and in whatever instructions a given session happened to carry; the repository itself said nothing,
+  and there was no `CLAUDE.md` or `AGENTS.md` for an agent to find.
+
+  On 2026-07-31 an audit was launched against "the repository" with a prohibition list that covered
+  editing but never mentioned the corpus. Three of its agents reached `_corpus/heldout/`; one ran a
+  detector across the whole corpus, opened two papers, and used the result as evidence for a
+  `check_figure_citation` change. That finding was quarantined and **not acted on**; every fix merged
+  that day was re-derived from purpose-built fixtures, and the corpus in place had already been
+  declared spent, so nothing measurable was lost.
+
+  What the episode demonstrated is worth more than what it cost: `_corpus/` is gitignored, so
+  `git status` can never report a change there and a clone does not carry it — and **neither fact
+  stops anything that scans the working tree.** A fence that exists only in a prompt is not a fence.
+  It now sits at the repository root as the first thing any agent working here is told, with the
+  reason attached, because a prohibition without its reason is one an agent will talk itself past.
+
+  `CONTRIBUTING.md` is deliberately left alone: `_corpus/` never reaches an outside contributor, so
+  the warning would be noise for the only audience that reads that file.
+
 ### Fixed
 
 - **`fill_journal_abbrev.py` had never run.** `parse_entries` returned the `Match` objects from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Working in this repository
+
+## `_corpus/heldout/` — do not read, do not run anything against it
+
+**This is the one instruction in this file that cannot be recovered from if you get it wrong.**
+
+`_corpus/heldout/` holds a frozen set of real published papers whose entire purpose is to be
+material **no detector was written knowing about**. Its protocol
+(`reverse_engineer/HELDOUT.md`) states the spend rule directly:
+
+| set | role | spent by |
+|---|---|---|
+| challenge-card fixtures | train | authored with the detector |
+| the current corpus | validation | **acting on a fire** |
+| a fresh frozen corpus | test — one unbiased number | **reading it** |
+
+Reading is not a neutral act here. A fire rate measured on these papers asserts *"no detector was
+written knowing this paper"*; reading one in order to author or justify a change is exactly how a
+detector comes to know it. The protocol's own instruction is **"Never open them again except to
+label a fire."**
+
+So, when working anywhere in this repository:
+
+- **Do not open** `_corpus/heldout/*.md`.
+- **Do not run** a detector, a grep, or a scan across `_corpus/`.
+- **Do not cite** a number derived from it as evidence for changing a detector.
+- If a task seems to require it, stop and ask. It almost certainly does not.
+
+`_corpus/` is gitignored, so `git status` will never show a change there and a clone will not carry
+it. Neither fact protects it: **anything scanning the working tree sees it.** That is not
+hypothetical — on 2026-07-31 an audit was launched against "the repository", three of its agents
+reached `_corpus/heldout/`, and one ran a detector across the corpus and opened two of the papers.
+The finding it produced was quarantined and not acted on, and the corpus in place was already spent,
+so nothing measurable was lost. The next corpus is the one that reading destroys, and this file
+exists because the fence was in a prompt instead of in the repository.
+
+## Everything else
+
+`CONTRIBUTING.md` is the entry point: how to run the gate mirror before pushing, the worktree
+discipline, and what a change is expected to ship with.

--- a/reverse_engineer/HELDOUT.md
+++ b/reverse_engineer/HELDOUT.md
@@ -48,6 +48,24 @@ live under `_corpus/heldout/`, which is gitignored, exactly like the rest of the
    `coverage` map declaring what design the paper *is*.
 3. Never open them again except to label a fire.
 
+That third rule needs somewhere to live other than this file, because the people and tools most
+likely to break it are the ones that have never read it. `CLAUDE.md` at the repository root now
+carries it as the first thing any agent working here is told.
+
+**2026-07-31 — the rule was broken, and the way it broke is the reason for that file.** An audit was
+launched against "the repository" with a prohibition list that covered editing but never mentioned
+the corpus. Three of its agents reached `_corpus/heldout/`; one ran a detector across the whole
+corpus and opened two papers (`ho_rct_11193124.md`, `ho_ml_ehr_12070005.md`), then used the result
+as evidence for a `check_figure_citation` change. The finding was quarantined and **not acted on**,
+and every fix merged that day was re-derived from purpose-built fixtures, so no detector in this repo
+has been tuned on this corpus. The corpus in place was already spent, so the measurable cost was
+nil.
+
+The cost that was not nil is the demonstration: `_corpus/` is gitignored, which means `git status`
+can never report a change there and a fresh clone will not carry it — and **neither fact stops
+anything that scans the working tree.** The fence was in a prompt. The next corpus is the one that
+reading destroys, so the fence had to move into the repository before that corpus is frozen.
+
 Choose papers that **span designs**. Six papers that are all retrospective single-centre CT
 detection studies are one pattern measured six times: a detector silent across them is silent on
 that pattern, and the denominator is inflated sixfold. That is what `coverage` is for, and the


### PR DESCRIPTION
## The rule, and where it was not

`_corpus/heldout/` exists to be material **no detector was written knowing about**. Its own protocol states the spend rule:

| set | role | spent by |
|---|---|---|
| challenge-card fixtures | train | authored with the detector |
| the current corpus | validation | acting on a fire |
| a fresh frozen corpus | test — one unbiased number | **reading it** |

and instructs: *"Never open them again except to label a fire."*

That rule lived in `reverse_engineer/HELDOUT.md` and in whatever instructions a given session happened to carry. **The repository itself said nothing** — no `CLAUDE.md`, no `AGENTS.md`, nothing an agent would find on its way in.

## What happened on 2026-07-31

An audit was launched against "the repository" with a prohibition list that covered editing but never mentioned the corpus. Three of its agents reached `_corpus/heldout/`; one ran a detector across the whole corpus, opened two papers (`ho_rct_11193124.md`, `ho_ml_ehr_12070005.md`), and used the result as evidence for a `check_figure_citation` change.

**Nothing measurable was lost**, and the reasons have nothing to do with care:

- the finding was quarantined and **not acted on**;
- every fix merged that day (#445–#453) was re-derived from purpose-built fixtures — `grep -ci "held-?out"` over their CHANGELOG entries returns **0** for all of them;
- the corpus in place had **already been declared spent** on 2026-07-25.

## What it demonstrated is worth more than what it cost

`_corpus/` is gitignored. So `git status` can never report a change there, and a fresh clone does not carry it. **Neither fact stops anything that scans the working tree** — which is exactly what an audit agent does when told to audit a repository.

A fence that exists only in a prompt is not a fence. The next corpus is the one that reading destroys, so it had to move before that corpus is frozen.

## What this PR does

- **`CLAUDE.md`** (new, repository root) — the fence as the first thing any agent working here is told: don't open, don't scan, don't cite it as evidence, stop and ask if a task seems to need it. **With the reason attached**, because a prohibition without its reason is one an agent talks itself past.
- **`reverse_engineer/HELDOUT.md`** — the violation recorded immediately beside the rule it broke, including what was read and why the cost was nil.
- **`CONTRIBUTING.md` deliberately untouched** — `_corpus/` never reaches an outside contributor, so the warning would be noise for the only audience that reads that file.

Docs only. Local mirror **230/230**. `skills 58 / detectors 84` unchanged.