### PR TITLE
Checklist fidelity 5/N: QUADAS-2 verified — three real defects, nothing invented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,38 @@
 
 ### Fixed
 
+- **QUADAS-2 verified against the published article, and three things it got wrong are corrected.**
+  Read through institutional access (Whiting et al., *Ann Intern Med* 2011;155(8):529-536). The good
+  news first: the four domains, the **3 / 2 / 2 / 3 split of the ten signalling questions**, what each
+  asks, the answer options, the judgement levels, and the restriction of applicability to the first
+  three domains all match. Unlike PROBAST and PRISMA-DTA, nothing here was invented.
+
+  What was wrong:
+
+  - **"No to any signalling question → High risk of bias."** The statement says a No establishes that
+    *potential for bias exists*, and the reviewer then applies the review-specific guidance to reach
+    the judgement. The file had replaced a judgement with an automatic rule, which over-rates bias and
+    removes the step the tool exists to structure.
+  - **The four phases were missing entirely** — state the review question, **tailor the tool to the
+    review**, draw the study's flow diagram, then judge. Tailoring is not optional in QUADAS-2; the
+    tool is meant to be adapted per review with written guidance, piloted by two people. A file that
+    presents ten fixed questions has quietly dropped the phase that makes the rest defensible.
+  - **The prohibition on summary quality scores was absent.** The statement is explicit that QUADAS-2
+    must not be used to produce one.
+
+  Also added: that Yes is phrased to mean low risk of bias, that Unclear is for insufficient
+  reporting rather than difficult judgement, how to report the assessment across studies, and that
+  QUADAS-2 does not cover comparisons of multiple index tests — the development group considered it
+  and found the evidence base insufficient.
+
+  **Licence.** Still *Annals of Internal Medicine*, still no open licence. The signalling questions
+  are now stated as what each asks in our own words, with numbering and structure — which are fact —
+  reproduced exactly. Same treatment as `PROBAST.md`.
+
+  The header's fidelity note is upgraded from "has not been compared against the published tool" to
+  what was actually checked, and a duplicate `Reference:` line left behind by the previous revision is
+  removed.
+
 - **`PRISMA_DTA.md` was not PRISMA-DTA. It was PRISMA 2009, renumbered.** Verified against the
   statement itself (McInnes et al., *JAMA* 2018;319(4):388-396, read through institutional access,
   including its 2020 correction). PRISMA-DTA keeps the count of 27 by **deleting items 15 and 22** and

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -773,8 +773,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS2.md",
-      "size": 3718,
-      "sha256": "fe644deaa01b54dd92dcde7bbbf3dfece2473b3f80e0d6840e8a443e6330f2f4"
+      "size": 7526,
+      "sha256": "556af8732884095eca550d915146dd6e93f335d667686703b7ac45d5f37b2f44"
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS_C.md",
@@ -2723,8 +2723,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/QUADAS2.md",
-      "size": 3718,
-      "sha256": "fe644deaa01b54dd92dcde7bbbf3dfece2473b3f80e0d6840e8a443e6330f2f4"
+      "size": 7526,
+      "sha256": "556af8732884095eca550d915146dd6e93f335d667686703b7ac45d5f37b2f44"
     },
     {
       "path": "skills/meta-analysis/references/checklists/ROBINS_I.md",

--- a/skills/check-reporting/references/checklists/QUADAS2.md
+++ b/skills/check-reporting/references/checklists/QUADAS2.md
@@ -1,81 +1,119 @@
 # QUADAS-2 Assessment Guide
 
 Quality Assessment of Diagnostic Accuracy Studies, version 2.
-Version: QUADAS-2 (2011) — 4 domains, each rated for risk of bias, with applicability for the first three.
+Version: QUADAS-2 (2011) — 4 domains, **10 signalling questions** (3 / 2 / 2 / 3), risk of bias for every
+domain and applicability for the first three only.
 Source: Whiting PF, Rutjes AWS, Westwood ME, Mallett S, Deeks JJ, Reitsma JB, et al. QUADAS-2: a
 revised tool for the quality assessment of diagnostic accuracy studies. *Ann Intern Med*
-2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009).
+2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009). The tool itself, training material
+and worked examples: www.quadas.org.
 
-> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American
-> College of Physicians) under **no open licence**; `LICENSES.md` previously claimed CC BY for it on
-> no evidence. This file is an **in-house summary of the tool's structure** and has **not** been
-> compared against the published tool, so the signalling questions below may be abbreviated or
-> incomplete. **Complete the official QUADAS-2 form for any assessment you report.**
-Reference: Whiting PF et al. Ann Intern Med 2011;155(8):529-536.
+> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American College
+> of Physicians) under **no open licence**. **Verified against the published article**: the four
+> domains, the 3 / 2 / 2 / 3 split of signalling questions, what each question asks, the answer
+> options, the judgement levels, and the restriction of applicability to the first three domains all
+> match. The descriptions below state what each question asks **in our own words** rather than
+> reproducing the published wording. **Complete the official QUADAS-2 form from www.quadas.org for
+> any assessment you report.**
 
-## Structure
+## How the tool is applied — four phases
 
-QUADAS-2 assesses 4 domains. Each domain has:
-- **Signalling questions**: answered Yes / No / Unclear
-- **Risk of bias judgment**: Low / High / Unclear
-- **Applicability concern** (domains 1-3 only): Low / High / Unclear
+QUADAS-2 is not a fixed questionnaire. The statement specifies four phases, and skipping the second
+is the most common misuse:
+
+1. **State the review question** — patients, index test, reference standard and target condition.
+   Describe patients by setting, the intended use of the index test, presentation, and prior testing,
+   because accuracy depends on where in the diagnostic pathway the test sits.
+2. **Tailor the tool to the review.** Add or omit signalling questions and write review-specific
+   guidance on how each is to be judged. (For an objective index test, for example, the question about
+   blinding the interpreter to the reference standard may not apply.) Avoid piling on extra questions.
+   At least two people should pilot the tailored tool; refine it if agreement is poor.
+3. **Draw the study's flow diagram** — use the published one, or draw it yourself if it is absent or
+   inadequate. It need not be reported; it exists to make the flow-and-timing judgements possible.
+4. **Judge bias and applicability**, recording the information each judgement rests on.
+
+## Answers and judgements
+
+- **Signalling questions**: Yes / No / Unclear, phrased so that **Yes indicates low risk of bias**.
+- **Risk of bias**: Low / High / Unclear.
+- **Applicability concern** (domains 1–3 only): Low / High / Unclear.
+- **Unclear is only for insufficient reporting**, not for a difficult judgement.
+
+**How a "No" is handled.** If every signalling question in a domain is Yes, risk of bias can be judged
+low. A **No does not automatically make the domain High** — it establishes that *potential for bias
+exists*, and the reviewer then applies the review-specific guidance written in phase 2 to reach the
+judgement. A file or workflow that maps "any No → High" has removed the judgement the tool asks for.
 
 ## Domain 1: Patient Selection
 
-### Signalling Questions
-1. Was a consecutive or random sample of patients enrolled?
-2. Was a case-control design avoided?
-3. Did the study avoid inappropriate exclusions?
+**Risk of bias — could patient selection have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether enrolment took a consecutive or random sample of eligible patients.
+2. Whether a case–control design was avoided.
+3. Whether the study avoided inappropriate exclusions.
 
-### Applicability
-- Are there concerns that the included patients and setting do not match the review question?
+*Why it matters*: enrolling patients whose diagnosis is already confirmed, or excluding the
+difficult-to-diagnose, inflates apparent accuracy; excluding patients with obvious signs of the target
+condition can deflate it.
+
+**Applicability** — whether the included patients and the setting differ from the review question
+(severity, demographics, comorbidity and differential diagnosis, setting, prior testing).
 
 ## Domain 2: Index Test
 
