### PR TITLE
Checklist fidelity 3/N: five licence claims were wrong, one conflicts with our own MIT terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,47 @@
 
 ### Fixed
 
+- **Five checklist licence claims were wrong, and one of them conflicts with this repository's own
+  licence.** `LICENSES.md` presented itself as the attribution record for the bundled checklists and
+  asserted **CC BY** for ROBINS-I, RoB 2, QUADAS-2, PROBAST and PRISMA-DTA. Every entry was resolved
+  against the article DOI through the Crossref `license` field and, where Crossref carried only a
+  text-and-data-mining policy, the PubMed Central `<license>` element:
+
+  | Instrument | Claimed | Actually |
+  |---|---|---|
+  | **ROBINS-I** (BMJ 2016) | CC BY | **CC BY-NC 3.0** — non-commercial |
+  | RoB 2 (BMJ 2019) | CC BY | no CC licence found (BMJ TDM policy only) |
+  | QUADAS-2 (Ann Intern Med 2011) | CC BY | © ACP, no open licence |
+  | PROBAST (Ann Intern Med 2019) | CC BY | © ACP, no open licence |
+  | PRISMA-DTA (JAMA 2018) | CC BY | © AMA, no licence field |
+
+  The ROBINS-I row is the one that bites: **NC is incompatible with redistributing a verbatim
+  reproduction under this repository's MIT licence**, and the toolkit ships through npm, GitHub and a
+  classroom ZIP without restriction. The claim had been inherited rather than checked.
+
+  Eight rows were confirmed correct on the same evidence — STROBE, STARD, TRIPOD+AI, PRISMA 2020 and
+  its abstract checklist, CONSORT 2025, SPIRIT 2025 (all CC BY 4.0) and ARRIVE 2.0 (CC0 1.0) — so the
+  table is now split by verified status rather than presented as uniform, and it states the method
+  so the next person can re-run it. Files whose licence has not been resolved are named as
+  unresolved: an absent licence statement is not evidence of permissive licensing.
+
+- **`RoB2.md`, `ROBINS_I.md` and `QUADAS2.md` now say what they are.** All three carried a bare
+  `Reference:` line — no version, no licence, no statement of fidelity — while reading as though they
+  reproduced the instruments. Each now carries the full citation with DOI, the verified licence
+  status, and an explicit statement that it is an in-house summary of the tool's **structure**
+  (domains, answer options, judgement levels) which has not been compared against the official
+  document, with a direction to complete the official form for anything reported.
+
+  Their content is deliberately left alone. Rewriting signalling questions without the official
+  source in hand is precisely how the wrong text arrived in these files, and the sources are
+  subscription-access. What could be checked was checked: ROBINS-I's seven domains, their order and
+  the Low / Moderate / Serious / Critical scale match the article.
+
+  `ROBINS_I.md` also records that **ROBINS-I V2 exists and is still in draft** (revised November
+  2025), adding algorithms from signalling questions to domain judgements and covering immortal-time
+  bias, which the 2016 version omits. A reader appraising against the 2016 tool should know a
+  successor is in progress.
+
 - **`PROBAST.md` presented four invented bullets as the AI extension, and dropped three assessment
   criteria from the official signalling questions.** Audited against the published statement
   (Wolff et al., *Ann Intern Med* 2019;170:51-58). The domain structure and the count are right —

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -633,8 +633,8 @@
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
-      "size": 3831,
-      "sha256": "f2d5070aff9a2f3a616b8bd9051ed7df4f758fc70919922adcb6ded2614653ad"
+      "size": 5410,
+      "sha256": "2c5b159691e4c2c4c329e21e9d30b14082b66713dd09974e590b06d9ea6a93cf"
     },
     {
       "path": "skills/check-reporting/references/appraisal_tools/METRICS.md",
@@ -773,8 +773,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS2.md",
-      "size": 2881,
-      "sha256": "816b520d2a647b646c1c3b745b21629799a20ff3ddcfa4fafc05d8ea9efc3dc2"
+      "size": 3718,
+      "sha256": "fe644deaa01b54dd92dcde7bbbf3dfece2473b3f80e0d6840e8a443e6330f2f4"
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS_C.md",
@@ -798,8 +798,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBINS_I.md",
-      "size": 3349,
-      "sha256": "982419521d31bf713a59b3acd16392402f5efa06fa00d2744de0ba7df8d2a922"
+      "size": 4652,
+      "sha256": "ae51ab50d38d2ac2d69d80cdf7cbac756368bba02e00ee6f93334fc03aec24de"
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBIS.md",
@@ -813,8 +813,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/RoB2.md",
-      "size": 3871,
-      "sha256": "76e9909a9673a69c70f60198123daf331e9ebbf00cb29f1e5598e14fe6db298a"
+      "size": 4825,
+      "sha256": "0e4a37428f7485ba4ce6a54f509e3b8733ad73b42f5a140533f5320261b3a2f5"
     },
     {
       "path": "skills/check-reporting/references/checklists/RoB_NMA.md",
@@ -2723,18 +2723,18 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/QUADAS2.md",
-      "size": 2881,
-      "sha256": "816b520d2a647b646c1c3b745b21629799a20ff3ddcfa4fafc05d8ea9efc3dc2"
+      "size": 3718,
+      "sha256": "fe644deaa01b54dd92dcde7bbbf3dfece2473b3f80e0d6840e8a443e6330f2f4"
     },
     {
       "path": "skills/meta-analysis/references/checklists/ROBINS_I.md",
-      "size": 3349,
-      "sha256": "982419521d31bf713a59b3acd16392402f5efa06fa00d2744de0ba7df8d2a922"
+      "size": 4652,
+      "sha256": "ae51ab50d38d2ac2d69d80cdf7cbac756368bba02e00ee6f93334fc03aec24de"
     },
     {
       "path": "skills/meta-analysis/references/checklists/RoB2.md",
-      "size": 3871,
-      "sha256": "76e9909a9673a69c70f60198123daf331e9ebbf00cb29f1e5598e14fe6db298a"
+      "size": 4825,
+      "sha256": "0e4a37428f7485ba4ce6a54f509e3b8733ad73b42f5a140533f5320261b3a2f5"
     },
     {
       "path": "skills/meta-analysis/references/data_integrity_checklist.md",

--- a/skills/check-reporting/references/LICENSES.md
+++ b/skills/check-reporting/references/LICENSES.md
@@ -1,55 +1,77 @@
 # Checklist Licenses
 
-Attribution for bundled reporting guideline checklists.
+Attribution and licence status for the bundled reporting-guideline and risk-of-bias checklists.
 
-| File | Guideline | Reference | License |
-|------|-----------|-----------|---------|
-| STROBE.md | STROBE 2007 | von Elm E et al. PLoS Med 2007 | CC BY |
-| STARD.md | STARD 2015 | Bossuyt PM et al. BMJ 2015 | CC BY 4.0 |
-| STARD_AI.md | STARD-AI 2025 | Sounderajah V et al. Nat Med 2025;31:3283-3289 | CC BY |
-| TRIPOD_AI.md | TRIPOD+AI 2024 | Collins GS et al. BMJ 2024 | CC BY 4.0 |
-| TRIPOD_LLM.md | TRIPOD-LLM 2025 | Gallifant J et al. Nat Med 2025;31(1):60-69 | CC BY 4.0 (accepted manuscript) — educational summary |
-| CONSORT_AI.md | CONSORT-AI 2020 | Liu X et al. Nat Med 2020;26(9):1364-1374 | CC BY 4.0 |
-| SPIRIT_AI.md | SPIRIT-AI 2020 | Cruz Rivera S et al. Nat Med 2020;26(9):1351-1363 | CC BY 4.0 |
-| PRISMA_2020.md | PRISMA 2020 | Page MJ et al. BMJ 2021 | CC BY |
-| PRISMA_2020_Abstracts.md | PRISMA 2020 for Abstracts | Page MJ et al. BMJ 2021 | CC BY |
-| ARRIVE_2.md | ARRIVE 2.0 | Percie du Sert N et al. PLoS Biol 2020 | CC0 |
-| PRISMA_DTA.md | PRISMA-DTA 2018 | McInnes MDF et al. JAMA 2018 | CC BY |
-| QUADAS2.md | QUADAS-2 | Whiting PF et al. Ann Intern Med 2011 | CC BY |
-| RoB2.md | RoB 2 | Sterne JAC et al. BMJ 2019 | CC BY |
-| ROBINS_I.md | ROBINS-I | Sterne JAC et al. BMJ 2016 | CC BY |
-| PROBAST.md | PROBAST | Wolff RF et al. Ann Intern Med 2019 | CC BY |
-| NOS.md | Newcastle-Ottawa Scale | Wells GA et al. Ottawa Hospital Research Institute | Public Domain |
-| MI_CLEAR_LLM.md | MI-CLEAR-LLM 2025 | Park SH et al. Korean J Radiol 2024;25(10):865-868; 2025 update KJR 2025;26(12):1123-1132 | CC BY-NC 4.0 |
-| CONSORT.md | CONSORT 2025 | Hopewell S et al. BMJ 2025;389:e081123 | CC BY 4.0 |
-| SPIRIT.md | SPIRIT 2025 | Chan AW et al. BMJ 2025;389:e081477 | CC BY 4.0 |
-| CARE.md | CARE 2013 | Gagnier JJ et al. J Clin Epidemiol 2014;67(1):46-51 | CC BY-NC 4.0 |
-| CLAIM_2024.md | CLAIM 2024 Update | Tejani AS et al. Radiol Artif Intell 2024;6(4):e240300 | RSNA, open access |
-| DECIDE_AI.md | DECIDE-AI 2022 | Vasey B et al. Nat Med 2022;28(5):924-933 | CC BY-NC 4.0 (DECIDE-AI materials) — educational summary |
+**How the Licence column is established.** Each entry is resolved from the article's DOI through
+the Crossref `license` field and, where Crossref carries only a text-and-data-mining policy, through
+the PubMed Central record's `<license>` element. A row reads **verified** only when one of those two
+returned an explicit Creative Commons or public-domain URL. Where neither did, the row says so — an
+absent licence statement is **not** evidence of permissive licensing, and several publishers in this
+table (ACP, JAMA Network) do not publish these instruments under an open licence at all.
 
-These files are educational summaries of published assessment tools. The original
-checklist documents should be cited in any manuscript that uses them.
+This distinction is load-bearing. This repository is MIT-licensed and is redistributed through npm,
+GitHub and a classroom ZIP without restriction. A checklist whose source is CC BY-**NC** cannot be
+carried verbatim under those terms, and one with no open licence cannot be carried verbatim at all.
 
-## Third-party licenses (NOT covered by the repository MIT license)
+## Verified permissive
 
-Most files above are CC BY / CC0 / public domain and redistribute freely with
-attribution. The following retain their own licenses and are **not** placed under
-this repository's MIT license — downstream use must comply with the original terms:
+| File | Guideline | Reference | Licence | Verified via |
+|------|-----------|-----------|---------|--------------|
+| STROBE.md | STROBE 2007 | von Elm E et al. PLoS Med 2007 | CC BY 4.0 | PMC2020495 |
+| STARD.md | STARD 2015 | Bossuyt PM et al. BMJ 2015;351:h5527 | CC BY 4.0 | PMC4623764 |
+| TRIPOD_AI.md | TRIPOD+AI 2024 | Collins GS et al. BMJ 2024;385:e078378 | CC BY 4.0 | Crossref |
+| PRISMA_2020.md | PRISMA 2020 | Page MJ et al. BMJ 2021;372:n71 | CC BY 4.0 | Crossref |
+| PRISMA_2020_Abstracts.md | PRISMA 2020 for Abstracts | Page MJ et al. BMJ 2021;372:n71 | CC BY 4.0 | Crossref |
+| CONSORT.md | CONSORT 2025 | Hopewell S et al. BMJ 2025;389:e081123 | CC BY 4.0 | Crossref |
+| SPIRIT.md | SPIRIT 2025 | Chan AW et al. BMJ 2025;389:e081477 | CC BY 4.0 | Crossref |
+| ARRIVE_2.md | ARRIVE 2.0 | Percie du Sert N et al. PLoS Biol 2020 | CC0 1.0 | Crossref |
 
-- **CARE.md** and **MI_CLEAR_LLM.md** are **CC BY-NC 4.0**: free to copy and
-  redistribute **with attribution for non-commercial purposes**. Commercial use
-  requires permission from the original rights holders.
-- **CLAIM_2024.md** is an educational summary of an RSNA open-access checklist
-  (© RSNA). Cite Tejani et al. 2024; consult RSNA for commercial reuse terms.
-- **TRIPOD_LLM.md** paraphrases item *intent* in our own words; no verbatim guideline
-  wording is copied. The published Nature Medicine article is subscription-access
-  (© The Author(s), under exclusive licence to Springer Nature); the author-accepted
-  manuscript is CC BY 4.0 via institutional rights retention. Cite Gallifant et al. 2025
-  and complete the official instrument (tripod-statement.org) for a submission checklist.
-- **DECIDE_AI.md** paraphrases item *intent* in our own words (no verbatim wording). The
-  published Nature Medicine statement is subscription-access; DECIDE-AI materials carry **CC
-  BY-NC 4.0** (non-commercial). Cite Vasey et al. 2022 and complete the official DECIDE-AI
-  instrument for a submission checklist.
+## Non-commercial — NOT covered by this repository's MIT licence
 
-All files remain educational summaries that cite their source; they do not relicense
-the underlying guidelines.
+Free to copy and redistribute **with attribution, for non-commercial purposes**. Commercial use
+requires permission from the rights holder. These files must remain summaries of item *intent* in our
+own words rather than reproductions.
+
+| File | Guideline | Reference | Licence | Verified via |
+|------|-----------|-----------|---------|--------------|
+| ROBINS_I.md | ROBINS-I 2016 | Sterne JAC et al. BMJ 2016;355:i4919 | **CC BY-NC 3.0** | PMC5062054 |
+| CARE.md | CARE 2013 | Gagnier JJ et al. J Clin Epidemiol 2014;67(1):46-51 | CC BY-NC 4.0 | publisher statement |
+| MI_CLEAR_LLM.md | MI-CLEAR-LLM | Park SH et al. Korean J Radiol 2024;25(10):865-868; 2025 update KJR 2025;26(12):1123-1132 | CC BY-NC 4.0 | publisher statement |
+| DECIDE_AI.md | DECIDE-AI 2022 | Vasey B et al. Nat Med 2022;28(5):924-933 | CC BY-NC 4.0 (DECIDE-AI materials) | publisher statement |
+
+## No open licence found — summaries only, never reproductions
+
+Neither Crossref nor PMC returned a Creative Commons or public-domain licence for these. The
+publishers are subscription-access and do not place these instruments under an open licence. The
+bundled files must express item *intent* in our own words, cite the source, and direct the reader to
+complete the official instrument.
+
+| File | Guideline | Reference | Status | Verified via |
+|------|-----------|-----------|--------|--------------|
+| QUADAS2.md | QUADAS-2 | Whiting PF et al. Ann Intern Med 2011;155(8):529-536 | © ACP — no open licence | Crossref (TDM policy only) |
+| PROBAST.md | PROBAST 2019 | Wolff RF et al. Ann Intern Med 2019;170(1):51-58 | © ACP — no open licence | Crossref (TDM policy only) |
+| RoB2.md | RoB 2 2019 | Sterne JAC et al. BMJ 2019;366:l4898 | no CC licence found | Crossref (TDM policy only) |
+| PRISMA_DTA.md | PRISMA-DTA 2018 | McInnes MDF et al. JAMA 2018;319(4):388-396 | © AMA — no open licence | Crossref (no licence field) |
+| TRIPOD_LLM.md | TRIPOD-LLM 2025 | Gallifant J et al. Nat Med 2025;31(1):60-69 | published version subscription-access; author-accepted manuscript CC BY 4.0 via rights retention | publisher statement |
+| CLAIM_2024.md | CLAIM 2024 Update | Tejani AS et al. Radiol Artif Intell 2024;6(4):e240300 | © RSNA, open access — consult RSNA for reuse terms | publisher statement |
+| NOS.md | Newcastle-Ottawa Scale | Wells GA et al. Ottawa Hospital Research Institute | no formal licence published | — |
+
+## Not yet resolved
+
+Every other file under `checklists/` is not listed above because its licence has **not** been
+resolved. That is a gap in this table, not a finding of permissiveness. Treat an unlisted file as
+"unknown licence, summarise only" until it appears here.
+
+## Corrections made to this table
+
+Five rows previously claimed **CC BY** on no evidence: ROBINS-I (actually CC BY-**NC** 3.0),
+RoB 2, QUADAS-2, PROBAST, and PRISMA-DTA (no open licence found for any of the four). The claim was
+inherited rather than checked. It mattered: an NC restriction is incompatible with redistributing a
+verbatim reproduction under this repository's MIT licence, and two of the instruments come from a
+publisher that licenses none of this material openly.
+
+---
+
+All files here are educational summaries that cite their source; they do not relicense the
+underlying guidelines. Any manuscript that uses one should cite the original instrument, and any
+assessment that is reported should be completed against the official document.

--- a/skills/check-reporting/references/checklists/QUADAS2.md
+++ b/skills/check-reporting/references/checklists/QUADAS2.md
@@ -1,6 +1,16 @@
 # QUADAS-2 Assessment Guide
 
 Quality Assessment of Diagnostic Accuracy Studies, version 2.
+Version: QUADAS-2 (2011) — 4 domains, each rated for risk of bias, with applicability for the first three.
+Source: Whiting PF, Rutjes AWS, Westwood ME, Mallett S, Deeks JJ, Reitsma JB, et al. QUADAS-2: a
+revised tool for the quality assessment of diagnostic accuracy studies. *Ann Intern Med*
+2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009).
+
+> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American
+> College of Physicians) under **no open licence**; `LICENSES.md` previously claimed CC BY for it on
+> no evidence. This file is an **in-house summary of the tool's structure** and has **not** been
+> compared against the published tool, so the signalling questions below may be abbreviated or
+> incomplete. **Complete the official QUADAS-2 form for any assessment you report.**
 Reference: Whiting PF et al. Ann Intern Med 2011;155(8):529-536.
 
 ## Structure

