### PR TITLE
fix(skills): four runs that reported success while producing the wrong artifact

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -324,6 +324,9 @@ jobs:
       - name: Run sync-submission preflight gate test (A6)
         run: bash skills/sync-submission/tests/test_preflight_gate.sh
 
+      - name: "Run sync-submission marked-build failure test (a failed Compare leaves no file behind)"
+        run: bash skills/sync-submission/tests/test_marked_build_failure.sh
+
       - name: "Run sync-submission portal-field-residue challenge (paste-verbatim .txt with markdown -> fires; clean -> clean)"
         run: bash skills/sync-submission/scripts/check_portal_field_residue_challenge/verify.sh
 
@@ -350,6 +353,9 @@ jobs:
 
       - name: "Run verify-refs last-field test (an entry's final field has no trailing comma)"
         run: bash skills/verify-refs/tests/test_bib_last_field.sh
+
+      - name: "Run verify-refs audit-source test (a committed audit must not carry an absolute path)"
+        run: bash skills/verify-refs/tests/test_audit_source_path.sh
 
       - name: "Run verify-refs claim-fidelity challenge (a real citation carrying a claim its source never makes)"
         run: bash skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
@@ -483,6 +489,9 @@ jobs:
 
       - name: Run fill-protocol form-fill test
         run: bash skills/fill-protocol/tests/test_fill_form.sh
+
+      - name: "Run fill-protocol newline test (a line break must reach the page, not hide in w:t)"
+        run: bash skills/fill-protocol/tests/test_fill_form_newlines.sh
 
       - name: Run fulltext-retrieval pdf_to_md helper test
         run: python3 skills/fulltext-retrieval/tests/test_pdf_to_md.py

--- a/docs/skills/academic-aio.md
+++ b/docs/skills/academic-aio.md
@@ -4,7 +4,7 @@
 
 > Medical AI paper optimization for AI search engines (Perplexity, ChatGPT web, Elicit, Consensus, SciSpace) and RAG-based literature tools. Applies when drafting or reviewing titles, abstracts, structured summary boxes (Key Points / Research in Context / Plain-Language Summary), manuscripts for high-impact medical AI journals (Lancet Digital Health, Radiology, Radiology-AI, npj Digital Medicine, Nature Medicine), preprints (medRxiv/arXiv), GitHub README + CITATION.cff + Zenodo archives, and Hugging Face model/dataset cards. Integrates TRIPOD+AI, CLAIM 2024, STARD-AI, TRIPOD-LLM, DECIDE-AI reporting requirements with generative engine optimization (GEO) principles. Produces a visible pass/fail checklist.
 
-**Invoke:** `/academic-aio` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
+**Invoke:** `/academic-aio` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 

--- a/docs/skills/find-journal.md
+++ b/docs/skills/find-journal.md
@@ -4,7 +4,7 @@
 
 > Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. Impact-factor and APC figures in a profile are point-in-time and may be stale — verify current metrics at the journal site. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 
-**Invoke:** `/find-journal` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
+**Invoke:** `/find-journal` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 

--- a/docs/skills/peer-review.md
+++ b/docs/skills/peer-review.md
@@ -4,7 +4,7 @@
 
 > Peer review assistant for medical journals. Generates structured review drafts with journal-specific formatting. Constructive developmental tone with systematic manuscript analysis.
 
-**Invoke:** `/peer-review` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
+**Invoke:** `/peer-review` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 

--- a/docs/skills/self-review.md
+++ b/docs/skills/self-review.md
@@ -4,7 +4,7 @@
 
 > Pre-submission self-review for the user's own manuscripts, applying a reviewer perspective. Systematic check across 10 categories with research-type branching. Outputs Anticipated Major/Minor Comments with severity framing and optional R0 numbering for /revise pipeline integration.
 