-### Signalling Questions
-1. Were the index test results interpreted without knowledge of the results of the reference standard?
-2. If a threshold was used, was it pre-specified?
+**Risk of bias — could the conduct or interpretation of the index test have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the index test was interpreted without knowledge of the reference standard result.
+2. Whether a threshold, if one was used, was prespecified.
 
-### Applicability
-- Are there concerns that the index test, its conduct, or interpretation differ from the review question?
+*Why it matters*: this is the diagnostic equivalent of blinding, and its force depends on how
+subjective the index test is and on the order of testing. Choosing the threshold after the fact to
+maximise sensitivity or specificity overstates performance that will not hold in a new sample.
+
+**Applicability** — whether the index test, how it was carried out, or how it was interpreted differs
+from the review question.
 
 ## Domain 3: Reference Standard
 
-### Signalling Questions
-1. Is the reference standard likely to correctly classify the target condition?
-2. Were the reference standard results interpreted without knowledge of the results of the index test?
+**Risk of bias — could the reference standard, its conduct or its interpretation have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the reference standard is likely to classify the target condition correctly.
+2. Whether the reference standard was interpreted without knowledge of the index test result.
 
-### Applicability
-- Are there concerns that the target condition as defined by the reference standard does not match the question?
+*Why it matters*: accuracy estimates assume the reference standard is correct, so that any
+disagreement is the index test's error.
+
+**Applicability** — whether the target condition **as the reference standard defines it** differs from
+the one in the review question.
 
 ## Domain 4: Flow and Timing
 
-### Signalling Questions
-1. Was there an appropriate interval between index test and reference standard?
-2. Did all patients receive the same reference standard?
-3. Were all patients included in the analysis?
+**Risk of bias — could patient flow have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the interval between index test and reference standard was appropriate.
+2. Whether all patients received the same reference standard.
+3. Whether all patients were included in the analysis.
 
-(No applicability concern for this domain)
+*Why it matters*: an interval long enough for the condition to change causes misclassification, and
+how long is too long depends on the condition. Verifying only some patients, or verifying different
+patients with different reference standards, biases the estimate. Patients lost between enrolment and
+the 2 × 2 table differ systematically from those who remain.
+
+**This domain has no applicability judgement.**
+
+## Reporting the assessment
+
+- **Do not produce a summary quality score.** The statement is explicit about this, for the reasons
+  well established in the literature on quality scores.
+- A study low on every domain may be called low risk of bias, or low concern for applicability,
+  overall. High or unclear on one or more domains means it is at risk of bias, or of concern.
+- At minimum, report the assessment across all included studies — how many were low, high or unclear
+  per domain — and consider highlighting signalling questions on which studies consistently do badly.
+- Restricting the primary analysis to low-risk studies is legitimate, but it is often better to
+  include everything and then investigate heterogeneity — by subgroup, sensitivity analysis, or by
+  entering domains as covariates in meta-regression.
+- QUADAS-2 does **not** cover studies comparing multiple index tests. The development group considered
+  it and concluded the evidence base was insufficient.
 
 ## Common Issues in DTA Studies
 
@@ -85,3 +123,8 @@ QUADAS-2 assesses 4 domains. Each domain has:
 - **Review bias**: Knowledge of index test results influences reference standard interpretation
 - **Clinical review bias**: Additional clinical information available during index test interpretation
 - **Uninterpretable results**: Exclusion of technically inadequate or indeterminate results
+
+## Related
+
+- `PRISMA_DTA.md` items 12 and 19 are the reporting counterparts: the methods used for this
+  assessment, and its result presented **for each study**.

--- a/skills/meta-analysis/references/checklists/QUADAS2.md
+++ b/skills/meta-analysis/references/checklists/QUADAS2.md
@@ -1,81 +1,119 @@
 # QUADAS-2 Assessment Guide
 
 Quality Assessment of Diagnostic Accuracy Studies, version 2.