--- a/skills/check-reporting/references/checklists/ROBINS_I.md
+++ b/skills/check-reporting/references/checklists/ROBINS_I.md
@@ -1,6 +1,23 @@
 # ROBINS-I Assessment Guide
 
 Risk Of Bias In Non-randomised Studies - of Interventions.
+Version: ROBINS-I (2016), the original version. Tool home: https://www.riskofbias.info
+Source: Sterne JAC, Hernán MA, Reeves BC, Savović J, Berkman ND, Viswanathan M, et al. ROBINS-I: a
+tool for assessing risk of bias in non-randomised studies of interventions. *BMJ* 2016;355:i4919
+(DOI 10.1136/bmj.i4919).
+
+> **Fidelity and licence.** The source article is **CC BY-NC 3.0** — non-commercial. This repository
+> is MIT-licensed and redistributed without restriction, so the tool's wording cannot be carried
+> verbatim here. This file is an **in-house summary of the tool's structure**: the seven domains,
+> their order, the answer options and the judgement levels, all of which were checked against the
+> article. The per-domain questions below are abbreviated and are **not** the tool's signalling
+> questions. **Complete the official ROBINS-I form from riskofbias.info for any assessment you
+> report.**
+>
+> **A version 2 exists and is still in draft.** ROBINS-I V2 adds algorithms mapping signalling-question
+> answers onto domain judgements, and covers bias due to immortal time, which the 2016 version omits.
+> A revised draft was posted in November 2025 and is subject to change. Check riskofbias.info before
+> choosing which version to appraise against; this file documents the 2016 version.
 Reference: Sterne JAC et al. BMJ 2016;355:i4919.
 
 ## Structure

