### PR TITLE
Checklist fidelity 6/N: STROBE-MR cited a non-existent author and dropped all 30 sub-items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,42 @@
 
 ### Fixed
 
+- **`STROBE_MR.md` cited a non-existent author, cited the wrong paper, dropped all 30 sub-items,
+  shifted the last four items by one, invented an item that does not exist — and carried a
+  "Verified" stamp.** Checked against the statement (Skrivankova et al., *JAMA*
+  2021;326(16):1614-1621).
+
+  - **Citation.** The file credited "Skidmore ME / Davey Smith G, Davies NM, et al. *BMJ*
+    2021;375:n2233". There is no such first author, and n2233 is the **Explanation and Elaboration**
+    paper, not the statement. The statement is in *JAMA*.
+  - **All 30 sub-items were absent.** The file listed items 1–20 only — which is close to a
+    re-lettered STROBE. Everything that makes a report a Mendelian-randomization report lives in the
+    sub-items: variant measurement, quality control and selection (**4c**), the MR estimator
+    (**6c**), preregistration (**9b**), 2-sample similarity and **participant overlap** (**10d**),
+    assumption-validity results (**12a/b**), direction of causation (**13c**), and gene-environment
+    equivalence (**16b**). None were scoreable.
+  - **Items 17–20 were shifted by one**: Funding sat at 17, where the statement has Generalizability;
+    Data sharing at 18; conflicts at 19 — and the file **invented an item 20, "Other"**, where the
+    statement has Conflicts of interest.
+  - **Licence claim wrong**: the statement was described as CC BY. It is *JAMA*, under no open
+    licence. (The E&E is a separate BMJ paper.)
+  - The assessor notes cited item numbers that do not exist in the instrument ("9c / 12e", "16" for
+    ancestry generalisability, which is 17).
+
+  The "Verified" stamp is the part worth dwelling on. A file can assert it was checked and be wrong
+  in six ways at once; the stamp is only as good as what was compared, and nothing here had been
+  compared against the published table.
+
+  Rebuilt: 20 items and 30 sub-items, asserted programmatically against the official structure,
+  section grouping restored, wording in our own words under the JAMA licence position, and the
+  relationship to STROBE stated correctly — a stand-alone extension in which every item and sub-item
+  was modified **except 6d**. The statement's own instruction that the checklist is **not** an
+  instrument for evaluating research quality is now carried.
+
+  **Fifth extension file audited, fifth with a structural defect.** PRISMA-DTA, PROBAST, PRISMA-ScR,
+  STROBE-MR — all four of the worst showed the same signature: the base instrument's skeleton with
+  the extension's substance dropped, renumbered, or invented.
+
 - **QUADAS-2 verified against the published article, and three things it got wrong are corrected.**
   Read through institutional access (Whiting et al., *Ann Intern Med* 2011;155(8):529-536). The good
   news first: the four domains, the **3 / 2 / 2 / 3 split of the ten signalling questions**, what each

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -858,8 +858,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/STROBE_MR.md",
-      "size": 8509,
-      "sha256": "684284ed275b0edcc16d8aeb6b8a9af738929626b2fe34774e832f1bc872fb76"
+      "size": 10668,
+      "sha256": "0a4662da8025c366b0ff3dc2e8b3b67043df91b523e76a834d7fa51144b92746"
     },
     {
       "path": "skills/check-reporting/references/checklists/SWiM.md",

--- a/skills/check-reporting/references/checklists/STROBE_MR.md
+++ b/skills/check-reporting/references/checklists/STROBE_MR.md
@@ -1,68 +1,134 @@
 # STROBE-MR Checklist
 
 **Strengthening the Reporting of Observational Studies in Epidemiology using Mendelian Randomization**
-Version: STROBE-MR 2021 (base STROBE 2007 + Mendelian-randomization extension)
-Source: Skidmore ME / Davey Smith G, Davies NM, et al. *BMJ* 2021;375:n2233 (the STROBE-MR statement). https://www.strobe-mr.org/ · EQUATOR Network.
+Version: STROBE-MR 2021 — **20 items and 30 sub-items** across six sections.
+Source (the statement): Skrivankova VW, Richmond RC, Woolf BAR, Yarmolinsky J, Davies NM, Swanson SA,
+et al. Strengthening the Reporting of Observational Studies in Epidemiology Using Mendelian
+Randomization: The STROBE-MR Statement. *JAMA* 2021;326(16):1614-1621 (DOI 10.1001/jama.2021.18236).
+Explanation and Elaboration: Skrivankova VW, et al. *BMJ* 2021;375:n2233. Also: https://www.strobe-mr.org
 
-Apply when the manuscript is a **Mendelian randomization (MR)** study (germline genetic variants used as instrumental variables for an exposure). STROBE-MR extends the base STROBE items with MR-specific reporting (instruments, the three IV assumptions, pleiotropy-robust sensitivity analyses). For the design-validity review of the same study, pair with the MR1–MR8 domain probes in `peer-review` / `self-review` `references/domain-probes/mendelian_randomization.md`; for the analysis, with `analyze-stats` `analysis_guides/mendelian_randomization.md`.
+> **Fidelity and licence.** The statement is published in *JAMA* (© American Medical Association) under
+> **no open licence**. The descriptions below state what each item asks **in our own words**; the
+> structure — 20 items, which sub-items exist and under which item, the section grouping — is
+> **verified against the statement**. **Complete the official checklist for anything you submit**, and
+> read the Explanation and Elaboration for the rationale and worked examples.
 
-## Checklist Items (20 items)
+> **What this file used to be.** It cited "Skidmore ME / Davey Smith G, Davies NM, et al. *BMJ*
+> 2021;375:n2233" as the statement — a non-existent first author, and the E&E paper rather than the
+> statement. It carried **items 1–20 with none of the 30 sub-items**, which is where every
+> MR-specific requirement lives. From item 17 on it was shifted by one (Funding at 17 instead of 18)
+> and it **invented an item 20, "Other"**, where the statement has Conflicts of interest. It also
+> claimed the statement was CC BY, and carried a "Verified" stamp. None of that survived contact with
+> the published table.
 
-### Title and Abstract
+**Scope.** Covers 1-sample and 2-sample MR, single or multiple exposures and outcomes, and MR
+following a GWAS reported in the same article. Does **not** cover GWAS themselves (use STREGA),
+sequencing or expression studies, or ordinary observational epidemiology (use `STROBE.md`). For MR
+that does not use instrumental-variable estimation — some gene-by-environment interaction studies —
+some items will not apply.
 
-| # | Item | Description |
-|---|------|-------------|
-| 1 | Title and abstract | Indicate Mendelian randomization (MR) as the study's design in the title and/or the abstract if that is a main purpose of the study. |
+**Relationship to STROBE.** A stand-alone extension: STROBE has 22 items and 18 sub-items, STROBE-MR
+has 20 items and 30 sub-items. Every item and sub-item was modified for MR **except sub-item 6d**
+(missing data), which is unchanged. Name both instruments in Methods.
 
-### Introduction
+**Not a quality instrument.** The statement says explicitly that the checklist is not to be used to
+evaluate the quality of MR research.
 
-| # | Item | Description |
-|---|------|-------------|
-| 2 | Background | Explain the scientific background and rationale for the reported study. What is the exposure? Is a causal effect plausible? Why use MR? |
-| 3 | Objectives | State specific objectives clearly, including prespecified causal hypotheses (if any). |
+## Title and Abstract
 
-### Methods
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 1 | Title and abstract | MR is named as the study design in the title and/or abstract, where that is a main purpose of the study. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 4 | Study design and data sources | Present key elements of the study design early in the article. Consider including a table listing sources of data for all phases of the study. (4a) Describe the study design and the underlying population, if possible. (4b) Give the eligibility criteria, and the sources and methods of selection of participants. (4c) Describe measurement, quality control, and selection of genetic variants. (4d) For each exposure, outcome, and other relevant variables, describe methods of assessment and diagnostic criteria for diseases. (4e) Provide details of ethics committee approval and participant informed consent, if relevant. |
-| 5 | Assumptions | Explicitly state the three core instrumental-variable assumptions (relevance, independence/exchangeability, exclusion restriction) and the conditions under which MR estimates a causal effect. |
-| 6 | Statistical methods: main analysis | Describe statistical methods and statistics used. (6a) Describe how quantitative variables were handled in the analyses (e.g., scale, units, transformation). (6b) Describe how genetic variants were handled in the analyses and, if applicable, how their weights were selected. (6c) Describe the MR estimator(s) (e.g., inverse-variance weighted) and their assumptions. (6d) Explain how missing data were addressed. (6e) If applicable, indicate how multiple testing / multiplicity was addressed. |
-| 7 | Statistical methods: assessment of assumptions | Describe any methods or prior knowledge used to assess the assumptions or justify their validity. |
-| 8 | Statistical methods: sensitivity analyses and additional analyses | Describe any sensitivity analyses or additional analyses performed (e.g., comparison of results from different MR analysis methods, MR-Egger, weighted median/mode, MR-PRESSO, assessment of instrument-outcome and instrument-exposure population overlap, the use of negative controls). |
+## Introduction
 
-### Results
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 2 | Background | The scientific background and rationale; what the exposure is; whether a causal exposure–outcome relationship is plausible; and **a justification of why MR helps answer this question**. |
+| 3 | Objectives | Specific objectives, including **prespecified causal hypotheses** if any, and a statement that MR estimates causal effects only under stated assumptions. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 9 | Descriptive data | (9a) Report the numbers of individuals at each stage of the study and reasons for exclusion. Report summary statistics for the genetic variants, the exposure, and the outcome. (9b) If the data sources include meta-analyses of previous studies, provide assessments of heterogeneity across these studies. (9c) Report on data sources, the participants, and whether the exposure and outcome data come from the same or different (non-overlapping) samples. |
-| 10 | Main results | (10a) Report the associations between genetic variant and exposure, and between genetic variant and outcome, preferably on an interpretable scale. (10b) Report MR estimates of the association between exposure and outcome, and the measures of uncertainty, on an interpretable scale (e.g., odds ratio or relative risk per standard-deviation difference). (10c) If relevant, consider translating estimates of relative risk into absolute risk for a meaningful time period. (10d) Consider plots to visualize results (e.g., forest plot, scatter plot of variant-outcome vs variant-exposure associations). |
-| 11 | Assessment of assumptions | (11a) Report the assessment of the validity of the assumptions. (11b) Report any additional statistics (e.g., assessments of heterogeneity across instruments, such as I² or Cochran's Q). |
-| 12 | Sensitivity analyses and additional analyses | (12a) Report any sensitivity analyses to assess the robustness of the main results to violations of the assumptions. (12b) Report any assessment of direction of causal effect (e.g., bidirectional MR, Steiger filtering). (12c) Report any additional analyses (e.g., analyses of subgroups; multivariable MR). (12d) When relevant, report and compare with estimates from non-MR analyses. (12e) Provide indications of any other potential sources of bias (e.g., selection bias, sample overlap, winner's curse). |
+## Methods
 
-### Discussion
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 4 | Study design and data sources | Key design elements early in the article; consider a table of data sources for every phase. Then, **for each data source**: |
+| 4a | — Setting | The design and underlying population; setting, locations and relevant dates, including recruitment, exposure, follow-up and data collection. |
+| 4b | — Participants | Eligibility criteria, how participants were selected, sample size, and whether any power or sample-size calculation was done **before** the main analysis. |
+| 4c | — Genetic variants | **Measurement, quality control and selection of the genetic variants.** |
+| 4d | — Variables | Assessment methods and diagnostic criteria for each exposure, outcome and other relevant variable. |
+| 4e | — Ethics | Ethics committee approval and participant informed consent, where relevant. |
+| 5 | Assumptions | **The three core IV assumptions stated explicitly** — relevance, independence, exclusion restriction — plus the assumptions of any additional or sensitivity analysis. |
+| 6 | Statistical methods: main analysis | The statistical methods and statistics used: |
+| 6a | — Quantitative variables | How they were handled — scale, units, model. |
+| 6b | — Genetic variants | How variants were handled and, if applicable, how their weights were chosen. |
+| 6c | — MR estimator | **Which estimator** (two-stage least squares, Wald ratio, …) and its related statistics; the covariates included; and for 2-sample MR whether the same covariate set was used in both samples. |
+| 6d | — Missing data | How missing data were addressed. *(The only sub-item unchanged from STROBE.)* |
+| 6e | — Multiple testing | How multiple testing was addressed, if applicable. |
+| 7 | Assessment of assumptions | The methods or prior knowledge used to **assess** the assumptions or justify their validity. |
+| 8 | Sensitivity and additional analyses | Any sensitivity or additional analyses — comparison of estimates from different approaches, independent replication, bias-analytic techniques, instrument validation, simulations. |
+| 9 | Software and preregistration | |
+| 9a | — Software | Statistical software and packages, **with version and settings**. |
+| 9b | — Preregistration | **Whether the protocol and details were preregistered**, and when and where. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 13 | Key results | Summarise key results with reference to study objectives. |
-| 14 | Limitations | Discuss limitations of the study, taking into account the validity of the IV assumptions, other sources of potential bias, and imprecision. Discuss both direction and magnitude of any potential bias. |
-| 15 | Interpretation | (15a) Give a cautious overall interpretation of results in the context of their limitations and in comparison with other studies. (15b) Discuss underlying biological mechanisms that could drive a potential causal effect, and whether the gene-environment equivalence assumption is reasonable. (15c) Discuss whether the results have clinical or public-policy relevance, and to what extent they inform effect sizes of possible interventions. |
-| 16 | Generalizability | Discuss the generalizability (external validity) of the study results, including the relevance of the population(s) and ancestry to which the findings apply. |
+## Results
 
-### Other Information
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 10 | Descriptive data | |
+| 10a | — Flow | Numbers of individuals at each stage of the included studies and reasons for exclusion; consider a flow diagram. |
+| 10b | — Summary statistics | For phenotypic exposures, outcomes and other relevant variables — means, SDs, proportions. |
+| 10c | — Heterogeneity | Where data sources include meta-analyses of previous studies, the assessments of heterogeneity across them. |
+| 10d | — 2-sample MR | (i) **Justification that the variant–exposure associations are similar** between the exposure and outcome samples; (ii) **the number of individuals overlapping** between the two studies. |
+| 11 | Main results | |
+| 11a | — Associations | The variant–exposure and variant–outcome associations, preferably on an interpretable scale. |
+| 11b | — MR estimates | The MR estimate of the exposure–outcome relationship with its uncertainty, on an interpretable scale such as an odds ratio or relative risk per SD. |
+| 11c | — Absolute risk | Where relevant, relative risk translated into absolute risk over a meaningful period. |
+| 11d | — Plots | Consider plots — forest plot, or variant–outcome against variant–exposure associations. |
+| 12 | Assessment of assumptions | |
+| 12a | — Validity | The assessment of the validity of the assumptions. |
+| 12b | — Statistics | Additional statistics — heterogeneity across variants (I², Q) or an E-value. |
+| 13 | Sensitivity and additional analyses | |
+| 13a | — Robustness | Sensitivity analyses testing robustness to violations of the assumptions. |
+| 13b | — Other | Results of other sensitivity or additional analyses. |
+| 13c | — Direction | **Any assessment of the direction of the causal relationship**, e.g. bidirectional MR. |
+| 13d | — Non-MR comparison | Where relevant, comparison with estimates from non-MR analyses. |
+| 13e | — Plots | Consider additional plots, e.g. leave-one-out analyses. |
 
-| # | Item | Description |
-|---|------|-------------|
-| 17 | Funding | Describe sources of funding and the role of funders in the present study and, if applicable, for the databases and original study or studies on which the present study is based. |
-| 18 | Data and data sharing | Provide the data used to perform all analyses, or report where and how the data can be accessed, and reference these sources in the article. Provide the statistical code needed to reproduce the results in the article, or report where and how it can be accessed. |
-| 19 | Conflicts of interest | All authors should declare all potential conflicts of interest. |
-| 20 | Other | Where applicable, report other study registration, protocol availability, or supplementary reporting (e.g., a completed STROBE-MR checklist). |
+## Discussion
 
----
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 14 | Key results | The key results summarised against the study objectives. |
+| 15 | Limitations | Limitations, taking in the validity of the IV assumptions, other sources of bias, and imprecision — with **the direction and magnitude** of any potential bias and what was done about it. |
+| 16 | Interpretation | |
+| 16a | — Meaning | A cautious overall interpretation in the light of the limitations and of other studies. |
+| 16b | — Mechanism | The biological mechanisms that could drive the relationship, and **whether the gene-environment equivalence assumption is reasonable**; causal language used carefully, making clear that IV estimates are causal only under certain assumptions. |
+| 16c | — Clinical relevance | Whether the results have clinical or public-policy relevance, and what they imply about the size of possible interventions. |
+| 17 | Generalizability | Generalisability of the results **(a) to other populations, (b) across other exposure periods or timings, and (c) across other levels of exposure**. |
+
+## Other Information
+
+| # | Item | What to check is reported |
+|---|------|---------------------------|
+| 18 | Funding | Sources of funding and the role of funders for this study and, where applicable, for the databases and original studies it rests on. |
+| 19 | Data and data sharing | The data used, or where and how it can be accessed, referenced in the article; and **the statistical code needed to reproduce the results**, or where it is publicly accessible. |
+| 20 | Conflicts of interest | Declared by **all** authors. |
 
 ## Notes for Assessors
 
-- STROBE-MR is an **extension of STROBE**; for the non-MR-specific items the base `STROBE.md` guidance also applies. Report both the base instrument and the extension when describing methods (do not cite STROBE-MR as if it replaced STROBE).
-- The highest-yield MR-specific items are **5** (the three IV assumptions stated explicitly), **8 / 12** (pleiotropy-robust sensitivity suite — not the IVW estimate alone), **9c / 12e** (sample overlap, winner's curse), and **16** (ancestry generalizability). A study that reports only an IVW estimate with no assumption assessment and no sensitivity analyses is non-compliant on items 5/8/11/12.
-- Item numbering follows the STROBE-MR statement's grouping by STROBE section; some sources present the same content as a 20-item list with lettered sub-items. Map the manuscript's content to the items rather than to exact numbering.
-- This checklist was authored as a faithful summary of the STROBE-MR statement (Davey Smith G, et al. *BMJ* 2021;375:n2233, CC BY) for item-by-item assessment; verify against the published statement and its explanation-and-elaboration document for full item wording. Verified 2026-06-27.
+- **The sub-items are the extension.** Items 1–20 alone are close to a re-lettered STROBE. What makes
+  a report an MR report is 4c (variant measurement, QC and selection), 6c (the estimator), 9b
+  (preregistration), 10d (2-sample similarity and **participant overlap**), 12a/12b (assumption
+  validity, heterogeneity across variants), 13c (direction of causation), and 16b (gene-environment
+  equivalence). Score them.
+- **Item 5 is the one most often skipped**: the three IV assumptions named explicitly — relevance,
+  independence, exclusion restriction — not gestured at.
+- A study reporting only an inverse-variance-weighted estimate, with no assessment of the assumptions
+  (7, 12) and no sensitivity analyses (8, 13), is non-compliant regardless of how well it reads.
+- **Name both instruments.** STROBE-MR is a stand-alone extension of STROBE; cite each. See
+  `STROBE.md` for the base items.
+- Authors are expected to address every item and sub-item, using supplementary material where space
+  is short.
+- For the design-validity review of the same study, pair with the MR domain probes in
+  `peer-review` / `self-review` `references/domain-probes/mendelian_randomization.md`; for the
+  analysis, with `analyze-stats` `analysis_guides/mendelian_randomization.md`.


### PR DESCRIPTION
Sixth batch. Checked against the statement (Skrivankova et al., *JAMA* 2021;326(16):1614-1621).

## Six things wrong at once, under a "Verified" stamp

**1. The citation.** The file credited *"Skidmore ME / Davey Smith G, Davies NM, et al. BMJ 2021;375:n2233"*. There is no such first author, and n2233 is the **Explanation and Elaboration** paper — not the statement, which is in *JAMA*.

**2. All 30 sub-items were absent.** The file carried items 1–20 and nothing else, which is close to a re-lettered STROBE. Everything that makes a report a Mendelian-randomization report lives in the sub-items:

| | |
|---|---|
| **4c** | measurement, quality control and selection of the genetic variants |
| **6c** | the MR estimator (2SLS, Wald ratio) and covariate handling across samples |
| **9b** | preregistration |
| **10d** | 2-sample: variant–exposure similarity, and **participant overlap between samples** |
| **12a/b** | assumption-validity results; heterogeneity across variants |
| **13c** | direction of the causal relationship (bidirectional MR) |
| **16b** | whether **gene-environment equivalence** is reasonable |

None were scoreable.

**3. Items 17–20 were shifted by one** — Funding at 17 where the statement has Generalizability — and the file **invented an item 20, "Other"**, where the statement has Conflicts of interest.

**4. The licence claim was wrong**: described as CC BY. It is *JAMA*, no open licence.

**5. The assessor notes cited item numbers that do not exist** in the instrument ("9c / 12e", and "16" for ancestry generalisability, which is 17).

**6. It carried a "Verified" stamp.** That is the part worth dwelling on: a file can assert it was checked and be wrong in six ways simultaneously. The stamp is only worth what was actually compared, and nothing here had been compared against the published table.

## What changed

Rebuilt to **20 items and 30 sub-items**, asserted programmatically against the official structure (`main == 1..20`, sub-item set exact, no missing and no extra). Section grouping restored. Wording in our own words, consistent with the JAMA licence position taken in #471/#473/#474.

The relationship to STROBE is now stated correctly — a stand-alone extension where **every item and sub-item was modified except 6d** (missing data) — as is the statement's own instruction that the checklist is **not** an instrument for evaluating research quality.

## The pattern is now five for five

| Extension file | Defect |
|---|---|
| PRISMA-DTA | items 15/22 kept, D1/D2 absent, renumbered (#473) |
| PROBAST | invented "PROBAST+AI Extensions" section (#471) |
| PRISMA-ScR | instrument renumbered 1–27 → 1–22; 10 items misnumbered; optional pair misidentified *(queued)* |
| **STROBE-MR** | **all sub-items dropped; tail shifted; item invented** |
| STARD-AI / CONSORT-AI / SPIRIT-AI | not yet audited |

**Every extension checklist audited so far has had a structural defect, and the base instruments have not.** The signature is consistent: the base skeleton survives and the extension's substance — the added items, the deleted items, the numbering, the statuses — does not. That is what you get from adapting a checklist by hand instead of transcribing the published table.

## Verification

`python3 scripts/run_ci_mirror.py` — **238/238 gates pass**.