-Version: QUADAS-2 (2011) — 4 domains, each rated for risk of bias, with applicability for the first three.
+Version: QUADAS-2 (2011) — 4 domains, **10 signalling questions** (3 / 2 / 2 / 3), risk of bias for every
+domain and applicability for the first three only.
 Source: Whiting PF, Rutjes AWS, Westwood ME, Mallett S, Deeks JJ, Reitsma JB, et al. QUADAS-2: a
 revised tool for the quality assessment of diagnostic accuracy studies. *Ann Intern Med*
-2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009).
+2011;155(8):529-536 (DOI 10.7326/0003-4819-155-8-201110180-00009). The tool itself, training material
+and worked examples: www.quadas.org.
 
-> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American
-> College of Physicians) under **no open licence**; `LICENSES.md` previously claimed CC BY for it on
-> no evidence. This file is an **in-house summary of the tool's structure** and has **not** been
-> compared against the published tool, so the signalling questions below may be abbreviated or
-> incomplete. **Complete the official QUADAS-2 form for any assessment you report.**
-Reference: Whiting PF et al. Ann Intern Med 2011;155(8):529-536.
+> **Fidelity and licence.** QUADAS-2 is published in *Annals of Internal Medicine* (© American College
+> of Physicians) under **no open licence**. **Verified against the published article**: the four
+> domains, the 3 / 2 / 2 / 3 split of signalling questions, what each question asks, the answer
+> options, the judgement levels, and the restriction of applicability to the first three domains all
+> match. The descriptions below state what each question asks **in our own words** rather than
+> reproducing the published wording. **Complete the official QUADAS-2 form from www.quadas.org for
+> any assessment you report.**
 
-## Structure
+## How the tool is applied — four phases
 
-QUADAS-2 assesses 4 domains. Each domain has:
-- **Signalling questions**: answered Yes / No / Unclear
-- **Risk of bias judgment**: Low / High / Unclear
-- **Applicability concern** (domains 1-3 only): Low / High / Unclear
+QUADAS-2 is not a fixed questionnaire. The statement specifies four phases, and skipping the second
+is the most common misuse:
+
+1. **State the review question** — patients, index test, reference standard and target condition.
+   Describe patients by setting, the intended use of the index test, presentation, and prior testing,
+   because accuracy depends on where in the diagnostic pathway the test sits.
+2. **Tailor the tool to the review.** Add or omit signalling questions and write review-specific
+   guidance on how each is to be judged. (For an objective index test, for example, the question about
+   blinding the interpreter to the reference standard may not apply.) Avoid piling on extra questions.
+   At least two people should pilot the tailored tool; refine it if agreement is poor.
+3. **Draw the study's flow diagram** — use the published one, or draw it yourself if it is absent or
+   inadequate. It need not be reported; it exists to make the flow-and-timing judgements possible.
+4. **Judge bias and applicability**, recording the information each judgement rests on.
+
+## Answers and judgements
+
+- **Signalling questions**: Yes / No / Unclear, phrased so that **Yes indicates low risk of bias**.
+- **Risk of bias**: Low / High / Unclear.
+- **Applicability concern** (domains 1–3 only): Low / High / Unclear.
+- **Unclear is only for insufficient reporting**, not for a difficult judgement.
+
+**How a "No" is handled.** If every signalling question in a domain is Yes, risk of bias can be judged
+low. A **No does not automatically make the domain High** — it establishes that *potential for bias
+exists*, and the reviewer then applies the review-specific guidance written in phase 2 to reach the
+judgement. A file or workflow that maps "any No → High" has removed the judgement the tool asks for.
 
 ## Domain 1: Patient Selection
 