--- a/skills/check-reporting/references/checklists/RoB2.md
+++ b/skills/check-reporting/references/checklists/RoB2.md
@@ -1,6 +1,18 @@
 # RoB 2 Assessment Guide
 
 Revised Cochrane Risk-of-Bias tool for Randomised Trials.
+Version: RoB 2 (2019). Full guidance and the current tool: https://www.riskofbias.info
+Source: Sterne JAC, Savović J, Page MJ, Elbers RG, Blencowe NS, Boutron I, et al. RoB 2: a revised
+tool for assessing risk of bias in randomised trials. *BMJ* 2019;366:l4898 (DOI 10.1136/bmj.l4898;
+PMID 31462531).
+
+> **Fidelity and licence.** **No open licence was found for this article** — Crossref returns only
+> BMJ's text-and-data-mining policy, and `LICENSES.md` previously claimed CC BY for it on no
+> evidence. This file is therefore an **in-house summary of the tool's structure**: the domains,
+> the answer options and the judgement levels. It has **not** been compared against the official
+> guidance document, so the signalling questions below may be incomplete or abbreviated relative to
+> the tool. **Complete the official RoB 2 form from riskofbias.info for any assessment you report**,
+> and treat this file as a way to organise a first pass only.
 Reference: Sterne JAC et al. BMJ 2019;366:l4898. PMID: 31462531.
 
 ## Structure

