### PR TITLE
Checklist fidelity 4/N: PRISMA_DTA.md was not PRISMA-DTA — it was PRISMA 2009 renumbered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,38 @@
 
 ### Fixed
 
+- **`PRISMA_DTA.md` was not PRISMA-DTA. It was PRISMA 2009, renumbered.** Verified against the
+  statement itself (McInnes et al., *JAMA* 2018;319(4):388-396, read through institutional access,
+  including its 2020 correction). PRISMA-DTA keeps the count of 27 by **deleting items 15 and 22** and
+  **adding items D1 and D2**. The file had:
+
+  - **items 15 and 22 present** — both deleted by the guideline;
+  - **D1 and D2 absent** — the two DTA-specific items the extension exists to add. **D1** asks for the
+    index test's intended use and clinical role, and the rationale for a minimally acceptable accuracy;
+    **D2** asks for the statistical methods used in the meta-analysis. A generic PRISMA checklist
+    cannot surface either, which is the whole reason the extension was written;
+  - **23 of the 25 shared items worded differently from the published item**, including item 4 asking
+    for "PIRD elements" where the statement asks for participants, index test and target conditions,
+    and item 2 asking a diagnostic-accuracy review to summarise "interventions".
+
+  Anyone who scored a DTA systematic review with this file scored two items the guideline had removed
+  and never scored the two it had introduced.
+
+  Rebuilt. The structure — which items exist, their numbering, section placement and topic labels —
+  now matches the statement exactly and is asserted by comparison against the parsed original. The
+  **abstract checklist** the statement carries (and to which its item 2 defers) is captured too, with
+  its own DTA-specific item A1, and scored with its own denominator like `PRISMA_2020_Abstracts.md`.
+  Item 20 reflects the published correction: "receiver operating characteristic **plot**", not "curve".
+
+  **Licence.** *JAMA* publishes this under no open licence — free to read is not free to reuse. The
+  descriptions are an in-house summary of what each item asks, in our own words; the longest run of
+  the published wording that survives anywhere in the file is eleven words of unavoidable terminology.
+  Structure is fact and is reproduced exactly; expression is ours.
+
+  Assessor notes name the two failure modes this file used to cause: scoring items 15 and 22, and
+  missing the unit-of-assessment requirement in item 13 (per patient vs per lesion), which changes
+  what every downstream accuracy estimate means.
+
 - **Five checklist licence claims were wrong, and one of them conflicts with this repository's own
   licence.** `LICENSES.md` presented itself as the attribution record for the bundled checklists and
   asserted **CC BY** for ROBINS-I, RoB 2, QUADAS-2, PROBAST and PRISMA-DTA. Every entry was resolved

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -748,8 +748,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_DTA.md",
-      "size": 4896,
-      "sha256": "35dbc17de6a993f972295c552632a3426c12f8e81db6981318d8450ceb69ede0"
+      "size": 10219,
+      "sha256": "2404f5f702975fb5365a408f3c20cc401b7f066a6885f3ec5fa954f38f520d50"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_P.md",
@@ -2713,8 +2713,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/PRISMA_DTA.md",
-      "size": 4896,
-      "sha256": "35dbc17de6a993f972295c552632a3426c12f8e81db6981318d8450ceb69ede0"
+      "size": 10219,
+      "sha256": "2404f5f702975fb5365a408f3c20cc401b7f066a6885f3ec5fa954f38f520d50"
     },
     {
       "path": "skills/meta-analysis/references/checklists/PROBAST.md",

--- a/skills/check-reporting/references/checklists/PRISMA_DTA.md
+++ b/skills/check-reporting/references/checklists/PRISMA_DTA.md
@@ -1,53 +1,123 @@
-# PRISMA-DTA Checklist
+# PRISMA-DTA Checklist (diagnostic test accuracy systematic reviews)
 
-Preferred Reporting Items for Systematic Reviews and Meta-Analyses of Diagnostic Test Accuracy Studies.
-Reference: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, et al. Preferred Reporting Items
-for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: the PRISMA-DTA
-statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163).
+**Preferred Reporting Items for Systematic Reviews and Meta-Analyses — diagnostic test accuracy extension**
+Version: PRISMA-DTA 2018 — 27 items. Two PRISMA items were **deleted** (15 and 22) and two DTA-specific
+items were **added** (D1 and D2), so the count matches the original while the numbering skips 15 and 22.
+A separate abstract checklist accompanies it (below).
+Source: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, the PRISMA-DTA Group, et al. Preferred
+Reporting Items for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: The
+PRISMA-DTA Statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163). Correction:
+*JAMA* 2020;323(6):580 — in item 20, "receiver operating characteristic curve" should read
+"receiver operating characteristic **plot**"; the correction is reflected below.
 
