### PR TITLE
fix(self-review): check_figure_citation reported orphans that were not there

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Run self-review orphan figure/table citation gate test
         run: bash skills/self-review/tests/test_figure_citation.sh
 
+      - name: "Run figure-citation label test (the summary must name the defect it found)"
+        run: bash skills/self-review/tests/test_figure_citation_labels.sh
+
       - name: Run self-review inline-emphasis over-use gate test
         run: bash skills/self-review/tests/test_emphasis_density.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`check_figure_citation` reported three orphan floats where there were none.** The detector emits
+  five verdicts, only two of which are orphans, and its summary line counted by **severity** while
+  printing the result as a **kind**:
+
+  ```
+  REVIEW: 3 orphan float(s).
+  ```
+
+  — on the repository's own `demo/01_wisconsin_bc`, where the orphan count is zero and all three
+  findings were `FIGURE_NOT_EMBEDDED`. The reader is sent looking for uncited floats that do not
+  exist. The summary now counts by verdict and names each part only when it occurred.
+
+  **And a document-level fact was stated once per figure.** `FIGURE_NOT_EMBEDDED`'s condition is
+  `not IMG_LINK_RE.search(text)` — true or false for the whole manuscript, never per figure — yet it
+  emitted one claim per caption. Three captioned figures produced three claims of one fact; across
+  the three demo manuscripts, **8 claims for 3 documents**, inflating every downstream count that
+  treats a claim as a finding. It is now one claim naming every affected figure, so the demos report
+  3 instead of 8.
+
+  **The docstring understated the exit contract**, in the direction that matters: it read *"1 with
+  `--strict` when any Major (none — Minor only)"* while `FIGURE_ATTR_STALE` is Major unconditionally
+  and `FIGURE_NOT_EMBEDDED` escalates to Major under `--require-embedded`. A submission-adjacent gate
+  was documented as unable to block. Corrected, and the test exercises both exit paths.
+
+  Evidence for all three comes from `demo/` only; `_corpus/heldout/` was not read (see `CLAUDE.md`).
+  `skills/self-review/tests/test_figure_citation_labels.sh` (wired) pins 15 assertions including the
+  negative controls — a real orphan still reports as an orphan, a clean manuscript still says OK.
+  The pre-existing `test_figure_citation.sh` and its challenge card pass unchanged. Reverting the
+  detector turns 9 of the 15 red.
+
 ### Added
 
 - **`CLAUDE.md` — the held-out corpus fence, moved out of a prompt and into the repository.**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4653,8 +4653,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_figure_citation.py",