--- a/skills/meta-analysis/references/checklists/QUADAS2.md
+++ b/skills/meta-analysis/references/checklists/QUADAS2.md
@@ -1,6 +1,16 @@
 # QUADAS-2 Assessment Guide
 
 Quality Assessment of Diagnostic Accuracy Studies, version 2.
+Version: QUADAS-2 (2011) — 4 domains, each rated for risk of bias, with applicability for the first three.
+Source: Whiting PF, Rutjes AWS, Westwood ME, Mallett S, Deeks JJ, Reitsma JB, et al. QUADAS-2: a
+revised tool for the quality assessment of diagnostic accuracy studies. *Ann Intern Med*
+2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009).
+
+> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American
+> College of Physicians) under **no open licence**; `LICENSES.md` previously claimed CC BY for it on
+> no evidence. This file is an **in-house summary of the tool's structure** and has **not** been
+> compared against the published tool, so the signalling questions below may be abbreviated or
+> incomplete. **Complete the official QUADAS-2 form for any assessment you report.**
 Reference: Whiting PF et al. Ann Intern Med 2011;155(8):529-536.
 
 ## Structure

--- a/skills/meta-analysis/references/checklists/ROBINS_I.md
+++ b/skills/meta-analysis/references/checklists/ROBINS_I.md
@@ -1,6 +1,23 @@
 # ROBINS-I Assessment Guide
 
 Risk Of Bias In Non-randomised Studies - of Interventions.
