### PR TITLE
perf(validator): --only <skill>, so a self-test stops paying for the whole repo

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,9 @@ jobs:
       - name: "Validator scope self-test (it must READ every directory it claims to scan)"
         run: bash tests/test_validator_scope.sh
 
+      - name: "Validator --only self-test (a scoped run must not read like a full one)"
+        run: bash tests/test_validator_only_flag.sh
+
       - name: "Run check_frontmatter_scope.py (a manuscript detector must not read YAML front matter as prose)"
         run: python3 scripts/check_frontmatter_scope.py --strict
 

--- a/docs/SKILL_TEMPLATE.md
+++ b/docs/SKILL_TEMPLATE.md
@@ -183,4 +183,6 @@ New skills should target **Mid** tier minimum. Core pipeline skills (write-paper
 - [ ] No hardcoded personal paths (use `${SKILL_DIR}` or `${CLAUDE_SKILL_DIR}`)
 - [ ] No PII or institution-specific content in examples
 - [ ] Triggers include both English and Korean keywords
-- [ ] `validate_skills.sh` passes for this skill
+- [ ] `bash scripts/validate_skills.sh --only <your-skill>` passes — seconds, instead of the whole
+      repo. It prints `SCOPED PASS`, not `ALL CHECKS PASSED`: the unscoped run is still the gate,
+      and CI runs it that way on your PR.

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -1,11 +1,48 @@
 #!/usr/bin/env bash
 # validate_skills.sh — Lint all medsci-skills for required structure
 # Run from repo root: bash scripts/validate_skills.sh
+#                     bash scripts/validate_skills.sh --only <skill-name>
+#
+# `--only` exists because the validator's own self-tests were paying for the whole repo. Fixing the
+# find-glob bug (#435) took this script from reading 58 files to ~1,200, and the two tests written
+# to prove that fix works each invoke the validator again — so CI ran the full scan three times and
+# the `validate` job went from 3m57s to 5-7 minutes. Nothing was wrong with either test; the cost
+# was structural, because the validator took no arguments and a test that needs to observe ONE
+# fixture skill had no way to ask for less than all of them.
+#
+# It is a test affordance, not a release gate. A scoped run deliberately does NOT print the verdict
+# a full run prints — see the exit block. A cheap gate is one that actually gets run; a gate whose
+# partial result reads identically to its full result is worse than a slow one.
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
+
+ONLY_SKILL=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --only)
+      [ $# -ge 2 ] || { echo "--only requires a skill name" >&2; exit 2; }
+      ONLY_SKILL="$2"; shift 2 ;;
+    --only=*)
+      ONLY_SKILL="${1#--only=}"; shift ;;
+    -h|--help)
+      echo "usage: validate_skills.sh [--only <skill-name>]"
+      echo "  (no args)       validate every skill + the public-surface scan + the repo-wide gates"
+      echo "  --only <name>   validate just skills/<name>/ — for self-tests; NOT a release gate"
+      exit 0 ;;
+    *)
+      echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# A name matching nothing must be an error, never an empty loop. #435 was a gate that scanned zero
+# files and printed PASS; a silently-unmatched --only would rebuild exactly that shape.
+if [ -n "$ONLY_SKILL" ] && [ ! -f "$SKILLS_DIR/$ONLY_SKILL/SKILL.md" ]; then
+  echo "no such skill: $ONLY_SKILL (expected $SKILLS_DIR/$ONLY_SKILL/SKILL.md)" >&2
+  exit 2
+fi
 # Precedent / personal-identifier scanner. Structural shapes stay as plaintext
 # regex inside it; real names / mentors / institutions / project codes are
 # matched against SHA-256 digests (scripts/precedent_hashes.txt) so this public