-      "size": 11137,
-      "sha256": "92847a5ca4faf32b94bceaf4369a6a9ca4c83a5aaa503606dd7b581c0770e093"
+      "size": 12859,
+      "sha256": "831aa1ef79cf6d2311adf4c9f97c766084d472b7e6dfa17e7f4f70b31ea89b43"
     },
     {
       "path": "skills/self-review/scripts/check_figure_citation_challenge/fixture/panel_regression.md",

--- a/skills/self-review/scripts/check_figure_citation.py
+++ b/skills/self-review/scripts/check_figure_citation.py
@@ -28,8 +28,10 @@ This needs no section-boundary heuristic — the caption line itself is the anch
 a caption that happens to reference another float still counts as citing that other
 float.
 
-Exit codes: 0 clean/report-only, 1 with --strict when any Major (none — Minor only),
-2 usage. Stdlib-only.
+Exit codes: 0 clean/report-only, 1 with --strict when any Major, 2 usage. Major is reachable two
+ways: FIGURE_ATTR_STALE is Major unconditionally, and FIGURE_NOT_EMBEDDED escalates to Major under
+--require-embedded. (This line used to read "none — Minor only", which was stale in the direction
+that matters: it described a submission-adjacent gate as unable to block.) Stdlib-only.
 
 Usage:
     python3 check_figure_citation.py --manuscript manuscript.md \
@@ -107,15 +109,19 @@ def check(text: str, require_embedded: bool = False) -> list[dict]:
         # is the "complete package that ships with the legends and none of the
         # figures" failure.
         sev = "Major" if require_embedded else "Minor"
-        for num, cap_line in figures:
-            claims.append({
-                "verdict": "FIGURE_NOT_EMBEDDED",
-                "severity": sev,
-                "detail": (f"Figure {num} is captioned (line {cap_line + 1}) but no image is embedded "
-                           f"anywhere in the manuscript; confirm the figure is embedded or attached as a "
-                           f"separate file before submission"),
-                "where": lines[cap_line].strip()[:120],
-            })
+        # ONE claim, because the condition above is document-level: `not IMG_LINK_RE.search(text)`
+        # is true or false for the whole manuscript, never per figure. Emitting it once per caption
+        # repeated a single fact N times — on the repo's own demo manuscripts, 8 claims for 3
+        # documents — which inflates every count downstream that treats a claim as a finding.
+        nums = ", ".join(f"Figure {n}" for n, _ in figures)
+        claims.append({
+            "verdict": "FIGURE_NOT_EMBEDDED",
+            "severity": sev,
+            "detail": (f"no image is embedded anywhere in the manuscript, while {len(figures)} "
+                       f"figure(s) are captioned ({nums}); confirm they are embedded or attached "
+                       f"as separate files before submission"),
+            "where": lines[figures[0][1]].strip()[:120],
+        })
 
     # Author-contributions / CRediT figure-number attribution. A "prepared Figure 4"
     # attribution silently breaks when figures are renumbered or merged; the canonical
@@ -160,6 +166,12 @@ def analyze(manuscript: str, require_embedded: bool = False) -> dict:
         sys.exit(2)
     claims = check(p.read_text(encoding="utf-8"), require_embedded=require_embedded)
     n_major = sum(1 for c in claims if c["severity"] == "Major")
+    # Counted BY VERDICT, because the summary line names a kind of defect and `n_major`/`n_flag`
+    # name a severity. This detector emits five verdicts, only two of which are orphans, so
+    # "n_flag orphan float(s)" described the wrong thing whenever a non-orphan was the finding —
+    # on the repo's own demo manuscripts it printed "3 orphan float(s)" with zero orphans present.
+    n_orphan = sum(1 for c in claims if c["verdict"] in ("FIGURE_ORPHAN", "TABLE_ORPHAN"))
+    n_not_embedded = sum(1 for c in claims if c["verdict"] == "FIGURE_NOT_EMBEDDED")
     return {
         "manuscript": str(p),
         "claims": claims,
@@ -167,6 +179,8 @@ def analyze(manuscript: str, require_embedded: bool = False) -> dict:
             "n_claims": len(claims),
             "n_major": n_major,
             "n_flag": len(claims) - n_major,
+            "n_orphan": n_orphan,
+            "n_not_embedded": n_not_embedded,
             "verdict": "MAJOR_CANDIDATE" if n_major else ("REVIEW" if claims else "OK"),
         },
     }
@@ -203,10 +217,19 @@ def main() -> int:
         print(render(result))
         print()
         s = result["summary"]
-        if s["n_major"]:
-            print(f"MAJOR: {s['n_major']} figure(s) captioned but not embedded; {s['n_flag']} orphan float(s).")
-        elif s["n_flag"]:
-            print(f"REVIEW: {s['n_flag']} orphan float(s).")
+        # Say what was found, by name. Each part appears only when it happened, so the line can no
+        # longer report a count of a thing that is not there.
+        parts = []
+        if s["n_orphan"]:
+            parts.append(f"{s['n_orphan']} orphan float(s)")
+        if s["n_not_embedded"]:
+            parts.append("no image embedded for the captioned figure(s)")
+        other = s["n_claims"] - s["n_orphan"] - s["n_not_embedded"]
+        if other:
+            parts.append(f"{other} other finding(s)")
+        if parts:
+            level = "MAJOR" if s["n_major"] else "REVIEW"
+            print(f"{level}: " + "; ".join(parts) + ".")
         else:
             print("OK: every captioned float is cited and embedded.")
 

