### PR TITLE
Checklist fidelity 7/N: PRISMA-ScR was renumbered — 10 of 22 items carried the wrong number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,50 @@
 
 ### Fixed
 
+- **`PRISMA_ScR.md` had renumbered the instrument, and 10 of its 22 items carried the wrong number.**
+  Checked against the statement's table (Tricco et al., *Ann Intern Med* 2018;169(7):467-473).
+
+  PRISMA-ScR keeps PRISMA's **1–27 numbering**. Five rows are marked *"Not applicable for scoping
+  reviews"* — **13** (summary measures), **15** and **22** (risk of bias across studies and its
+  results counterpart), **16** and **23** (additional analyses and its counterpart) — and two are
+  optional, phrased *"If done"*: **12** and **19**, the critical-appraisal pair. That is how
+  27 rows come to be described as "20 essential items + 2 optional".
+
+  The file had deleted the five N/A rows and closed the gaps, renumbering everything from 13 onward:
+
+  | Official | This file said |
+  |---|---|
+  | 14 Synthesis of results (Methods) | 13 |
+  | 17 Selection of sources of evidence | 14 |
+  | 18 Characteristics of sources | 15 |
+  | **19 Critical appraisal within sources** | **16** |
+  | 20 Results of individual sources | 17 |
+  | 21 Synthesis of results (Results) | 18 |
+  | 24 Summary of evidence | 19 |
+  | 25 Limitations | 20 |
+  | 26 Conclusions | 21 |
+  | 27 Funding | 22 |
+
+  Item numbers are how authors, reviewers and editors refer to a checklist. A reviewer asking about
+  "PRISMA-ScR item 25" means Limitations; this file had no item 25 and put Limitations at 20. A
+  compliance report citing "item 19" from it meant Summary of evidence, where the guideline's item 19
+  is the critical-appraisal results.
+
+  Compounding it, the header and the assessor notes named the optional pair as **"12 and 16"**. Item
+  16 is *Additional analyses* and is **N/A** — a different item with a different status. An assessor
+  following the file would have looked for optional appraisal data under 16 and never scored item 19
+  at all.
+
+  Restored to 1–27 with the five N/A rows present and labelled, and the optional pair at 12 and 19 —
+  asserted programmatically (`ids == 1..27`, N/A set `[13, 15, 16, 22, 23]`, optional set `[12, 19]`,
+  20 essential). The item descriptions, which were sound, are unchanged apart from the numbering and
+  the cross-references in the notes. The statement's terminology footnote is now carried: *critical
+  appraisal* rather than risk of bias, *sources of evidence* rather than studies, *charting* rather
+  than extraction — and why.
+
+  The previous revision carried a "Verified" stamp, as `STROBE_MR.md` did. Neither had been compared
+  against the published table.
+
 - **`STROBE_MR.md` cited a non-existent author, cited the wrong paper, dropped all 30 sub-items,
   shifted the last four items by one, invented an item that does not exist — and carried a
   "Verified" stamp.** Checked against the statement (Skrivankova et al., *JAMA*

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -758,8 +758,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_ScR.md",
-      "size": 7700,
-      "sha256": "ed77ad95bf03fd798db978444514ae66bd36e39685155da320345524e4afddc6"
+      "size": 9217,
+      "sha256": "3bc17ee943c4d495c94f235b2b307e055f52b453d6674184b53bf01f4600d919"
     },
     {
       "path": "skills/check-reporting/references/checklists/PROBAST.md",

--- a/skills/check-reporting/references/checklists/PRISMA_ScR.md
+++ b/skills/check-reporting/references/checklists/PRISMA_ScR.md
@@ -1,12 +1,35 @@
 # PRISMA-ScR Checklist (scoping reviews)
 
 **Preferred Reporting Items for Systematic reviews and Meta-Analyses extension for Scoping Reviews**
-Version: PRISMA-ScR 2018 — 20 essential items + 2 optional (items 12 and 16, critical appraisal). Organised by the IMRAD-plus-Funding sections of the source.
-Source: Tricco AC, Lillie E, Zarin W, O'Brien KK, Colquhoun H, Levac D, et al. *Ann Intern Med* 2018;169(7):467–473 (the PRISMA-ScR statement; DOI 10.7326/M18-0850). EQUATOR Network. Scoping-review conduct guidance: JBI (Peters et al.); Arksey & O'Malley; Levac et al.
+Version: PRISMA-ScR 2018 — the checklist keeps PRISMA's **1–27 numbering**. Of those 27 rows, **5 are
+"Not applicable for scoping reviews"** (13, 15, 16, 22, 23) and **2 are optional, phrased "If done"**
+(**12** and **19**, critical appraisal), leaving **20 essential items**.
+Source: Tricco AC, Lillie E, Zarin W, O'Brien KK, Colquhoun H, Levac D, et al. PRISMA Extension for
+Scoping Reviews (PRISMA-ScR): Checklist and Explanation. *Ann Intern Med* 2018;169(7):467-473
+(DOI 10.7326/M18-0850). EQUATOR Network. Scoping-review conduct guidance: JBI (Peters et al.);
+Arksey & O'Malley; Levac et al.
 
-Apply when the manuscript is a **scoping review** — a review that *maps* the breadth of evidence on a topic, characterises concepts/definitions, and identifies gaps, rather than answering a focused effectiveness/accuracy question (that is a systematic review → use PRISMA 2020 / PRISMA-DTA). For the design/conduct review of the same study, pair with the SC1–SC8 domain probes in `peer-review` / `self-review` `references/domain-probes/scoping_review.md`; for the flow diagram use `make-figures` (PRISMA-style); for an SR/MA instead, use `PRISMA_2020.md` / `PRISMA_DTA.md`.
+Apply when the manuscript is a **scoping review** — a review that *maps* the breadth of evidence on a
+topic, characterises concepts and definitions, and identifies gaps, rather than answering a focused
+effectiveness or accuracy question (that is a systematic review → `PRISMA_2020.md` / `PRISMA_DTA.md`).
+For the design/conduct review of the same study, pair with the SC1–SC8 domain probes in
+`peer-review` / `self-review` `references/domain-probes/scoping_review.md`; for the flow diagram use
+`make-figures` (PRISMA-style).
 
-> Licensing note: the PRISMA-ScR statement is published in *Annals of Internal Medicine* (© American College of Physicians); the official EQUATOR checklist carries only the citation, with **no Creative Commons licence** (one secondary source lists CC BY-NC-SA 3.0 — also not permissively reusable). The items below are an **in-house, faithful summary of the reporting items (facts/intents, paraphrased — not the verbatim PRISMA-ScR wording)** for item-by-item assessment; consult the published article (DOI 10.7326/M18-0850) for exact item text. Items 12 and 16 (critical appraisal) are **optional** — a scoping review is not required to appraise risk of bias.
+> **Fidelity and licence.** Published in *Annals of Internal Medicine* (© American College of
+> Physicians) under **no open licence**; one secondary source lists CC BY-NC-SA 3.0, which is also not
+> permissively reusable. The descriptions below are an **in-house summary of item intent in our own
+> words — not the published wording**. The structure — the 1–27 numbering, which rows are N/A, which
+> are optional, and the section grouping — is **verified against the statement's table**. Consult the
+> published article for exact item text, and complete the official checklist for anything you submit.
+
+> **What this file used to be.** It numbered the items **1–22**: it had deleted the five "Not
+> applicable" rows and closed the gaps, so every item from 13 onward carried the wrong number — 10 of
+> 22. Critical appraisal within sources of evidence sat at 16 instead of **19**; Limitations at 20
+> instead of **25**; Funding at 22 instead of **27**. The header and the assessor notes named the
+> optional pair as "12 and 16", but 16 is *Additional analyses* and is **N/A**, not optional. Item
+> numbers are how authors, reviewers and editors refer to a checklist, so a renumbered instrument
+> silently breaks every reference to it.
 
 ## Reporting items (grouped by section)
 
@@ -32,39 +55,61 @@ Apply when the manuscript is a **scoping review** — a review that *maps* the b
 | 5 | Protocol and registration | Whether an a-priori **protocol** exists, where it can be accessed, and any registration details. (Note: PROSPERO does **not** register scoping reviews; OSF/Figshare or a published protocol is used.) |
 | 6 | Eligibility criteria | Characteristics used as eligibility criteria (years, language, publication status, source types) **with a rationale**. |
 | 7 | Information sources | All information sources searched (databases with coverage dates, grey-literature sources, author contact) and the date the most recent search was run. |
-| 8 | Search | A reproducible search strategy for **one or more databases** (search terms and any limits), detailed enough to be repeated by another team. |
+| 8 | Search | A reproducible search strategy for **at least one database** (search terms and any limits), detailed enough to be repeated by another team. |
 | 9 | Selection of sources of evidence | The process for selecting **sources of evidence** (screening and eligibility) into the review. |
 | 10 | Data charting process | The **data-charting** methods (calibrated/team-tested form; whether charting was independent/duplicate; iterative refinement) and any process for obtaining/confirming data from investigators. "Charting," not "extraction." |
 | 11 | Data items | The data items charted — every variable sought — plus any assumptions or simplifications made. |
-| 12 | Critical appraisal of individual sources of evidence (**optional**) | *If done*, the rationale for critical appraisal, the methods used, and how the information was used. Scoping reviews are **not required** to appraise; "critical appraisal" is used instead of "risk of bias." |
-| 13 | Synthesis of results | The methods for **handling and summarising (charting/mapping)** the charted data. |
+| **12** | Critical appraisal of individual sources of evidence — **OPTIONAL** | *If done*, the rationale for critical appraisal, the methods used, and how the information was used in any data synthesis. Scoping reviews are **not required** to appraise; "critical appraisal" is used instead of "risk of bias." |
+| 13 | Summary measures | **Not applicable for scoping reviews.** |
+| 14 | Synthesis of results | The methods for **handling and summarising (charting/mapping)** the charted data. |
+| 15 | Risk of bias across studies | **Not applicable for scoping reviews.** |
+| 16 | Additional analyses | **Not applicable for scoping reviews.** |
 
 ### Results
 | # | Item | What to check is reported |
 |---|------|---------------------------|
-| 14 | Selection of sources of evidence | Numbers screened, assessed for eligibility, and included, with reasons for exclusion at each stage — ideally a **flow diagram**. |
-| 15 | Characteristics of sources of evidence | Per-source characteristics for which data were charted, with citations. |
-| 16 | Critical appraisal within sources of evidence (**optional**) | *If done* (see item 12), the critical-appraisal data per source. Optional. |
-| 17 | Results of individual sources of evidence | For each included source, the relevant charted data that relate to the review questions/objectives. |
-| 18 | Synthesis of results | The charting results **summarised/mapped** in relation to the review questions/objectives — a **map/characterisation, not a pooled effect estimate**. |
+| 17 | Selection of sources of evidence | Numbers screened, assessed for eligibility, and included, with reasons for exclusion at each stage — ideally a **flow diagram**. |
+| 18 | Characteristics of sources of evidence | Per-source characteristics for which data were charted, with citations. |
+| **19** | Critical appraisal within sources of evidence — **OPTIONAL** | *If done* (see item 12), the critical-appraisal data per source. |
+| 20 | Results of individual sources of evidence | For each included source, the relevant charted data that relate to the review questions/objectives. |
+| 21 | Synthesis of results | The charting results **summarised/mapped** in relation to the review questions/objectives — a **map/characterisation, not a pooled effect estimate**. |
+| 22 | Risk of bias across studies | **Not applicable for scoping reviews.** |
+| 23 | Additional analyses | **Not applicable for scoping reviews.** |
 
 ### Discussion
 | # | Item | What to check is reported |
 |---|------|---------------------------|
-| 19 | Summary of evidence | The main results summarised (overview of concepts, themes, evidence types), linked to the questions/objectives and their relevance to key groups. |
-| 20 | Limitations | Limitations of the **scoping-review process**. |
-| 21 | Conclusions | A general interpretation against the questions/objectives, with potential implications and/or next steps (e.g. whether a systematic review is warranted). |
+| 24 | Summary of evidence | The main results summarised (overview of concepts, themes, evidence types), linked to the questions/objectives and their relevance to key groups. |
+| 25 | Limitations | Limitations of the **scoping-review process**. |
+| 26 | Conclusions | A general interpretation against the questions/objectives, with potential implications and/or next steps (e.g. whether a systematic review is warranted). |
 
 ### Funding
 | # | Item | What to check is reported |
 |---|------|---------------------------|
-| 22 | Funding | Sources of funding for the included sources of evidence **and** for the scoping review, and the funders' role. |
+| 27 | Funding | Sources of funding for the included sources of evidence **and** for the scoping review, and the funders' role. |
 
 ---
 
 ## Notes for Assessors
 
-- The **highest-yield** checks (where scoping reviews most often go wrong): **item 4** (objectives framed as PCC mapping, not a focused PICO effectiveness question — a study that asks "is X effective/accurate?" should be a systematic review, not a scoping review), **item 18** (results presented as a **map** — counts, categories, themes, evidence gaps — **not** a pooled OR/RR/AUC or a definitive effectiveness/accuracy conclusion), and **items 12/16** (critical appraisal is **optional** — do not penalise a scoping review for omitting risk-of-bias, and do not let it claim GRADE-style certainty it did not derive).
-- A "scoping review" that reports pooled effect estimates / a meta-analysis, or concludes that an intervention is effective / a test is accurate, has overstepped its design — its synthesis (item 18) and conclusions (item 21) should be downgraded to descriptive mapping, or the study reframed as a systematic review.
-- Terminology matters: **charting** (not extraction), **sources of evidence** (not only studies), **critical appraisal** (not risk of bias). A scoping review claiming PROSPERO registration is in error (PROSPERO excludes scoping reviews).
-- This is an **in-house faithful summary of the PRISMA-ScR items (paraphrased intents, not verbatim)**; map the manuscript's content to the items rather than to exact wording, and verify against the published statement (Tricco et al. *Ann Intern Med* 2018; DOI 10.7326/M18-0850). Verified 2026-06-30.
+- **Score against 1–27, not 1–20.** The five N/A rows stay in the table so the numbering matches the
+  guideline; mark them N/A rather than deleting them. The denominator for compliance is the 20
+  essential items, plus the two optional items only where the review says it appraised.
+- **The optional pair is 12 and 19**, not 12 and 16. Item 16 is *Additional analyses* and is N/A.
+  Why they are optional: a scoping review may include documents, blogs, websites, interviews and
+  opinions, and is not required to examine risk of bias in what it includes.
+- The **highest-yield** checks (where scoping reviews most often go wrong): **item 4** (objectives
+  framed as PCC mapping, not a focused PICO effectiveness question — a study asking "is X
+  effective/accurate?" should be a systematic review), **item 21** (results presented as a **map** —
+  counts, categories, themes, evidence gaps — **not** a pooled OR/RR/AUC or a definitive
+  effectiveness conclusion), and **items 12/19** (do not penalise a scoping review for omitting
+  critical appraisal, and do not let it claim GRADE-style certainty it never derived).
+- A "scoping review" that reports pooled effect estimates or a meta-analysis, or concludes an
+  intervention is effective or a test accurate, has overstepped its design — its synthesis (21) and
+  conclusions (26) should be downgraded to descriptive mapping, or the study reframed as a systematic
+  review.
+- **Terminology is deliberate and the statement says so**: **charting** rather than extraction,
+  **sources of evidence** rather than studies, and **critical appraisal** rather than risk of bias —
+  the last because risk of bias suits systematic reviews of interventions, while a scoping review
+  takes in quantitative and qualitative research, expert opinion and policy documents. A scoping
+  review claiming PROSPERO registration is in error; PROSPERO excludes them.


### PR DESCRIPTION
Seventh batch. Checked against the statement's table (Tricco et al., *Ann Intern Med* 2018;169(7):467-473).

## The structure PRISMA-ScR actually has

It keeps PRISMA's **1–27 numbering**. Five rows are marked *"Not applicable for scoping reviews"* — **13** (summary measures), **15** and **22** (risk of bias across studies, and its results counterpart), **16** and **23** (additional analyses, and its counterpart). Two are optional, phrased *"If done"*: **12** and **19**, the critical-appraisal pair.

27 rows − 5 N/A − 2 optional = **20 essential items**, which is how the statement describes itself.

## What the file did

It deleted the five N/A rows and closed the gaps, renumbering everything from 13 onward:

| Official | This file said |
|---|---|
| 14 Synthesis of results (Methods) | 13 |
| 17 Selection of sources of evidence | 14 |
| 18 Characteristics of sources | 15 |
| **19 Critical appraisal within sources** | **16** |
| 20 Results of individual sources | 17 |
| 21 Synthesis of results (Results) | 18 |
| 24 Summary of evidence | 19 |
| 25 Limitations | 20 |
| 26 Conclusions | 21 |
| 27 Funding | 22 |

**10 of 22 items carried the wrong number.** Item numbers are how authors, reviewers and editors refer to a checklist. A reviewer asking about "PRISMA-ScR item 25" means Limitations; this file had no item 25 and put Limitations at 20. A compliance report citing "item 19" from it meant Summary of evidence, where the guideline's item 19 is the critical-appraisal results.

Compounding it, the header and the assessor notes named the optional pair as **"12 and 16"**. Item 16 is *Additional analyses* and is **N/A** — a different item with a different status. An assessor following the file would look for optional appraisal data under 16 and never score item 19 at all.

## What changed

Restored to 1–27 with the five N/A rows present and labelled, and the optional pair at 12 and 19 — asserted programmatically: `ids == 1..27`, N/A set `[13, 15, 16, 22, 23]`, optional set `[12, 19]`, 20 essential.

The item descriptions were sound and are unchanged apart from their numbering and the cross-references in the notes. The statement's terminology footnote is now carried and explained: **critical appraisal** rather than risk of bias (because a scoping review takes in quantitative and qualitative research, expert opinion and policy documents), **sources of evidence** rather than studies, **charting** rather than extraction.

## Two "Verified" stamps have now failed

This file and `STROBE_MR.md` (#475) both carried one. Neither had been compared against the published table. A stamp is worth exactly what it was compared against, and neither recorded that.

## The extension pattern holds at six for six

| Extension file | Defect |
|---|---|
| PRISMA-DTA | items 15/22 kept, D1/D2 absent, renumbered (#473) |
| PROBAST | invented "PROBAST+AI Extensions" section (#471) |
| STROBE-MR | all 30 sub-items dropped, tail shifted, item invented (#475) |
| **PRISMA-ScR** | **renumbered 1–27 → 1–22; optional pair misidentified** |
| PRISMA 2020 for Abstracts | authored in this audit, verified (#469) |
| STARD-AI / CONSORT-AI / SPIRIT-AI / RECORD | not yet audited |

Base instruments audited so far — PRISMA 2020, QUADAS-2, TRIPOD+AI, PROBAST+AI — were materially better. The extensions were adapted by hand from their base; the bases were transcribed.

## Verification

`python3 scripts/run_ci_mirror.py` — **238/238 gates pass**.