### PR TITLE
Checklist fidelity 8/N: CONSORT-AI and SPIRIT-AI verified clean — and the audit's pattern was wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,34 @@
   assumed correlation to be stated and varied, since primary studies almost never report it. DTA
   was already covered by the bivariate/HSROC requirement; nothing else was.
 
+### Changed
+
+- **CONSORT-AI and SPIRIT-AI verified clean — and they correct the pattern this audit had been
+  claiming.** Both enumerated from the articles' own checklist tables via PMC XML and compared
+  label-by-label. **CONSORT-AI: 14/14** (11 Extensions, 3 Elaborations). **SPIRIT-AI: 15/15**
+  (12 Extensions, 3 Elaborations). Nothing missing, nothing invented, labels exact.
+
+  The audit had been reporting that *extension* checklists were the dangerous class — four for four
+  at the time. That generalisation does not survive these two. The variable that actually separates
+  the good files from the bad is **whether the source could be opened**:
+
+  | Source | Files | Worst defect found |
+  |---|---|---|
+  | **Open (CC BY)** | TRIPOD+AI, CONSORT-AI, SPIRIT-AI, PRISMA 2020 | wording drift — PRISMA 2020's items 4 and 13b |
+  | **Paywalled (JAMA, ACP)** | PRISMA-DTA, STROBE-MR, PRISMA-ScR, PROBAST, QUADAS-2 | **structural** — an instrument that was not the instrument, all 30 sub-items dropped, a renumbered checklist, an invented section |
+
+  Every structural defect came from a file whose source was behind a paywall. Where the table could
+  be opened and transcribed, it was transcribed. Where it could not, someone reconstructed it from
+  the base instrument or from memory — and that is where invented sections, dropped sub-items and
+  closed numbering gaps come from. This predicts the risk in the 35 files not yet audited far better
+  than "is it an extension".
+
+  Both files also gain a distinction the statements make and the files did not: an **Extension** is a
+  new reporting requirement the base instrument does not contain; an **Elaboration** clarifies how an
+  existing base item applies to an AI intervention. Both are assessed, but only Extensions are
+  additional obligations — reporting an Elaboration as though CONSORT 2010 or SPIRIT 2013 had been
+  silent overstates what the extension added. Elaborations are now marked **(E)**.
+
 ### Fixed
 
 - **`PRISMA_ScR.md` had renumbered the instrument, and 10 of its 22 items carried the wrong number.**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -683,8 +683,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/CONSORT_AI.md",
