### PR TITLE
Checklist fidelity 10/N: MOOSE verified 35/35 — and the second over-generalisation, corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,26 @@
   additional obligations — reporting an Elaboration as though CONSORT 2010 or SPIRIT 2013 had been
   silent overstates what the extension added. Elaborations are now marked **(E)**.
 
+### Changed
+
+- **MOOSE verified against the published table — clean, 35/35 — and the backlog shrinks to 31.**
+  Read through institutional access (Stroup et al., *JAMA* 2000;283(15):2008-2012). The item set,
+  the six groups and their counts (Background 6, Search strategy 10, Methods 8, Results 4,
+  Discussion 3, Conclusions 4), and the order all match. Nothing missing, nothing added.
+
+  The file now declares its DOI, its licence position (*JAMA*, no open licence — the descriptions
+  are an in-house summary, not the published wording) and what it was verified against, so it
+  leaves the provenance gate's backlog. **This is the ratchet doing the job it exists for:** the
+  backlog can only shrink, and `--audit-backlog` fails if an entry becomes compliant and is not
+  removed.
+
+  MOOSE also sharpens a claim this audit has been making. It is **paywalled and correct**, so
+  "paywalled" is not a rule — the honest statement is that **every structural defect found so far
+  occurred in a paywalled file, while not every paywalled file is defective**. A risk factor, not a
+  law. The audit has now over-generalised twice (first "extensions are the dangerous class", then
+  "paywalled sources are"), and both times the correction came from widening the sample rather than
+  from reasoning about it.
+
 ### Fixed
 
 - **`PRISMA_ScR.md` had renumbered the instrument, and 10 of its 22 items carried the wrong number.**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -723,8 +723,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/MOOSE.md",
-      "size": 6191,
-      "sha256": "73cde9184e71bc8f39fef12d194cc9e53c575266cf1515e45e78bb235121dbba"
+      "size": 6695,
+      "sha256": "592795bb92f23b4e7e436aa4acf38f7fa4f51c9d94d624ca652f661b8d507513"
     },
     {
       "path": "skills/check-reporting/references/checklists/NOS.md",

--- a/scripts/check_checklist_provenance.py
+++ b/scripts/check_checklist_provenance.py
@@ -148,7 +148,7 @@ def check_file(path: Path) -> list[Finding]:
 # ---------------------------------------------------------------------------
 BACKLOG = {
     "AMSTAR2.md", "ARRIVE_2.md", "CARE.md", "CHEERS_2022.md", "CLAIM_2024.md",
-    "CLEAR.md", "CONSORT.md", "COSMIN_RoB.md",     "DECIDE_AI.md", "GATHER.md", "GRRAS.md", "MI_CLEAR_LLM.md", "MOOSE.md",
+    "CLEAR.md", "CONSORT.md", "COSMIN_RoB.md",     "DECIDE_AI.md", "GATHER.md", "GRRAS.md", "MI_CLEAR_LLM.md",
     "NOS.md", "PGS_RS.md", "PRISMA_P.md", "PROBAST_AI.md", "QUADAS_C.md",
     "RECORD.md", "REMARK.md", "ROBINS_E.md", "ROBIS.md", "ROB_ME.md",
     "RoB_NMA.md", "SPIRIT.md", "SQUIRE_2.md",     "STARD.md", "STROBE.md", "SWiM.md", "TARGET.md",

--- a/skills/check-reporting/references/checklists/MOOSE.md
+++ b/skills/check-reporting/references/checklists/MOOSE.md
@@ -1,9 +1,16 @@
 # MOOSE Checklist
 
 **Meta-analysis Of Observational Studies in Epidemiology**
-Version: MOOSE 2000
-Source: https://doi.org/10.1001/jama.283.15.2008
-Reference: Stroup DF, Berlin JA, Morton SC, et al. Meta-analysis of observational studies in epidemiology: a proposal for reporting. JAMA. 2000;283(15):2008-2012. doi:10.1001/jama.283.15.2008
+Version: MOOSE 2000 — 35 items in six groups (Background 6, Search strategy 10, Methods 8,
+Results 4, Discussion 3, Conclusions 4).
+Source: Stroup DF, Berlin JA, Morton SC, Olkin I, Williamson GD, Rennie D, et al. Meta-analysis of
+observational studies in epidemiology: a proposal for reporting. *JAMA* 2000;283(15):2008-2012
+(DOI 10.1001/jama.283.15.2008).
+Licence: *JAMA* (© American Medical Association) — **no open licence**. The descriptions below are
+an in-house summary of what each item asks, in our own words, not the published wording.
+Verification: all 35 items were compared against the checklist table published in the statement.
+The item set, the six groups, their counts and their order all match; nothing is missing and
+nothing has been added.
 
 ## Checklist Items (35 items)
 


### PR DESCRIPTION
MOOSE read through institutional access (Stroup et al., *JAMA* 2000;283(15):2008-2012).

## Clean, 35/35

The item set, the six groups and their counts, and the order all match the published table:

| Group | Official | This file |
|---|---|---|
| Background | 6 | 6 |
| Search strategy | 10 | 10 |
| Methods | 8 | 8 |
| Results | 4 | 4 |
| Discussion | 3 | 3 |
| Conclusions | 4 | 4 |

Nothing missing, nothing added.

## The backlog shrinks — the ratchet doing its job

The file now declares its DOI, its licence position (*JAMA*, no open licence; the descriptions are an in-house summary, not the published wording), and what it was verified against. It therefore leaves the provenance gate's `BACKLOG`: **32 → 31**.

`--audit-backlog` fails if an entry becomes compliant and is not removed, so the list cannot silently rot. This is the first entry retired through the intended path.

## The audit's second over-generalisation, corrected

PR #479 replaced "extension checklists are the dangerous class" with "paywalled sources are". **MOOSE is paywalled and correct**, so that is not a rule either.

The honest statement:

> Every structural defect found so far occurred in a paywalled file. Not every paywalled file is defective.

A risk factor, not a law. Worth noting how both corrections arrived: **by widening the sample, not by reasoning about it.** The first pattern held at 4/4 and broke at 5. The second held at 5/5 and broke at 6. Neither would have been caught by thinking harder about the files already seen.

## Running total

**16 of 48 audited; 11 needed correction.** Backlog 31.

## Verification

`python3 scripts/run_ci_mirror.py` — **241/241 gates pass**, including the provenance gate's three steps and its eight-case challenge card.