### PR TITLE
fix(sync-submission): a figure builder's config is a figure source

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -291,6 +291,9 @@ jobs:
       - name: Run sync-submission asset-anonymization gate test (A2)
         run: bash skills/sync-submission/tests/test_asset_anonymization.sh
 
+      - name: "Run anonymization config-scan test (the config that draws the figure is a figure source)"
+        run: bash skills/sync-submission/tests/test_anonymization_config_scan.sh
+
       - name: "Run word-count heading-form test (setext and ATX must measure the same manuscript alike)"
         run: bash skills/sync-submission/tests/test_wordcount_heading_forms.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@
   No gate added. The recurrence risk is real — these are three-line snippets nobody executes — but a
   CI check that runs documented install commands is a new gate, and that is a decision to make
   deliberately rather than as a side effect of a two-line fix.
+- **The anonymisation gate declared a double-blind leak clean because it was in a `.yaml`.**
+  `check_asset_anonymization` scanned `.r` and `.py` under `figures/`. But `/make-figures` documents
+  its STROBE builder as `build_strobe_template.py --config figures/figure1_strobe.yaml`, and the
+  first box of a STROBE flow diagram is exactly where *"Patients screened at &lt;Hospital&gt;"* lives.
+  The identical string, in the same directory, got opposite verdicts:
+
+  ```
+  figures/figure1_strobe.py    ->  FAIL: institution-like token in figure script
+  figures/figure1_strobe.yaml  ->  PASS: no anonymization leak   ({'figure_scripts': 0})
+  ```
+
+  The `figure_scripts: 0` inside that PASS is the tell — a gate reporting success over an empty
+  input set looks exactly like a gate that passed. With the config scanned it reads
+  `figure_scripts: 1`, so "found nothing" is now distinguishable from "looked at nothing", and the
+  test asserts that counter rather than only the verdict.
+
+  `.yaml`, `.yml` and `.json` under `figures/` are now read the way the scripts already were — as
+  text, line by line, which is all this check ever needed. Both formats are in scope because the
+  builders in this repo parse both.
+
+  `skills/sync-submission/tests/test_anonymization_config_scan.sh` (wired) pins 9 assertions
+  including the scope control: the same leak *outside* `figures/` is still not a figure source and
+  still passes. Reverting the scanner turns 5 red.
 
 - **The front page understated the verification layer by more than half, and the gate built to
   prevent exactly that was not looking at it.** `README.md` introduced MedSci-Audit as *"a named

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5288,8 +5288,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/check_asset_anonymization.py",
-      "size": 13914,
-      "sha256": "a4552caa7bfcfba93c32d1b8f5b24fdcde49b4201768e977cd10a3d8fba06dc0"
+      "size": 14907,
+      "sha256": "9d826fc7f408ccc5d679774cd8e9c8921763b2a0066536b14173610301265587"
     },
     {
       "path": "skills/sync-submission/scripts/check_checklist_dump_leak.py",

--- a/skills/sync-submission/scripts/check_asset_anonymization.py
+++ b/skills/sync-submission/scripts/check_asset_anonymization.py
@@ -233,8 +233,21 @@ def build_report(root: Path, names: list[str], poppler: bool) -> Report:
         suffix = p.suffix.lower()
         rel = str(p.relative_to(root))
 
-        # 1. figure-generating scripts
-        if suffix in (".r", ".py") and _is_under_figures(p):
+        # 1. figure-generating scripts AND the config files that drive them.
+        #
+        # A figure builder does not have to be a script. `/make-figures` documents its STROBE
+        # builder as `build_strobe_template.py --config figures/figure1_strobe.yaml`, and the first
+        # box of a STROBE flow diagram is exactly where "Patients screened at <Hospital>" lives.
+        # Scanning only .r/.py meant the identical institution string blocked in one file and
+        # passed in the other:
+        #
+        #   figures/figure1_strobe.py    -> FAIL: institution-like token in figure script
+        #   figures/figure1_strobe.yaml  -> PASS: no anonymization leak  ({'figure_scripts': 0})
+        #
+        # For a double-blind submission that is an anonymity leak which the anonymisation gate
+        # declared clean. The builders in this repo parse YAML and JSON alike, so both are now read
+        # the way the scripts already were — as text, line by line, which is all this check needs.
+        if suffix in (".r", ".py", ".yaml", ".yml", ".json") and _is_under_figures(p):
             scripts += 1
             text = p.read_text(encoding="utf-8", errors="replace")
             for i, line in enumerate(text.splitlines(), 1):

--- a/skills/sync-submission/tests/test_anonymization_config_scan.sh
+++ b/skills/sync-submission/tests/test_anonymization_config_scan.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression test: a figure builder's CONFIG is as much a figure source as its script.
+#
+# `check_asset_anonymization` scanned `.r` and `.py` under `figures/`. But `/make-figures` documents
+# its STROBE builder as `build_strobe_template.py --config figures/figure1_strobe.yaml`, and the
+# first box of a STROBE flow diagram is exactly where "Patients screened at <Hospital>" lives. So
+# the identical institution string blocked in one file and passed in the other:
+#
+#   figures/figure1_strobe.py    ->  FAIL: institution-like token in figure script
+#   figures/figure1_strobe.yaml  ->  PASS: no anonymization leak   ({'figure_scripts': 0})
+#
+# For a double-blind submission that is an anonymity leak which the anonymisation gate declared
+# clean — and the `figure_scripts: 0` in that PASS line is the tell: a gate reporting success over
+# an empty input set looks exactly like a gate that passed.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+A="$REPO_ROOT/skills/sync-submission/scripts/check_asset_anonymization.py"
+WORK="$(mktemp -d -t anon_config_test.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+LEAK='Patients screened at Seoul National University Hospital (n = 4,102)'
+
+run_on() {  # run_on <relative path> <content> -> exit code; output at $WORK/out
+  local rel="$1" content="$2" d="$WORK/p$RANDOM"
+  mkdir -p "$d/$(dirname "$rel")"
+  printf '%s\n' "$content" > "$d/$rel"
+  python3 "$A" --dir "$d" --strict > "$WORK/out" 2>&1
+  local rc=$?
+  cp "$WORK/out" "$WORK/last.out"
+  echo $rc
+}
+
+echo "==== a config under figures/ is scanned, whatever its format ===="
+ck "figures/*.yaml with an institution"  1 \
+   "$(run_on figures/f1.yaml "spine:
+  - {text: \"$LEAK\"}")"
+ck "  and the file is named" yes \
+   "$(grep -q 'figures/f1.yaml' "$WORK/last.out" && echo yes || echo no)"
+ck "figures/*.yml with an institution"   1 "$(run_on figures/f1.yml "text: \"$LEAK\"")"
+ck "figures/*.json with an institution"  1 "$(run_on figures/panel.json "{\"title\": \"$LEAK\"}")"
+
+echo "==== the path that already worked must keep working ===="
+ck "figures/*.py with an institution"    1 "$(run_on figures/f1.py "title = \"$LEAK\"")"
+ck "figures/*.R with an institution"     1 "$(run_on figures/f1.R "title <- \"$LEAK\"")"
+
+echo "==== NEGATIVE CONTROLS ===="
+ck "a clean config passes"               0 \
+   "$(run_on figures/clean.yaml "spine:
+  - {text: \"Analytic cohort (n = 3,655)\"}")"
+# The counter is the difference between "looked and found nothing" and "looked at nothing".
+ck "  and the run reports it scanned it" yes \
+   "$(grep -q "'figure_scripts': 1" "$WORK/last.out" && echo yes || echo no)"
+# Scope is still figures/: a config elsewhere in the tree is not a figure source.
+ck "same leak outside figures/ is not scanned" 0 \
+   "$(run_on config/app.yaml "site: \"$LEAK\"")"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || { echo "--- last run ---"; cat "$WORK/last.out"; exit 1; }
+echo "OK: the config that draws the figure is scanned like the script that draws it."