--- a/skills/self-review/tests/test_figure_citation_labels.sh
+++ b/skills/self-review/tests/test_figure_citation_labels.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Regression test: the summary line must name the defect it found, and a document-level fact must be
+# stated once.
+#
+# `check_figure_citation` emits five verdicts, only two of which are orphans. Its summary line
+# counted by SEVERITY and printed the result as a KIND:
+#
+#     REVIEW: 3 orphan float(s).
+#
+# — on the repository's own `demo/01_wisconsin_bc`, where the orphan count is zero and all three
+# findings were FIGURE_NOT_EMBEDDED. A reader is told to go looking for uncited floats that do not
+# exist.
+#
+# And FIGURE_NOT_EMBEDDED was emitted once per caption while its condition is document-level
+# (`not IMG_LINK_RE.search(text)` — true or false for the whole file, never per figure). Three
+# figures produced three claims of one fact; across the three demo manuscripts, 8 claims for 3
+# documents, inflating every count downstream that treats a claim as a finding.
+#
+# Evidence for this fix comes from `demo/` only. `_corpus/heldout/` was not read — see CLAUDE.md.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+D="$REPO_ROOT/skills/self-review/scripts/check_figure_citation.py"
+WORK="$(mktemp -d -t figcite_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-50s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-50s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- fixtures ------------------------------------------------------------------------------------
+# Captioned and cited, but the manuscript embeds no image at all.
+cat > "$WORK/not_embedded.md" <<'EOF'
+## Results
+
+Enrolment is shown in Figure 1, survival in Figure 2 and calibration in Figure 3.
+
+**Figure 1.** Study flow diagram.
+
+**Figure 2.** Kaplan-Meier survival curves.
+
+**Figure 3.** Calibration plot.
+EOF
+
+# A genuine orphan: Figure 2 is captioned and never cited. An image IS embedded, so the
+# not-embedded branch stays silent and the orphan branch is the only thing left.
+cat > "$WORK/orphan.md" <<'EOF'
+## Results
+
+Enrolment is shown in Figure 1.
+
+**Figure 1.** Study flow diagram.
+
+![flow](figures/flow.png)
+
+**Figure 2.** A figure nobody mentions.
+EOF
+
+# Clean: captioned, cited, embedded.
+cat > "$WORK/clean.md" <<'EOF'
+## Results
+
+Enrolment is shown in Figure 1.
+
+**Figure 1.** Study flow diagram.
+
+![flow](figures/flow.png)
+EOF
+
+summary_line() { python3 "$D" --manuscript "$WORK/$1" 2>/dev/null | tail -1; }
+jq_field() {  # jq_field <fixture> <summary key>
+  python3 "$D" --manuscript "$WORK/$1" --out "$WORK/$1.json" --quiet >/dev/null 2>&1
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['summary'][sys.argv[2]])" \
+    "$WORK/$1.json" "$2"
+}
+
+echo "==== the summary line must not report orphans that are not there ===="
+ck "no 'orphan' in the not-embedded summary" no \
+   "$(summary_line not_embedded.md | grep -qi orphan && echo yes || echo no)"
+ck "it names what it did find" yes \
+   "$(summary_line not_embedded.md | grep -qi 'no image embedded' && echo yes || echo no)"
+ck "n_orphan is 0"        0 "$(jq_field not_embedded.md n_orphan)"
+ck "n_not_embedded is 1"  1 "$(jq_field not_embedded.md n_not_embedded)"
+
+echo "==== a document-level fact is stated once, and names every figure ===="
+ck "3 captioned figures -> 1 claim" 1 "$(jq_field not_embedded.md n_claims)"
+for n in 1 2 3; do
+  ck "  claim names Figure $n" yes \
+     "$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+print('yes' if 'Figure $n' in d['claims'][0]['detail'] else 'no')" "$WORK/not_embedded.md.json")"
+done
+
+echo "==== NEGATIVE CONTROLS — a real orphan is still an orphan ===="
+ck "orphan fixture: n_orphan is 1"          1 "$(jq_field orphan.md n_orphan)"
+ck "orphan fixture: summary says 'orphan'"  yes \
+   "$(summary_line orphan.md | grep -qi 'orphan float' && echo yes || echo no)"
+ck "orphan fixture: not_embedded is 0"      0 "$(jq_field orphan.md n_not_embedded)"
+ck "clean manuscript: no claims"            0 "$(jq_field clean.md n_claims)"
+ck "clean manuscript: says OK"              yes \
+   "$(summary_line clean.md | grep -q '^OK:' && echo yes || echo no)"
+
+echo "==== the documented exit contract is real: Major IS reachable ===="
+python3 "$D" --manuscript "$WORK/not_embedded.md" --require-embedded --strict >/dev/null 2>&1
+ck "--require-embedded --strict exits 1"    1 "$?"
+python3 "$D" --manuscript "$WORK/not_embedded.md" --strict >/dev/null 2>&1
+ck "without --require-embedded it exits 0"  0 "$?"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: the summary names the defect it found, and one fact is stated once."