@@ -66,8 +103,16 @@ _personal_path_hit() {
 RULE_IMPERATIVE='(apply|applies|follow|enforce|obey|adhere to|refer to|as required by|as specified in|read)[^|]{0,40}\.claude/rules/'
 
 echo "========================================="
-echo " MedSci Skills Validator"
+if [ -n "$ONLY_SKILL" ]; then
+  echo " MedSci Skills Validator — SCOPED to '$ONLY_SKILL'"
+else
+  echo " MedSci Skills Validator"
+fi
 echo "========================================="
+if [ -n "$ONLY_SKILL" ]; then
+  echo " Per-skill rules for this one skill only."
+  echo " NOT run: the other skills, the public-surface PII scan, the repo-wide gates."
+fi
 echo ""
 
 # Tool dependencies. exiftool is required for rule 10 (binary EXIF metadata
@@ -82,7 +127,13 @@ if ! command -v exiftool >/dev/null 2>&1; then
   exit 2
 fi
 
-for skill_dir in "$SKILLS_DIR"/*/; do
+if [ -n "$ONLY_SKILL" ]; then
+  SKILL_DIRS=("$SKILLS_DIR/$ONLY_SKILL/")
+else
+  SKILL_DIRS=("$SKILLS_DIR"/*/)
+fi
+
+for skill_dir in "${SKILL_DIRS[@]}"; do
   skill_name=$(basename "$skill_dir")
   skill_file="$skill_dir/SKILL.md"
 
@@ -474,6 +525,10 @@ PY
   echo ""
 done
 
+META_FAIL=0
+META_SCANNED=0
+if [ -z "$ONLY_SKILL" ]; then
+
 echo "========================================="
 echo " Public-surface PII scan (all tracked text outside skills/)"
 echo "========================================="
@@ -494,8 +549,6 @@ echo "========================================="
 # those files the precedent scan runs with --allow-author (the author's own name
 # digest is exempted), so other PII (hospital, project codes, personal paths) on
 # the same line is still caught. The author name is no longer spelled out here.
-META_FAIL=0
-META_SCANNED=0
 AUTHOR_ATTRIB_RE='^(README\.md|CITATION\.cff|paper\.md|\.zenodo\.json|MAINTAINERS\.md)$'
 while IFS= read -r rel; do
   case "$rel" in
@@ -535,6 +588,8 @@ echo "  Scanned $META_SCANNED tracked non-skills text files"
 [ "$META_FAIL" -eq 0 ] && pass "Public-surface PII scan clean (docs/, root, metadata)"
 echo ""
 
+fi  # end: whole-repo public-surface scan (skipped under --only)
+
 echo "========================================="
 echo " Summary"
 echo "========================================="
@@ -542,26 +597,34 @@ echo -e " Skills checked: ${TOTAL}"
 echo -e " ${GREEN}PASS${NC}: ${PASS}"
 echo -e " ${YELLOW}WARN${NC}: ${WARN}"
 echo -e " ${RED}FAIL${NC}: ${FAIL}"
-echo -e " Meta-doc FAIL: ${META_FAIL}"
+[ -z "$ONLY_SKILL" ] && echo -e " Meta-doc FAIL: ${META_FAIL}"
 echo ""
 
-python3 "$REPO_ROOT/scripts/validate_skill_contracts.py"
-contract_status=$?
-echo ""
+# The three repo-wide gates below reason about the whole skills/ tree (contracts, vendoring drift,
+# script reachability). Under --only they would either scan everything — defeating the point — or
+# report on a set the caller did not ask about. They are skipped, and the exit block says so.
+contract_status=0
+domain_probe_status=0
+script_reach_status=0
+if [ -z "$ONLY_SKILL" ]; then
+  python3 "$REPO_ROOT/scripts/validate_skill_contracts.py"
+  contract_status=$?
+  echo ""
 
-# Vendoring drift gate (all vendored sets: domain probes + RoB checklists + any undeclared
-# cross-skill duplicate). Capture the exit status explicitly: this script runs under
-# `set -uo pipefail` (not `set -e`), so a bare call would not abort and the failure would be
-# silently buried before the summary.
-python3 "$REPO_ROOT/scripts/check_domain_probe_sync.py" --strict
-domain_probe_status=$?
-echo ""
+  # Vendoring drift gate (all vendored sets: domain probes + RoB checklists + any undeclared
+  # cross-skill duplicate). Capture the exit status explicitly: this script runs under
+  # `set -uo pipefail` (not `set -e`), so a bare call would not abort and the failure would be
+  # silently buried before the summary.
+  python3 "$REPO_ROOT/scripts/check_domain_probe_sync.py" --strict
+  domain_probe_status=$?
+  echo ""
 
-# Script reachability. A script no SKILL.md invokes never runs for a user, however well it is
-# tested — the non-detector sibling of check_detector_reachability.py.
-python3 "$REPO_ROOT/scripts/check_script_reachability.py" --strict
-script_reach_status=$?
-echo ""
+  # Script reachability. A script no SKILL.md invokes never runs for a user, however well it is
+  # tested — the non-detector sibling of check_detector_reachability.py.
+  python3 "$REPO_ROOT/scripts/check_script_reachability.py" --strict
+  script_reach_status=$?
+  echo ""
+fi
 
 if [ "$FAIL" -gt 0 ]; then
   echo -e "${RED}VALIDATION FAILED${NC} — fix $FAIL issue(s) before release"
