### PR TITLE
Checklist fidelity: four PRISMA 2020 items did not match the published checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,41 @@
 
 ### Fixed
 
+- **Four items in the vendored PRISMA 2020 checklist did not match the published checklist, and two
+  of them would have changed a score.** The file carried a bare `Source:` URL, no DOI, no licence
+  line and no statement of how faithful it was, and it had never been compared against the official
+  checklist. Run character-for-character against the official PDF, 42 of 42 sub-items present, five
+  cells divergent:
+
+  | Item | This file said | The statement says |
+  |---|---|---|
+  | **4** | "…the review addresses **using the PICO framework or similar**" | "…the review addresses." — PICO is PRISMA **2009** wording |
+  | **13b** | "…such as handling of **multi-arm studies and multiple outcome measures**" | "…such as handling of **missing summary statistics, or data conversions**" |
+  | 16a | reordered, "PRISMA flow diagram" | "…ideally using a flow diagram" |
+  | 19 | "structured tables or **forest** plots" | "structured tables or plots" |
+  | 2 | an editorial gloss appended in-cell | "See the PRISMA 2020 for Abstracts checklist." |
+
+  Items 4 and 13b are not cosmetic. A reviewer scoring against item 4 would mark down a manuscript
+  that states its objectives without a PICO frame, which the guideline does not ask for; item 13b
+  sent an assessor looking for multi-arm handling when the item is about missing summary statistics
+  and data conversions. All five are restored to the official wording, and the 42/42 verbatim
+  comparison now runs clean. The file gains a full citation, DOI, CC BY licence line, and a fidelity
+  statement; editorial comment moved out of the item cells into *Notes for Assessors*, because an
+  assessor must read the guideline's words rather than ours.
+
+- **`PRISMA_DTA.md` carries a warning: one item is known wrong and the rest are unverified.** Its
+  item 2 asks a *diagnostic test accuracy* review to summarise **"interventions"** — the same
+  PRISMA 2009 inheritance, never adapted. The published checklist is in JAMA and was not available
+  to run the comparison, so the remaining items are neither confirmed nor corrected. The file now
+  says so at the top and tells the reader to complete the official checklist for anything they
+  submit, rather than presenting itself as submission-ready.
+
+  This is a first result, not a survey: **one of 48 vendored checklists has been audited.** The
+  audited one was in the better-documented tier — it had a source line and a LICENSES row — and it
+  still carried four divergences. Twelve files carry no provenance at all, thirty-five carry no
+  licence statement, and fifteen declare themselves faithful in-house summaries rather than
+  reproductions, which leaves thirty-three reading as verbatim without saying so.
+
 - **`/meta-analysis` handed every binary outcome the one specification Cochrane says to avoid for
   rare events.** `references/phase6_statistical_synthesis.md` prescribed
   `method = "Inverse"`, `method.tau = "DL"`, `incr = 0.5` unconditionally, and told the reader in

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -738,8 +738,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_2020.md",
-      "size": 10054,
-      "sha256": "339237f8d53cbfd8c3d3d3a82243885477e9d475e14d1d763ba8179bb5ee8461"
+      "size": 11111,
+      "sha256": "2929a83ada5e5aca614109beefffff467bc8ebc7560ae44b929372352a9d7afa"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_2020_Abstracts.md",
@@ -748,8 +748,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_DTA.md",
-      "size": 3705,
-      "sha256": "9147e4b491d70a6afaab9ce3f24e044965ff268b97d40f8410fc633e19ca060f"
+      "size": 4896,
+      "sha256": "35dbc17de6a993f972295c552632a3426c12f8e81db6981318d8450ceb69ede0"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_P.md",
@@ -2713,8 +2713,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/PRISMA_DTA.md",
-      "size": 3705,
-      "sha256": "9147e4b491d70a6afaab9ce3f24e044965ff268b97d40f8410fc633e19ca060f"
+      "size": 4896,
+      "sha256": "35dbc17de6a993f972295c552632a3426c12f8e81db6981318d8450ceb69ede0"
     },
     {
       "path": "skills/meta-analysis/references/checklists/PROBAST.md",

--- a/skills/check-reporting/references/checklists/PRISMA_2020.md
+++ b/skills/check-reporting/references/checklists/PRISMA_2020.md
@@ -1,8 +1,16 @@
 # PRISMA 2020 Checklist
 
 **Preferred Reporting Items for Systematic Reviews and Meta-Analyses**
-Version: PRISMA 2020
-Source: https://www.prisma-statement.org
+Version: PRISMA 2020 — 27 items / 42 sub-items.
+Source: Page MJ, McKenzie JE, Bossuyt PM, Boutron I, Hoffmann TC, Mulrow CD, et al. The PRISMA 2020
+statement: an updated guideline for reporting systematic reviews. *BMJ* 2021;372:n71
+(DOI 10.1136/bmj.n71). Official checklist: https://www.prisma-statement.org
+Licence: CC BY 4.0. Item text is reproduced verbatim from the official checklist with attribution.
+
+> **Fidelity**: every one of the 42 sub-item cells below has been compared, normalised and
+> character-for-character, against the official PRISMA 2020 checklist PDF. Any editorial comment
+> of ours lives in *Notes for Assessors*, never inside an item cell — an assessor scoring a
+> manuscript must read the guideline's words, not ours.
 
 ## Checklist Items (27 items)
 
@@ -16,14 +24,14 @@ Source: https://www.prisma-statement.org
 
 | # | Item | Description |
 |---|------|-------------|
-| 2 | Abstract | See the PRISMA 2020 for Abstracts checklist — the statement devotes a separate 12-item instrument to the abstract rather than describing it here. Assess it with `PRISMA_2020_Abstracts.md` and report that score with its own denominator; a manuscript can satisfy every main-text item and still fail most of the twelve. |
+| 2 | Abstract | See the PRISMA 2020 for Abstracts checklist. |
 
 ### Introduction
 
 | # | Item | Description |
 |---|------|-------------|
 | 3 | Rationale | Describe the rationale for the review in the context of existing knowledge. |
-| 4 | Objectives | Provide an explicit statement of the objective(s) or question(s) the review addresses using the PICO framework or similar. |
+| 4 | Objectives | Provide an explicit statement of the objective(s) or question(s) the review addresses. |
 
 ### Methods
 
@@ -39,7 +47,7 @@ Source: https://www.prisma-statement.org
 | 11 | Study risk of bias assessment | Specify the methods used to assess risk of bias in the included studies, including details of the tool(s) used, how many reviewers assessed each study and whether they worked independently, and if applicable, details of automation tools used in the process. |
 | 12 | Effect measures | Specify for each outcome the effect measure(s) (e.g., risk ratio, mean difference) used in the synthesis or presentation of results. |
 | 13a | Synthesis methods | Describe the processes used to decide which studies were eligible for each synthesis (e.g., tabulating the study intervention characteristics and comparing against the planned groups for each synthesis). |
-| 13b | Synthesis methods | Describe any methods required to prepare the data for presentation or synthesis, such as handling of multi-arm studies and multiple outcome measures. |
+| 13b | Synthesis methods | Describe any methods required to prepare the data for presentation or synthesis, such as handling of missing summary statistics, or data conversions. |
 | 13c | Synthesis methods | Describe any methods used to tabulate or visually display results of individual studies and syntheses. |
 | 13d | Synthesis methods | Describe any methods used to synthesize results and provide a rationale for the choice(s). If meta-analysis was performed, describe the model(s), method(s) to identify the presence and extent of statistical heterogeneity, and software package(s) used. |
 | 13e | Synthesis methods | Describe any methods used to explore possible causes of heterogeneity among study results (e.g., subgroup analysis, meta-regression). |
@@ -51,11 +59,11 @@ Source: https://www.prisma-statement.org
 
 | # | Item | Description |
 |---|------|-------------|
-| 16a | Study selection | Describe the results of the search and selection process, ideally with a PRISMA flow diagram, from the number of records identified to the number of studies included in the review. |
+| 16a | Study selection | Describe the results of the search and selection process, from the number of records identified in the search to the number of studies included in the review, ideally using a flow diagram. |
 | 16b | Study selection | Cite studies that might appear to meet the inclusion criteria, but which were excluded, and explain why they were excluded. |
 | 17 | Study characteristics | Cite each included study and present its characteristics. |
 | 18 | Risk of bias in studies | Present assessments of risk of bias for each included study. |
-| 19 | Results of individual studies | For all outcomes, present, for each study: (a) summary statistics for each group (where appropriate) and (b) an effect estimate and its precision (e.g., confidence/credible interval), ideally using structured tables or forest plots. |
+| 19 | Results of individual studies | For all outcomes, present, for each study: (a) summary statistics for each group (where appropriate) and (b) an effect estimate and its precision (e.g. confidence/credible interval), ideally using structured tables or plots. |
 | 20a | Results of syntheses | For each synthesis, briefly summarise the characteristics and risk of bias among contributing studies. |
 | 20b | Results of syntheses | Present results of all statistical syntheses conducted. If meta-analysis was done, present for each the summary estimate and its precision (e.g., confidence/credible interval) and measures of statistical heterogeneity. If comparing groups, describe the direction of the effect. |
 | 20c | Results of syntheses | Present results of all investigations of possible causes of heterogeneity among study results. |
@@ -127,7 +135,9 @@ INCLUDED
 ## Notes for Assessors
 
 - PRISMA 2020 expanded from the original 27-item checklist; several items now have sub-items (e.g., 10a/10b, 13a-13f, 16a/16b).
-- Item 2 delegates to a **separate 12-item abstract checklist** (`PRISMA_2020_Abstracts.md`). Run it as its own pass — a high main-text compliance percentage carries no information about it, and its items fail together because the abstract is written last, to a word limit.
+- Item 2 delegates to a **separate 12-item abstract checklist** (`PRISMA_2020_Abstracts.md`). The statement's own item 2 is that one sentence and nothing more. Run the abstract checklist as its own pass and report its score with its own denominator — a manuscript can satisfy every main-text item and still fail most of the twelve, and a high main-text percentage carries no information about it.
+- **Item 4 does not require PICO.** This file previously read "using the PICO framework or similar", which is PRISMA *2009* wording; the 2020 item asks only for an explicit statement of the objective(s) or question(s). Do not score a manuscript down for stating its objectives without a PICO frame.
+- **Item 13b is about missing summary statistics and data conversions**, not about multi-arm studies or multiple outcome measures — this file previously asked for the latter, which is a different requirement and sent assessors looking for the wrong thing.
 - Item 7 (full search strategy): the complete strategy for at least one database must be provided, either in the manuscript or supplementary materials.
 - Item 15 (certainty assessment): GRADE is the most common framework; mark as MISSING if no certainty assessment is reported.
 - Item 24 (registration): PROSPERO is the standard registry for systematic reviews. If not registered, the authors should explicitly state this.

--- a/skills/check-reporting/references/checklists/PRISMA_DTA.md
+++ b/skills/check-reporting/references/checklists/PRISMA_DTA.md
@@ -1,7 +1,24 @@
 # PRISMA-DTA Checklist
 
 Preferred Reporting Items for Systematic Reviews and Meta-Analyses of Diagnostic Test Accuracy Studies.
-Reference: McInnes MDF et al. JAMA 2018;319(4):388-396.
+Reference: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, et al. Preferred Reporting Items
+for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: the PRISMA-DTA
+statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163).
+
+> ⚠️ **This file has not been verified against the published statement, and at least one item is
+> known to be wrong. Do not use it as the checklist you submit.**
+>
+> Item 2 below asks for a structured abstract summarising, among other things, **"interventions"** —
+> a diagnostic test accuracy review has no interventions. That wording is inherited from the
+> PRISMA 2009 intervention-review checklist and was never adapted; the same defect was found and
+> corrected in `PRISMA_2020.md`, whose 42 sub-items are now verified character-for-character
+> against the official checklist. PRISMA-DTA is published in JAMA and the official checklist was
+> not available to run that comparison, so the remaining items here are **unverified** — they may
+> be faithful, and no one has checked.
+>
+> Complete the official checklist from the statement or EQUATOR for anything you submit. Use this
+> file to organise a first pass only, and read every item you rely on against the source.
+
 
 ## Checklist Items
 