-> ⚠️ **This file has not been verified against the published statement, and at least one item is
-> known to be wrong. Do not use it as the checklist you submit.**
->
-> Item 2 below asks for a structured abstract summarising, among other things, **"interventions"** —
-> a diagnostic test accuracy review has no interventions. That wording is inherited from the
-> PRISMA 2009 intervention-review checklist and was never adapted; the same defect was found and
-> corrected in `PRISMA_2020.md`, whose 42 sub-items are now verified character-for-character
-> against the official checklist. PRISMA-DTA is published in JAMA and the official checklist was
-> not available to run that comparison, so the remaining items here are **unverified** — they may
-> be faithful, and no one has checked.
->
-> Complete the official checklist from the statement or EQUATOR for anything you submit. Use this
-> file to organise a first pass only, and read every item you rely on against the source.
+> **Fidelity and licence.** The statement is published in *JAMA* (© American Medical Association) under
+> **no open licence** — free to read is not free to reuse. The descriptions below are therefore an
+> **in-house summary of what each item asks, in our own words — not the published wording**. What *is*
+> verified against the statement is the structure: which items exist, their numbering (including the
+> deleted 15 and 22 and the added D1 and D2), their section placement, and their topic labels.
+> **Complete the official checklist from the statement or EQUATOR for anything you submit.**
 
+> **What this file used to be.** Until this revision it listed items 1–27 sequentially — including 15
+> and 22, which PRISMA-DTA deletes, and **without D1 and D2, the two DTA-specific items the extension
+> exists to add**. Its item 2 asked a diagnostic-accuracy review to summarise "interventions". It was
+> PRISMA 2009 renumbered, presented as PRISMA-DTA. Any assessment made with it scored two items the
+> guideline had removed and never scored the two it had introduced.
 
-## Checklist Items
+## Main checklist (27 items)
 