-### Signalling Questions
-1. Was a consecutive or random sample of patients enrolled?
-2. Was a case-control design avoided?
-3. Did the study avoid inappropriate exclusions?
+**Risk of bias — could patient selection have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether enrolment took a consecutive or random sample of eligible patients.
+2. Whether a case–control design was avoided.
+3. Whether the study avoided inappropriate exclusions.
 
-### Applicability
-- Are there concerns that the included patients and setting do not match the review question?
+*Why it matters*: enrolling patients whose diagnosis is already confirmed, or excluding the
+difficult-to-diagnose, inflates apparent accuracy; excluding patients with obvious signs of the target
+condition can deflate it.
+
+**Applicability** — whether the included patients and the setting differ from the review question
+(severity, demographics, comorbidity and differential diagnosis, setting, prior testing).
 
 ## Domain 2: Index Test
 
-### Signalling Questions
-1. Were the index test results interpreted without knowledge of the results of the reference standard?
-2. If a threshold was used, was it pre-specified?
+**Risk of bias — could the conduct or interpretation of the index test have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the index test was interpreted without knowledge of the reference standard result.
+2. Whether a threshold, if one was used, was prespecified.
 
-### Applicability
-- Are there concerns that the index test, its conduct, or interpretation differ from the review question?
+*Why it matters*: this is the diagnostic equivalent of blinding, and its force depends on how
+subjective the index test is and on the order of testing. Choosing the threshold after the fact to
+maximise sensitivity or specificity overstates performance that will not hold in a new sample.
+
+**Applicability** — whether the index test, how it was carried out, or how it was interpreted differs
+from the review question.
 
 ## Domain 3: Reference Standard
 
-### Signalling Questions
-1. Is the reference standard likely to correctly classify the target condition?
-2. Were the reference standard results interpreted without knowledge of the results of the index test?
+**Risk of bias — could the reference standard, its conduct or its interpretation have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the reference standard is likely to classify the target condition correctly.
+2. Whether the reference standard was interpreted without knowledge of the index test result.
 
-### Applicability
-- Are there concerns that the target condition as defined by the reference standard does not match the question?
+*Why it matters*: accuracy estimates assume the reference standard is correct, so that any
+disagreement is the index test's error.
+
+**Applicability** — whether the target condition **as the reference standard defines it** differs from
+the one in the review question.
 
 ## Domain 4: Flow and Timing
 
-### Signalling Questions
-1. Was there an appropriate interval between index test and reference standard?
-2. Did all patients receive the same reference standard?
-3. Were all patients included in the analysis?
+**Risk of bias — could patient flow have introduced bias?**
 
-### Risk of Bias
-- **Low**: Yes to all signalling questions
-- **High**: No to any signalling question
-- **Unclear**: Insufficient information
+1. Whether the interval between index test and reference standard was appropriate.
+2. Whether all patients received the same reference standard.
+3. Whether all patients were included in the analysis.
 
-(No applicability concern for this domain)
+*Why it matters*: an interval long enough for the condition to change causes misclassification, and
+how long is too long depends on the condition. Verifying only some patients, or verifying different
+patients with different reference standards, biases the estimate. Patients lost between enrolment and
+the 2 × 2 table differ systematically from those who remain.
+
+**This domain has no applicability judgement.**
+
+## Reporting the assessment
+
+- **Do not produce a summary quality score.** The statement is explicit about this, for the reasons
+  well established in the literature on quality scores.
+- A study low on every domain may be called low risk of bias, or low concern for applicability,
+  overall. High or unclear on one or more domains means it is at risk of bias, or of concern.
+- At minimum, report the assessment across all included studies — how many were low, high or unclear
+  per domain — and consider highlighting signalling questions on which studies consistently do badly.
+- Restricting the primary analysis to low-risk studies is legitimate, but it is often better to
+  include everything and then investigate heterogeneity — by subgroup, sensitivity analysis, or by
+  entering domains as covariates in meta-regression.
+- QUADAS-2 does **not** cover studies comparing multiple index tests. The development group considered
+  it and concluded the evidence base was insufficient.
 
 ## Common Issues in DTA Studies
 