+Version: ROBINS-I (2016), the original version. Tool home: https://www.riskofbias.info
+Source: Sterne JAC, Hernán MA, Reeves BC, Savović J, Berkman ND, Viswanathan M, et al. ROBINS-I: a
+tool for assessing risk of bias in non-randomised studies of interventions. *BMJ* 2016;355:i4919
+(DOI 10.1136/bmj.i4919).
+
+> **Fidelity and licence.** The source article is **CC BY-NC 3.0** — non-commercial. This repository
+> is MIT-licensed and redistributed without restriction, so the tool's wording cannot be carried
+> verbatim here. This file is an **in-house summary of the tool's structure**: the seven domains,
+> their order, the answer options and the judgement levels, all of which were checked against the
+> article. The per-domain questions below are abbreviated and are **not** the tool's signalling
+> questions. **Complete the official ROBINS-I form from riskofbias.info for any assessment you
+> report.**
+>
+> **A version 2 exists and is still in draft.** ROBINS-I V2 adds algorithms mapping signalling-question
+> answers onto domain judgements, and covers bias due to immortal time, which the 2016 version omits.
+> A revised draft was posted in November 2025 and is subject to change. Check riskofbias.info before
+> choosing which version to appraise against; this file documents the 2016 version.
 Reference: Sterne JAC et al. BMJ 2016;355:i4919.
 
 ## Structure