-| # | Section | Item |
-|---|---------|------|
-| 1 | Title | Identify the report as a systematic review (+/- meta-analysis) of diagnostic test accuracy studies |
-| 2 | Abstract - Structured | Provide structured summary including objectives, data sources, study eligibility, participants, interventions, study appraisal and synthesis methods, results, limitations, conclusions, registration number |
-| 3 | Introduction - Rationale | Describe the rationale for the review in the context of what is already known |
-| 4 | Introduction - Objectives | State precise objectives, including PIRD elements |
-| 5 | Methods - Protocol | Indicate if a review protocol exists, where it can be accessed, and registration information |
-| 6 | Methods - Eligibility | Specify study characteristics and reporting characteristics used as criteria for eligibility |
-| 7 | Methods - Information sources | Describe all information sources in the search and date last searched |
-| 8 | Methods - Search | Present full electronic search strategy for at least one database |
-| 9 | Methods - Study selection | State the process for selecting studies |
-| 10 | Methods - Data collection | Describe method of data extraction from primary DTA studies and any processes for obtaining and confirming data from investigators |
-| 11 | Methods - Data items | List and define all variables for which data were sought and any assumptions/simplifications made |
-| 12 | Methods - Risk of bias | Describe methods used for assessing risk of bias of individual studies and how this information is used in data synthesis |
-| 13 | Methods - Diagnostic accuracy measures | State the principal diagnostic accuracy measures and how they were calculated |
-| 14 | Methods - Synthesis | Describe methods of handling data and combining results of studies including measures of statistical consistency |
-| 15 | Methods - Risk of bias across studies | Specify any assessment of risk of bias that may affect the cumulative evidence |
-| 16 | Methods - Additional analyses | Describe methods of additional analyses if done (e.g., sensitivity or subgroup analyses, meta-regression) |
-| 17 | Results - Study selection | Give numbers of studies screened, assessed for eligibility, and included with reasons for exclusions at each stage; consider a flow diagram |
-| 18 | Results - Study characteristics | For each study, present characteristics for which data were extracted and provide the citations |
-| 19 | Results - Risk of bias within studies | Present risk of bias assessments for each included study |
-| 20 | Results - Individual study results | For each analysis in each study, report 2x2 data with confidence intervals |
-| 21 | Results - Synthesis of results | Describe test performance and present key results including confidence intervals for the meta-analysis |
-| 22 | Results - Risk of bias across studies | Present results of any assessment of risk of bias across studies |
-| 23 | Results - Additional analyses | Give results of additional analyses (subgroup, sensitivity, meta-regression) |
-| 24 | Discussion - Summary | Summarize the main findings including strength of evidence |
-| 25 | Discussion - Limitations | Discuss limitations at study and outcome level and at review level |
-| 26 | Discussion - Conclusions | Provide a general interpretation of the results in the context of other evidence and implications for future research |
-| 27 | Funding | Describe sources of funding for the systematic review and other support; role of funders |
+### Title
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 1 | Title | The report is identified as a systematic review, or meta-analysis, **of DTA studies**. |
+
+### Abstract
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 2 | Abstract | Assessed with the **abstract checklist below**, not by a single item here. |
+
+### Introduction
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 3 | Rationale | Why the review was done, set against what is already known. |
+| **D1** | **Clinical role of index test** | The scientific and clinical background: what the index test is **intended to be used for** and its **role in the care pathway**, plus — where relevant — the reasoning behind a minimally acceptable accuracy (or a minimum difference in accuracy, for a comparative design). **DTA-specific; has no counterpart in PRISMA.** |
+| 4 | Objectives | An explicit statement of the question in terms of **participants, index test, and target conditions**. |
+
+### Methods
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 5 | Protocol and registration | Where the protocol can be read (e.g. a web address), and the registration number where one exists. |
+| 6 | Eligibility criteria | The study characteristics used to decide eligibility — participants, setting, index test, reference standards, target conditions, study design — and the report characteristics (years, language, publication status), **with the reasoning for them**. |
+| 7 | Information sources | Every source searched, including databases with their coverage dates and any contact with study authors, and the date each was last searched. |
+| 8 | Search | The **full** search strategy for every database and other source, with any limits, in enough detail to repeat it. |
+| 9 | Study selection | How studies were selected — screening, eligibility, inclusion in the review, and where applicable inclusion in the meta-analysis. |
+| 10 | Data collection process | How data were extracted from reports (piloted forms, independent extraction, duplicate extraction) and how data were obtained or confirmed from investigators. |
+| 11 | Definitions for data extraction | The definitions used when extracting and classifying **target conditions, index tests, reference standards** and other characteristics such as study design and clinical setting. |
+| 12 | Risk of bias and applicability | The methods used to assess risk of bias in each study **and** concerns about applicability to the review question. |
+| 13 | Diagnostic accuracy measures | Which accuracy measures are the principal ones (sensitivity, specificity, and so on) **and the unit of assessment** — per patient or per lesion. |
+| 14 | Synthesis of results | How the data were handled and combined and how between-study variability was described. The statement names six cases to address: multiple definitions of the target condition; multiple positivity thresholds; multiple index-test readers; indeterminate results; grouping and comparing tests; and differing reference standards. |
+| **D2** | **Meta-analysis** | The statistical methods used for the meta-analysis, where one was performed. **DTA-specific; has no counterpart in PRISMA.** |
+| 16 | Additional analyses | The methods of any additional analyses — sensitivity, subgroup, meta-regression — **and which of them were prespecified**. |
+
+### Results
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 17 | Study selection | The count at every stage of selection — records screened, those whose eligibility was assessed, studies entering the review, and studies entering any meta-analysis — together with why studies dropped out at each stage, ideally drawn as a flow diagram. |
+| 18 | Study characteristics | For each included study, a citation and its key characteristics: participant presentation and prior testing, clinical setting, study design, target-condition definition, index test, reference standard, sample size, and funding source. |
+| 19 | Risk of bias and applicability | The risk-of-bias and applicability assessment **for each study**. |
+| 20 | Results of individual studies | For every analysis in every study — each unique combination of index test, reference standard and positivity threshold — the **2 × 2 data (TP, FP, FN, TN)** with accuracy estimates and confidence intervals, ideally shown as a forest plot or a receiver operating characteristic **plot**. |
+| 21 | Synthesis of results | Test accuracy including its variability; where a meta-analysis was done, the results with confidence intervals. |
+| 23 | Additional analyses | The results of any additional analyses, including sensitivity, subgroup and meta-regression analyses, and analyses of the index test such as failure rates, the proportion of inconclusive results, and adverse events. |
+
+### Discussion
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 24 | Summary | The main findings, **with the strength of the evidence**. |
+| 25 | Limitations | Limitations of the included studies (risk of bias, applicability) **and** limitations of the review process itself, such as incomplete retrieval. |
+| 26 | Conclusions | A general interpretation against other evidence, and implications for future research and for clinical practice — including the intended use and clinical role of the index test. |
+
+### Funding
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 27 | Funding | Sources of funding and other support for the review, and the role of the funders. |
+
+## Abstract checklist
+
+PRISMA-DTA carries its own abstract checklist; item 2 above defers to it. Score it separately, with its
+own denominator — the same discipline as `PRISMA_2020_Abstracts.md`. Its items, in our own words:
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 1 | Title | Identified as a systematic review, or meta-analysis, of DTA studies. |
+| 2 | Objectives | The research question, with its components — participants, index test, target conditions. |
+| 3 | Eligibility criteria | The study characteristics used to decide eligibility. |
+| 4 | Information sources | The key databases searched and the search dates. |
+| 5 | Risk of bias and applicability | The methods used to assess risk of bias and applicability. |
+| **A1** | **Synthesis of results** (methods) | The methods used for the data synthesis. **DTA-specific.** |
+| 6 | Included studies | How many studies and of what type, and the participants and relevant study characteristics, including the reference standard. |
+| 7 | Synthesis of results (results) | The diagnostic-accuracy results, preferably with the number of studies and participants; accuracy and its variability, and where a meta-analysis was done, summary results with confidence intervals. |
+
+The remaining abstract items (interpretation, funding, registration) follow the PRISMA pattern; consult
+Table 3 of the statement for their exact wording before scoring an abstract you intend to report.
+
+## Notes for Assessors
+
+- **Do not score items 15 or 22.** PRISMA-DTA deletes them. An assessment that reports 27 sequential
+  items has not used this instrument.
+- **D1 and D2 are the point of the extension.** A review that never states the index test's intended
+  clinical role (D1), or that meta-analyses without reporting the statistical methods used (D2), is
+  missing the DTA-specific requirements — and these are exactly the items a generic PRISMA checklist
+  cannot surface.
+- **Item 13's unit of assessment** (per patient vs per lesion) is the item most often skipped in
+  imaging reviews, and it changes what every downstream accuracy estimate means.
+- **Item 20 wants the 2 × 2 cells**, not just sensitivity and specificity. Without TP/FP/FN/TN a reader
+  cannot recompute the estimates or pool them.
+- For the risk-of-bias assessment referenced by items 12 and 19, see `QUADAS2.md`.
+- For a review that is not diagnostic test accuracy, use `PRISMA_2020.md` with
+  `PRISMA_2020_Abstracts.md`.

