### PR TITLE
Checklist fidelity 2/N: PROBAST carried invented AI addenda; TRIPOD+AI verified clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,51 @@
 
 ### Fixed
 
+- **`PROBAST.md` presented four invented bullets as the AI extension, and dropped three assessment
+  criteria from the official signalling questions.** Audited against the published statement
+  (Wolff et al., *Ann Intern Med* 2019;170:51-58). The domain structure and the count are right —
+  20 signalling questions, 2 / 3 / 6 / 9 across the four domains — but:
+
+  - A section headed **"PROBAST+AI Extensions (2024)"** listed four bullets ("Data: training/
+    validation/test split…", "Model: architecture transparency…") that appear nowhere in any
+    version of the tool. PROBAST+AI is a real instrument with 16 development and 18 evaluation
+    signalling questions, it is dated **2025** not 2024, and this repository already vendors it
+    correctly as `PROBAST_AI.md`. An assessor following that section was appraising against
+    something a maintainer made up.
+  - **4.8 dropped "underfitting"** — the official question asks about overfitting, underfitting
+    *and* optimism.
+  - **4.6 dropped its examples** — censoring, competing risks, and sampling of control participants
+    are what make that question assessable.
+  - 3.6 dropped "determination" (the interval runs to when the outcome was *determined*), and 4.9
+    dropped "results from the".
+
+  All restored, and the AI section replaced by a pointer to `PROBAST_AI.md` with the correct
+  citation. The file also now records that **PROBAST 2019 is superseded by PROBAST+AI 2025** for new
+  assessments, which the tool's own authors state and this file did not.
+
+  **Licence.** PROBAST is published in *Annals of Internal Medicine* (© American College of
+  Physicians) under **no open licence**, and this file had been reproducing its signalling questions
+  near-verbatim with no licence statement. The questions are now an **in-house summary of what each
+  asks**, labelled as such, with the numbering and structure (which are facts, not expression)
+  verified against the statement, and a direction to complete the official tool for anything
+  reported. This is the first file where the audit's two risks pointed in opposite directions:
+  diverging from the original makes the instrument wrong, and matching it too closely makes it a
+  reproduction we have no licence for.
+
+- **`TRIPOD_AI.md` verified clean — 52/52 against the official supplements.** Compared
+  character-for-character against ST1 (expanded checklist) and ST2 (fillable checklist); every
+  sub-item matches and the D/E designations match the statement exactly. Five orthographic
+  differences were normalised to the published wording (an added "the" in items 2 and 5a, hyphenation
+  in 12c and 22, and British spellings of "generalizability" in 26 and 27c). Two official footnotes
+  that qualify how items are scored were not being carried and now are: item 12c is assessed
+  **separately for each model-building approach**, and 18f (analysis code) is a different question
+  from 22 (code to implement the model for a new individual). The header records what it was verified
+  against, so the next person does not have to redo it to find out.
+
+  This file was already the best of the ones audited so far — it carried a citation, a DOI, a
+  licence line, a correct 27-item/52-sub-item count, and an explicit "NOT official items" fence
+  around the toolkit's own supplemental checks. That is the shape the rest should be brought to.
+
 - **Four items in the vendored PRISMA 2020 checklist did not match the published checklist, and two
   of them would have changed a score.** The file carried a bare `Source:` URL, no DOI, no licence
   line and no statement of how faithful it was, and it had never been compared against the official

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -763,8 +763,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PROBAST.md",
-      "size": 3184,
-      "sha256": "5220ab27658cb9a372b39d94a208147abc15559d221ab528beab885d1c8a9eca"
+      "size": 5099,
+      "sha256": "b05dd5e132c569fd0b0cb7884a437a59b5084e73cdd45044bd55010907e3be5b"
     },
     {
       "path": "skills/check-reporting/references/checklists/PROBAST_AI.md",
@@ -878,8 +878,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_AI.md",
-      "size": 13826,
-      "sha256": "0ec248b9846a06bf4e13890daaa1f61e69b7588b390d0612dcabefed78c42975"
+      "size": 14461,
+      "sha256": "64ea85b19951d297274559c5a668dd16a37f93a6fd6ee11bbcadd3ec89309e0d"
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_LLM.md",
@@ -2718,8 +2718,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/PROBAST.md",
-      "size": 3184,
-      "sha256": "5220ab27658cb9a372b39d94a208147abc15559d221ab528beab885d1c8a9eca"
+      "size": 5099,
+      "sha256": "b05dd5e132c569fd0b0cb7884a437a59b5084e73cdd45044bd55010907e3be5b"
     },
     {
       "path": "skills/meta-analysis/references/checklists/QUADAS2.md",

--- a/skills/check-reporting/references/checklists/PROBAST.md
+++ b/skills/check-reporting/references/checklists/PROBAST.md
@@ -1,8 +1,22 @@
 # PROBAST Assessment Guide
 
 Prediction model Risk Of Bias ASsessment Tool.
-Reference: Wolff RF et al. Ann Intern Med 2019;170(1):51-58. PMID: 30596875.
-AI extension: PROBAST+AI (BMJ 2024).
+Version: PROBAST 2019 — 20 signalling questions across 4 domains (2 / 3 / 6 / 9).
+Source: Wolff RF, Moons KGM, Riley RD, Whiting PF, Westwood M, Collins GS, et al. PROBAST: A Tool to
+Assess the Risk of Bias and Applicability of Prediction Model Studies. *Ann Intern Med*
+2019;170(1):51-58 (PMID 30596875; DOI 10.7326/M18-1376). Explanation and Elaboration:
+*Ann Intern Med* 2019;170(1):W1-W33.
+
+> **Fidelity and licence.** PROBAST is published in *Annals of Internal Medicine* (© American College
+> of Physicians) and carries **no open licence**. The signalling questions below are therefore an
+> **in-house summary of what each question asks — not the published wording**. The numbering,
+> the domain structure and the count (2 / 3 / 6 / 9) are verified against the statement; the phrasing
+> is ours. **Complete the official tool from probast.org or the statement for any assessment you
+> report.** Use this file to organise a first pass.
+
+> **PROBAST 2019 is superseded.** PROBAST+AI (2025) replaces it for all new assessments, covering
+> regression and AI/ML models alike — see `PROBAST_AI.md`. Use this file only when appraising against
+> the 2019 instrument specifically (for example, reproducing an earlier review).
 
 ## Structure
 
@@ -13,63 +27,74 @@ PROBAST assesses 4 domains, each for Risk of Bias AND Applicability.
 
 ## Domain 1: Participants
 
-### Signalling Questions (Risk of Bias)
-1. Were appropriate data sources used (e.g., cohort, RCT, nested case-control)?
-2. Were all inclusions and exclusions of participants appropriate?
+### Signalling questions (risk of bias) — what each asks
+
+1.1 Whether the data source suits the question — a cohort, a randomised trial, or nested
+    case–control data, rather than a design that distorts the sampling.
+1.2 Whether every inclusion and exclusion applied to participants was appropriate.
 
 ### Applicability
 - Do the participants and setting match the review question?
 
 ## Domain 2: Predictors
 
-### Signalling Questions (Risk of Bias)
-1. Were predictors defined and assessed in a similar way for all participants?
-2. Were predictor assessments made without knowledge of outcome data?
-3. Are all predictors available at the time the model is intended to be used?
+### Signalling questions (risk of bias) — what each asks
+
+2.1 Whether predictors were defined and assessed the same way for every participant.
+2.2 Whether predictors were assessed without knowledge of the outcome.
+2.3 Whether every predictor is available at the moment the model is meant to be used.
 
 ### Applicability
 - Do the predictors, their assessment, and timing match the review question?
 
 ## Domain 3: Outcome
 
-### Signalling Questions (Risk of Bias)
-1. Was the outcome determined appropriately?
-2. Was a pre-specified or standard outcome definition used?
-3. Were predictors excluded from the outcome definition?
-4. Was the outcome defined and determined in a similar way for all participants?
-5. Was the outcome determined without knowledge of predictor information?
-6. Was the time interval between predictor assessment and outcome appropriate?
+### Signalling questions (risk of bias) — what each asks
+
+3.1 Whether the outcome was determined by an appropriate method.
+3.2 Whether the outcome definition was prespecified or a standard one.
+3.3 Whether predictors were kept out of the outcome definition.
+3.4 Whether the outcome was defined and determined the same way for every participant.
+3.5 Whether the outcome was determined without knowledge of predictor information.
+3.6 Whether the interval between predictor assessment and **outcome determination** was
+    appropriate — the question is about when the outcome was *determined*, not merely when it
+    occurred.
 
 ### Applicability
 - Does the outcome and its definition/timing match the review question?
 
 ## Domain 4: Analysis
 
-### Signalling Questions (Risk of Bias)
-1. Were there a reasonable number of participants with the outcome?
-2. Were continuous and categorical predictors handled appropriately?
-3. Were all enrolled participants included in the analysis?
-4. Were participants with missing data handled appropriately?
-5. Was selection of predictors based on univariable analysis avoided?
-6. Were complexities in the data accounted for appropriately?
-7. Were relevant model performance measures evaluated appropriately?
-8. Were model overfitting and optimism in model performance accounted for?
-9. Do predictors and their assigned weights in the final model correspond to the reported multivariable analysis?
+### Signalling questions (risk of bias) — what each asks
 
-### For Validation Studies (additional)
+4.1 Whether the number of participants with the outcome was reasonable.
+4.2 Whether continuous and categorical predictors were handled appropriately.
+4.3 Whether every enrolled participant was included in the analysis.
+4.4 Whether participants with missing data were handled appropriately.
+4.5 Whether selection of predictors on the basis of univariable analysis was avoided.
+4.6 Whether complexities in the data were accounted for — the statement names **censoring,
+    competing risks, and the sampling of control participants** as the cases to look for.
+4.7 Whether relevant measures of model performance were evaluated appropriately.
+4.8 Whether **overfitting, underfitting, and optimism** in model performance were accounted for.
+    All three, not overfitting alone.
+4.9 Whether the predictors and their assigned weights in the final model correspond to the
+    **results from** the reported multivariable analysis.
+
+### For validation studies (additional)
 - Were the model and its performance evaluated appropriately?
 
-## PROBAST+AI Extensions (2024)
+## For AI / machine-learning models
 
-For AI/ML prediction models, additional considerations:
-- **Data**: Training/validation/test split, data leakage check
-- **Model**: Architecture transparency, hyperparameter tuning method
-- **Performance**: Discrimination (AUC), calibration, fairness across subgroups
-- **Reproducibility**: Code/data availability, external validation
+Use **`PROBAST_AI.md`** (PROBAST+AI 2025; Moons KGM et al. *BMJ* 2025;388:e082505,
+DOI 10.1136/bmj-2024-082505), which carries the instrument's own 16 development and 18 evaluation
+signalling questions. Do not improvise AI addenda on top of the 2019 questions: an earlier version of
+this file listed four invented bullets under a heading that implied they were part of the extension,
+which they were not.
 
 ## When to Use
 
 - Diagnostic prediction models (e.g., AI classifiers for imaging findings)
 - Prognostic prediction models (e.g., risk scores, survival prediction)
 - Both development AND validation studies
-- Use PROBAST+AI when the model involves machine learning or deep learning
+- For any model developed with machine learning or deep learning, and for new assessments generally,
+  use PROBAST+AI (`PROBAST_AI.md`) rather than this file

--- a/skills/check-reporting/references/checklists/TRIPOD_AI.md
+++ b/skills/check-reporting/references/checklists/TRIPOD_AI.md
@@ -6,7 +6,8 @@
 - **Citation:** Collins GS, Moons KGM, Dhiman P, et al. *TRIPOD+AI statement: updated guidance for reporting clinical prediction models that use regression or machine learning methods.* BMJ 2024;385:e078378.
 - **DOI:** 10.1136/bmj-2023-078378
 - **Source:** https://www.tripod-statement.org — official expanded checklist: https://www.tripod-statement.org/wp-content/uploads/2024/04/TRIPODAI-Supplement.pdf
-- **Licence:** CC BY 4.0. Item wording below is reproduced faithfully from the published statement with attribution.
+- **Licence:** CC BY 4.0. Item wording below is reproduced from the published statement with attribution.
+- **Verified:** all 52 sub-items compared against the official supplements (ST1 expanded checklist, ST2 fillable checklist). 52/52 match in substance; the D/E designations match the statement exactly. Differences are orthographic only.
 
 **TRIPOD+AI 2024 supersedes and replaces TRIPOD 2015.** It is not TRIPOD 2015 plus AI addenda — it is a
 complete rewrite, applicable to prediction-model studies using **either** regression **or** machine-learning
@@ -32,7 +33,7 @@ and Discussion (25–27).
 
 | Item | Topic | D/E | Checklist item |
 |---|---|---|---|
-| 2 | Abstract | D;E | See the TRIPOD+AI for Abstracts checklist. |
+| 2 | Abstract | D;E | See TRIPOD+AI for Abstracts checklist. |
 
 ### Introduction
 
@@ -47,7 +48,7 @@ and Discussion (25–27).
 
 | Item | Topic | D/E | Checklist item |
 |---|---|---|---|
-| 5a | Data | D;E | Describe the sources of data separately for the development and evaluation datasets (e.g., randomised trial, cohort, routine care or registry data), the rationale for using these data, and the representativeness of the data. |
+| 5a | Data | D;E | Describe the sources of data separately for the development and evaluation datasets (e.g., randomised trial, cohort, routine care or registry data), the rationale for using these data, and representativeness of the data. |
 | 5b | Data | D;E | Specify the dates of the collected participant data, including start and end of participant accrual; and, if applicable, end of follow-up. |
 | 6a | Participants | D;E | Specify key elements of the study setting (e.g., primary care, secondary care, general population) including the number and location of centres. |
 | 6b | Participants | D;E | Describe the eligibility criteria for study participants. |
@@ -63,7 +64,7 @@ and Discussion (25–27).
 | 11 | Missing data | D;E | Describe how missing data were handled. Provide reasons for omitting any data. |
 | 12a | Analytical methods | D | Describe how the data were used (e.g., for development and evaluation of model performance) in the analysis, including whether the data were partitioned, considering any sample size requirements. |
 | 12b | Analytical methods | D | Depending on the type of model, describe how predictors were handled in the analyses (functional form, rescaling, transformation, or any standardisation). |
-| 12c | Analytical methods | D | Specify the type of model, rationale, all model building steps, including any hyperparameter tuning, and method for internal validation. |
+| 12c | Analytical methods | D | Specify the type of model, rationale, all model-building steps, including any hyperparameter tuning, and method for internal validation. |
 | 12d | Analytical methods | D;E | Describe if and how any heterogeneity in estimates of model parameter values and model performance was handled and quantified across clusters (e.g., hospitals, countries). See TRIPOD-Cluster for additional considerations. |
 | 12e | Analytical methods | D;E | Specify all measures and plots used (and their rationale) to evaluate model performance (e.g., discrimination, calibration, clinical utility) and, if relevant, to compare multiple models. |
 | 12f | Analytical methods | E | Describe any model updating (e.g., recalibration) arising from the model evaluation, either overall or for particular sociodemographic groups or settings. |
@@ -99,7 +100,7 @@ and Discussion (25–27).
 | 20b | Participants | D;E | Report the characteristics overall and, where applicable, for each data source or setting, including the key dates, key predictors (including demographics), treatments received, sample size, number of outcome events, follow-up time, and amount of missing data. A table may be helpful. Report any differences across key demographic groups. |
 | 20c | Participants | E | For model evaluation, show a comparison with the development data of the distribution of important predictors (demographics, predictors, and outcome). |
 | 21 | Model development | D;E | Specify the number of participants and outcome events in each analysis (e.g., for model development, hyperparameter tuning, model evaluation). |
-| 22 | Model specification | D | Provide details of the full prediction model (e.g., formula, code, object, application programming interface) to allow predictions in new individuals and to enable third party evaluation and implementation, including any restrictions to access or reuse (e.g., freely available, proprietary). |
+| 22 | Model specification | D | Provide details of the full prediction model (e.g., formula, code, object, application programming interface) to allow predictions in new individuals and to enable third-party evaluation and implementation, including any restrictions to access or re-use (e.g., freely available, proprietary). |
 | 23a | Model performance | D;E | Report model performance estimates with confidence intervals, including for any key subgroups (e.g., sociodemographic). Consider plots to aid presentation. |
 | 23b | Model performance | D;E | If examined, report results of any heterogeneity in model performance across clusters. See TRIPOD-Cluster for additional details. |
 | 24 | Model updating | E | Report the results from any model updating, including the updated model and subsequent performance. |
@@ -109,10 +110,10 @@ and Discussion (25–27).
 | Item | Topic | D/E | Checklist item |
 |---|---|---|---|
 | 25 | Interpretation | D;E | Give an overall interpretation of the main results, including issues of fairness in the context of the objectives and previous studies. |
-| 26 | Limitations | D;E | Discuss any limitations of the study (such as a non-representative sample, sample size, overfitting, missing data) and their effects on any biases, statistical uncertainty, and generalisability. |
+| 26 | Limitations | D;E | Discuss any limitations of the study (such as a non-representative sample, sample size, overfitting, missing data) and their effects on any biases, statistical uncertainty, and generalizability. |
 | 27a | Usability of the model in the context of current care | D | Describe how poor quality or unavailable input data (e.g., predictor values) should be assessed and handled when implementing the prediction model. |
 | 27b | Usability of the model in the context of current care | D | Specify whether users will be required to interact in the handling of the input data or use of the model, and what level of expertise is required of users. |
-| 27c | Usability of the model in the context of current care | D;E | Discuss any next steps for future research, with a specific view to applicability and generalisability of the model. |
+| 27c | Usability of the model in the context of current care | D;E | Discuss any next steps for future research, with a specific view to applicability and generalizability of the model. |
 
 ---
 
@@ -135,6 +136,12 @@ Official item **14 (Fairness)**, **18f (Code sharing)**, **22 (Model specificati
 under their official items, not as extras here.
 
 ## Notes for assessors
+
+- **Footnotes carried from the official checklist.** Item 12c is assessed **separately for every
+  model-building approach** used, not once for the study. Item 18f (code sharing) refers to the
+  *analysis* code — data cleaning, feature engineering, model building, evaluation — while item 22
+  refers to the code needed to *implement* the model for a new individual; a study can satisfy one
+  and not the other.
 
 - **Applicability.** Mark items labelled `D` (development-only) or `E` (evaluation-only) as N/A when they do
   not apply to the study design; `D;E` items apply to both.

--- a/skills/meta-analysis/references/checklists/PROBAST.md
+++ b/skills/meta-analysis/references/checklists/PROBAST.md
@@ -1,8 +1,22 @@
 # PROBAST Assessment Guide
 
 Prediction model Risk Of Bias ASsessment Tool.
-Reference: Wolff RF et al. Ann Intern Med 2019;170(1):51-58. PMID: 30596875.
-AI extension: PROBAST+AI (BMJ 2024).
+Version: PROBAST 2019 — 20 signalling questions across 4 domains (2 / 3 / 6 / 9).
+Source: Wolff RF, Moons KGM, Riley RD, Whiting PF, Westwood M, Collins GS, et al. PROBAST: A Tool to
+Assess the Risk of Bias and Applicability of Prediction Model Studies. *Ann Intern Med*
+2019;170(1):51-58 (PMID 30596875; DOI 10.7326/M18-1376). Explanation and Elaboration:
+*Ann Intern Med* 2019;170(1):W1-W33.
+
+> **Fidelity and licence.** PROBAST is published in *Annals of Internal Medicine* (© American College
+> of Physicians) and carries **no open licence**. The signalling questions below are therefore an
+> **in-house summary of what each question asks — not the published wording**. The numbering,
+> the domain structure and the count (2 / 3 / 6 / 9) are verified against the statement; the phrasing
+> is ours. **Complete the official tool from probast.org or the statement for any assessment you
+> report.** Use this file to organise a first pass.
+
+> **PROBAST 2019 is superseded.** PROBAST+AI (2025) replaces it for all new assessments, covering
+> regression and AI/ML models alike — see `PROBAST_AI.md`. Use this file only when appraising against
+> the 2019 instrument specifically (for example, reproducing an earlier review).
 
 ## Structure
 
@@ -13,63 +27,74 @@ PROBAST assesses 4 domains, each for Risk of Bias AND Applicability.
 
 ## Domain 1: Participants
 
-### Signalling Questions (Risk of Bias)
-1. Were appropriate data sources used (e.g., cohort, RCT, nested case-control)?
-2. Were all inclusions and exclusions of participants appropriate?
+### Signalling questions (risk of bias) — what each asks
+
+1.1 Whether the data source suits the question — a cohort, a randomised trial, or nested
+    case–control data, rather than a design that distorts the sampling.
+1.2 Whether every inclusion and exclusion applied to participants was appropriate.
 
 ### Applicability
 - Do the participants and setting match the review question?
 
 ## Domain 2: Predictors
 
-### Signalling Questions (Risk of Bias)
-1. Were predictors defined and assessed in a similar way for all participants?
-2. Were predictor assessments made without knowledge of outcome data?
-3. Are all predictors available at the time the model is intended to be used?
+### Signalling questions (risk of bias) — what each asks
+
+2.1 Whether predictors were defined and assessed the same way for every participant.
+2.2 Whether predictors were assessed without knowledge of the outcome.
+2.3 Whether every predictor is available at the moment the model is meant to be used.
 
 ### Applicability
 - Do the predictors, their assessment, and timing match the review question?
 
 ## Domain 3: Outcome
 
-### Signalling Questions (Risk of Bias)
-1. Was the outcome determined appropriately?
-2. Was a pre-specified or standard outcome definition used?
-3. Were predictors excluded from the outcome definition?
-4. Was the outcome defined and determined in a similar way for all participants?
-5. Was the outcome determined without knowledge of predictor information?
-6. Was the time interval between predictor assessment and outcome appropriate?
+### Signalling questions (risk of bias) — what each asks
+
+3.1 Whether the outcome was determined by an appropriate method.
+3.2 Whether the outcome definition was prespecified or a standard one.
+3.3 Whether predictors were kept out of the outcome definition.
+3.4 Whether the outcome was defined and determined the same way for every participant.
+3.5 Whether the outcome was determined without knowledge of predictor information.
+3.6 Whether the interval between predictor assessment and **outcome determination** was
+    appropriate — the question is about when the outcome was *determined*, not merely when it
+    occurred.
 
 ### Applicability
 - Does the outcome and its definition/timing match the review question?
 
 ## Domain 4: Analysis
 
-### Signalling Questions (Risk of Bias)
-1. Were there a reasonable number of participants with the outcome?
-2. Were continuous and categorical predictors handled appropriately?
-3. Were all enrolled participants included in the analysis?
-4. Were participants with missing data handled appropriately?
-5. Was selection of predictors based on univariable analysis avoided?
-6. Were complexities in the data accounted for appropriately?
-7. Were relevant model performance measures evaluated appropriately?
-8. Were model overfitting and optimism in model performance accounted for?
-9. Do predictors and their assigned weights in the final model correspond to the reported multivariable analysis?
+### Signalling questions (risk of bias) — what each asks
 
-### For Validation Studies (additional)
+4.1 Whether the number of participants with the outcome was reasonable.
+4.2 Whether continuous and categorical predictors were handled appropriately.
+4.3 Whether every enrolled participant was included in the analysis.
+4.4 Whether participants with missing data were handled appropriately.
+4.5 Whether selection of predictors on the basis of univariable analysis was avoided.
+4.6 Whether complexities in the data were accounted for — the statement names **censoring,
+    competing risks, and the sampling of control participants** as the cases to look for.
+4.7 Whether relevant measures of model performance were evaluated appropriately.
+4.8 Whether **overfitting, underfitting, and optimism** in model performance were accounted for.
+    All three, not overfitting alone.
+4.9 Whether the predictors and their assigned weights in the final model correspond to the
+    **results from** the reported multivariable analysis.
+
+### For validation studies (additional)
 - Were the model and its performance evaluated appropriately?
 
-## PROBAST+AI Extensions (2024)
+## For AI / machine-learning models
 
-For AI/ML prediction models, additional considerations:
-- **Data**: Training/validation/test split, data leakage check
-- **Model**: Architecture transparency, hyperparameter tuning method
-- **Performance**: Discrimination (AUC), calibration, fairness across subgroups
-- **Reproducibility**: Code/data availability, external validation
+Use **`PROBAST_AI.md`** (PROBAST+AI 2025; Moons KGM et al. *BMJ* 2025;388:e082505,
+DOI 10.1136/bmj-2024-082505), which carries the instrument's own 16 development and 18 evaluation
+signalling questions. Do not improvise AI addenda on top of the 2019 questions: an earlier version of
+this file listed four invented bullets under a heading that implied they were part of the extension,
+which they were not.
 
 ## When to Use
 
 - Diagnostic prediction models (e.g., AI classifiers for imaging findings)
 - Prognostic prediction models (e.g., risk scores, survival prediction)
 - Both development AND validation studies
-- Use PROBAST+AI when the model involves machine learning or deep learning
+- For any model developed with machine learning or deep learning, and for new assessments generally,
+  use PROBAST+AI (`PROBAST_AI.md`) rather than this file


### PR DESCRIPTION
Second batch of the vendored-checklist audit. Sources: the official PROBAST 2019 statement and the TRIPOD+AI 2024 supplements (ST1 expanded checklist, ST2 fillable checklist).

## PROBAST — a section of the file was invented

The structure was right: 20 signalling questions, 2 / 3 / 6 / 9 across the four domains, matching the statement. The content was not.

**A section headed "PROBAST+AI Extensions (2024)" listed four bullets that appear in no version of the tool** — "Data: training/validation/test split, data leakage check", "Model: architecture transparency, hyperparameter tuning method", and two more. PROBAST+AI is a real instrument with **16 development and 18 evaluation signalling questions**, it is dated **2025**, and this repository already vendors it correctly as `PROBAST_AI.md`. Anyone appraising a study against that section was appraising against something a maintainer made up.

Three official criteria had been silently narrowed:

| | Official | This file |
|---|---|---|
| **4.8** | "model **overfitting, underfitting,** and optimism" | "model overfitting and optimism" |
| **4.6** | "complexities in the data **(e.g., censoring, competing risks, sampling of control participants)**" | "complexities in the data" |
| 3.6 | interval to "outcome **determination**" | interval to "outcome" |
| 4.9 | "correspond to the **results from the** reported multivariable analysis" | "correspond to the reported multivariable analysis" |

All restored. The AI section is now a pointer to `PROBAST_AI.md` with the correct citation, and the file records what its own authors state and it did not: **PROBAST 2019 is superseded by PROBAST+AI 2025** for new assessments.

### The licence half

PROBAST is published in *Annals of Internal Medicine* (© American College of Physicians) under **no open licence**, and this file had been reproducing its signalling questions near-verbatim with no licence statement at all.

They are now an **in-house summary of what each question asks**, labelled as such, with the numbering and domain structure — facts, not expression — verified against the statement, and a direction to complete the official tool for anything reported.

This is the first file where the audit's two risks pointed in opposite directions. Diverging from the original makes the instrument wrong; matching it too closely makes it a reproduction we have no licence for. Both were true of this file at once.

## TRIPOD+AI — verified clean, 52/52

Compared character-for-character against ST1 and ST2. Every sub-item matches and the D/E designations match the statement exactly. Five orthographic differences normalised to the published wording (an added "the" in items 2 and 5a, hyphenation in 12c and 22, British "generalisability" in 26 and 27c). The only remaining difference is a footnote superscript the PDF carries and a markdown table should not.

Two official footnotes that qualify how items are scored were not being carried, and now are: **12c is assessed separately for each model-building approach**, and **18f (analysis code) is a different question from 22** (the code needed to implement the model for a new individual) — a study can satisfy one and not the other. The header now records what the file was verified against, so the next person does not have to redo the comparison to find out whether it was done.

This file was already the best of those audited: citation, DOI, licence line, a correct 27-item/52-sub-item count, and an explicit "NOT official items" fence around the toolkit's own supplemental checks. That is the shape the remaining files should be brought to.

## Running total

| | Result |
|---|---|
| PRISMA 2020 | 4 divergences, 2 score-changing — fixed (#470) |
| PRISMA-DTA | 1 confirmed wrong, rest unverified — warned (#470) |
| PROBAST | invented section + 3 narrowed criteria — fixed; relicensed as summary |
| PROBAST+AI | clean |
| TRIPOD+AI | clean, 52/52 |

**5 of 48 audited.** Three of the five needed correction.

## Verification

- `python3 scripts/run_ci_mirror.py` — **238/238 gates pass**
- Vendored copies in `meta-analysis` synced via `check_domain_probe_sync.py`