@@ -578,6 +641,12 @@ elif [ "$domain_probe_status" -ne 0 ]; then
 elif [ "$script_reach_status" -ne 0 ]; then
   echo -e "${RED}VALIDATION FAILED${NC} — a skill script is never invoked by any SKILL.md (see check_script_reachability.py)"
   exit 1
+elif [ -n "$ONLY_SKILL" ]; then
+  # Deliberately NOT "ALL CHECKS PASSED". A caller grepping for that string — a human skimming, a
+  # test, a future CI step — must not be able to get it out of a run that looked at one skill and
+  # skipped every repo-wide gate. The scoped verdict names its own scope.
+  echo -e "${GREEN}SCOPED PASS${NC} — skills/$ONLY_SKILL only; repo-wide gates NOT run"
+  exit 0
 else
   echo -e "${GREEN}ALL CHECKS PASSED${NC}"
   exit 0

--- a/tests/test_personal_rule_refs.sh
+++ b/tests/test_personal_rule_refs.sh
@@ -96,10 +96,11 @@ cat > "$FIXTURE_DIR/references/neg-table-cell.md" <<'EOF'
 | 3 | Numbers must come from the CSV | `~/.claude/rules/numerical-safety.md` |
 EOF
 
-OUT="$(bash "$REPO_ROOT/scripts/validate_skills.sh" 2>&1)"
-FLAGGED="$(printf '%s\n' "$OUT" | grep "$VERDICT" || true)"
-
 FIXTURE_NAME="$(basename "$FIXTURE_DIR")"
+# Scoped to the fixture — see the same note in tests/test_validator_scope.sh. Both assertions and
+# negative controls live inside this one skill's references/, so scanning the repo bought nothing.
+OUT="$(bash "$REPO_ROOT/scripts/validate_skills.sh" --only "$FIXTURE_NAME" 2>&1)"
+FLAGGED="$(printf '%s\n' "$OUT" | grep "$VERDICT" || true)"
 named() { printf '%s\n' "$FLAGGED" | grep -q "$FIXTURE_NAME/references/$1"; }
 
 named 'pos-apply.md';      ck "an 'apply <personal rule path>' instruction is caught"        0 "$?"