--- a/skills/meta-analysis/references/checklists/PRISMA_DTA.md
+++ b/skills/meta-analysis/references/checklists/PRISMA_DTA.md
@@ -1,53 +1,123 @@
-# PRISMA-DTA Checklist
+# PRISMA-DTA Checklist (diagnostic test accuracy systematic reviews)
 
-Preferred Reporting Items for Systematic Reviews and Meta-Analyses of Diagnostic Test Accuracy Studies.
-Reference: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, et al. Preferred Reporting Items
-for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: the PRISMA-DTA
-statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163).
+**Preferred Reporting Items for Systematic Reviews and Meta-Analyses — diagnostic test accuracy extension**
+Version: PRISMA-DTA 2018 — 27 items. Two PRISMA items were **deleted** (15 and 22) and two DTA-specific
+items were **added** (D1 and D2), so the count matches the original while the numbering skips 15 and 22.
+A separate abstract checklist accompanies it (below).
+Source: McInnes MDF, Moher D, Thombs BD, McGrath TA, Bossuyt PM, the PRISMA-DTA Group, et al. Preferred
+Reporting Items for a Systematic Review and Meta-analysis of Diagnostic Test Accuracy Studies: The
+PRISMA-DTA Statement. *JAMA* 2018;319(4):388-396 (DOI 10.1001/jama.2017.19163). Correction:
+*JAMA* 2020;323(6):580 — in item 20, "receiver operating characteristic curve" should read
+"receiver operating characteristic **plot**"; the correction is reflected below.
 
