### PR TITLE
fix(gates): a translated README hit two walls the English one is exempt from

### DIFF
--- a/scripts/validate_catalog_consistency.py
+++ b/scripts/validate_catalog_consistency.py
@@ -114,7 +114,17 @@ GUIDELINE_CLAIM_FILES = [
 SKILLS_TAGLINE_FILES = ["README.md"]
 # README shields badge (img.shields.io/badge/Skills-N-...). Scoped to the badge URL so
 # only the literal badge count is checked, never arbitrary "Skills" prose.
-SKILLS_BADGE_FILES = ["README.md"]
+#
+# Translated READMEs are included by GLOB, not by enumeration. The badge is a shields.io URL
+# with the count written into it as a literal, and a translation copies that URL
+# character-for-character — so the number rides along into a file no gate was watching, and the
+# translated page goes quietly wrong the first time a skill is added while the English page stays
+# green. Because the URL is identical across locales, no new pattern is needed: the existing
+# `badge_re` matches it wherever it appears. A glob also means the next language is covered on
+# arrival rather than after someone remembers to add it here.
+SKILLS_BADGE_FILES = ["README.md"] + sorted(
+    p.name for p in ROOT.glob("README.*.md") if p.name != "README.md"
+)
 # Catalog-total SKILL claim in prose (not the tagline/badge). README "All N skills"
 # (skill-table intro) and paper.md "N task-bounded skills" (JOSS Summary) drifted
 # because only the tagline+badge were gated. Anchored to those two phrasings so

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -549,7 +549,15 @@ echo "========================================="
 # those files the precedent scan runs with --allow-author (the author's own name
 # digest is exempted), so other PII (hospital, project codes, personal paths) on
 # the same line is still caught. The author name is no longer spelled out here.
-AUTHOR_ATTRIB_RE='^(README\.md|CITATION\.cff|paper\.md|\.zenodo\.json|MAINTAINERS\.md)$'
+#
+# `README.<locale>.md` is matched as a FAMILY rather than enumerated. The first translated
+# README (zh-CN) failed CI on its byline — the same "Created & maintained by ..." line README.md
+# carries and is allowlisted for. A translation carries that byline by definition, so every
+# future locale hits the identical wall, and enumerating them one at a time rebuilds the wall
+# per language. The allowance stays narrow: `--allow-author` exempts only the author-name digest,
+# so a hospital name, a project code or a personal path in a translated README is still caught
+# exactly as it is in the English one.
+AUTHOR_ATTRIB_RE='^(README\.md|README\.[A-Za-z]{2}(-[A-Za-z]{2,4})?\.md|CITATION\.cff|paper\.md|\.zenodo\.json|MAINTAINERS\.md)$'
 while IFS= read -r rel; do
   case "$rel" in
     scripts/validate_skills.sh|scripts/check_precedent.py|scripts/precedent_hashes.txt|scripts/precedent_author_hashes.txt) continue ;;  # self-exempt: blocklist machinery


### PR DESCRIPTION
The first translated README (zh-CN, #467) failed CI on its **byline** — the same `Created & maintained by …` line `README.md` carries and is allowlisted for:

```
FAIL  Personal precedent in README.zh-CN.md: 35:yoojin nam
VALIDATION FAILED — fix 1 issue(s)
```

A translation carries that byline by definition, so every future locale hits the identical wall. A second wall sat just behind it, silent: the shields.io badge writes the skill count into its URL as a literal, and a translation copies that URL character-for-character — so the number rode into a file **no gate was watching**, and the translated page would go quietly wrong the first time a skill was added while the English page stayed green.

### Both matched as a family, not enumerated

| gate | change |
|---|---|
| `validate_skills.sh` `AUTHOR_ATTRIB_RE` | accepts `README.<locale>.md` |
| `validate_catalog_consistency.py` `SKILLS_BADGE_FILES` | globs `README.*.md` |

Enumerating a locale rebuilds the wall for the next language. Globbing means zh-CN, ja, es are covered on arrival rather than after someone remembers to add them.

The allowance stays narrow. `--allow-author` exempts **only the author-name digest**, so a hospital name, a project code or a personal path in a translated README is still caught exactly as it is in the English one.

### Verified in both directions

- with a translated README present, the badge list becomes `['README.md', 'README.zh-CN.md']`
- a deliberately wrong count in it **fails**: `README.zh-CN.md L14 skills badge: claims 57, expected 58`
- the byline **passes** the precedent scan with `--allow-author` (exit 0) and still **fails** without it (exit 3, `35:yoojin nam`) — so it is the allowance letting it through, not a hole in the scanner

Local mirror **238 / 238**.

### Why this was found the hard way

I told the contributor the opposite in [#119](https://github.com/Aperivue/medsci-skills/issues/119#issuecomment-5191344471) — that `validate_skills.sh` only scans `skills/*/SKILL.md` and no rule would fire on their file. It has a **public-surface PII pass over all tracked text outside `skills/`**, which is exactly what went red. I had audited the count-gate file lists carefully and never looked at the author-attribution allowlist sitting in the same validator, in the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