--- a/tests/test_validator_only_flag.sh
+++ b/tests/test_validator_only_flag.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Regression test: --only must narrow the WORK without narrowing the honesty of the verdict.
+#
+# The flag exists for speed — the two validator self-tests each re-ran the whole scan, so CI paid
+# for it three times per push. But a scope flag is the classic way to manufacture a meaningless
+# green: run less, print the same words, and every downstream reader concludes the same thing from
+# a weaker fact. #435 was already that shape once, from the other direction — a `find` glob that
+# matched zero files while the validator printed PASS for every rule.
+#
+# So this test asserts both halves:
+#   the flag WORKS      — one skill is scanned, the repo-wide gates do not run, it is fast
+#   the flag is HONEST  — the scoped verdict is a different string, the scope is announced, and a
+#                         name matching nothing is an error rather than an empty loop
+#
+# The last one is the load-bearing case. `--only typo` running zero skills and exiting 0 would
+# reproduce #435 exactly, inside the fix for its cost.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+V="$REPO_ROOT/scripts/validate_skills.sh"
+
+pass=0
+fail=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  PASS  %-58s %s\n' "$label" "$actual"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-58s expected=%s actual=%s\n' "$label" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# A real skill, chosen from disk rather than hardcoded so this does not rot when skills are renamed.
+TARGET="$(basename "$(find "$REPO_ROOT/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | sort | head -1 | xargs dirname)")"
+OTHER="$(basename "$(find "$REPO_ROOT/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | sort | tail -1 | xargs dirname)")"
+[ -n "$TARGET" ] && [ "$TARGET" != "$OTHER" ] || { echo "ENV-ERR: need two skills on disk" >&2; exit 2; }
+
+OUT="$(bash "$V" --only "$TARGET" 2>&1)"
+rc=$?
+
+echo "==== the flag works ===="
+ck "scoped run exit code"                    "0"  "$rc"
+printf '%s\n' "$OUT" | grep -q "^\[$TARGET\]"
+ck "the named skill was scanned"             "0"  "$?"
+printf '%s\n' "$OUT" | grep -q "^\[$OTHER\]"
+ck "another skill was NOT scanned"           "1"  "$?"
+ck "exactly one skill counted"               "1"  "$(printf '%s\n' "$OUT" | sed -n 's/^ Skills checked: \([0-9]*\)$/\1/p')"
+
+echo "==== the repo-wide gates did not run ===="
+# Each of the three prints a distinctive line; their absence is what makes the run cheap, and is
+# exactly what the verdict must therefore not paper over.
+#
+# Match a line the scan emits only when it RUNS, not its name. The first draft of this assertion
+# grepped for "Public-surface PII scan" and failed — against correct code — because the scoped
+# banner announces that very phrase in its list of what it is skipping. A test that cannot tell
+# "did the thing" from "named the thing" is measuring the wrong noun.
+printf '%s\n' "$OUT" | grep -qE 'Scanned [0-9]+ tracked non-skills text files'
+ck "public-surface scan skipped"             "1"  "$?"
+printf '%s\n' "$OUT" | grep -qi 'vendored\|domain probe'
+ck "vendoring-drift gate skipped"            "1"  "$?"
+printf '%s\n' "$OUT" | grep -qi 'reachable from a SKILL.md'
+ck "script-reachability gate skipped"        "1"  "$?"
+
+echo "==== the verdict is honest about its scope ===="
+printf '%s\n' "$OUT" | grep -q 'ALL CHECKS PASSED'
+ck "does NOT print the full-run verdict"     "1"  "$?"
+printf '%s\n' "$OUT" | grep -q 'SCOPED PASS'
+ck "prints a scoped verdict instead"         "0"  "$?"
+printf '%s\n' "$OUT" | grep -qi 'SCOPED to'
+ck "announces the scope in the banner"       "0"  "$?"
+printf '%s\n' "$OUT" | grep -qi 'repo-wide gates NOT run'
+ck "names what it did not do"                "0"  "$?"
+
+echo "==== a name matching nothing is an error, not an empty pass ===="
+bad_out="$(bash "$V" --only definitely-not-a-skill 2>&1)"; bad_rc=$?
+ck "unknown skill exit code"                 "2"  "$bad_rc"
+printf '%s\n' "$bad_out" | grep -q 'ALL CHECKS PASSED\|SCOPED PASS'
+ck "unknown skill prints no pass verdict"    "1"  "$?"
+bash "$V" --only >/dev/null 2>&1
+ck "--only with no argument exits 2"         "2"  "$?"
+bash "$V" --bogus-flag >/dev/null 2>&1
+ck "an unknown flag exits 2"                 "2"  "$?"
+
+echo "==== the unscoped run is still what CI actually runs ===="
+# This test deliberately does NOT invoke the full validator. That would take ~3 minutes and put
+# back the third full scan this whole change exists to remove — a regression test that reproduces
+# the cost it is testing the fix for is not a regression test, it is the bug with an assertion on
+# top. CI already runs the unscoped validator as its own step, and that step failing IS the
+# assertion that the full path still works.
+#
+# What is checkable here, and cheap, is that the step exists — i.e. that the coverage claim above
+# is true of the workflow rather than merely believed. If someone ever "optimises" CI by adding
+# --only to that step, the full scan silently stops happening and this fails.
+WF="$REPO_ROOT/.github/workflows/validate.yml"
+grep -qE 'bash scripts/validate_skills\.sh[[:space:]]*$' "$WF"
+ck "validate.yml runs the validator unscoped"  "0"  "$?"
+grep -qE 'scripts/validate_skills\.sh.*--only' "$WF"
+ck "no CI step scopes the release gate"        "1"  "$?"
+
+echo
+echo "  passed=$pass failed=$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "OK: --only narrows the work, says so, and refuses to narrow itself to nothing."

--- a/tests/test_validator_scope.sh
+++ b/tests/test_validator_scope.sh
@@ -74,10 +74,13 @@ printf -- 'note: "%s"\n'                   "$LEAK" > "$FIXTURE_DIR/skill.yml"
 # the rule is that this scan matches what the public sees, not what is on disk.
 printf -- '- scratch: %s\n'                "$LEAK" > "$FIXTURE_DIR/TODO_scratch.md"
 