-> ⚠️ **This file has not been verified against the published statement, and at least one item is
-> known to be wrong. Do not use it as the checklist you submit.**
->
-> Item 2 below asks for a structured abstract summarising, among other things, **"interventions"** —
-> a diagnostic test accuracy review has no interventions. That wording is inherited from the
-> PRISMA 2009 intervention-review checklist and was never adapted; the same defect was found and
-> corrected in `PRISMA_2020.md`, whose 42 sub-items are now verified character-for-character
-> against the official checklist. PRISMA-DTA is published in JAMA and the official checklist was
-> not available to run that comparison, so the remaining items here are **unverified** — they may
-> be faithful, and no one has checked.
->
-> Complete the official checklist from the statement or EQUATOR for anything you submit. Use this
-> file to organise a first pass only, and read every item you rely on against the source.
+> **Fidelity and licence.** The statement is published in *JAMA* (© American Medical Association) under
+> **no open licence** — free to read is not free to reuse. The descriptions below are therefore an
+> **in-house summary of what each item asks, in our own words — not the published wording**. What *is*
+> verified against the statement is the structure: which items exist, their numbering (including the
+> deleted 15 and 22 and the added D1 and D2), their section placement, and their topic labels.
+> **Complete the official checklist from the statement or EQUATOR for anything you submit.**
 
+> **What this file used to be.** Until this revision it listed items 1–27 sequentially — including 15
+> and 22, which PRISMA-DTA deletes, and **without D1 and D2, the two DTA-specific items the extension
+> exists to add**. Its item 2 asked a diagnostic-accuracy review to summarise "interventions". It was
+> PRISMA 2009 renumbered, presented as PRISMA-DTA. Any assessment made with it scored two items the
+> guideline had removed and never scored the two it had introduced.
 
-## Checklist Items
+## Main checklist (27 items)
 
