### PR TITLE
fix(gates): a gate that passed on ignored files, and one that flagged the panel's only independent lens

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -114,6 +114,9 @@ jobs:
       - name: "Run script-reachability self-test (de-wired script and undocumented allowlist entry fail)"
         run: bash tests/test_script_reachability.sh
 
+      - name: "Run tag-cleanup-gate self-test (both scan backends must reach the same verdict)"
+        run: bash tests/test_tag_cleanup_gate.sh
+
       - name: "Run check_bundled_media_license.py (an MIT package may only ship what it holds — including inside a .pptx)"
         run: python3 scripts/check_bundled_media_license.py --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,46 @@
 
 ### Fixed
 
+- **The submission tag gate printed `PASS ... tag-clean` on a package carrying live `TODO` and
+  `FIXME`, and which answer you got depended on whether ripgrep was installed.**
+  `scripts/tag_cleanup_gate.sh` has two scan backends. The `grep -r` fallback reads every file
+  under the scaffold directories; the ripgrep branch honoured `.gitignore`/`.ignore` and skipped
+  dotfiles. So a draft tag sitting in an ignored `build/` directory, or in a hidden working note,
+  was invisible to one backend and caught by the other — and the blind backend was the one that
+  exits 0. Reproduced end to end: a package with `FIXME` in `7_Manuscript/.draft_note.md` and a
+  `TODO` in an ignored `7_Manuscript/build/generated.md` returned
+  `PASS: 0 hits. Submission package is tag-clean.` The rg branch now passes `--no-ignore --hidden`,
+  restoring parity.
+
+  The same PASS sentence carried a quieter overclaim. The scan covers only whichever of the six
+  scaffold directories exist, yet it spoke for "the submission package" — a project laid out under
+  different names would have received a clean bill of health from a scan that read nothing of it.
+  It now names the directories it read and, when any declared directory is absent, says so and
+  states that the result does not cover the tree.
+
+  `tests/test_tag_cleanup_gate.sh` is new and CI-wired: the gate previously shipped with **no test
+  at all**. It builds its fixtures at runtime (so this repository ships no live draft tags of its
+  own), runs the gate under both backends, and asserts the property that actually matters — the two
+  reach the **same verdict on the same tree**. Against the pre-fix script it fails 8 of its 16
+  checks. The exclusion globs and the `DI-8:ignore-file` opt-out are asserted under both backends,
+  so the widened scan cannot quietly break them.
+
+- **The panel diversity gate told the editor that the panel's only independent reviewer had added
+  nothing.** `LENS_COLLAPSE` (`skills/self-review/scripts/check_panel_diversity.py`) fires when one
+  reviewer's concern families are all covered by others — reasonable evidence of a redundant
+  assignment when that reviewer shares the generator's model substrate, and close to backwards when
+  it does not. Cross-substrate agreement is corroboration, and that reviewer is the very lens
+  `SUBSTRATE_MONOCULTURE` (in the same file) requires the panel to contain. It fired for real on a
+  panel containing a Codex reviewer, recommending the editor reconsider the one thing making the
+  review independent.
+
+  `LENS_COLLAPSE` is now exempt when the roster declares a reviewer on a different substrate from
+  the generator, and the exemption is **recorded** in `summary.lens_collapse_substrate_exempt` and
+  printed — a skipped check that prints nothing is indistinguishable from a check that passed.
+  Gated on both substrates being declared, so a roster without substrate fields behaves exactly as
+  before. Three regression cases were added, including one asserting the check **still fires** on a
+  same-substrate redundant lens, so the exemption cannot be satisfied by deleting the check.
+
 - **The demo reproducibility-lock CI step stopped at demo 3, and a stale lock had already reached
   main.** `demo/04_pneumoniamnist_cnn/manifest.lock.json` did not verify: its
   `qc/reference_audit.json` was edited after the lock was built (an absolute path scrubbed out), so

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4828,8 +4828,8 @@
     },
     {
       "path": "skills/self-review/scripts/check_panel_diversity.py",
-      "size": 23979,
-      "sha256": "dd02d1fc1f6dca07bca8339883bdbaab31ba8b927171a4ac12cca42041a5493b"
+      "size": 25969,
+      "sha256": "476633595d64532c0b87994d5ad374b52ca67337744e909389c134b6970be5d0"
     },
     {
       "path": "skills/self-review/scripts/check_paren_spans.py",

--- a/scripts/tag_cleanup_gate.sh
+++ b/scripts/tag_cleanup_gate.sh
@@ -34,7 +34,13 @@ EXCLUDE_GLOBS=(
 # (Handled post-scan by filtering hits whose file starts with that marker.)
 
 if command -v rg >/dev/null 2>&1; then
-    GREP_CMD=(rg -n --no-heading -e "$PATTERN")
+    # --no-ignore --hidden are load-bearing. Without them rg honours .gitignore/.ignore and
+    # skips dotfiles, so an ignored build/ directory or a hidden draft inside the submission
+    # package is never read — while the grep fallback below reads both. That made the gate's
+    # verdict depend on which tool happened to be installed, and the rg side was the one that
+    # printed PASS on a package carrying live TODO/FIXME tags.
+    # Regressed by tests/test_tag_cleanup_gate.sh.
+    GREP_CMD=(rg -n --no-heading --no-ignore --hidden -e "$PATTERN")
     for g in "${EXCLUDE_GLOBS[@]}"; do
         GREP_CMD+=(-g "!$g")
     done
@@ -46,8 +52,9 @@ else
 fi
 
 EXISTING_DIRS=()
+MISSING_DIRS=()
 for d in "${DIRS[@]}"; do
-    [[ -d "$d" ]] && EXISTING_DIRS+=("$d")
+    if [[ -d "$d" ]]; then EXISTING_DIRS+=("$d"); else MISSING_DIRS+=("$d"); fi
 done
 
 if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
@@ -83,5 +90,12 @@ if [[ -n "$HITS" ]]; then
     exit 1
 fi
 
-echo "PASS: 0 hits. Submission package is tag-clean."
+# Name what was actually read. The scan covers only the scaffold dirs that exist, so an
+# unqualified "the submission package is tag-clean" claims coverage the run never had — a
+# package whose manuscript lives outside these names would pass on an empty scan.
+echo "PASS: 0 hits in: ${EXISTING_DIRS[*]}"
+if [[ ${#MISSING_DIRS[@]} -gt 0 ]]; then
+    echo "      NOT scanned (absent from $PROJECT_ROOT): ${MISSING_DIRS[*]}"
+    echo "      This is a clean result for the directories above, not for the whole tree."
+fi
 exit 0

--- a/skills/self-review/scripts/check_panel_diversity.py
+++ b/skills/self-review/scripts/check_panel_diversity.py
@@ -21,7 +21,12 @@ schema the editor already collects) and reports these diversity and panel-indepe
                      reviewer already covered — a fully-redundant lens that
                      added no independent signal. Distinct from healthy
                      CONSENSUS (a reviewer agreeing on SOME themes but also
-                     raising at least one family nobody else did). (Flag)
+                     raising at least one family nobody else did). Exempt when
+                     the roster declares that reviewer on a DIFFERENT substrate
+                     from the generator: agreement reached from another substrate
+                     is corroboration, not a redundant assignment, and it is the
+                     very lens SUBSTRATE_MONOCULTURE requires. Exempted ids are
+                     reported in summary.lens_collapse_substrate_exempt. (Flag)
   SUBSTRATE_MONOCULTURE  every reviewer the roster declares shares the *generator's*
                      model substrate — a same-model panel inherits the blind spots that
                      produced the draft and is not an independent check. Fires only when
@@ -336,7 +341,19 @@ def check(reviewers: list[dict], research_type: str | None,
                     f"{f}={c}" for f, c in sorted(family_hist.items(), key=lambda kv: -kv[1])),
             })
 
-    # 3) LENS_COLLAPSE — a reviewer whose every family is also covered by another
+    # 3) LENS_COLLAPSE — a reviewer whose every family is also covered by another.
+    #
+    # Exempt: a reviewer whose declared substrate DIFFERS from the generator's. For a
+    # same-substrate lens, raising only families others already raised is evidence of a
+    # redundant assignment. For a cross-substrate lens it is close to the opposite —
+    # independent corroboration is the strongest signal a panel can produce, and that lens is
+    # exactly what SUBSTRATE_MONOCULTURE (0b, above) requires the panel to contain. Firing
+    # here told the editor to reconsider the one reviewer keeping the panel independent.
+    # Gated on both substrates being declared, so an unlabelled roster is unaffected.
+    gen_sub = (generator_substrate or "").strip().lower()
+    declared_subs = {rid: str(s).strip().lower()
+                     for rid, s in (reviewer_substrates or {}).items() if s}
+    cross_substrate_exempt: list[str] = []
     for rid, fams in rev_families.items():
         own = {f for f in fams if f != "other"}
         if not own:
@@ -345,6 +362,11 @@ def check(reviewers: list[dict], research_type: str | None,
         for other_rid, other_fams in rev_families.items():
             if other_rid != rid:
                 others |= {f for f in other_fams if f != "other"}
+        if own and own <= others and gen_sub and declared_subs.get(rid, gen_sub) != gen_sub:
+            # Recorded, never silent: a skipped check that prints nothing is
+            # indistinguishable from a check that passed.
+            cross_substrate_exempt.append(rid)
+            continue
         if own and own <= others:  # fully subsumed by other reviewers
             claims.append({
                 "verdict": "LENS_COLLAPSE",
@@ -377,6 +399,7 @@ def check(reviewers: list[dict], research_type: str | None,
         "covered_axes": sorted(covered),
         "uncovered_axes": uncovered,
         "research_type_known": bool(research_type and research_type in EXPECTED_AXES),
+        "lens_collapse_substrate_exempt": sorted(cross_substrate_exempt),
     }
     return claims, summary
 
@@ -457,6 +480,11 @@ def main() -> int:
         if not s["research_type_known"]:
             print("NOTE: research type unknown — UNCOVERED_AXIS skipped "
                   "(pass --research-type to enable axis-coverage checks).")
+        if s.get("lens_collapse_substrate_exempt"):
+            print("NOTE: LENS_COLLAPSE exempt for "
+                  f"{', '.join(s['lens_collapse_substrate_exempt'])} — declared on a different "
+                  f"substrate from the generator, so full agreement reads as cross-substrate "
+                  f"corroboration, not a redundant lens.")
         if s["n_major"]:
             print(f"MAJOR candidate: {s['n_major']} diversity failure(s); "
                   f"covered axes: {', '.join(s['covered_axes']) or '(none)'}.")

--- a/skills/self-review/tests/test_panel_diversity.sh
+++ b/skills/self-review/tests/test_panel_diversity.sh
@@ -97,5 +97,39 @@ check "no SUBSTRATE_MONOCULTURE with an independent lens" no_verdict SUBSTRATE_M
 python3 "$SCRIPT" --panel "$GOOD" --roster "$ROSTER3" --out "$OUT" --quiet >/dev/null 2>&1
 check "no SUBSTRATE_MONOCULTURE without substrate info (backward compatible)" no_verdict SUBSTRATE_MONOCULTURE
 
+# (11) LENS_COLLAPSE must NOT fire on a reviewer declared on a DIFFERENT substrate from the
+#      generator. In COLLAPSE, R3's families are fully subsumed by R1's; under INDEPSUB, R3 is
+#      the non-claude lens — the very one whose presence stops SUBSTRATE_MONOCULTURE (case 9).
+#      Firing here told the editor that the panel's only independent lens "added no independent
+#      axis", i.e. to consider dropping it. Agreement reached from another substrate is
+#      corroboration, not a redundant assignment. Observed live in a Codex-reviewer panel.
+python3 "$SCRIPT" --panel "$COLLAPSE" --roster "$INDEPSUB" --out "$OUT" --strict --quiet >/dev/null 2>&1
+check "exit 0 (cross-substrate reviewer is not a collapsed lens)" test "$?" -eq 0
+check "no LENS_COLLAPSE on a cross-substrate reviewer" no_verdict LENS_COLLAPSE
+check "the exemption is recorded, not silent" python3 -c "
+import json
+d=json.load(open('$OUT'))
+ex=d['summary'].get('lens_collapse_substrate_exempt')
+assert ex == ['R3'], f'expected R3 recorded as exempt, got {ex!r}'
+"
+
+# (12) ...and the exemption is NOT a blanket disable: the same panel with an all-same-substrate
+#      roster must still raise LENS_COLLAPSE on R3. Without this, case (11) could be passed by
+#      simply deleting the check.
+python3 "$SCRIPT" --panel "$COLLAPSE" --roster "$MONOSUB" --out "$OUT" --quiet >/dev/null 2>&1
+check "LENS_COLLAPSE still fires when the redundant lens shares the generator substrate" \
+    has_verdict LENS_COLLAPSE
+check "nothing exempted when every substrate matches the generator" python3 -c "
+import json
+d=json.load(open('$OUT'))
+ex=d['summary'].get('lens_collapse_substrate_exempt')
+assert ex == [], f'expected no exemptions, got {ex!r}'
+"
+
+# (13) substrate-gated, as everywhere else: with no substrate info the pre-existing behaviour
+#      is unchanged — LENS_COLLAPSE fires exactly as it did before this exemption existed.
+python3 "$SCRIPT" --panel "$COLLAPSE" --roster "$ROSTER3" --out "$OUT" --quiet >/dev/null 2>&1
+check "LENS_COLLAPSE unchanged on a roster without substrate fields" has_verdict LENS_COLLAPSE
+
 echo "fail=$fail"; [[ "$fail" -eq 0 ]] && echo "ALL PASS" || echo "FAILURES: $fail"
 exit "$fail"

--- a/tests/test_tag_cleanup_gate.sh
+++ b/tests/test_tag_cleanup_gate.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Regression test for scripts/tag_cleanup_gate.sh (DI-8 draft-tag submission gate).
+#
+# The defect this exists for: the gate has two scan backends and they read DIFFERENT file
+# sets. ripgrep honours .gitignore/.ignore and skips dotfiles; the `grep -r` fallback reads
+# both. A submission package carrying a live TODO inside an ignored build/ directory, or a
+# FIXME in a hidden draft, was therefore invisible to the rg backend — and the gate printed
+#
+#     PASS: 0 hits. Submission package is tag-clean.
+#
+# and exited 0, while the same package on a machine without ripgrep correctly exited 1. The
+# verdict depended on which tool happened to be installed, and the silent side was the one
+# that passed. A second, quieter overclaim: the PASS sentence spoke for "the submission
+# package" while the scan covers only whichever scaffold directories exist.
+#
+# So the invariant under test is not "the gate runs" but PARITY: both backends must reach the
+# same verdict on the same tree, and the passing sentence must name what it actually read.
+#
+# Fixtures are built at runtime, so this file ships no live draft-stage tags of its own.
+# Stdlib/POSIX tools only.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HERE/../scripts/tag_cleanup_gate.sh"
+TMP="$(mktemp -d -t di8gate_XXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+skipped=0
+check() { local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then printf '  PASS  %s\n' "$label"
+    else printf '  FAIL  %s\n' "$label"; fail=$((fail+1)); fi
+}
+
+[[ -f "$GATE" ]] || { echo "ENV-ERR: $GATE missing" >&2; exit 2; }
+
+# A PATH with every directory that provides ripgrep removed, so the gate takes its grep
+# branch. Filtering the real PATH (rather than substituting a hand-built minimal one) keeps
+# every other tool the script may reach for available.
+strip_rg_from_path() {
+    local out="" d
+    local -a dirs
+    IFS=':' read -ra dirs <<< "$PATH"
+    for d in "${dirs[@]}"; do
+        [[ -n "$d" && -x "$d/rg" ]] && continue
+        out="${out:+$out:}$d"
+    done
+    printf '%s' "$out"
+}
+NORG_PATH="$(strip_rg_from_path)"
+HAVE_RG=0
+command -v rg >/dev/null 2>&1 && HAVE_RG=1
+
+# Run the gate on $2 under backend $1 ("rg" | "grep"); capture output and exit code.
+GATE_OUT=""; GATE_RC=0
+run_gate() {
+    local backend="$1" root="$2"
+    if [[ "$backend" == "grep" ]]; then
+        GATE_OUT="$(PATH="$NORG_PATH" bash "$GATE" "$root" 2>&1)"; GATE_RC=$?
+    else
+        GATE_OUT="$(bash "$GATE" "$root" 2>&1)"; GATE_RC=$?
+    fi
+}
+rc_is()      { test "$GATE_RC" -eq "$1"; }
+out_has()    { printf '%s' "$GATE_OUT" | grep -q -- "$1"; }
+out_lacks()  { ! printf '%s' "$GATE_OUT" | grep -q -- "$1"; }
+
+# --- fixture: a package whose only live tags sit where rg used to not look -----------------
+TAGGED="$TMP/tagged"
+mkdir -p "$TAGGED/7_Manuscript/build"
+printf 'build/\n' > "$TAGGED/.gitignore"
+# Split the markers so this test file itself carries no live draft tag.
+printf 'A hidden working note with FIX%s.\n' "ME" > "$TAGGED/7_Manuscript/.draft_note.md"
+printf 'Generated prose with TO%s left in it.\n' "DO" > "$TAGGED/7_Manuscript/build/generated.md"
+printf 'Clean prose, nothing to remove.\n' > "$TAGGED/7_Manuscript/main.md"
+git init -q "$TAGGED" 2>/dev/null && GIT_OK=1 || GIT_OK=0
+
+# (1) grep backend — always exercisable, and the branch that was already correct.
+run_gate grep "$TAGGED"
+check "grep backend: exit 1 on a package with hidden/ignored draft tags" rc_is 1
+check "grep backend: names the hidden file"    out_has ".draft_note.md"
+GREP_RC="$GATE_RC"
+
+# (2) rg backend — the regressed branch. Without --no-ignore --hidden this returned exit 0
+#     and the tag-clean sentence.
+if [[ "$HAVE_RG" -eq 1 ]]; then
+    run_gate rg "$TAGGED"
+    check "rg backend: exit 1 on the same package (was 0 before --no-ignore --hidden)" rc_is 1
+    check "rg backend: names the hidden file"   out_has ".draft_note.md"
+    check "rg backend: never claims tag-clean here" out_lacks "PASS"
+    # (3) parity — the property that makes the gate toolchain-independent.
+    check "parity: both backends reach the same verdict" test "$GATE_RC" -eq "$GREP_RC"
+    # (4) the gitignored hit, when git is available to make .gitignore meaningful to rg.
+    if [[ "$GIT_OK" -eq 1 ]]; then
+        check "rg backend: reads a gitignored file inside the package" out_has "generated.md"
+    else
+        printf '  SKIP  gitignored-file case (git unavailable; .gitignore inert for rg)\n'
+        skipped=$((skipped+1))
+    fi
+else
+    printf '  SKIP  rg backend NOT exercised (ripgrep not installed on this machine)\n'
+    printf '        The regressed branch is unverified here; CI runners carry ripgrep.\n'
+    skipped=$((skipped+1))
+fi
+
+# --- fixture: clean package, only some scaffold dirs present ------------------------------
+CLEAN="$TMP/clean"
+mkdir -p "$CLEAN/7_Manuscript"
+printf 'Clean prose only.\n' > "$CLEAN/7_Manuscript/main.md"
+
+run_gate grep "$CLEAN"
+check "clean package: exit 0"                       rc_is 0
+check "PASS names the directory actually scanned"   out_has "0 hits in: 7_Manuscript"
+check "PASS discloses the scaffold dirs it did NOT scan" out_has "NOT scanned"
+check "PASS no longer claims the whole package is tag-clean" out_lacks "Submission package is tag-clean"
+
+# --- no scaffold dirs at all -> exit 2, not a pass ----------------------------------------
+EMPTY="$TMP/empty"; mkdir -p "$EMPTY/some_other_layout"
+run_gate grep "$EMPTY"
+check "no scaffold dirs: exit 2 (not a silent pass)" rc_is 2
+
+# --- opt-out and exclusion behaviour must survive the widened scan -------------------------
+OPTOUT="$TMP/optout"
+mkdir -p "$OPTOUT/7_Manuscript"
+printf 'DI-8:ignore-file\nThis file quotes TO%s as a convention example.\n' "DO" \
+    > "$OPTOUT/7_Manuscript/tag_conventions.md"
+run_gate grep "$OPTOUT"
+check "DI-8:ignore-file opt-out still honoured (grep)" rc_is 0
+if [[ "$HAVE_RG" -eq 1 ]]; then
+    run_gate rg "$OPTOUT"
+    check "DI-8:ignore-file opt-out still honoured (rg)" rc_is 0
+fi
+
+EXCL="$TMP/excluded"
+mkdir -p "$EXCL/7_Manuscript"
+printf 'Reviewer 2 asked us to remove every TO%s marker.\n' "DO" \
+    > "$EXCL/7_Manuscript/peer_review_round1.md"
+run_gate grep "$EXCL"
+check "meta-discussion exclusion glob still honoured (grep)" rc_is 0
+if [[ "$HAVE_RG" -eq 1 ]]; then
+    run_gate rg "$EXCL"
+    check "meta-discussion exclusion glob still honoured (rg)" rc_is 0
+fi
+
+echo "fail=$fail skipped=$skipped"
+if [[ "$fail" -eq 0 ]]; then
+    [[ "$skipped" -eq 0 ]] && echo "ALL PASS" || echo "ALL PASS ($skipped skipped — see SKIP lines)"
+else
+    echo "FAILURES: $fail"
+fi
+exit "$fail"


### PR DESCRIPTION
Two maintainer-facing gates were reaching the wrong verdict. Neither was caught by a test, because one of them had none.

## `scripts/tag_cleanup_gate.sh` — a false PASS, decided by which tool you had installed

The gate picks between ripgrep and `grep -r` at runtime. The two read **different file sets**: rg honours `.gitignore`/`.ignore` and skips dotfiles; `grep -r` reads both. Reproduced end to end on a package containing `FIXME` in `7_Manuscript/.draft_note.md` and `TODO` in an ignored `7_Manuscript/build/generated.md`:

```
$ bash scripts/tag_cleanup_gate.sh .          # with ripgrep installed
PASS: 0 hits. Submission package is tag-clean.
EXIT=0
```

The same tree exits 1 on a machine without ripgrep. The verdict depended on the toolchain, and the blind backend was the one that passes. The rg branch now passes `--no-ignore --hidden`.

The PASS line carried a second, quieter overclaim: it spoke for "the submission package" while the scan covers only whichever of the six scaffold directories exist — a project laid out under other names got a clean bill of health from a scan that read nothing of it. It now names the directories it read and, when a declared directory is absent, says so and states that the result does not cover the tree.

## `skills/self-review/scripts/check_panel_diversity.py` — LENS_COLLAPSE against the one lens keeping the panel independent

`LENS_COLLAPSE` fires when a reviewer's concern families are all covered by others. That is reasonable evidence of a redundant assignment **when the reviewer shares the generator's model substrate**, and close to the opposite when it does not — agreement reached from a different substrate is corroboration, and that reviewer is precisely the lens `SUBSTRATE_MONOCULTURE` (same file) requires the panel to contain. It fired on a panel containing a cross-substrate reviewer, advising the editor to reconsider the one thing making the review independent.

Now exempt when the roster declares a reviewer on a different substrate from the generator. The exemption is **recorded** in `summary.lens_collapse_substrate_exempt` and printed — a check that skips silently is indistinguishable from one that passed. Gated on both substrates being declared, so a roster without substrate fields behaves exactly as before.

## Tests

`tests/test_tag_cleanup_gate.sh` is **new and CI-wired**; the gate shipped with no test at all. It builds its fixtures at runtime (so the repo ships no live draft tags of its own), runs the gate under **both** backends, and asserts the property that actually matters — the two reach the **same verdict on the same tree**. Against the pre-fix script it fails **8 of its 16** checks. The exclusion globs and the `DI-8:ignore-file` opt-out are asserted under both backends so the widened scan cannot quietly break them.

Three panel cases added, including one asserting `LENS_COLLAPSE` **still fires** on a same-substrate redundant lens — so the exemption cannot be satisfied by deleting the check.

## Verification

- `python3 scripts/run_ci_mirror.py` → **234/234 gates pass**, exit 0
- Both defects reproduced *before* the fix and re-run after
- `check_workflow_yaml.py` OK · 245 workflow steps all carry `run:`/`uses:` · `check_test_wiring.py`: 193 test assets all run by a workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)