--- a/skills/meta-analysis/references/checklists/PRISMA_DTA.md
+++ b/skills/meta-analysis/references/checklists/PRISMA_DTA.md
@@ -1,7 +1,24 @@
 # PRISMA-DTA Checklist
 
 Preferred Reporting Items for Systematic Reviews and Meta-Analyses of Diagnostic Test Accuracy Studies.
-Reference: McInnes MDF et al. JAMA 2018;319(4):388-396.
+Reference: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, et al. Preferred Reporting Items
+for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: the PRISMA-DTA
+statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163).
+
+> ⚠️ **This file has not been verified against the published statement, and at least one item is
+> known to be wrong. Do not use it as the checklist you submit.**
+>
+> Item 2 below asks for a structured abstract summarising, among other things, **"interventions"** —
+> a diagnostic test accuracy review has no interventions. That wording is inherited from the
+> PRISMA 2009 intervention-review checklist and was never adapted; the same defect was found and
+> corrected in `PRISMA_2020.md`, whose 42 sub-items are now verified character-for-character
+> against the official checklist. PRISMA-DTA is published in JAMA and the official checklist was
+> not available to run that comparison, so the remaining items here are **unverified** — they may
+> be faithful, and no one has checked.
+>
+> Complete the official checklist from the statement or EQUATOR for anything you submit. Use this
+> file to organise a first pass only, and read every item you rely on against the source.
+
 
 ## Checklist Items
 