-OUT="$(bash "$REPO_ROOT/scripts/validate_skills.sh" 2>&1)"
-FLAGGED="$(printf '%s\n' "$OUT" | grep 'Personal path in' || true)"
-
 FIXTURE_NAME="$(basename "$FIXTURE_DIR")"
+# Scoped to the fixture. Every assertion below is about locations INSIDE one skill, so the other
+# 57 and the whole-repo scan were pure cost — this test alone was ~90 s of CI, and it runs on every
+# push. `--only` errors out on a name it cannot find, so a typo here fails loudly rather than
+# validating nothing and letting `[ -n "$FLAGGED" ]` be the only thing standing.
+OUT="$(bash "$REPO_ROOT/scripts/validate_skills.sh" --only "$FIXTURE_NAME" 2>&1)"
+FLAGGED="$(printf '%s\n' "$OUT" | grep 'Personal path in' || true)"
 seen() { printf '%s\n' "$FLAGGED" | grep -q "$FIXTURE_NAME/$1"; }
 
 seen 'references/note.md';    ck "references/ is scanned"                    0 "$?"


### PR DESCRIPTION
`validate_skills.sh` gains `--only <skill-name>`, and the two self-tests that were re-running the
whole validator now use it.

### The cost was structural, not a mistake

Fixing the find-glob bug (#435) took the validator from reading 58 files to ~1,200 — that fix was
right, and the scan it restored is the one that had been silently doing nothing for two months. But
the two tests written to prove it works each invoke the validator again, so CI ran the full scan
**three times per push**. Neither test was wrong. The validator took no arguments, so a test that
needs to observe ONE fixture skill had no way to ask for less than all of them.

Measured, not estimated — the `validate` job on the sibling PR opened today took **9m6s**.

| | before | after |
|---|---:|---:|
| `tests/test_validator_scope.sh` | ~90 s | **0.58 s** |
| `tests/test_personal_rule_refs.sh` | ~90 s | **0.60 s** |
| a scoped run (`--only humanize`) | n/a | **1.2 s** |
| full validator runs per CI push | 3 | **1** |

### The part that needed care: a scope flag is how you manufacture a meaningless green

Running less and printing the same words would let every downstream reader draw the same conclusion
from a weaker fact. This repo has already been there once from the other direction — #435 was a
`find` glob that matched zero files while the validator printed PASS for every rule. So:

- the banner says `SCOPED to '<name>'` and names what it is **not** running;
- the verdict is `SCOPED PASS — skills/<name> only; repo-wide gates NOT run`, deliberately **not**
  the `ALL CHECKS PASSED` string a full run prints, so nothing grepping for it can get it out of a
  partial run;
- **a name matching nothing is `exit 2`**, never an empty loop. `--only typo` silently validating
  zero skills and exiting 0 would rebuild #435 inside the fix for its cost. On the pre-fix tree
  that is exactly what happens — the old validator ignores arguments, so `--only definitely-not-a-skill`
  runs everything and exits 0.

Skipped under `--only`: the other skills, the public-surface PII scan, and the three repo-wide gates
(`validate_skill_contracts`, `check_domain_probe_sync`, `check_script_reachability`). Every per-skill
rule still runs — the scoped run on `humanize` reports all 13.

### Verification

`tests/test_validator_only_flag.sh` (new, wired into `validate.yml`, 1.4 s) asserts both halves: the
flag works, and it is honest about what it did not do. Against the **pre-fix** validator it fails
**13 of 17**, and the 4 that pass are exactly the invariants that must not move — the named skill is
still scanned, and CI's own invocation is still unscoped.

The test deliberately does **not** invoke the full validator. A regression test that reproduces the
3-minute cost it exists to remove is the bug with an assertion on top. What it checks instead is
that `validate.yml` still runs the validator unscoped — so the coverage claim is true of the
workflow rather than merely believed, and an "optimisation" that adds `--only` to that step fails
here.

One assertion had to be corrected before it counted: it first grepped for the string
`Public-surface PII scan` and failed against correct code, because the scoped banner announces that
very phrase in its list of what it is skipping. It now matches a line the scan emits only when it
runs.

### Not done, on purpose

The candidate's second half — batching `check_precedent.py` so the hash set loads once instead of
per file — is left out. It is the larger term in the remaining full run, but rewriting the
precedent-scan plumbing needs its own test asserting batch mode finds exactly what per-file mode
finds, and that belongs in its own change rather than riding along with a scope flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
