### PR TITLE
fix(docs): two of the four install paths were broken, and the worse one succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Fixed
 
+- **Two of the four documented install paths were broken, and the worse one succeeded.** Install
+  Option 1 creates the destination first (`mkdir -p ~/.claude/skills`); Options 2 and 3 did not, and
+  on a machine where `~/.claude/skills` does not yet exist — which is every first install — BSD `cp`
+  does this:
+
+  ```
+  Option 2:  cp: ~/.claude/skills: Not a directory     → nothing copied, at least it is loud
+  Option 3:  exit 0, and ~/.claude/skills/SKILL.md     → the skills DIRECTORY became the skill
+  ```
+
+  Option 3 is the one that matters: no error, no output, and a `~/.claude/skills` that contains a
+  skill's files instead of the skill. Claude Code then finds nothing, and the person following the
+  README has no signal to act on. Both now carry the same `mkdir -p` line Option 1 already had;
+  verified, including on a re-run so the corrected form stays idempotent.
+
+  No gate added. The recurrence risk is real — these are three-line snippets nobody executes — but a
+  CI check that runs documented install commands is a new gate, and that is a decision to make
+  deliberately rather than as a side effect of a two-line fix.
+
 - **The front page understated the verification layer by more than half, and the gate built to
   prevent exactly that was not looking at it.** `README.md` introduced MedSci-Audit as *"a named
   suite of **36 deterministic detectors**"* — the **v4.10** count — while

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ MedSci Skills가 설치됐는지 확인하고, 오늘 실습에 쓸 대표 스�
 
 ```bash
 git clone https://github.com/Aperivue/medsci-skills.git
+mkdir -p ~/.claude/skills
 cp -r medsci-skills/skills/* ~/.claude/skills/
 ```
 
@@ -599,6 +600,7 @@ cp -r medsci-skills/skills/* ~/.claude/skills/
 
 ```bash
 git clone https://github.com/Aperivue/medsci-skills.git
+mkdir -p ~/.claude/skills
 cp -r medsci-skills/skills/check-reporting ~/.claude/skills/
 ```
 


### PR DESCRIPTION
## Reproduced on BSD `cp`, with `~/.claude/skills` absent — which is every first install

```
Option 2:  cp: ~/.claude/skills: Not a directory     → 0 files copied
Option 3:  exit 0                                    → ~/.claude/skills/SKILL.md
```

Option 1 (line 89) has always created the destination first. Options 2 and 3 did not.

**Option 3 is the one that matters.** It does not fail — it *succeeds*, and makes `~/.claude/skills` **itself** the skill instead of the directory holding it. No error, no output, no exit code. Claude Code then finds nothing, and the person following the README has nothing to act on.

## The fix

The same `mkdir -p ~/.claude/skills` line Option 1 already carried. Verified in throwaway directories on BSD `cp`:

```
corrected Option 2:  skills installed: check-reporting write-paper
corrected Option 3:  ~/.claude/skills/check-reporting/SKILL.md
  re-run:            ~/.claude/skills/check-reporting/SKILL.md   ← idempotent
```

## No gate added, deliberately

The recurrence risk is real — these are three-line snippets nobody executes, which is exactly how they drifted. But a CI check that runs documented install commands is a **new gate**, and this repository already has 231. That is a decision worth making on its own merits rather than smuggling in behind a two-line documentation fix.

Docs only. Local mirror **231/231**. `skills 58 / detectors 84` unchanged.