-| # | Section | Item |
-|---|---------|------|
-| 1 | Title | Identify the report as a systematic review (+/- meta-analysis) of diagnostic test accuracy studies |
-| 2 | Abstract - Structured | Provide structured summary including objectives, data sources, study eligibility, participants, interventions, study appraisal and synthesis methods, results, limitations, conclusions, registration number |
-| 3 | Introduction - Rationale | Describe the rationale for the review in the context of what is already known |
-| 4 | Introduction - Objectives | State precise objectives, including PIRD elements |
-| 5 | Methods - Protocol | Indicate if a review protocol exists, where it can be accessed, and registration information |
-| 6 | Methods - Eligibility | Specify study characteristics and reporting characteristics used as criteria for eligibility |
-| 7 | Methods - Information sources | Describe all information sources in the search and date last searched |
-| 8 | Methods - Search | Present full electronic search strategy for at least one database |
-| 9 | Methods - Study selection | State the process for selecting studies |
-| 10 | Methods - Data collection | Describe method of data extraction from primary DTA studies and any processes for obtaining and confirming data from investigators |
-| 11 | Methods - Data items | List and define all variables for which data were sought and any assumptions/simplifications made |
-| 12 | Methods - Risk of bias | Describe methods used for assessing risk of bias of individual studies and how this information is used in data synthesis |
-| 13 | Methods - Diagnostic accuracy measures | State the principal diagnostic accuracy measures and how they were calculated |
-| 14 | Methods - Synthesis | Describe methods of handling data and combining results of studies including measures of statistical consistency |
-| 15 | Methods - Risk of bias across studies | Specify any assessment of risk of bias that may affect the cumulative evidence |
-| 16 | Methods - Additional analyses | Describe methods of additional analyses if done (e.g., sensitivity or subgroup analyses, meta-regression) |
-| 17 | Results - Study selection | Give numbers of studies screened, assessed for eligibility, and included with reasons for exclusions at each stage; consider a flow diagram |
-| 18 | Results - Study characteristics | For each study, present characteristics for which data were extracted and provide the citations |
-| 19 | Results - Risk of bias within studies | Present risk of bias assessments for each included study |
-| 20 | Results - Individual study results | For each analysis in each study, report 2x2 data with confidence intervals |
-| 21 | Results - Synthesis of results | Describe test performance and present key results including confidence intervals for the meta-analysis |
-| 22 | Results - Risk of bias across studies | Present results of any assessment of risk of bias across studies |
-| 23 | Results - Additional analyses | Give results of additional analyses (subgroup, sensitivity, meta-regression) |
-| 24 | Discussion - Summary | Summarize the main findings including strength of evidence |
-| 25 | Discussion - Limitations | Discuss limitations at study and outcome level and at review level |
-| 26 | Discussion - Conclusions | Provide a general interpretation of the results in the context of other evidence and implications for future research |
-| 27 | Funding | Describe sources of funding for the systematic review and other support; role of funders |
+### Title
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 1 | Title | The report is identified as a systematic review, or meta-analysis, **of DTA studies**. |
+
+### Abstract
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 2 | Abstract | Assessed with the **abstract checklist below**, not by a single item here. |
+
+### Introduction
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 3 | Rationale | Why the review was done, set against what is already known. |
+| **D1** | **Clinical role of index test** | The scientific and clinical background: what the index test is **intended to be used for** and its **role in the care pathway**, plus — where relevant — the reasoning behind a minimally acceptable accuracy (or a minimum difference in accuracy, for a comparative design). **DTA-specific; has no counterpart in PRISMA.** |
+| 4 | Objectives | An explicit statement of the question in terms of **participants, index test, and target conditions**. |
+
+### Methods
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 5 | Protocol and registration | Where the protocol can be read (e.g. a web address), and the registration number where one exists. |
+| 6 | Eligibility criteria | The study characteristics used to decide eligibility — participants, setting, index test, reference standards, target conditions, study design — and the report characteristics (years, language, publication status), **with the reasoning for them**. |
+| 7 | Information sources | Every source searched, including databases with their coverage dates and any contact with study authors, and the date each was last searched. |
+| 8 | Search | The **full** search strategy for every database and other source, with any limits, in enough detail to repeat it. |
+| 9 | Study selection | How studies were selected — screening, eligibility, inclusion in the review, and where applicable inclusion in the meta-analysis. |
+| 10 | Data collection process | How data were extracted from reports (piloted forms, independent extraction, duplicate extraction) and how data were obtained or confirmed from investigators. |
+| 11 | Definitions for data extraction | The definitions used when extracting and classifying **target conditions, index tests, reference standards** and other characteristics such as study design and clinical setting. |
+| 12 | Risk of bias and applicability | The methods used to assess risk of bias in each study **and** concerns about applicability to the review question. |
+| 13 | Diagnostic accuracy measures | Which accuracy measures are the principal ones (sensitivity, specificity, and so on) **and the unit of assessment** — per patient or per lesion. |
+| 14 | Synthesis of results | How the data were handled and combined and how between-study variability was described. The statement names six cases to address: multiple definitions of the target condition; multiple positivity thresholds; multiple index-test readers; indeterminate results; grouping and comparing tests; and differing reference standards. |
+| **D2** | **Meta-analysis** | The statistical methods used for the meta-analysis, where one was performed. **DTA-specific; has no counterpart in PRISMA.** |
+| 16 | Additional analyses | The methods of any additional analyses — sensitivity, subgroup, meta-regression — **and which of them were prespecified**. |
+
+### Results
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 17 | Study selection | The count at every stage of selection — records screened, those whose eligibility was assessed, studies entering the review, and studies entering any meta-analysis — together with why studies dropped out at each stage, ideally drawn as a flow diagram. |
+| 18 | Study characteristics | For each included study, a citation and its key characteristics: participant presentation and prior testing, clinical setting, study design, target-condition definition, index test, reference standard, sample size, and funding source. |
+| 19 | Risk of bias and applicability | The risk-of-bias and applicability assessment **for each study**. |
+| 20 | Results of individual studies | For every analysis in every study — each unique combination of index test, reference standard and positivity threshold — the **2 × 2 data (TP, FP, FN, TN)** with accuracy estimates and confidence intervals, ideally shown as a forest plot or a receiver operating characteristic **plot**. |
+| 21 | Synthesis of results | Test accuracy including its variability; where a meta-analysis was done, the results with confidence intervals. |
+| 23 | Additional analyses | The results of any additional analyses, including sensitivity, subgroup and meta-regression analyses, and analyses of the index test such as failure rates, the proportion of inconclusive results, and adverse events. |
+
+### Discussion
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 24 | Summary | The main findings, **with the strength of the evidence**. |
+| 25 | Limitations | Limitations of the included studies (risk of bias, applicability) **and** limitations of the review process itself, such as incomplete retrieval. |
+| 26 | Conclusions | A general interpretation against other evidence, and implications for future research and for clinical practice — including the intended use and clinical role of the index test. |
+
+### Funding
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 27 | Funding | Sources of funding and other support for the review, and the role of the funders. |
+
+## Abstract checklist
+
+PRISMA-DTA carries its own abstract checklist; item 2 above defers to it. Score it separately, with its
+own denominator — the same discipline as `PRISMA_2020_Abstracts.md`. Its items, in our own words:
+
+| # | Topic | What to check is reported |
+|---|-------|---------------------------|
+| 1 | Title | Identified as a systematic review, or meta-analysis, of DTA studies. |
+| 2 | Objectives | The research question, with its components — participants, index test, target conditions. |
+| 3 | Eligibility criteria | The study characteristics used to decide eligibility. |
+| 4 | Information sources | The key databases searched and the search dates. |
+| 5 | Risk of bias and applicability | The methods used to assess risk of bias and applicability. |
+| **A1** | **Synthesis of results** (methods) | The methods used for the data synthesis. **DTA-specific.** |
+| 6 | Included studies | How many studies and of what type, and the participants and relevant study characteristics, including the reference standard. |
+| 7 | Synthesis of results (results) | The diagnostic-accuracy results, preferably with the number of studies and participants; accuracy and its variability, and where a meta-analysis was done, summary results with confidence intervals. |
+
+The remaining abstract items (interpretation, funding, registration) follow the PRISMA pattern; consult
+Table 3 of the statement for their exact wording before scoring an abstract you intend to report.
+
+## Notes for Assessors
+
+- **Do not score items 15 or 22.** PRISMA-DTA deletes them. An assessment that reports 27 sequential
+  items has not used this instrument.
+- **D1 and D2 are the point of the extension.** A review that never states the index test's intended
+  clinical role (D1), or that meta-analyses without reporting the statistical methods used (D2), is
+  missing the DTA-specific requirements — and these are exactly the items a generic PRISMA checklist
+  cannot surface.
+- **Item 13's unit of assessment** (per patient vs per lesion) is the item most often skipped in
+  imaging reviews, and it changes what every downstream accuracy estimate means.
+- **Item 20 wants the 2 × 2 cells**, not just sensitivity and specificity. Without TP/FP/FN/TN a reader
+  cannot recompute the estimates or pool them.
+- For the risk-of-bias assessment referenced by items 12 and 19, see `QUADAS2.md`.
+- For a review that is not diagnostic test accuracy, use `PRISMA_2020.md` with
+  `PRISMA_2020_Abstracts.md`.


