### PR TITLE
Checklist fidelity 9/N: a gate that makes every checklist say what it is and what was checked

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -421,6 +421,15 @@ jobs:
       - name: Run clean-data reverse-coding test
         run: bash skills/clean-data/tests/test_reverse_coding.sh
 
+      - name: Run check_checklist_provenance.py (a checklist must say what it is and what was checked)
+        run: python3 scripts/check_checklist_provenance.py --strict
+
+      - name: Checklist-provenance backlog ratchet (the list may only shrink)
+        run: python3 scripts/check_checklist_provenance.py --audit-backlog
+
+      - name: Run checklist-provenance challenge (a bare "Verified" claim must fail)
+        run: bash scripts/checklist_provenance_challenge/verify.sh
+
       - name: Run lit-sync poll-logic test
         run: bash skills/lit-sync/tests/test_poll_logic.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,48 @@
   assumed correlation to be stated and varied, since primary studies almost never report it. DTA
   was already covered by the bivariate/HSROC requirement; nothing else was.
 
+### Added
+
+- **A gate that makes every vendored checklist say what it is and what was checked.**
+  `scripts/check_checklist_provenance.py`, wired to CI with a challenge card. It requires four
+  declarations per file — **version, source with DOI, licence, and verification status** — and it
+  fails a file that claims **"Verified"** without naming what it was compared against. That exact
+  shape appeared twice in this audit (`STROBE_MR.md`, `PRISMA_ScR.md`); between them those two files
+  were wrong in ten ways under their stamps. **A file that honestly says "not compared" passes** —
+  the gate is about honesty, not about having done the work.
+
+  On first run it found **two more bare claims nobody had spotted by hand**: `QUADAS_C.md` and
+  `REMARK.md`.
+
+  **What it deliberately does not do.** It never reads the instrument. It cannot: the sources are
+  copyrighted and cannot ship here, so CI can never re-derive content. Automating even the *DOIs*
+  was tried and abandoned — a Crossref bibliographic query returned a **Who's Who biography** for
+  NOS, a **Letter to the Editor** for ROBIS, and a **code listing** for QUADAS-C, all above the
+  similarity threshold that looked reasonable. Writing those in would have mass-produced the exact
+  defect this audit exists to remove. The gate's scope is the honest one: declarations, not content.
+
+  **Backlog ratchet.** 32 files predate the gate and several need a DOI read off the actual article.
+  They are named in a `BACKLOG` set: a file *not* on the list must satisfy every declaration, so new
+  files comply from the start; a listed file is reported but does not block. `--audit-backlog` fails
+  if an entry has quietly become compliant and was not removed, so the list can only shrink and
+  cannot decay into a rubber stamp. It earned its keep immediately — it caught six entries that were
+  already compliant when the list was first written.
+
+  The challenge card builds its fixtures at runtime (this repository ships no deliberately
+  undeclared checklist) and asserts **exit codes**, including that an empty input directory exits 2
+  rather than reporting success. Two of its eight cases are the real defect shapes; against a gate
+  without the check they fail.
+
+  **The first draft of this gate rejected four files whose wording was correct** — it demanded the
+  word "verified" and broke on markdown emphasis inside `has **not** been compared`. That is this
+  repository's dominant historical defect, a checker that accepts only its own preferred notation,
+  reproduced by the person auditing it. It now matches against a de-emphasised copy and accepts the
+  notation the files actually use. A later draft also fired on an item description reading "when
+  groups are **compared**"; a verification *claim* is now the word itself, and ordinary prose is not
+  a claim.
+
+  **241 gates** (was 238).
+
 ### Changed
 
 - **CONSORT-AI and SPIRIT-AI verified clean — and they correct the pattern this audit had been

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -743,8 +743,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_2020_Abstracts.md",
-      "size": 5803,
-      "sha256": "77cb1edb0cbddfa956e0b2273ca25eb524a8cc3d1674cb47826158df1d6ccca5"
+      "size": 5926,
+      "sha256": "bd81f26fcd4ab6c4ead3de8fb6c0236331aa5d195ddbefcce8e9662b9559084b"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_DTA.md",