### PR DESCRIPTION
First result of an audit of the vendored reporting checklists against their published originals. **One of 48 files has been audited.** It was in the better-documented tier — it had a source line and a `LICENSES.md` row — and it still carried four divergences, two of which would change a score.

## PRISMA 2020 — 42/42 sub-items compared, 5 cells divergent

Compared character-for-character (Unicode-normalised, punctuation-folded, substring containment) against the official PRISMA 2020 checklist PDF.

| Item | This file said | The statement says |
|---|---|---|
| **4** | "…the review addresses **using the PICO framework or similar**" | "…the review addresses." |
| **13b** | "…such as handling of **multi-arm studies and multiple outcome measures**" | "…such as handling of **missing summary statistics, or data conversions**" |
| 16a | reordered; "PRISMA flow diagram" | "…ideally using a flow diagram" |
| 19 | "structured tables or **forest** plots" | "structured tables or plots" |
| 2 | an editorial gloss appended inside the cell | "See the PRISMA 2020 for Abstracts checklist." |

Items 4 and 13b are not cosmetic:

- **Item 4** imposed a requirement the guideline does not make. PICO is PRISMA **2009** wording. A manuscript that states its objectives without a PICO frame was being marked down against a criterion that does not exist in PRISMA 2020.
- **Item 13b** asked for something else entirely. The official item is about missing summary statistics and data conversions; this file sent assessors looking for multi-arm handling.