-**Invoke:** `/self-review` · **Tools:** Read, Write, Edit, Grep, Glob · **Model:** inherit
+**Invoke:** `/self-review` · **Tools:** Read, Write, Edit, Bash, Grep, Glob · **Model:** inherit
 
 ## When to use
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -83,8 +83,8 @@
     },
     {
       "path": "skills/academic-aio/SKILL.md",
-      "size": 32767,
-      "sha256": "5ed6874b7aa1036b1867f96149247eebffb2e61332c39696027811530de5282f"
+      "size": 32773,
+      "sha256": "9e43ec3cc38ab1988770cd0e071be92431bdef0d596d8f80b86abe79379c0117"
     },
     {
       "path": "skills/academic-aio/references/ai_tool_citation_framing.md",
@@ -1328,8 +1328,8 @@
     },
     {
       "path": "skills/fill-protocol/scripts/fill_form.py",
-      "size": 24311,
-      "sha256": "da014f1fcd965297765d3e383750c5ea20b10e303383a9d3da7715fbe751e19a"
+      "size": 25981,
+      "sha256": "1cbb68a6653df6e2a08c02882fa6937619babe2ac913c200999b857f60958122"
     },
     {
       "path": "skills/fill-protocol/scripts/inspect_template.py",
@@ -1388,8 +1388,8 @@
     },
     {
       "path": "skills/find-journal/SKILL.md",
-      "size": 18598,
-      "sha256": "fe4188fc24ecaecf1af22ad8a889525746fa6a98b0e03726e5c27ea7ef0b5f54"
+      "size": 18604,
+      "sha256": "7cfe761e0cb7fff71b7d4016c64052b2df6800c221838b8103a57452b3823461"
     },
     {
       "path": "skills/find-journal/references/acceptance_signals_schema.md",
@@ -3293,8 +3293,8 @@
     },
     {
       "path": "skills/peer-review/SKILL.md",
-      "size": 81702,
-      "sha256": "18d9c54589be0e30086b43ff50ac285815e1e852ae527905cf2225977492c35d"
+      "size": 81708,
+      "sha256": "68d3fd70d945dc6f0c8b5dd9a7f15e276d35d55b315f0029a79c34b0ce8f65ee"
     },
     {
       "path": "skills/peer-review/references/aczel_2021_reviewer2_patterns.md",
@@ -4243,8 +4243,8 @@
     },
     {
       "path": "skills/self-review/SKILL.md",
-      "size": 62498,
-      "sha256": "891b019237132a910e1157a9f0d6e5ac58bcab2a7077ab969b68e95e3ae5a63b"
+      "size": 62504,
+      "sha256": "1381805c3b91171c9bac2bcac9c5b8b061164ccdfeb86044517dbe82881c21f3"
     },
     {
       "path": "skills/self-review/references/domain-probes/ai_overclaiming.md",
@@ -5323,8 +5323,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/build_marked_manuscript.py",
-      "size": 6413,
-      "sha256": "259d027039bc05d41d6bdcd5e0648aa35aed88b053449015f3736e38107afe31"
+      "size": 8145,
+      "sha256": "9c2d6ab487bc15088aadc8b9c95c57e458f9598488e210a46459b70cb37dcb58"
     },
     {
       "path": "skills/sync-submission/scripts/check_asset_anonymization.py",
@@ -5648,8 +5648,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 47979,
-      "sha256": "4631625bb9a5bb2514d6c3f910d1f6d1cf443710e8aec554e5d35522ca6deebb"
+      "size": 49238,
+      "sha256": "5e631278ab1b38960d6ba1865cc360855fb2d600024fb67a8e3a9c5a82d5ba9c"
     },
     {
       "path": "skills/verify-refs/skill.yml",

--- a/skills/academic-aio/SKILL.md
+++ b/skills/academic-aio/SKILL.md
@@ -2,7 +2,7 @@
 name: academic-aio
 description: Medical AI paper optimization for AI search engines (Perplexity, ChatGPT web, Elicit, Consensus, SciSpace) and RAG-based literature tools. Applies when drafting or reviewing titles, abstracts, structured summary boxes (Key Points / Research in Context / Plain-Language Summary), manuscripts for high-impact medical AI journals (Lancet Digital Health, Radiology, Radiology-AI, npj Digital Medicine, Nature Medicine), preprints (medRxiv/arXiv), GitHub README + CITATION.cff + Zenodo archives, and Hugging Face model/dataset cards. Integrates TRIPOD+AI, CLAIM 2024, STARD-AI, TRIPOD-LLM, DECIDE-AI reporting requirements with generative engine optimization (GEO) principles. Produces a visible pass/fail checklist.
 triggers: AIO, LLMO, GEO, AI search optimization, discoverability, abstract optimization, structured abstract, Key Points, Research in context, plain-language summary, preprint strategy, GitHub README, CITATION.cff, Zenodo DOI, Hugging Face model card, dataset card, Perplexity, Elicit, Consensus, SciSpace, RAG visibility, reporting guideline compliance, TRIPOD-AI, CLAIM, STARD-AI, taxonomy review paper, Radiology Key Points, Lancet Digital Health Research in context, npj Digital Medicine
-tools: Read, Write, Edit, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
 

--- a/skills/fill-protocol/scripts/fill_form.py
+++ b/skills/fill-protocol/scripts/fill_form.py
@@ -69,6 +69,30 @@ def _make_blank_paragraph() -> "OxmlElement":
     return p
 
 
+def _append_text_with_breaks(run_elem, text: str) -> None:
+    """Fill a `w:r` with `text`, turning every `\\n` into a real `w:br`.
+
+    Word does not read a newline inside `w:t` as a line break — it collapses it to a space. So
+    `t.text = chunk` on multi-line content produces a document that opens cleanly, validates, and
+    has silently run the author's list together. Three call sites built runs by hand and only one
+    of them split on `\\n`, which meant `section_replace` content kept its line breaks in the FIRST
+    paragraph and lost them in every paragraph after it — an IRB form's inclusion criteria arriving
+    as a single flowed sentence, under a `[OK]` line and a clean `validate()`. Nothing but opening
+    the rendered PDF could see it.
+
+    Every run-building path goes through here now, so the class cannot come back one call site at
+    a time.
+    """
+    for i, line in enumerate(text.split("\n")):
+        if i > 0:
+            run_elem.append(OxmlElement("w:br"))
+        if line:
+            t = OxmlElement("w:t")
+            t.text = line
+            t.set(qn("xml:space"), "preserve")
+            run_elem.append(t)
+
+
 def _replace_paragraph_text_keep_style(para: Paragraph, new_text: str,
                                         korean_font: str | None = None) -> None:
     """Replace the entire text content of a paragraph while keeping its style.
@@ -97,17 +121,7 @@ def _replace_paragraph_text_keep_style(para: Paragraph, new_text: str,
         from copy import deepcopy
         new_run.append(deepcopy(template_rPr))
 
-    # Split on \n — insert w:br between lines, w:t for text segments
-    lines = new_text.split("\n")
-    for i, line in enumerate(lines):
-        if i > 0:
-            br = OxmlElement("w:br")
-            new_run.append(br)
-        if line:
-            t = OxmlElement("w:t")
-            t.text = line
-            t.set(qn("xml:space"), "preserve")
-            new_run.append(t)
+    _append_text_with_breaks(new_run, new_text)
 
     para._element.append(new_run)
 
@@ -160,10 +174,7 @@ def _replace_cell_text(cell: _Cell, new_text: str,
             new_r = OxmlElement("w:r")
             if first_rPr is not None:
                 new_r.append(deepcopy(first_rPr))
-            t = OxmlElement("w:t")
-            t.text = line
-            t.set(qn("xml:space"), "preserve")
-            new_r.append(t)
+            _append_text_with_breaks(new_r, line)
             new_p.append(new_r)
             cell._tc.append(new_p)
 
@@ -304,10 +315,7 @@ class FormFiller:
                 new_p = OxmlElement("w:p")
                 # New paragraph should NOT have header style — use default (no pPr)
                 new_r = OxmlElement("w:r")
-                t = OxmlElement("w:t")
-                t.text = chunk
-                t.set(qn("xml:space"), "preserve")
-                new_r.append(t)
+                _append_text_with_breaks(new_r, chunk)
                 new_p.append(new_r)
                 insert_after.addnext(new_p)
                 # Apply Korean font
@@ -356,10 +364,7 @@ class FormFiller:
             new_r = OxmlElement("w:r")
             if first_rPr is not None:
                 new_r.append(deepcopy(first_rPr))
-            t = OxmlElement("w:t")
-            t.text = chunk
-            t.set(qn("xml:space"), "preserve")
-            new_r.append(t)
+            _append_text_with_breaks(new_r, chunk)
             new_p.append(new_r)
             insert_after.addnext(new_p)
             from docx.text.run import Run
@@ -459,7 +464,27 @@ class FormFiller:
             warnings.append(f"[TABLE-MISS] Label not found: {label!r}")
         for header in self._paragraph_results.unmatched:
             warnings.append(f"[SECTION-MISS] Header not found: {header!r}")
+        warnings.extend(self._raw_newline_warnings())
         return warnings
+
+    def _raw_newline_warnings(self) -> list[str]:
+        """A newline that survived into `w:t` is a line break the reader will never see.
+
+        This is the only failure in this tool that both fills and validates cleanly: every label
+        matches, every section is found, the file opens in Word — and the list the author wrote is
+        one flowed sentence, because Word treats a newline inside `w:t` as a space. It went to an
+        institutional review board that way once. Checking the produced XML is what makes the
+        `[OK]` line mean something; checking the fill results only ever proved the fill ran.
+        """
+        out: list[str] = []
+        for t in self.doc.element.body.iter(qn("w:t")):
+            if t.text and "\n" in t.text:
+                shown = t.text.strip().replace("\n", "\\n")[:60]
+                out.append(
+                    f"[RAW-NEWLINE] A line break will render as a space: {shown!r} "
+                    "— the text needs a w:br or a new paragraph, not a newline in w:t"
+                )
+        return out
 
     def report(self) -> str:
         n_table_ok = len(self._table_results.matched)

--- a/skills/fill-protocol/tests/test_fill_form_newlines.sh
+++ b/skills/fill-protocol/tests/test_fill_form_newlines.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Regression test: a newline in section content must become a line break the reader can see.
+#
+# `section_replace` splits its content on `\n\n` into paragraphs. Only the FIRST of those went
+# through the run builder that turns `\n` into `w:br`; every later one did `t.text = chunk`, which
+# leaves the newline inside `w:t` — and Word renders a newline in `w:t` as a space. An IRB form's
+# inclusion criteria, written as "1) ...\n2) ...\n3) ...", therefore arrived as one flowed
+# sentence. The run printed `[OK]` for every label and `validate()` returned clean, because both
+# were reporting on the fill, not on the document. Only opening the rendered PDF showed it.
+#
+# Both defective paths are covered here: the branch that REPLACES existing body paragraphs, and
+# the branch that INSERTS when a header is immediately followed by the next header. The assertions
+# are made against the produced XML — the artifact — not against the filler's own report.
+#
+# Builds its template at runtime; no committed binary fixture. Network-free.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../scripts/fill_form.py"
+TMP="$(mktemp -d -t fillnl_XXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+[ -f "$SCRIPT" ] || { echo "ENV-ERR: fill_form.py missing" >&2; exit 2; }
+python3 -c "import docx, yaml" 2>/dev/null || { echo "SKIP: python-docx/pyyaml unavailable"; exit 0; }
+
+TEMPLATE="$TMP/template.docx"
+CONTENT="$TMP/content.yaml"
+OUTPUT="$TMP/filled.docx"
+
+python3 - "$TEMPLATE" <<'PY'
+import sys
+from docx import Document
+doc = Document()
+doc.add_paragraph("1. Background")
+doc.add_paragraph("TODO: background placeholder")     # replace-path: a body paragraph exists
+doc.add_paragraph("2. Eligibility")
+doc.add_paragraph("3. References")                    # insert-path: header follows header
+doc.add_paragraph("TODO: references placeholder")
+doc.save(sys.argv[1])
+PY
+
+# Chunk 0 of Background carries one newline; chunk 1 carries two. Eligibility has no body
+# paragraph after it, so it takes the insert branch, and its single chunk carries two newlines.
+# The single-line section is the negative control: it must produce no break at all.
+cat > "$CONTENT" <<'YAML'
+section_replace:
+  "1. Background": "Opening line one\nOpening line two\n\nInclusion criteria:\n1) age 19 or over\n2) index CT available\n3) written consent"
+  "2. Eligibility": "Exclusion criteria:\n1) prior surgery\n2) no follow-up"
+  "3. References": "A single line with no breaks at all."
+YAML
+
+LOG="$TMP/run.log"
+python3 "$SCRIPT" --template "$TEMPLATE" --content "$CONTENT" --output "$OUTPUT" >"$LOG" 2>&1
+rc=$?
+ck "fill_form exit code" "0" "$rc"
+
+out="$(python3 - "$OUTPUT" <<'PY'
+import json, sys, zipfile, re
+xml = zipfile.ZipFile(sys.argv[1]).read("word/document.xml").decode("utf-8")
+from docx import Document
+doc = Document(sys.argv[1])
+res = {}
+# w:br elements are the line breaks a reader actually sees.
+res["breaks"] = str(len(re.findall(r"<w:br\s*/>", xml)))
+# A newline surviving inside w:t is the defect itself, in the artifact.
+res["raw_newlines_in_wt"] = str(len(re.findall(r"<w:t[^>]*>[^<]*\n[^<]*</w:t>", xml)))
+# Every criterion must still be present as text — a fix that dropped content would be worse.
+blob = "\n".join(p.text for p in doc.paragraphs)
+for token in ("age 19 or over", "index CT available", "written consent",
+              "prior surgery", "no follow-up", "Opening line two"):
+    res["has_" + token.split()[0] + token.split()[-1]] = str(token in blob).lower()
+res["single_line_intact"] = str("A single line with no breaks at all." in blob).lower()
+print(json.dumps(res))
+PY
+)"
+get() { python3 -c "import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])" "$out" "$1"; }
+
+echo "==== every newline became a break the reader can see ===="
+# Background: 1 (chunk 0) + 3 (chunk 1) = 4.  Eligibility, insert path: 2.  References: 0.
+ck "w:br elements in the produced document"   "6"     "$(get breaks)"
+
+echo "==== NEGATIVE CONTROLS ===="
+ck "newlines left inside w:t"                 "0"     "$(get raw_newlines_in_wt)"
+ck "single-line section unchanged"            "true"  "$(get single_line_intact)"
+
+echo "==== no criterion was dropped in the process ===="
+ck "chunk 0, second line"                     "true"  "$(get has_Openingtwo)"
+ck "replace path, first criterion"            "true"  "$(get has_ageover)"
+ck "replace path, last criterion"             "true"  "$(get has_writtenconsent)"
+ck "insert path, first criterion"             "true"  "$(get has_priorsurgery)"
+ck "insert path, last criterion"              "true"  "$(get has_nofollow-up)"
+
+echo "==== validate() can see the defect if it ever returns ===="
+warned="$(python3 - "$SCRIPT" "$TMP" <<'PY'
+import importlib.util, sys
+from pathlib import Path
+from docx import Document
+from docx.oxml.ns import qn
+
+spec = importlib.util.spec_from_file_location("ff", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["ff"] = m
+spec.loader.exec_module(m)
+
+# A document poisoned the way the old code poisoned it: a newline sitting inside w:t.
+p = Path(sys.argv[2]) / "poisoned.docx"
+doc = Document()
+para = doc.add_paragraph()
+run = para.add_run()
+t = run._element.find(qn("w:t"))
+if t is None:
+    from docx.oxml import OxmlElement
+    t = OxmlElement("w:t")
+    run._element.append(t)
+t.text = "1) first\n2) second"
+doc.save(p)
+
+filler = m.FormFiller(str(p))
+hits = [w for w in filler.validate() if "RAW-NEWLINE" in w]
+print(len(hits))
+PY
+)"
+ck "warning raised on a poisoned document"    "1"     "$warned"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: line breaks reach the page, no newline hides in w:t, and validate() would say so."

--- a/skills/find-journal/SKILL.md
+++ b/skills/find-journal/SKILL.md
@@ -2,7 +2,7 @@
 name: find-journal
 description: Journal recommendation engine for medical manuscripts. 2-pass matching against a curated public profile library plus any user-local private profiles, enriched with detailed write-paper profiles for top-5 output. Returns ranked recommendations with scope fit rationale, AI disclosure policy, and homepage links. Impact-factor and APC figures in a profile are point-in-time and may be stale — verify current metrics at the journal site. A pre-ranking acceptance-readiness pre-flight scans the manuscript for design-ceiling, unfixable-defect, and importance-risk signals to add an acceptance-feasibility axis alongside scope fit, and the output includes a reject-fallback cascade plan.
 triggers: find journal, recommend journal, where to submit, which journal, journal selection, target journal, journal match
-tools: Read, Write, Edit, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
 

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -2,7 +2,7 @@
 name: peer-review
 description: Peer review assistant for medical journals. Generates structured review drafts with journal-specific formatting. Constructive developmental tone with systematic manuscript analysis.
 triggers: peer review, manuscript review, review paper, reviewer comments, 리뷰, 논문 리뷰, review invitation, journal review
-tools: Read, Write, Edit, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -2,7 +2,7 @@
 name: self-review
 description: Pre-submission self-review for the user's own manuscripts, applying a reviewer perspective. Systematic check across 10 categories with research-type branching. Outputs Anticipated Major/Minor Comments with severity framing and optional R0 numbering for /revise pipeline integration.
 triggers: self-review, pre-submission check, check my paper, reviewer perspective, manuscript self-check
-tools: Read, Write, Edit, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: inherit
 ---
 

--- a/skills/sync-submission/scripts/build_marked_manuscript.py
+++ b/skills/sync-submission/scripts/build_marked_manuscript.py
@@ -77,7 +77,19 @@ def run_compare(original: Path, revised: Path, out: Path, author: str, timeout: 
         )
 
     # Seed the destination with the original so Word opens — and may therefore write — it.
+    #
+    # That seeding is why every failure below must delete `out`. A Compare that dies leaves this
+    # copy behind: a plausible .docx of plausible size, carrying zero tracked changes, sitting at
+    # exactly the path the user asked the marked manuscript to be written to. Observed on an AJNR
+    # major revision, where a near-total rewrite blew past the old 180-second default and the
+    # AppleEvent failed -1712 — the run reported the failure, but the file it left was
+    # indistinguishable by inspection from a marked manuscript with nothing to mark.
     shutil.copyfile(original, out)
+
+    def _abandon(message: str) -> "SystemExit":
+        out.unlink(missing_ok=True)
+        return SystemExit(message)
+
     script = APPLESCRIPT.format(
         timeout=timeout,
         out=_as_literal(str(out)),
@@ -89,12 +101,21 @@ def run_compare(original: Path, revised: Path, out: Path, author: str, timeout: 
             ["osascript", "-e", script], capture_output=True, text=True, timeout=timeout + 30
         )
     except subprocess.TimeoutExpired:
-        raise SystemExit(
+        raise _abandon(
             "Word did not respond. It is most likely showing a modal sheet — check for a "
-            '"Grant File Access" dialog and dismiss it, then re-run.'
+            '"Grant File Access" dialog and dismiss it, then re-run. '
+            f"({out.name} was removed; it held no comparison.)"
         )
     if p.returncode != 0:
-        raise SystemExit(f"Word Compare failed: {p.stderr.strip()}")
+        err = p.stderr.strip()
+        hint = ""
+        if "-1712" in err or "timed out" in err.lower():
+            hint = (
+                f"\nThat is the AppleEvent timeout: Compare needed longer than --timeout "
+                f"({timeout}s). A whole-manuscript revision routinely does. Re-run with a "
+                f"larger --timeout."
+            )
+        raise _abandon(f"Word Compare failed: {err}{hint}\n({out.name} was removed.)")
 
 
 def inject_line_numbers(path: Path) -> None:
@@ -131,7 +152,18 @@ def main() -> int:
         "--author", required=True, help="name to attribute every revision to (the submitting author)"
     )
     ap.add_argument("--line-numbers", action="store_true", help="inject continuous line numbering")
-    ap.add_argument("--timeout", type=int, default=180)
+    # 180 was the old default and it is not enough. A major revision is measured in whole
+    # sections moved, not sentences edited, and Word's Compare on one (149 paragraphs and no
+    # tables against 193 paragraphs and two) ran past 180s and failed; the same pair completed
+    # in well under 600. Waiting is cheap here — the cost of the low default was a failed run
+    # and a file that looked like a result.
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="seconds Word may spend comparing (default 600; a whole-manuscript revision needs "
+             "minutes, and the old 180 failed on one)",
+    )
     a = ap.parse_args()
 
     for f in (a.original, a.revised):

--- a/skills/sync-submission/tests/test_marked_build_failure.sh
+++ b/skills/sync-submission/tests/test_marked_build_failure.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Regression test: a Compare that fails must not leave a file where the marked manuscript goes.
+#
+# `run_compare` seeds `--out` with a copy of the original so Word has something to open. When the
+# comparison then dies, that copy stays: a plausible .docx, of plausible size, at exactly the path
+# the user asked the marked manuscript to be written to — and carrying zero tracked changes. On an
+# AJNR major revision (149 paragraphs and no tables against 193 and two, i.e. a rewrite) Compare
+# ran past the then-default 180-second timeout and failed -1712. The run said so, but the artifact
+# it left behind could not be told apart by inspection from a revision with nothing to revise.
+#
+# Two things are pinned here: the failure removes the seed, and the default timeout is no longer
+# the one that failed. Word itself is never invoked — `subprocess.run` and `platform.system` are
+# both substituted — so this runs on CI's Linux exactly as it does on a Mac.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+B="$REPO_ROOT/skills/sync-submission/scripts/build_marked_manuscript.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+out="$(python3 - "$B" <<'PY'
+import importlib.util, json, re, subprocess, sys, tempfile, types
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("bmm", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["bmm"] = m
+spec.loader.exec_module(m)
+
+results = {}
+
+# The default a user gets when they do not pass --timeout. 180 is the value that failed.
+src = Path(sys.argv[1]).read_text(encoding="utf-8")
+mo = re.search(r'"--timeout",\s*\n?\s*type=int,\s*\n?\s*default=(\d+)', src)
+results["default_timeout"] = mo.group(1) if mo else "NOT FOUND"
+
+m.platform = types.SimpleNamespace(system=lambda: "Darwin")
+
+
+def _run_fake(returncode, stderr):
+    def _fake(*a, **k):
+        return subprocess.CompletedProcess(a[0] if a else [], returncode, "", stderr)
+    return _fake
+
+
+with tempfile.TemporaryDirectory() as td:
+    td = Path(td)
+    original = td / "r0.docx"
+    revised = td / "r1.docx"
+    original.write_bytes(b"PK\x03\x04original")
+    revised.write_bytes(b"PK\x03\x04revised")
+
+    # 1. AppleEvent timeout: Compare needed longer than --timeout.
+    out1 = td / "marked_timeout.docx"
+    m.subprocess = types.SimpleNamespace(
+        run=_run_fake(1, "execution error: Microsoft Word got an error: AppleEvent timed out. (-1712)"),
+        TimeoutExpired=subprocess.TimeoutExpired,
+    )
+    try:
+        m.run_compare(original, revised, out1, "A Author", 180)
+        results["timeout_raised"] = "false"
+        results["timeout_message"] = ""
+    except SystemExit as e:
+        results["timeout_raised"] = "true"
+        results["timeout_message"] = str(e)
+    results["timeout_left_a_file"] = str(out1.exists()).lower()
+
+    # 2. Any other Compare failure — the seed must go too.
+    out2 = td / "marked_other.docx"
+    m.subprocess = types.SimpleNamespace(
+        run=_run_fake(1, "execution error: Word could not open the document."),
+        TimeoutExpired=subprocess.TimeoutExpired,
+    )
+    try:
+        m.run_compare(original, revised, out2, "A Author", 600)
+    except SystemExit:
+        pass
+    results["other_failure_left_a_file"] = str(out2.exists()).lower()
+
+    # 3. NEGATIVE CONTROL — a Compare that SUCCEEDS must leave the file alone.
+    out3 = td / "marked_ok.docx"
+    m.subprocess = types.SimpleNamespace(
+        run=_run_fake(0, ""), TimeoutExpired=subprocess.TimeoutExpired
+    )
+    m.run_compare(original, revised, out3, "A Author", 600)
+    results["success_kept_the_file"] = str(out3.exists()).lower()
+
+print(json.dumps(results))
+PY
+)"
+
+get() { python3 -c "import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])" "$out" "$1"; }
+
+echo "==== the default is no longer the one that failed ===="
+ck "--timeout default"                       "600"   "$(get default_timeout)"
+
+echo "==== a failed Compare leaves nothing to mistake for a result ===="
+ck "AppleEvent timeout raises"               "true"  "$(get timeout_raised)"
+ck "timeout left a file at --out"            "false" "$(get timeout_left_a_file)"
+ck "other failure left a file at --out"      "false" "$(get other_failure_left_a_file)"
+
+echo "==== NEGATIVE CONTROL — success is untouched ===="
+ck "successful Compare kept its output"      "true"  "$(get success_kept_the_file)"
+
+echo "==== the timeout failure says what to do about it ===="
+msg="$(get timeout_message)"
+case "$msg" in
+  *--timeout*) ck "message names --timeout" "yes" "yes" ;;
+  *)           ck "message names --timeout" "yes" "no  ($msg)" ;;
+esac
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: a Compare that fails removes its seed, and the default timeout fits a real revision."

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -998,6 +998,30 @@ def flag_pagination_placeholder(record: RefRecord) -> None:
         record.evidence = f"{record.evidence} | {ev}".strip(" |") if record.evidence else ev
 
 
+def portable_source(source: Path, project_root: Path) -> str:
+    """Render the audited file's path so the audit can travel with the manuscript.
+
+    `source` was written with `str()`, i.e. whatever the caller passed — and the caller
+    resolves it, so on a real run that is an absolute path. On a maintainer's machine an
+    absolute path contains the home directory, and therefore a username, inside
+    `qc/reference_audit.json`, which is a COMMITTED artifact. The public-surface PII gate
+    caught exactly that three times between 2026-07-31 and 2026-08-01; the field is
+    rewritten on every render, so hand-scrubbing it lost twice.
+
+    Nothing consumes the absolute form. The audit file lives beside the manuscript and
+    moves with it, so a path relative to the project root is not merely PII-free, it is
+    the correct referent. Falls back to the CWD, then to the bare filename, so a source
+    outside the project (a shared .bib) still yields something readable and still carries
+    no home directory.
+    """
+    for base in (project_root, Path.cwd()):
+        try:
+            return source.resolve().relative_to(base.resolve()).as_posix()
+        except ValueError:
+            continue
+    return source.name
+
+
 def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
                   duplicate_findings: list[dict]) -> None:
     """Audit-only writer (v1.3.0).
@@ -1024,7 +1048,7 @@ def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
         counts[rec.status] = counts.get(rec.status, 0) + 1
     audit = {
         "schema_version": 4,
-        "source": str(source),
+        "source": portable_source(source, project_root),
         "total_references": len(records),
         "counts": counts,
         "duplicate_findings": duplicate_findings,

--- a/skills/verify-refs/tests/test_audit_source_path.sh
+++ b/skills/verify-refs/tests/test_audit_source_path.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression test: the audit's `source` field must never carry an absolute path.
+#
+# `qc/reference_audit.json` is a committed artifact that travels with the manuscript, and its
+# `source` was written as `str(source)` — the caller resolves the input, so on a real run that is
+# an absolute path. On a maintainer's machine an absolute path contains the home directory, and
+# therefore a username. The public-surface PII gate caught it three times between 2026-07-31 and
+# 2026-08-01: the field is rewritten on every render, so hand-scrubbing lost twice.
+#
+# The fix is `portable_source()`. This test pins BOTH directions: the path is relative (so the
+# audit is portable and PII-free) AND it still identifies the file (so the field keeps its
+# meaning). The last two cases are negative controls — a name that merely *looks* like a home
+# directory, and a source outside the project, which must degrade to a bare filename rather than
+# leaking the way there.
+#
+# Network-free: nothing here calls PubMed, CrossRef or OpenAlex.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+V="$REPO_ROOT/skills/verify-refs/scripts/verify_refs.py"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-52s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-52s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+out="$(python3 - "$V" <<'PY'
+import importlib.util, json, os, sys, tempfile
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("vr", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+sys.modules["vr"] = m
+spec.loader.exec_module(m)
+
+results = {}
+with tempfile.TemporaryDirectory() as td:
+    td = Path(td).resolve()
+    # A directory tree shaped like the real thing: a home, a project inside it, a bib inside that.
+    home = td / "Users" / "someone"
+    project = home / "workspace" / "05_Paper"
+    (project / "manuscript").mkdir(parents=True)
+    bib = project / "manuscript" / "refs.bib"
+    bib.write_text("@article{k,\n  title = {A title}\n}\n", encoding="utf-8")
+
+    results["inside_project"] = m.portable_source(bib, project)
+
+    # Source outside the project entirely — a shared library .bib two levels up.
+    shared = home / "shared" / "library.bib"
+    shared.parent.mkdir(parents=True)
+    shared.write_text("", encoding="utf-8")
+    results["outside_project"] = m.portable_source(shared, project)
+
+    # The end-to-end path: write_outputs is what actually produces the committed file.
+    m.write_outputs([], project, bib, [])
+    audit = json.loads((project / "qc" / "reference_audit.json").read_text(encoding="utf-8"))
+    results["written"] = audit["source"]
+    results["written_is_absolute"] = str(Path(audit["source"]).is_absolute()).lower()
+    # The whole point: the serialized artifact must not contain the tree above the project.
+    blob = (project / "qc" / "reference_audit.json").read_text(encoding="utf-8")
+    results["home_leaked"] = str("someone" in blob).lower()
+
+    # Relative-to-CWD fallback: a source under the CWD but outside --project-root.
+    cwd_before = Path.cwd()
+    try:
+        os.chdir(home)
+        results["under_cwd"] = m.portable_source(shared, project)
+    finally:
+        os.chdir(cwd_before)
+
+print(json.dumps(results))
+PY
+)"
+
+get() { python3 -c "import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])" "$out" "$1"; }
+
+echo "==== the source is relative, and still names the file ===="
+ck "source inside the project root"        "manuscript/refs.bib"  "$(get inside_project)"
+ck "as written into reference_audit.json"  "manuscript/refs.bib"  "$(get written)"
+
+echo "==== NEGATIVE CONTROLS — nothing above the project may appear ===="
+ck "written path is absolute"              "false"                "$(get written_is_absolute)"
+ck "home directory name in the artifact"   "false"                "$(get home_leaked)"
+
+echo "==== a source outside the project degrades to a name, not a route ===="
+ck "outside project, no CWD match"         "library.bib"          "$(get outside_project)"
+ck "outside project, but under the CWD"    "shared/library.bib"   "$(get under_cwd)"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: reference_audit.json names its source without naming the machine."


### PR DESCRIPTION
Four defects that share one shape: the run reported success, and the artifact was wrong. Each was
carried in the review backlog; each was verified against `main` before being touched, by reading the
code rather than the report of it.

Verifying first mattered more than expected. Nine backlog items of this kind were checked against
`main`: **four were already fixed** and needed no change, and a fifth had had its defect fixed while
the gate it actually asked for was still missing. Those five are recorded and closed or re-scoped
rather than re-fixed.

---

### 1. `/fill-protocol` — a line break that renders as a space, under `[OK]`

`section_replace` splits its content on `\n\n` into paragraphs. Only the **first** of those went
through the run builder that turns `\n` into `w:br`; every later one did `t.text = chunk`, leaving
the newline inside `w:t`. Word renders a newline inside `w:t` as a space, so an institutional form's
inclusion criteria — written `1) …\n2) …\n3) …` — arrived as one flowed sentence.

Both defective paths are fixed (the branch that replaces existing body paragraphs, and the branch
that inserts when a section header is immediately followed by the next header). All run-building
sites now share `_append_text_with_breaks`, so the class cannot return one call site at a time.

`validate()` gains a `[RAW-NEWLINE]` warning that reads the produced XML. That is the part that
makes `[OK]` mean something: every label matched, every section was found, the file opened in Word,
and `validate()` was clean — because all of them were reporting on the fill, not on the document.

### 2. Four skills instructed their own gates to run, and could not run them

`self-review` names **32** script invocations in its body and had `tools: Read, Write, Edit, Grep,
Glob` — no `Bash`. Same for `peer-review` (5), `academic-aio` (2) and `find-journal` (1). A gate that
is documented but unrunnable is worse than an absent one, because the documentation reads as
coverage. (`humanize` hit this in #368; the sweep it implied was never run. The backlog item named
two skills; there were four.)

### 3. `/sync-submission` — a failed Compare left a file where the marked manuscript goes

`run_compare` seeds `--out` with a copy of the original so Word has something to open. When the
comparison then failed, that copy stayed: a plausible `.docx`, of plausible size, at exactly the
requested path, carrying zero tracked changes. Every failure path now removes it.

The default `--timeout` moves 180 → 600. On a real major revision — 149 paragraphs and no tables
against 193 and two, i.e. a rewrite — Compare ran past 180 s and failed `-1712`; the same pair
completed well under 600. The failure message now names `--timeout` when the error is that timeout.

### 4. `/verify-refs` — a username in a committed audit file

`qc/reference_audit.json` recorded `source` as `str(source)`, and the caller resolves its input, so
on a real run that is an absolute path — containing, on a maintainer's machine, a home directory.
The public-surface PII gate caught it three times between 2026-07-31 and 08-01, because the field is
rewritten on every render and hand-scrubbing lost twice. `portable_source()` writes it relative to
the project root, falling back to the CWD and then to the bare filename. Nothing consumed the
absolute form; the audit travels with the manuscript, so relative is also the correct referent.

---

### Verification

Three regression tests, all network-free, all wired into `validate.yml`:

| test | run against the UNFIXED tree |
|---|---|
| `fill-protocol/tests/test_fill_form_newlines.sh` | **3 of 10 fail** — 1 `w:br` instead of 6, 2 newlines left in `w:t`, no warning |
| `sync-submission/tests/test_marked_build_failure.sh` | **3 of 6 fail** — default 180, and both failure paths leave the seed |
| `verify-refs/tests/test_audit_source_path.sh` | **3 of 6 fail** — absolute path written, home directory in the artifact |

Each also carries negative controls, because a test that only proves a gate fires cannot distinguish
a fix from a mute: single-line content must still produce **no** break; a Compare that succeeds must
**keep** its output; a source outside the project must degrade to a name rather than leak the route
to it. Those assertions pass on both trees, which is what makes the failures above evidence.

The pre-existing `test_fill_form.sh` still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
