### PR TITLE
fix(dist): the inventory described a payload no install reproduced

### DIFF
--- a/installers/tests/test_distribution_manifest.py
+++ b/installers/tests/test_distribution_manifest.py
@@ -39,6 +39,14 @@ def run(*args: str) -> int:
 def classroom_payload() -> set[str]:
     excl = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules", ".git", "tests", ".logs"}
     exclf = {".DS_Store"}
+    # Named exclusions, mirrored deliberately from gen_distribution_manifest.EXCLUDE_RELPATHS.
+    #
+    # `skills/MAINTENANCE.md` is a maintainer document at the skills/ root. install.py places
+    # skill DIRECTORIES, so it was inventoried and never installed — the ZIP and a local install
+    # disagreed and nothing compared them. Narrowing the payload is a scope change, so per the
+    # note below it is made in BOTH places on purpose; this test failing on the one-sided edit is
+    # the mechanism working, not an obstacle to route around by importing the generator.
+    exclrel = {"skills/MAINTENANCE.md"}
     payload: set[str] = set()
     # Deliberately re-derived here rather than imported: this is the independent oracle that
     # catches the payload scope widening by accident. Widening it on purpose means editing
@@ -52,7 +60,8 @@ def classroom_payload() -> set[str]:
             for f in p.rglob("*"):
                 rel = f.relative_to(ROOT)
                 if (f.is_file() and not (set(rel.parts) & excl)
-                        and f.name not in exclf and not f.name.endswith(".pyc")):
+                        and f.name not in exclf and rel.as_posix() not in exclrel
+                        and not f.name.endswith(".pyc")):
                     payload.add(rel.as_posix())
     return payload
 
@@ -89,6 +98,27 @@ def main() -> int:
           gdm._included(f"installers/.logs/{log_name}", log_name) is False)
     check("a normal installer file is still included",
           gdm._included("installers/install.py", "install.py") is True)