-      "size": 4376,
-      "sha256": "e923b3d2f550351f952334053978d5f0ca726ddb4798f3c1e4adba36939bd662"
+      "size": 5209,
+      "sha256": "b1c0b76ee5c84ae0fdd515c98e26594b318366f1cb1cd3db4cedb28bc2c44ecd"
     },
     {
       "path": "skills/check-reporting/references/checklists/COREQ.md",
@@ -828,8 +828,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/SPIRIT_AI.md",
-      "size": 4163,
-      "sha256": "d4ac52674c7f7d92ae1f042ed85631ab13b03ca57349abd261ff08031b30ae51"
+      "size": 4994,
+      "sha256": "0174d3b05e4ec68eee8e3ec686cd7c6d57bbc9e5120921a7c09687abb9937021"
     },
     {
       "path": "skills/check-reporting/references/checklists/SQUIRE_2.md",

--- a/skills/check-reporting/references/checklists/CONSORT_AI.md
+++ b/skills/check-reporting/references/checklists/CONSORT_AI.md
@@ -8,6 +8,17 @@ Reference: Liu X, Cruz Rivera S, Moher D, et al. Nat Med 2020;26(9):1364-1374. d
 > Educational summary, authored in our own words from the CC BY 4.0 source. Use the official
 > CONSORT-AI checklist for a submission-ready form and cite Liu et al. 2020.
 
+> **Verified against the published statement.** All 14 AI items were enumerated from the article's
+> own checklist table via the PMC XML and compared label-by-label: **11 Extensions and
+> 3 Elaborations**, matching exactly with no item missing and none invented.
+
+> **Extension vs Elaboration — the statement distinguishes them, and it matters.** An **Extension**
+> is a *new* reporting requirement that CONSORT 2010 does not contain. An **Elaboration** clarifies how an
+> existing CONSORT 2010 item applies when the intervention involves AI; the requirement already existed,
+> the guidance is what is new. Both are assessed, but only the Extensions are additional obligations —
+> do not report an Elaboration as though the base instrument had been silent on it. Elaborations are
+> marked **(E)** below.
+
 ## Naming and scope (read first)
 
 - CONSORT-AI is an **extension** of **CONSORT 2010**, for reports of randomized clinical trials of
@@ -26,8 +37,8 @@ Status each PRESENT / PARTIAL / MISSING / N/A.
 
 | # | Item | Description (intent) |
 |---|------|----------------------|
-| 1a,b (i) | AI identification | State in the title/abstract that the intervention involves AI/ML and specify the type of model. |
-| 1a,b (ii) | Intended use | State the intended use of the AI intervention in the title/abstract. |
+| 1a,b (i) **(E)** | AI identification | State in the title/abstract that the intervention involves AI/ML and specify the type of model. |
+| 1a,b (ii) **(E)** | Intended use | State the intended use of the AI intervention in the title/abstract. |
 
 ### Introduction — Background and objectives
 
@@ -39,7 +50,7 @@ Status each PRESENT / PARTIAL / MISSING / N/A.
 
 | # | Item | Description (intent) |
 |---|------|----------------------|
-| 4a (i) | Participant eligibility | State the participant-level inclusion and exclusion criteria. |
+| 4a (i) **(E)** | Participant eligibility | State the participant-level inclusion and exclusion criteria. |
 | 4a (ii) | Input-data eligibility | State the inclusion and exclusion criteria at the level of the **input data** to the AI system. |
 | 4b | Setting integration | Describe how the AI intervention was integrated into the trial setting, including any onsite or offsite requirements. |
 | 5 (i) | Algorithm version | State which version of the AI algorithm was used. |

--- a/skills/check-reporting/references/checklists/SPIRIT_AI.md
+++ b/skills/check-reporting/references/checklists/SPIRIT_AI.md
@@ -8,6 +8,17 @@ Reference: Cruz Rivera S, Liu X, Chan AW, et al. Nat Med 2020;26(9):1351-1363. d
 > Educational summary, authored in our own words from the CC BY 4.0 source. Use the official
 > SPIRIT-AI checklist for a submission-ready form and cite Cruz Rivera et al. 2020.
 
+> **Verified against the published statement.** All 15 AI items were enumerated from the article's
+> own checklist table via the PMC XML and compared label-by-label: **12 Extensions and
+> 3 Elaborations**, matching exactly with no item missing and none invented.
+
+> **Extension vs Elaboration — the statement distinguishes them, and it matters.** An **Extension**
+> is a *new* reporting requirement that SPIRIT 2013 does not contain. An **Elaboration** clarifies how an
+> existing SPIRIT 2013 item applies when the intervention involves AI; the requirement already existed,
+> the guidance is what is new. Both are assessed, but only the Extensions are additional obligations —
+> do not report an Elaboration as though the base instrument had been silent on it. Elaborations are
+> marked **(E)** below.
+
 ## Naming and scope (read first)
 
 - SPIRIT-AI is an **extension** of **SPIRIT 2013**, for **protocols** of randomized clinical trials of
@@ -25,8 +36,8 @@ Status each PRESENT / PARTIAL / MISSING / N/A.
 
 | # | Item | Description (intent) |
 |---|------|----------------------|
-| 1 (i) | AI identification | State in the title that the intervention involves AI/ML and specify the type of model. |
-| 1 (ii) | Intended use | State the intended use of the AI intervention. |
+| 1 (i) **(E)** | AI identification | State in the title that the intervention involves AI/ML and specify the type of model. |
+| 1 (ii) **(E)** | Intended use | State the intended use of the AI intervention. |
 
 ### Introduction — Background and rationale
 
@@ -40,7 +51,7 @@ Status each PRESENT / PARTIAL / MISSING / N/A.
 | # | Item | Description (intent) |
 |---|------|----------------------|
 | 9 | Setting integration | Describe the onsite and offsite requirements needed to integrate the AI intervention into the trial setting. |
-| 10 (i) | Participant eligibility | State the participant-level inclusion and exclusion criteria. |
+| 10 (i) **(E)** | Participant eligibility | State the participant-level inclusion and exclusion criteria. |
 | 10 (ii) | Input-data eligibility | State the inclusion and exclusion criteria at the level of the **input data**. |
 | 11a (i) | Algorithm version | Specify which version of the AI algorithm will be used. |
 | 11a (ii) | Input acquisition | Specify how the input data will be acquired and selected. |


### PR DESCRIPTION
Eighth batch, and a correction to what the previous seven have been claiming.

## Both clean

Enumerated from the articles' own checklist tables via PMC XML and compared label-by-label.

| | Result |
|---|---|
| **CONSORT-AI** | **14/14** — 11 Extensions, 3 Elaborations |
| **SPIRIT-AI** | **15/15** — 12 Extensions, 3 Elaborations |

Nothing missing, nothing invented, labels exact.

## The pattern this audit was reporting is wrong

PRs #471–#477 said the dangerous class was **extension** checklists — four for four at the time. That generalisation does not survive these two: both are extensions, both are clean, and both are **CC BY**.

The variable that actually separates the good files from the bad is **whether the source could be opened**:

| Source | Files | Worst defect found |
|---|---|---|
| **Open (CC BY)** | TRIPOD+AI, CONSORT-AI, SPIRIT-AI, PRISMA 2020 | **wording drift** — PRISMA 2020 items 4 and 13b |
| **Paywalled (JAMA, ACP)** | PRISMA-DTA, STROBE-MR, PRISMA-ScR, PROBAST, QUADAS-2 | **structural** — an instrument that was not the instrument; all 30 sub-items dropped; a renumbered checklist; an invented section |

Every structural defect came from a file whose source was behind a paywall. Where the table could be opened, it was transcribed. Where it could not, someone reconstructed it from the base instrument or from memory — and that is exactly where invented sections, dropped sub-items and closed numbering gaps come from.

Extensions remain where a reconstruction does the most damage, because an extension is *defined* by modifying its base — adding, deleting, renumbering. Reconstruct it and those modifications are the first thing lost. But the extension label is a symptom; **paywall status is the predictor**, and it predicts risk in the 35 unaudited files far better.

## One improvement to both files

The statements distinguish two kinds of AI item and the files did not:

- an **Extension** is a *new* reporting requirement the base instrument does not contain;
- an **Elaboration** clarifies how an *existing* base item applies when the intervention involves AI.

Both are assessed, but only Extensions are additional obligations. Reporting an Elaboration as though CONSORT 2010 or SPIRIT 2013 had been silent on it overstates what the extension added. Elaborations are now marked **(E)**, and each file records what it was verified against.

## Running total

**15 of 48 audited; 11 needed correction.** 8 PRs.

## Verification

`python3 scripts/run_ci_mirror.py` — **238/238 gates pass**. No count change (documentation only).