### PR TITLE
fix: the front page said 36 detectors; the catalog, the audit doc and the paper said 84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Fixed
 
+- **The front page understated the verification layer by more than half, and the gate built to
+  prevent exactly that was not looking at it.** `README.md` introduced MedSci-Audit as *"a named
+  suite of **36 deterministic detectors**"* — the **v4.10** count — while
+  `metadata/catalog_counts.json`, `MEDSCI_AUDIT.md` and `paper.md` all said **84**. Anyone deciding
+  whether this toolkit was worth installing read 36; the paper claiming 84 sat one link away.
+
+  `validate_catalog_consistency.py` exists to stop that drift and watched
+  `["MEDSCI_AUDIT.md", "paper.md"]` — the two files that were already right. Demonstrated both ways:
+  with `README.md` in scope the stale number fails as
+  `README.md L419 detector total: claims 36, expected 84`; with the previous scope the identical
+  file passes as *"OK: SSOT and all doc count claims agree with disk."*
+
+  README is now watched. Its **thirteen** dated version notes ("61 integrity detectors" in the
+  v5.21 entry, and so on) are untouched and unflagged — the detector patterns were already scoped
+  to current-state phrasings, so a release note recording the count at its release stays correct as
+  history rather than being rewritten.
+
 - **`check_figure_citation` reported three orphan floats where there were none.** The detector emits
   five verdicts, only two of which are orphans, and its summary line counted by **severity** while
   printing the result as a **kind**:

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Earlier in this series: analysis-integrity guards (confounding completeness, cla
 | **Battle-tested** | Used on real manuscript submissions by a practicing physician-researcher | Unknown provenance and validation |
 | **Depth per skill** | 150-600 lines of documentation + bundled reference files (curated journal profile library, checklists, formula sheets, code templates) | Typically thin SKILL.md templates |
 
-**MedSci-Audit** — the verification edge in the first rows above is a named suite of **36 deterministic detectors** (citation & reference integrity, cohort & pool arithmetic, scope/estimand contracts, reporting compliance, and more) that catch fabricated or drifted content before a manuscript reaches a reviewer. See **[`MEDSCI_AUDIT.md`](MEDSCI_AUDIT.md)** for the suite, its six families, and its evaluation evidence.
+**MedSci-Audit** — the verification edge in the first rows above is a named suite of **84 deterministic detectors** (citation & reference integrity, cohort & pool arithmetic, scope/estimand contracts, reporting compliance, and more) that catch fabricated or drifted content before a manuscript reaches a reviewer. See **[`MEDSCI_AUDIT.md`](MEDSCI_AUDIT.md)** for the suite, its six families, and its evaluation evidence.
 
 ---
 

--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -133,7 +133,13 @@ SKILLS_PROSE_FILES = ["README.md", "paper.md"]
 # paper.md (the JOSS submission) states the total in its Summary and was ungated
 # until the suite grew past it — a paper whose headline number disagrees with the
 # software it describes is exactly the drift this file exists to prevent.
-DETECTOR_CLAIM_FILES = ["MEDSCI_AUDIT.md", "paper.md"]
+# README carries the same claim in its MedSci-Audit tagline and was NOT watched, so it sat at
+# 36 — the v4.10 count — while the catalog, MEDSCI_AUDIT.md and paper.md moved to 84. The
+# front page of the project understated its own verification layer by more than half, and the
+# gate built to prevent exactly that was not looking at it. The patterns above are already
+# scoped to current-state phrasings, so the dated version notes ("61 integrity detectors" in
+# the v5.21 entry) do not match and stay correct as history.
+DETECTOR_CLAIM_FILES = ["MEDSCI_AUDIT.md", "paper.md", "README.md"]
 DETECTOR_CLAIM_PATTERNS = [
     r"\b(\d{1,3})\s+deterministic detectors\b",
     r"\bThe\s+(\d{1,3})\s+detectors\s+fall into\b",


### PR DESCRIPTION
## The number a prospective user reads was less than half the real one

| file | claimed |
|---|---|
| `README.md:419` — the MedSci-Audit tagline | **36** |
| `metadata/catalog_counts.json` | 84 |
| `MEDSCI_AUDIT.md:3` | 84 |
| `paper.md:23` | 84 |

36 is the **v4.10** count. Anyone deciding whether this toolkit was worth installing read it on the front page, with the paper claiming 84 one link away.

## The gate built to stop this was not looking at the file

`validate_catalog_consistency.py` watched `DETECTOR_CLAIM_FILES = ["MEDSCI_AUDIT.md", "paper.md"]` — the two files that were already correct. Demonstrated in both directions on the same tree:

```
with README.md in scope:   FAIL: README.md L419 detector total: claims 36, expected 84   (rc=1)
with the previous scope:   OK: SSOT and all doc count claims agree with disk             (rc=0)
```

The second line is the defect: an identical, wrong file passing as verified.

## Version history is left alone

README carries **13** further detector counts inside dated release notes (`**v5.21** — … 61 integrity detectors …`). Those are correct as history and must not be rewritten when the current count moves. They are untouched and unflagged, because `DETECTOR_CLAIM_PATTERNS` was already scoped to current-state phrasings — the file's own docstring says so, and the simulation confirms exactly one hit either way.

So this PR needed no new pattern, no exemption list, and no `version_note_re` skip: only the file that was never in scope.

Local mirror **231/231**. `skills 58 / detectors 84` unchanged — this makes the public claim match them.