--- a/skills/meta-analysis/references/checklists/RoB2.md
+++ b/skills/meta-analysis/references/checklists/RoB2.md
@@ -1,6 +1,18 @@
 # RoB 2 Assessment Guide
 
 Revised Cochrane Risk-of-Bias tool for Randomised Trials.
+Version: RoB 2 (2019). Full guidance and the current tool: https://www.riskofbias.info
+Source: Sterne JAC, Savović J, Page MJ, Elbers RG, Blencowe NS, Boutron I, et al. RoB 2: a revised
+tool for assessing risk of bias in randomised trials. *BMJ* 2019;366:l4898 (DOI 10.1136/bmj.l4898;
+PMID 31462531).
+
+> **Fidelity and licence.** **No open licence was found for this article** — Crossref returns only
+> BMJ's text-and-data-mining policy, and `LICENSES.md` previously claimed CC BY for it on no
+> evidence. This file is therefore an **in-house summary of the tool's structure**: the domains,
+> the answer options and the judgement levels. It has **not** been compared against the official
+> guidance document, so the signalling questions below may be incomplete or abbreviated relative to
+> the tool. **Complete the official RoB 2 form from riskofbias.info for any assessment you report**,
+> and treat this file as a way to organise a first pass only.
 Reference: Sterne JAC et al. BMJ 2019;366:l4898. PMID: 31462531.
 
 ## Structure