### PR DESCRIPTION
Fourth batch of the vendored-checklist audit, and the most serious finding so far. Verified against the statement itself (McInnes et al., *JAMA* 2018;319(4):388-396), read through institutional access, including its 2020 correction.

## The finding

PRISMA-DTA keeps the count of 27 items by **deleting items 15 and 22** and **adding items D1 and D2**. The vendored file had neither change.

| | |
|---|---|
| **Items 15 and 22** | **present** — both deleted by the guideline |
| **Items D1 and D2** | **absent** — the two DTA-specific items the extension exists to add |
| Shared items | **23 of 25 worded differently** from the published item |

The two missing items are the point of the extension:

- **D1 — Clinical role of index test.** The scientific and clinical background: what the index test is intended to be used for, its role in the care pathway, and the rationale for a minimally acceptable accuracy.
- **D2 — Meta-analysis.** The statistical methods used, where a meta-analysis was performed.

A generic PRISMA checklist surfaces neither. That is why the extension was written.

Two of the reworded items show where the file actually came from: item 4 asked for "PIRD elements" where the statement asks for participants, index test and target conditions; **item 2 asked a diagnostic-accuracy review to summarise "interventions"** — the PRISMA 2009 intervention-review wording, which is what first flagged this file in #470.

**Anyone who scored a DTA systematic review with this file scored two items the guideline had removed and never scored the two it had introduced.**