All five restored to the official wording; the 42/42 verbatim comparison now runs clean. The file gains its full citation, DOI, CC BY licence line, and a fidelity statement. Editorial comment moved out of the item cells into *Notes for Assessors* — an assessor scoring a manuscript must read the guideline's words, not ours.

## PRISMA-DTA — a warning, not a fix

`PRISMA_DTA.md` item 2 asks a *diagnostic test accuracy* review to summarise **"interventions"**. A DTA review has no interventions; this is the same PRISMA 2009 inheritance, never adapted. It needs no access to the original to be certain it is wrong.

The published PRISMA-DTA checklist is in JAMA and was not available to run the comparison, so the remaining 26 items are **unverified — not confirmed faithful, and not corrected**. Guessing at the official wording without the source is how the wrong text arrived in the first place, so nothing was rewritten. The file now says all of this at the top and directs the reader to complete the official checklist for anything they submit.

## Scope note

The checklists are vendored from `check-reporting` into `meta-analysis`, with byte-identity enforced by `check_domain_probe_sync.py`; the vendored copy is synced here, so auditing the canonical set is sufficient.

Across the 48 files: 12 carry no provenance at all, 35 carry no licence statement, and 15 declare themselves in-house summaries — which leaves 33 reading as verbatim reproductions without saying so. That cuts two ways: divergence from the original makes the instrument wrong, and fidelity to a non-permissively-licensed original makes it a reproduction. Both are being worked through file by file.

## Verification

- `python3 scripts/run_ci_mirror.py` — **238/238 gates pass**
- 42/42 sub-items verbatim-contained in the official checklist after the fix (0 before, for the five listed)