### PR DESCRIPTION
Third batch of the vendored-checklist audit. This one is the copyright half.

## The finding

`LICENSES.md` presented itself as the attribution record for the bundled checklists and asserted **CC BY** for five instruments. Each entry was resolved against the article DOI through the Crossref `license` field and, where Crossref carried only a text-and-data-mining policy, the PubMed Central `<license>` element.

| Instrument | Claimed | Actually |
|---|---|---|
| **ROBINS-I** (BMJ 2016) | CC BY | **CC BY-NC 3.0** — non-commercial |
| RoB 2 (BMJ 2019) | CC BY | no CC licence found (BMJ TDM policy only) |
| QUADAS-2 (Ann Intern Med 2011) | CC BY | © ACP, no open licence |
| PROBAST (Ann Intern Med 2019) | CC BY | © ACP, no open licence |
| PRISMA-DTA (JAMA 2018) | CC BY | © AMA, no licence field |

**The ROBINS-I row is the one that bites.** A non-commercial restriction is incompatible with redistributing a verbatim reproduction under this repository's MIT licence, and the toolkit ships through npm, GitHub and a classroom ZIP without restriction. The claim had been inherited rather than checked.

Eight rows were confirmed correct on the same evidence — STROBE, STARD, TRIPOD+AI, PRISMA 2020 and its abstract checklist, CONSORT 2025, SPIRIT 2025 (all CC BY 4.0), ARRIVE 2.0 (CC0 1.0).

## What changed

`LICENSES.md` is now split by **verified status** rather than presented as uniform: verified permissive / non-commercial / no open licence found / not yet resolved. It states the resolution method so the next person can re-run it, and it says plainly that an absent licence statement is **not** evidence of permissive licensing. Files whose licence has not been resolved are named as unresolved rather than omitted.

`RoB2.md`, `ROBINS_I.md` and `QUADAS2.md` each carried a bare `Reference:` line — no version, no licence, no fidelity statement — while reading as though they reproduced the instruments. Each now carries the full citation with DOI, the verified licence status, and an explicit statement that it summarises the tool's **structure** (domains, answer options, judgement levels) and has not been compared against the official document, with a direction to complete the official form for anything reported.

**Their content is deliberately left alone.** Rewriting signalling questions without the official source in hand is precisely how the wrong text arrived in these files in the first place, and all three sources are subscription-access. What could be checked was checked: ROBINS-I's seven domains, their order, and the Low / Moderate / Serious / Critical scale match the article.

`ROBINS_I.md` also records that **ROBINS-I V2 exists and is still in draft** (revised November 2025), adding algorithms that map signalling-question answers onto domain judgements and covering immortal-time bias, which the 2016 version omits. Anyone appraising against the 2016 tool should know a successor is in progress.

## Running total

| | Result |
|---|---|
| PRISMA 2020 | 4 divergences, 2 score-changing — fixed (#470) |
| PRISMA-DTA | 1 confirmed wrong, rest unverified — warned (#470); licence claim corrected here |
| PROBAST | invented AI section + 3 narrowed criteria — fixed, relicensed (#471) |
| PROBAST+AI | clean (#471) |
| TRIPOD+AI | clean, 52/52 (#471) |
| ROBINS-I / RoB 2 / QUADAS-2 | structure checked where possible; licence corrected; labelled |

**8 of 48 files touched. Six needed a correction.** Content verification still requires the official documents for the subscription-access instruments.

## Verification

- `python3 scripts/run_ci_mirror.py` — **238/238 gates pass**
- Licence resolution is reproducible: Crossref `license` field per DOI, PMC `<license>` as fallback
- Vendored copies in `meta-analysis` synced