--- a/scripts/check_checklist_provenance.py
+++ b/scripts/check_checklist_provenance.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Every vendored checklist must declare what it is, where it came from, and what was checked.
+
+This gate exists because of an audit in which 11 of 15 vendored checklists needed correction.
+Four of them were structurally wrong — one was not the instrument it named, one had dropped all
+30 of its sub-items, one had renumbered the guideline, one carried a section that exists in no
+version of the tool. Two of those four carried a dated **"Verified"** line.
+
+What that taught: a verification claim asserts nothing unless it records *what it was compared
+against*. So this gate does not check content — it cannot, because the sources are copyrighted and
+cannot ship here (see LICENSES.md). It checks that each file makes four declarations honestly:
+
+  1. VERSION      which edition of the instrument this is
+  2. SOURCE       a citation, with a DOI where one exists
+  3. LICENCE      the source's licence, or an explicit statement that none was found
+  4. VERIFICATION either what it was compared against, or an explicit NOT VERIFIED
+
+A file that says "not verified" passes. A file that says "verified" without naming what it was
+compared against FAILS — that is the exact shape that failed twice.
+
+Stdlib only. Usage:
+    python3 scripts/check_checklist_provenance.py [--strict] [--dir DIR]
+
+Exit 0 when every file declares all four (or with --strict, exit 1 on any violation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DIR = ROOT / "skills" / "check-reporting" / "references" / "checklists"
+
+# Header region: declarations must be near the top, where a reader meets them before the items.
+HEADER_LINES = 40
+
+# A label may be written "Version:", "**Version:**", "- **Version:**" — accept the notation the
+# repository actually uses rather than one canonical spelling. (A checker that accepts only its own
+# generator's output is this repository's dominant historical defect.)
+def _label(field: str) -> re.Pattern[str]:
+    return re.compile(rf"^[-*\s>]*\**\s*{field}\s*\**\s*[:—-]", re.I | re.M)
+
+
+VERSION_RE = _label("version")
+SOURCE_RE = _label("source|citation|reference")
+LICENCE_RE = _label("licen[cs]e|licensing|fidelity and licen[cs]e")
+DOI_RE = re.compile(r"\b10\.\d{4,9}/\S+", re.I)
+
+# Licence may also be stated inline in a fidelity paragraph rather than as a labelled field.
+LICENCE_INLINE_RE = re.compile(
+    r"\bCC[ -]?BY(?:[ -]?NC)?(?:[ -]?SA)?\b|\bCC0\b|public domain|no open licence|"
+    r"no open license|no Creative Commons|©",
+    re.I,
+)
+
+# Markdown emphasis lands inside these phrases in real files ("has **not** been compared"),
+# so match against a de-emphasised copy. A checker that only accepts its own preferred notation
+# is this repository's dominant historical defect — and the first draft of this gate rejected
+# four files whose wording was correct, for exactly that reason.
+EMPHASIS_RE = re.compile(r"[*_`]+")
+
+
+def deemphasise(s: str) -> str:
+    return re.sub(r"\s+", " ", EMPHASIS_RE.sub("", s))
+
+
+# A verification CLAIM is the word itself. Bare "compared"/"checked" are ordinary prose — an item
+# description reading "when groups are compared" is not a claim about this file, and an earlier
+# draft of this gate flagged exactly that. Those verbs count only inside the object pattern below.
+VERIFIED_CLAIM_RE = re.compile(r"\bverif(?:ied|ication|y)\b", re.I)
+# What makes a claim answerable: it names the artifact compared against.
+VERIFIED_OBJECT_RE = re.compile(
+    r"\b(?:verif\w*|compared|checked)\b[^.\n]{0,160}?\b(?:against|with|from)\b[^.\n]{0,200}?"
+    r"(statement|checklist|table|article|supplement|supplements|PDF|PMC|XML|official|published|source)",
+    re.I,
+)
+NOT_VERIFIED_RE = re.compile(
+    r"\bnot\s+been\s+(?:compared|verified|checked)\b|\bnot\s+verified\b|\bunverified\b|"
+    r"\bhas\s+not\s+been\s+checked\b|\bneither\s+confirmed\s+nor\s+corrected\b",
+    re.I,
+)
+
+
+class Finding:
+    __slots__ = ("path", "code", "message")
+
+    def __init__(self, path: Path, code: str, message: str) -> None:
+        self.path, self.code, self.message = path, code, message
+
+    def __str__(self) -> str:
+        return f"  {self.code:22} {self.path.name}\n{' ' * 26}{self.message}"
+
+
+def check_file(path: Path) -> list[Finding]:
+    text = path.read_text(encoding="utf-8")
+    head = "\n".join(text.splitlines()[:HEADER_LINES])
+    out: list[Finding] = []
+
+    if not VERSION_RE.search(head):
+        out.append(Finding(path, "NO_VERSION", "no Version: declaration in the first "
+                                               f"{HEADER_LINES} lines — which edition is this?"))
+    if not SOURCE_RE.search(head):
+        out.append(Finding(path, "NO_SOURCE", "no Source:/Citation:/Reference: declaration — "
+                                              "a file with no named source cannot be audited."))
+    elif not DOI_RE.search(head):
+        out.append(Finding(path, "NO_DOI", "a source is cited but carries no DOI. Add one, or state "
+                                           "why the instrument has none (e.g. a web-only tool)."))
+
+    if not (LICENCE_RE.search(head) or LICENCE_INLINE_RE.search(head)):
+        out.append(Finding(path, "NO_LICENCE", "no licence statement. 'Free to read' is not 'free to "
+                                               "reuse'; say which it is, or that none was found."))
+
+    flat = deemphasise(text)
+    claims = VERIFIED_CLAIM_RE.search(flat)
+    stated = VERIFIED_OBJECT_RE.search(flat)
+    disclaims = NOT_VERIFIED_RE.search(flat)
+    if not claims and not stated and not disclaims:
+        out.append(Finding(path, "NO_VERIFICATION", "says nothing about whether it was ever compared "
+                                                    "against the published source. Silence reads as "
+                                                    "'verified'. State it either way."))
+    elif claims and not disclaims and not stated:
+        out.append(Finding(path, "BARE_VERIFIED_CLAIM",
+                           "claims verification without naming what it was compared against. Two "
+                           "files carried exactly this and were wrong in ten ways between them. "
+                           "Write 'verified against <the artifact>'."))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Backlog ratchet.
+#
+# 46 of 48 files predate this gate and cannot be brought into compliance by
+# editing alone: several need a DOI that must be read off the actual article.
+# Resolving them automatically was tried and abandoned — a Crossref
+# bibliographic query returned a Who's Who biography for NOS, a Letter to the
+# Editor for ROBIS, and a code listing for QUADAS-C, all above the similarity
+# threshold. Writing those in would have mass-produced the exact defect this
+# audit exists to remove.
+#
+# So the backlog is named here instead. The rules:
+#   * a file NOT in this list must satisfy every declaration (new files included)
+#   * a file in this list is reported but does not fail the build
+#   * the list may only SHRINK — `--audit-backlog` fails if an entry has become
+#     compliant and was not removed, so it cannot quietly become a rubber stamp
+# ---------------------------------------------------------------------------
+BACKLOG = {
+    "AMSTAR2.md", "ARRIVE_2.md", "CARE.md", "CHEERS_2022.md", "CLAIM_2024.md",
+    "CLEAR.md", "CONSORT.md", "COSMIN_RoB.md",     "DECIDE_AI.md", "GATHER.md", "GRRAS.md", "MI_CLEAR_LLM.md", "MOOSE.md",
+    "NOS.md", "PGS_RS.md", "PRISMA_P.md", "PROBAST_AI.md", "QUADAS_C.md",
+    "RECORD.md", "REMARK.md", "ROBINS_E.md", "ROBIS.md", "ROB_ME.md",
+    "RoB_NMA.md", "SPIRIT.md", "SQUIRE_2.md",     "STARD.md", "STROBE.md", "SWiM.md", "TARGET.md",
+    "TRIPOD.md", "TRIPOD_LLM.md", }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on any violation (CI uses this; without it the gate reports only)")
+    ap.add_argument("--dir", default=str(DEFAULT_DIR), help="directory of checklist .md files")
+    ap.add_argument("--audit-backlog", action="store_true",
+                    help="fail if a backlogged file is now compliant and was not removed from the "
+                         "list, or if the list names a file that does not exist")
+    args = ap.parse_args()
+
+    d = Path(args.dir)
+    if not d.is_dir():
+        print(f"ERROR: not a directory: {d}", file=sys.stderr)
+        return 2
+
+    files = sorted(p for p in d.glob("*.md") if p.name != "README.md")
+    if not files:
+        # An empty input set is the classic way a gate passes while checking nothing.
+        print(f"ERROR: no checklist files found under {d} — refusing to report success.",
+              file=sys.stderr)
+        return 2
+
+    per_file: dict[str, list[Finding]] = {}
+    for p in files:
+        per_file[p.name] = check_file(p)
+
+    names = {p.name for p in files}
+    stale = sorted(BACKLOG - names)
+    cleared = sorted(n for n in BACKLOG & names if not per_file[n])
+    if args.audit_backlog:
+        problems = []
+        if stale:
+            problems.append(f"BACKLOG names {len(stale)} file(s) that do not exist: {stale}")
+        if cleared:
+            problems.append(f"{len(cleared)} backlogged file(s) now comply and must be removed from "
+                            f"BACKLOG so the ratchet holds: {cleared}")
+        if problems:
+            print("BACKLOG_DRIFT")
+            for pr in problems:
+                print("  " + pr)
+            return 1
+        print(f"OK: backlog is {len(BACKLOG & names)} file(s); none has silently become compliant.")
+        return 0
+
+    findings: list[Finding] = [f for n in sorted(per_file) for f in per_file[n]]
+    blocking = [f for f in findings if f.path.name not in BACKLOG]
+
+    print("=" * 41)
+    print(" Checklist Provenance")
+    print("=" * 41)
+    print(f"  scanned: {len(files)} checklist file(s) in {d.relative_to(ROOT) if d.is_relative_to(ROOT) else d}")
+
+    print(f"  backlog: {len(BACKLOG & names)} file(s) predate this gate (reported, not blocking)")
+
+    if not findings:
+        print(f"\nOK: all {len(files)} files declare version, source, licence and verification status.")
+        return 0
+
+    by_code: dict[str, int] = {}
+    for f in findings:
+        by_code[f.code] = by_code.get(f.code, 0) + 1
+    bad_files = {f.path for f in findings}
+
+    print(f"\n{len(findings)} undeclared item(s) across {len(bad_files)} file(s):\n")
+    for f in findings:
+        print(f)
+    print("\n  " + "  ".join(f"{k}={v}" for k, v in sorted(by_code.items())))
+    print("\nThis gate does not read the instrument — the sources are copyrighted and cannot ship")
+    print("here. It only requires each file to say what it is and what was checked.")
+
+    if blocking:
+        print(f"\n{len(blocking)} of these are in files NOT on the backlog and must be fixed.")
+    else:
+        print("\nEvery finding is in a backlogged file. No non-backlogged file is undeclared.")
+    return 1 if (args.strict and blocking) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checklist_provenance_challenge/verify.sh
+++ b/scripts/checklist_provenance_challenge/verify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Challenge card for check_checklist_provenance.py
+#
+# Fixtures are built at runtime in a temp directory so this repository ships no
+# deliberately-undeclared checklist of its own. Every case asserts the gate's
+# EXIT CODE, not its chatter — a gate that prints a complaint and exits 0 is the
+# failure this repository keeps re-learning.
+#
+# The negative controls are the two shapes that actually occurred:
+#   * a file claiming "Verified" with nothing named as the object of the check
+#   * a file that says nothing at all about verification
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HERE/../check_checklist_provenance.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+check() { # name expected_rc actual_rc
+  if [ "$2" = "$3" ]; then printf '  PASS  %s (rc=%s)\n' "$1" "$3"; pass=$((pass+1))
+  else printf '  FAIL  %s (expected rc=%s, got %s)\n' "$1" "$2" "$3"; fail=$((fail+1)); fi
+}
+
+run() { python3 "$GATE" --strict --dir "$1" >/dev/null 2>&1; echo $?; }
+
+# ---------------------------------------------------------------- positive
+mkdir -p "$TMP/good"
+cat > "$TMP/good/GOOD.md" <<'EOF'
+# Good Checklist
+Version: GOOD 2020 — 3 items.
+Source: Someone A, Someone B. A guideline. *Journal* 2020;1:1-2 (DOI 10.1000/example.1).
+Licence: CC BY 4.0.
+Verification: all 3 items compared against the official checklist table in the statement.
+EOF
+check "compliant file passes" 0 "$(run "$TMP/good")"
+
+# ------------------------------------------------- negative control 1: bare claim
+mkdir -p "$TMP/bare"
+cat > "$TMP/bare/BARE.md" <<'EOF'
+# Bare Claim Checklist
+Version: BARE 2020.
+Source: Someone A. A guideline. *Journal* 2020;1:1-2 (DOI 10.1000/example.2).
+Licence: CC BY 4.0.
+Verified 2026-06-30.
+EOF
+check "bare 'Verified' with no object FAILS" 1 "$(run "$TMP/bare")"
+
+# ------------------------------------------- negative control 2: silent on verification
+mkdir -p "$TMP/silent"
+cat > "$TMP/silent/SILENT.md" <<'EOF'
+# Silent Checklist
+Version: SILENT 2020.
+Source: Someone A. A guideline. *Journal* 2020;1:1-2 (DOI 10.1000/example.3).
+Licence: CC BY 4.0.
+EOF
+check "silence about verification FAILS" 1 "$(run "$TMP/silent")"
+
+# ------------------------------------------- negative control 3: no licence, no DOI
+mkdir -p "$TMP/thin"
+cat > "$TMP/thin/THIN.md" <<'EOF'
+# Thin Checklist
+Reference: Someone A. A guideline. Journal 2020.
+Verification: compared against the published statement table.
+EOF
+check "missing version, DOI and licence FAILS" 1 "$(run "$TMP/thin")"
+
+# ------------------------------------------------------ honest 'not verified' passes
+mkdir -p "$TMP/honest"
+cat > "$TMP/honest/HONEST.md" <<'EOF'
+# Honest Checklist
+Version: HONEST 2020.
+Source: Someone A. A guideline. *Journal* 2020;1:1-2 (DOI 10.1000/example.4).
+Licence: no open licence found.
+This file has **not** been compared against the published statement.
+EOF
+check "explicit 'not compared' passes (honesty is the point)" 0 "$(run "$TMP/honest")"
+
+# ----------------------------------------- notation the repo actually uses is accepted
+mkdir -p "$TMP/notation"
+cat > "$TMP/notation/NOTATION.md" <<'EOF'
+# Notation Checklist
+
+**Preferred Reporting Items**
+- **Version:** NOTATION 2021
+- **Citation:** Someone A. *Journal* 2021;2:3-4. doi:10.1000/example.5
+- **Licence:** CC BY 4.0
+
+> **Fidelity.** Every item was **compared** against the official **checklist** table.
+EOF
+check "bold/list label notation is accepted" 0 "$(run "$TMP/notation")"
+
+# ------------------------------------------------ an empty set must not report success
+mkdir -p "$TMP/empty"
+check "empty directory refuses to pass" 2 "$(run "$TMP/empty")"
+
+# ----------------------------------------------------------- backlog ratchet self-test
+python3 "$GATE" --audit-backlog >/dev/null 2>&1
+check "backlog ratchet: no entry has silently become compliant" 0 "$?"
+
+printf '\nSummary: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/skills/check-reporting/references/checklists/PRISMA_2020_Abstracts.md
+++ b/skills/check-reporting/references/checklists/PRISMA_2020_Abstracts.md
@@ -5,6 +5,8 @@ Version: PRISMA 2020 for Abstracts — 12 items, grouped by the sections of a st
 Source: Page MJ, McKenzie JE, Bossuyt PM, Boutron I, Hoffmann TC, Mulrow CD, et al. The PRISMA 2020
 statement: an updated guideline for reporting systematic reviews. *BMJ* 2021;372:n71
 (DOI 10.1136/bmj.n71). Published under CC BY 4.0; item text is reproduced with attribution.
+Verification: all 12 items were transcribed from, and checked against, the abstract checklist
+published in that statement.
 
 Apply to the **abstract of a systematic review or meta-analysis**. This is a separate instrument
 from the 27-item main checklist in `PRISMA_2020.md`, not a subset of it: the main checklist devotes


### PR DESCRIPTION
The mechanism the previous eight PRs kept pointing at. **241 gates** (was 238).

## What it requires

Four declarations per checklist file — **version**, **source with DOI**, **licence**, **verification status** — and it **fails a file that claims "Verified" without naming what it was compared against**.

That exact shape appeared twice in this audit: `STROBE_MR.md` and `PRISMA_ScR.md` both carried dated "Verified" lines, and between them were wrong in ten ways under those stamps. **A file that honestly says "not compared" passes.** The gate is about honesty, not about having done the work.

On first run it found **two more bare claims nobody had spotted by hand**: `QUADAS_C.md` and `REMARK.md`.

## What it deliberately does not do

**It never reads the instrument.** It cannot — the sources are copyrighted and cannot ship here, so CI can never re-derive content. Naming that limit is part of the design rather than a gap in it.

Automating even the *DOIs* was tried and abandoned. A Crossref bibliographic query returned:

| File | What Crossref gave back |
|---|---|
| `NOS.md` | a **Who's Who biography** of a researcher at an Ottawa institute |
| `ROBIS.md` | a **Letter to the Editor** |
| `QUADAS_C.md` | a **code listing** from a PeerJ CS paper |
| `STROBE.md` | an unrelated repository's checklist copy |

— all above a similarity threshold that had looked reasonable, while the *correct* matches for RECORD, TRIPOD and PRISMA-P scored below it. Writing those in would have mass-produced the exact defect this audit exists to remove. Nothing was auto-applied.

## Backlog ratchet

32 files predate the gate, and several need a DOI read off the actual article. They are named in a `BACKLOG` set:

- a file **not** on the list must satisfy every declaration → **new files comply from the start**
- a listed file is reported but does not block
- `--audit-backlog` **fails if an entry has quietly become compliant and was not removed**, so the list can only shrink and cannot decay into a rubber stamp

It earned its keep immediately: it caught **six entries that were already compliant** when the list was first written.

## The challenge card

Eight cases, fixtures built at runtime (this repository ships no deliberately undeclared checklist), asserting **exit codes** rather than chatter:

```
PASS  compliant file passes (rc=0)
PASS  bare 'Verified' with no object FAILS (rc=1)
PASS  silence about verification FAILS (rc=1)
PASS  missing version, DOI and licence FAILS (rc=1)
PASS  explicit 'not compared' passes (honesty is the point) (rc=0)
PASS  bold/list label notation is accepted (rc=0)
PASS  empty directory refuses to pass (rc=2)
PASS  backlog ratchet: no entry has silently become compliant (rc=0)
```

Two of them are the real defect shapes. An empty input directory exits **2**, not 0 — an empty input set is how a gate reports success while checking nothing.

## Two bugs I put in it, both this repository's signature defect

**The first draft rejected four files whose wording was correct.** It demanded the literal word "verified" and broke on markdown emphasis inside `has **not** been compared`. That is a checker that accepts only its own preferred notation — the dominant historical defect here — reproduced by the person auditing for it.

**A later draft fired on an item description** reading "when groups are **compared**, which group the effect favours". Ordinary prose is not a claim about the file. A verification claim is now the word itself, matched against a de-emphasised copy; `compared`/`checked` count only inside the "against &lt;artifact&gt;" pattern.

Both are noted in the source so the next person does not re-introduce them.

## Verification

`python3 scripts/run_ci_mirror.py` — **241/241 gates pass**.