### PR DESCRIPTION
## The same string, the same directory, opposite verdicts

```
figures/figure1_strobe.py    →  FAIL: institution-like token in figure script
figures/figure1_strobe.yaml  →  PASS: no anonymization leak  ({'figure_scripts': 0})
```

`check_asset_anonymization` scanned `.r` and `.py` under `figures/`. But `/make-figures` documents its STROBE builder as

```bash
build_strobe_template.py --config figures/figure1_strobe.yaml
```

and the first box of a STROBE flow diagram is exactly where *"Patients screened at &lt;Hospital&gt;"* lives.

**For a double-blind submission that is an anonymity leak which the anonymisation gate declared clean.**

## The `figure_scripts: 0` is the tell

A gate reporting success over an **empty input set** looks exactly like a gate that passed. That counter sat inside the PASS line the whole time. With the config scanned it reads `figure_scripts: 1`, so *"found nothing"* becomes distinguishable from *"looked at nothing"* — and the test asserts **that counter**, not only the verdict.

## Scope

`.yaml`, `.yml` and `.json` under `figures/`, read the way the scripts already were — as text, line by line, which is all this check ever needed. Both formats are in scope because the builders in this repo parse both (`yaml.safe_load` ×3, `json.load` ×5).

## Verification

`skills/sync-submission/tests/test_anonymization_config_scan.sh` (wired), 9 assertions:

| | |
|---|---|
| `.yaml` / `.yml` / `.json` with an institution | exit **1**, file named with line number |
| `.py` / `.R` — the path that already worked | exit **1**, unchanged |
| a clean config | exit **0**, and `figure_scripts: 1` asserted |
| **the same leak outside `figures/`** | exit **0** — scope preserved |

Reverting the scanner turns **5 of 9 red**.

Local mirror on the rebased tree **232/232**. `skills 58 / detectors 84` unchanged.