## What changed

Rebuilt. The structure — which items exist, their numbering, section placement and topic labels — now matches the statement exactly, asserted by programmatic comparison against the parsed original (`27/27`, ids `1, 2, 3, D1, 4…14, D2, 16…21, 23…27`).

The **abstract checklist** the statement carries, and to which its item 2 defers, is captured too — including its own DTA-specific item **A1** — and is scored with its own denominator, the same discipline as `PRISMA_2020_Abstracts.md`.

Item 20 reflects the published correction: "receiver operating characteristic **plot**", not "curve".

Assessor notes name the failure modes this file used to cause, including the unit-of-assessment requirement in item 13 (per patient vs per lesion), which changes what every downstream accuracy estimate means.

## Licence

*JAMA* publishes this under **no open licence** — free to read is not free to reuse. The descriptions are an in-house summary of what each item asks, in our own words. The longest run of published wording surviving anywhere in the file is **eleven words** of unavoidable terminology, measured programmatically against the parsed original.

**Structure is fact and is reproduced exactly; expression is ours.** Same treatment as `PROBAST.md` in #471.

## Running total

**9 of 48 files audited or corrected; 7 needed a correction.**

| File | Result |
|---|---|
| **PRISMA-DTA** | **not the instrument at all — rebuilt** |
| PROBAST | invented AI section + 3 narrowed criteria — fixed, relicensed (#471) |
| PRISMA 2020 | 4 divergences, 2 score-changing — fixed (#470) |
| ROBINS-I / RoB 2 / QUADAS-2 | licence corrected, labelled; content unverified (#472) |
| PROBAST+AI / TRIPOD+AI | clean (#471) |
| PRISMA 2020 for Abstracts | new, verified (#469) |

The pattern so far: **the files labelled as extensions are the dangerous ones.** PRISMA-DTA and PROBAST were the two worst, and both showed the same signature — a base instrument adapted by hand instead of transcribed from the source.

## Verification

- `python3 scripts/run_ci_mirror.py` — **237/238**. The single failure, `Run lit-sync poll-logic test`, is a **pre-existing flake unrelated to this change**: re-run in isolation it fails a *different* scenario each time (`debounce-late`, then `detect-within-window`, then none). Worth fixing separately — an unreliable gate weakens the signal from the other 237.
- Structure asserted against the parsed official checklist; verbatim-reuse measured, not assumed.