+
+    # regression: the inventory must describe a payload install.py can actually reproduce.
+    #
+    # install.py places skill DIRECTORIES — `p.is_dir() and (p / "SKILL.md").exists()`. Anything
+    # else under skills/ is inventoried but never installed, so the ZIP and a local install
+    # diverge and nothing compares them. `skills/MAINTENANCE.md` sat that way: a maintainer
+    # document shipped to every classroom, absent from every install. Assert the two agree by
+    # construction rather than by anyone remembering to look.
+    skills_root = ROOT / "skills"
+    installable = {p.name for p in skills_root.iterdir() if p.is_dir() and (p / "SKILL.md").is_file()}
+    orphans = sorted(
+        e for e in inv
+        if e.startswith("skills/")
+        and (len(e.split("/")) < 3 or e.split("/")[1] not in installable)
+    )
+    check(f"every skills/ inventory entry lands in an installed skill dir (orphans: {orphans})",
+          not orphans)
+    # negative control: the rule must be about installability, not about the count. A real skill
+    # file has to still be in the inventory, or "0 orphans" would also be true of an empty one.
+    sample = next((e for e in sorted(inv) if e.startswith("skills/") and e.endswith("/SKILL.md")), None)
+    check("a real skill's SKILL.md is still inventoried", sample is not None)
 
     print("----")
     print(f"test_distribution_manifest: {PASS} passed, {FAIL} failed")

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -77,11 +77,6 @@
       "sha256": "2851980bd25d3f435788f032239d50e3d026d8c13f9c0128afc3a935d26f8cfa"
     },
     {
-      "path": "skills/MAINTENANCE.md",
-      "size": 7422,
-      "sha256": "8cf861afba71d93940ccd72f16e9ad62e6ce6d22e5d2cce166f6ffc10c7af6d7"
-    },
-    {
       "path": "skills/academic-aio/SKILL.md",
       "size": 32773,
       "sha256": "9e43ec3cc38ab1988770cd0e071be92431bdef0d596d8f80b86abe79379c0117"

--- a/scripts/build_classroom_release.py
+++ b/scripts/build_classroom_release.py
@@ -54,9 +54,32 @@ EXCLUDE_FILE_NAMES = {
 }
 EXCLUDE_NAME_PREFIXES = ("TODO_", "HANDOFF_", "PLAN_", "PLANNED_")
 EXCLUDE_SUFFIXES = {".pyc", ".pyo", ".swp"}
+# Excluded by full relative path rather than by name — mirrors
+# gen_distribution_manifest.EXCLUDE_RELPATHS.
+#
+# `skills/MAINTENANCE.md` is a maintainer document sitting at the skills/ root. `skills` is an
+# include path here, so the walk picked it up, while `install.py` never placed it (that copies
+# directories carrying a SKILL.md). The ZIP shipped it to every classroom and no install had it.
+#
+# "What ships" is implemented THREE times: here, in gen_distribution_manifest.py, and in the
+# independent oracle inside installers/tests/test_distribution_manifest.py. The duplication is
+# deliberate — the oracle exists so the payload scope cannot change by accident — and it is
+# guarded: the release-ZIP round-trip test builds the ZIP and runs the updater's safe-extract
+# against the inventory, so any two of the three disagreeing turns the build red. It is what
+# caught this file being removed from two of them and not the third.
+EXCLUDE_RELPATHS = {"skills/MAINTENANCE.md"}
 
 
 def _is_excluded(path: Path) -> bool:
+    # Callers pass ABSOLUTE paths (add_path walks `path.rglob("*")` from a repo-rooted dir), so
+    # the relpath comparison has to normalise first. Comparing `path.as_posix()` directly matches
+    # nothing and fails open — the file ships and the check reads as if it ran.
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in EXCLUDE_RELPATHS:
+        return True
     if path.name in EXCLUDE_FILE_NAMES:
         return True
     if path.name.startswith(EXCLUDE_NAME_PREFIXES):

--- a/scripts/gen_distribution_manifest.py
+++ b/scripts/gen_distribution_manifest.py
@@ -64,6 +64,18 @@ EXCLUDE_RELPATHS = {
     "metadata/distribution_files.json",
     "provenance.json",
     "metadata/provenance.json",
+    # A maintainer document that happens to sit at the skills/ root. `skills` is a payload root,
+    # so the walk swept it into the inventory — while `install.py` never placed it, because that
+    # copies directories carrying a SKILL.md. The manifest therefore described a payload no
+    # install reproduces: the classroom ZIP shipped it, a local install did not, and nothing
+    # compared the two. This file's own docstring calls the inventory "the classroom/common
+    # install payload", so the inventory is the side that was wrong.
+    #
+    # The document stays where it is. Seven live references name `skills/MAINTENANCE.md` — the
+    # run-once-tool allowlist in check_script_reachability.py cites it by path to justify three
+    # exemptions, and tests/test_script_reachability.sh copies and restores it. Moving the file
+    # for tidiness would cost all of that; excluding it from the payload costs one line.
+    "skills/MAINTENANCE.md",
 }
 # ".logs" excludes installers/.logs/ — the gitignored, per-machine install logs
 # install.py writes; without this, running install.py locally then regenerating would


### PR DESCRIPTION
`metadata/distribution_files.json` calls itself *"the classroom/common install payload"*. It listed `skills/MAINTENANCE.md` — a maintainer document that happens to sit at the `skills/` root.

`install.py` places skill **directories** (`p.is_dir() and (p / "SKILL.md").exists()`), so it never placed that file. The classroom ZIP shipped it to every user, no local install had it, and nothing compared the two. The inventory was the side that was wrong.

Found while auditing repo state, not by a failure: a hash-by-hash comparison of the installed tree against the manifest came back `1229 match / 0 drift / 1 missing`.

### The document stays where it is

Seven live references name `skills/MAINTENANCE.md` — the run-once-tool allowlist in `check_script_reachability.py` cites it **by path** to justify three exemptions, and `tests/test_script_reachability.sh` copies and restores it. Moving the file for tidiness would cost all of that. Excluding it from the payload costs one line per implementation.

### There are three implementations of "what ships"

| | |
|---|---|
| `scripts/gen_distribution_manifest.py` | writes the inventory |
| `scripts/build_classroom_release.py` | writes the ZIP |
| `installers/tests/test_distribution_manifest.py::classroom_payload()` | the independent oracle |

The duplication is **deliberate** — the oracle's own comment says re-deriving the rules is what catches the payload scope changing by accident, and that changing it on purpose means editing that tuple too. So all three moved.

It is also **guarded**, which is the part worth reading: `installers/tests/test_release_zip.sh` builds the ZIP and runs the updater's `safe_extract` against the inventory, so any two of the three disagreeing is a red build. It failed twice on the way here:

1. when only two of the three had been edited — `safe-extract: unexpected file not in inventory: skills/MAINTENANCE.md`;
2. again after the builder was edited, because `_is_excluded` receives **absolute** paths (`add_path` walks `rglob` from a repo-rooted dir) while the new comparison was against a repo-relative string. It matched nothing and **failed open** — the file shipped and the check read as though it had run.

The second one is the more instructive: a scope exclusion that silently matches nothing is indistinguishable from one that works, and only the round-trip against the real artifact could tell them apart.

### Regression

`test_distribution_manifest.py` now asserts every `skills/` inventory entry lands inside a directory `install.py` would copy. Against the pre-fix tree it fails and **names the orphan** rather than reporting a count. A negative control asserts a real skill's `SKILL.md` is still inventoried, so `0 orphans` cannot be satisfied by an empty inventory.

Local mirror **238/238**. Payload 1245 → 1244 files; `shipped-but-not-installed` is now empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