@@ -85,3 +123,8 @@ QUADAS-2 assesses 4 domains. Each domain has:
 - **Review bias**: Knowledge of index test results influences reference standard interpretation
 - **Clinical review bias**: Additional clinical information available during index test interpretation
 - **Uninterpretable results**: Exclusion of technically inadequate or indeterminate results
+
+## Related
+
+- `PRISMA_DTA.md` items 12 and 19 are the reporting counterparts: the methods used for this
+  assessment, and its result presented **for each study**.


### PR DESCRIPTION
Fifth batch. QUADAS-2 read through institutional access (Whiting et al., *Ann Intern Med* 2011;155(8):529-536).

## The good news first

Unlike PROBAST and PRISMA-DTA, **nothing here was invented.** Verified against the article: the four domains, the **3 / 2 / 2 / 3 split of the ten signalling questions**, what each question asks, the answer options, the judgement levels, and the restriction of applicability to the first three domains — all correct.

## Three real defects

**1. "No to any signalling question → High risk of bias."**
The statement says a No establishes that *potential for bias exists*, and the reviewer then applies the review-specific guidance written in phase 2 to reach the judgement. The file had replaced a judgement with an automatic rule. That over-rates bias and deletes the step the tool exists to structure.

**2. The four phases were missing entirely.**
QUADAS-2 is applied in four phases: state the review question → **tailor the tool to the review** → draw the study's flow diagram → judge. Tailoring is not optional; the tool is meant to be adapted per review, with written review-specific guidance, piloted by at least two people. A file that presents ten fixed questions has quietly dropped the phase that makes every later judgement defensible.

**3. The prohibition on summary quality scores was absent.**
The statement is explicit that QUADAS-2 must not be used to generate one.

Also added: that Yes is phrased so it means low risk of bias; that Unclear is for insufficient *reporting*, not for a difficult judgement; how to report the assessment across studies; and that QUADAS-2 does **not** cover studies comparing multiple index tests — the development group considered it and concluded the evidence base was insufficient.

## Licence

Still *Annals of Internal Medicine*, still no open licence. The signalling questions are now stated as what each asks **in our own words**, with numbering and structure — which are fact, not expression — reproduced exactly. Same treatment as `PROBAST.md` in #471.

The header's fidelity note is upgraded from "has not been compared against the published tool" to what was actually checked, and a duplicate `Reference:` line left behind by #472 is removed.

## Running total

**10 of 48 audited; 8 needed a correction.**

| File | Result |
|---|---|
| PRISMA-DTA | not the instrument at all — rebuilt (#473) |
| PROBAST | invented AI section + 3 narrowed criteria (#471) |
| PRISMA 2020 | 4 divergences, 2 score-changing (#470) |
| **QUADAS-2** | **structure correct; judgement rule, tailoring phases and score prohibition wrong or missing** |
| LICENSES.md | 5 licence claims wrong, one incompatible with MIT (#472) |
| ROBINS-I / RoB 2 | labelled; content still unverified (#472) |
| PROBAST+AI / TRIPOD+AI | clean (#471) |
| PRISMA 2020 for Abstracts | new, verified (#469) |

## Next, already measured

`STROBE_MR.md` carries **items 1–20 and none of the 30 subitems**. The statement is "20 main items and 30 subitems", and the subitems are where the MR-specific content lives — genetic-variant measurement and selection (4c), the MR estimator (6c), preregistration (9b), 2-sample participant overlap (10d-ii), assumption-validity results (12a/b), bidirectional MR (13c), gene-environment equivalence (16b). Same signature as PRISMA-DTA and PROBAST: the base instrument's skeleton with the extension's substance dropped. The official structure is captured and the fix is queued.

## Verification

`python3 scripts/run_ci_mirror.py` — **238/238 gates pass**.