### PR DESCRIPTION
## On the repository's own demo

```
| FIGURE_NOT_EMBEDDED | Minor | Figure 1 is captioned (line 73) but no image is embedded anywhere ... |
| FIGURE_NOT_EMBEDDED | Minor | Figure 2 ... |
| FIGURE_NOT_EMBEDDED | Minor | Figure 3 ... |

REVIEW: 3 orphan float(s).        ← the orphan count is zero
```

Three defects, all reproduced on `demo/01–03`:

**1. The summary counted by severity and printed the result as a kind.** The detector emits five verdicts (`FIGURE_ORPHAN`, `TABLE_ORPHAN`, `FIGURE_NOT_EMBEDDED`, `AUTHOR_CONTRIB_FIGURE_REF`, `FIGURE_ATTR_STALE`) — only two are orphans. `n_flag` is "everything not Major", so the line reported orphans whenever anything else was the finding, sending the reader after floats that do not exist.

**2. A document-level fact was stated once per figure.** `FIGURE_NOT_EMBEDDED`'s condition is `not IMG_LINK_RE.search(text)` — true or false for the *whole manuscript*, never per figure — yet it emitted one claim per caption. Across the three demos: **8 claims for 3 documents**, inflating every downstream count that treats a claim as a finding. Now one claim naming every affected figure (8 → 3).

**3. The docstring understated the exit contract**, in the direction that matters:

> Exit codes: 0 clean/report-only, 1 with `--strict` when any Major **(none — Minor only)**

`FIGURE_ATTR_STALE` is `"severity": "Major"` **unconditionally**, and `FIGURE_NOT_EMBEDDED` escalates to Major under `--require-embedded`. A submission-adjacent gate was documented as unable to block.

## Provenance note

The finding that originally pointed at this detector was derived from `_corpus/heldout/` and was **quarantined, not used** (see #454). This was re-derived from scratch on `demo/` only. Defect 3 is one the original finding did not contain — it came from reading the code during re-derivation.

## Verification

`skills/self-review/tests/test_figure_citation_labels.sh` (wired), 15 assertions, negative controls first-class:

| control | result |
|---|---|
| a genuine orphan | still reports as an orphan, still counted |
| a clean manuscript | still `OK:` |
| `--require-embedded --strict` | exit **1** |
| plain `--strict` | exit **0** |

The pre-existing `test_figure_citation.sh` and its challenge card **pass unchanged** — this did not require rewriting an existing contract. Reverting the detector turns **9 of 15 red**.

Local mirror **231/231**. `skills 58 / detectors 84` unchanged.