### PR TITLE
Checklist fidelity 11/N: every checklist declares itself — provenance backlog is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,37 @@
   "paywalled sources are"), and both times the correction came from widening the sample rather than
   from reasoning about it.
 
+### Changed
+
+- **Every one of the 48 vendored checklists now declares what it is, where it came from, and whether
+  it has been checked. The provenance backlog is zero.**
+
+  31 files were carrying gaps — no DOI, no licence, or silence about verification. Each now states
+  all four. The facts were not guessed: **every DOI was resolved through Crossref and confirmed by
+  the title it returned**, and every licence is the Crossref `license` URL or the PMC `<license>`
+  element. Two candidate DOIs were rejected by that check — one for TARGET returned 404, and one for
+  the RoB NMA tool resolved to a paper on Kenward-Roger corrections. Both were replaced with the real
+  articles rather than shipped.
+
+  **Three files carried bare "Verified" stamps** — `GATHER.md`, `QUADAS_C.md`, `REMARK.md` — found by
+  the gate, not by hand. They now say what was and was not compared.
+
+  **What most of these files now say is "NOT VERIFIED".** 32 of 48 have not been compared against
+  their published table, and they say so in the header rather than leaving a reader to assume
+  otherwise. That is the point: the gate cannot make a checklist correct, but it can stop one from
+  implying it has been checked when it has not.
+
+  Two licence corrections fell out of the sweep:
+
+  - **ROBIS is CC BY 4.0.** `LICENSES.md` recorded "no open licence found" for it in #472; that was
+    wrong, and the Crossref record is unambiguous.
+  - **PROBAST+AI and ROBINS-E are CC BY-NC 4.0** — non-commercial, and so in the same position as
+    ROBINS-I: not redistributable verbatim under this repository's MIT licence. Both are now labelled.
+
+  The gate gains one exception it was always meant to have: **an instrument with no DOI may say so**.
+  The Newcastle-Ottawa Scale is distributed from an institute web page and has never been issued one.
+  Demanding a DOI unconditionally is how a checker pressures someone into inventing a fact.
+
 ### Fixed
 
 - **`PRISMA_ScR.md` had renumbered the instrument, and 10 of its 22 items carried the wrong number.**

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -648,38 +648,38 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/AMSTAR2.md",
-      "size": 4566,
-      "sha256": "065863e9072d1f88f660f043fe3be23c00181dffd580bb9b737a44c89ef060fb"
+      "size": 4837,
+      "sha256": "ed8483d880c40ccd9779e0c460dfcdf789654deaeead324a692c468d42ba7e51"
     },
     {
       "path": "skills/check-reporting/references/checklists/ARRIVE_2.md",
-      "size": 11181,
-      "sha256": "9f737ea8b415991df8108269f1fd53f11be36e94ff8320b5208f9046171c3d6b"
+      "size": 11730,
+      "sha256": "1d1346f9056948889828580b1f60a4ace7343dac3bd157919c1d5f446d4389eb"
     },
     {
       "path": "skills/check-reporting/references/checklists/CARE.md",
-      "size": 5746,
-      "sha256": "4bac869891f4b334cdc211409062a1dd3d6a31a0b62218ad4d9ced1a34000f77"
+      "size": 6341,
+      "sha256": "5a8a16a79900b5296f2ed8582ae9b4126bc9265798cad0cf889c58eb2fb64b8f"
     },
     {
       "path": "skills/check-reporting/references/checklists/CHEERS_2022.md",
-      "size": 8054,
-      "sha256": "830dc33cc4d74a3ebd4f024bb05fd064174002b150b363c3f3f03a13e2bd9a4f"
+      "size": 8294,
+      "sha256": "e381939bf6b857a06ad2404a2d3371875a5e39d73dda40b4565bd22fd4aa1b92"
     },
     {
       "path": "skills/check-reporting/references/checklists/CLAIM_2024.md",
-      "size": 6678,
-      "sha256": "1e9fefe06160cf1b498e6a44c8c4ae2863d66cfdeecadcaa15976e025f3c08dd"
+      "size": 6974,
+      "sha256": "abdf5dde20240bc2f33b191b084fb74741e0321f47c94141d6ac77de0e9acdf9"
     },
     {
       "path": "skills/check-reporting/references/checklists/CLEAR.md",
-      "size": 7781,
-      "sha256": "0bbfe04ffbea69bc1099086ad1489f09289ba13a3160d0f9f69e1edf75655333"
+      "size": 7970,
+      "sha256": "5811cdba2c7c0e1834c8d2438b3fb383a6a1961a30f108c72331f22d66b8a12c"
     },
     {
       "path": "skills/check-reporting/references/checklists/CONSORT.md",
-      "size": 6629,
-      "sha256": "339edfb5cd3787d21b9b53d73ee7475f53e15e2b67f4240322d1f0a605a606d4"
+      "size": 7079,
+      "sha256": "6f93c173e37fa31abeaa70a709ed984af32ed0d4eac13178ac8e904a367b8955"
     },
     {
       "path": "skills/check-reporting/references/checklists/CONSORT_AI.md",
@@ -693,8 +693,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/COSMIN_RoB.md",
-      "size": 5535,
-      "sha256": "d5c677b029a9f7a8ecff6cd2cb9d532149d29de6026b89bc7d4d4d8e1571be94"
+      "size": 6055,
+      "sha256": "9c87adc8c3b7828121383e81e2f09f67384fff540299aad13c687f1a823cb2cb"
     },
     {
       "path": "skills/check-reporting/references/checklists/CROSS.md",
@@ -703,23 +703,23 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/DECIDE_AI.md",
-      "size": 5321,
-      "sha256": "f2ad5827ecc061a04b4e33dc307a85b5eaf9031b2a34f8db9be3ed7132ed88b6"
+      "size": 5510,
+      "sha256": "fdc2462c224d4a1265fab4ef2300d4d1ac3288106ea8ad3b68472310165c308f"
     },
     {
       "path": "skills/check-reporting/references/checklists/GATHER.md",
-      "size": 6271,
-      "sha256": "71a950e0c69f37d7b3b5d3b5f2a091dd1c54c7b8197e3af3e83c52752fd254c2"
+      "size": 6772,
+      "sha256": "f4d1bc97326864035988f21f3a64ad5dc003c58a399e34a82507c6d732a50972"
     },
     {
       "path": "skills/check-reporting/references/checklists/GRRAS.md",
-      "size": 5214,
-      "sha256": "f7a533e5dfc4cfced60fd6d26c1f1f1072cb23d4e89c9f4d3787d5de2fb15543"
+      "size": 5469,
+      "sha256": "bbcab67e5c4da74ec72805ec1f46e79dde24071c8a0018c616bd5cc187d92ad9"
     },
     {
       "path": "skills/check-reporting/references/checklists/MI_CLEAR_LLM.md",
-      "size": 8468,
-      "sha256": "8e369bd75d4d2c6646693f856c719825ff4135d231c754518575116ea8f7a112"
+      "size": 8657,
+      "sha256": "d39193b755f71c47986dd06d7fbee049f030874184ca44131bdaf0625a932c64"
     },
     {
       "path": "skills/check-reporting/references/checklists/MOOSE.md",
@@ -728,13 +728,13 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/NOS.md",
-      "size": 2725,
-      "sha256": "ebdbf8f3024d74e74ce0dbc54d946388377ce800e8f2d695440cf9cf7e55a43a"
+      "size": 3338,
+      "sha256": "44c2a0161189cf7583e57643800286b102379bd0ac2c6cdb5c500ad3deec40b3"
     },
     {
       "path": "skills/check-reporting/references/checklists/PGS_RS.md",
-      "size": 6030,
-      "sha256": "aa4912c11f980c90b1945d45849f175febd81d798f99df9d37cfa624eab6229f"
+      "size": 6369,
+      "sha256": "cd8576f104a0a6ca1117f4c05742066082c1341682bdd30e19b6a108aead2fe7"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_2020.md",
@@ -753,8 +753,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_P.md",
-      "size": 4780,
-      "sha256": "4727f5970496e5fe4928b426e3eff72a1181e6ae83ea0163cd5b4ec623aa8282"
+      "size": 5290,
+      "sha256": "11103b1c6c9570a4a5b7ce8536c5ba0413a6ead54ff0e08f3c6f81df76dea3a3"
     },
     {
       "path": "skills/check-reporting/references/checklists/PRISMA_ScR.md",
@@ -768,8 +768,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/PROBAST_AI.md",
-      "size": 5644,
-      "sha256": "d446b9b12141071a18b0d82b15fdd161ad4e84c36fc1f1cbbb9860d6c1214f9c"
+      "size": 6063,
+      "sha256": "0789104531cf1b4f9f26aba1c282cb6c85529bc74290a919381a319ac87e2e05"
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS2.md",
@@ -778,23 +778,23 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS_C.md",
-      "size": 7571,
-      "sha256": "f3527f32851fbf4d446e7f9961b134d455c2fa19d7615ea65168ae0479fb6685"
+      "size": 8115,
+      "sha256": "4f7b4a3ef029896dadf3f1ade76c1f2c8b22a78fe358cf53b78c3e9d02454914"
     },
     {
       "path": "skills/check-reporting/references/checklists/RECORD.md",
-      "size": 6530,
-      "sha256": "186000d9cd72e025ce483995735c05400450d9356f89f8f95b855d5815e925fa"
+      "size": 6788,
+      "sha256": "1500b2584f32000be5e9186fe9643f9826fb615a5639c83cba1cad917279aa4e"
     },
     {
       "path": "skills/check-reporting/references/checklists/REMARK.md",
-      "size": 6020,
-      "sha256": "bfe8781663c33fc8a906d2d07f790f7237012ca100351bf2676e0d1f7ec89e11"
+      "size": 6692,
+      "sha256": "6186d680d1dda3f426ea00685e577ac78661caeb4d49bd65b83c2e83c96610d0"
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBINS_E.md",
-      "size": 8206,
-      "sha256": "268b634aeead53804b6d278d38398fa10575887b440ee882ed1ee5108f8561b8"
+      "size": 8553,
+      "sha256": "6b55b3f348ab9f04bf57e7afec9c1241391694753ade34d73c540f737ecaf780"
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBINS_I.md",
@@ -803,13 +803,13 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBIS.md",
-      "size": 5640,
-      "sha256": "af838d6c3cc1565421450aeb3bf66df6960c7fb2633eb1bfd1e5e14abad9f7df"
+      "size": 6237,
+      "sha256": "1508a9ecd8b10f20eff59df2ec163a31a87ff1a125464ad1952d3714b511e9f7"
     },
     {
       "path": "skills/check-reporting/references/checklists/ROB_ME.md",
-      "size": 6768,
-      "sha256": "252612c191a42f9a577a5a01db31eb9dc78887ccfcedd9c8cd289cfa77dd3e60"
+      "size": 7319,
+      "sha256": "20918a7d00dacd919932fff4b6736243fad3d027819e9d30c5d84d375fa847a3"
     },
     {
       "path": "skills/check-reporting/references/checklists/RoB2.md",
@@ -818,13 +818,13 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/RoB_NMA.md",
-      "size": 4678,
-      "sha256": "78502dae50b6ea130ccc61029878449b3cdd87ea5cf16ea4eb0b91a0230c3cb6"
+      "size": 5120,
+      "sha256": "c29f5fc99f64560e0e0294b482bdde70f5f01f916a0e6ad1c886e74fa56484b0"
     },
     {
       "path": "skills/check-reporting/references/checklists/SPIRIT.md",
-      "size": 10562,
-      "sha256": "ecd48ad87a66173b57392936df54042b8960a74777cc4758d8930633843f6956"
+      "size": 11008,
+      "sha256": "29902802575b06aeabe4e45702149103d1a93cef225b0fd3d0972efbdea4fd6c"
     },
     {
       "path": "skills/check-reporting/references/checklists/SPIRIT_AI.md",
@@ -833,8 +833,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/SQUIRE_2.md",
-      "size": 5730,
-      "sha256": "d145e612c8fb7a182d8212257790f2599cd218810a57ae97c0c6309cd6c4f613"
+      "size": 5974,
+      "sha256": "3693117194d0cc46719b828354bc8d2126945b5bf9a5c710d318d7ed9e3855c8"
     },
     {
       "path": "skills/check-reporting/references/checklists/SRQR.md",
@@ -843,8 +843,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/STARD.md",
-      "size": 6440,
-      "sha256": "afa913b1059945513e83cf146281b5f58cff3e856ca2f74be0ce3cdf60289b60"
+      "size": 6926,
+      "sha256": "c69579312a8d9905dbf04e7fe2bb2ff14b8e06f079550c687e260349dd87275c"
     },
     {
       "path": "skills/check-reporting/references/checklists/STARD_AI.md",
@@ -853,8 +853,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/STROBE.md",
-      "size": 6185,
-      "sha256": "4c7752f7c086a737f7f74935897bc5dcd0dbb12e3529006ecf7207a78f1005f3"
+      "size": 6689,
+      "sha256": "8e29276d9dc8a2b466c3cea26d3d67547f5159a653141b9b8ac57fbcdf295a7d"
     },
     {
       "path": "skills/check-reporting/references/checklists/STROBE_MR.md",
@@ -863,18 +863,18 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/SWiM.md",
-      "size": 3516,
-      "sha256": "118171e304491812709ee2311b1b968f8caac92e689431622a8fb81b2684e970"
+      "size": 3752,
+      "sha256": "046c4331ce92aa0bf7775d169737a6b517dc72b99cd445e210cf6acaf3b19d40"
     },
     {
       "path": "skills/check-reporting/references/checklists/TARGET.md",
-      "size": 7406,
-      "sha256": "0ddbbe10245d902a191a23a5832d24ada3515314e3b08ce562dd12200356f452"
+      "size": 7666,
+      "sha256": "c9bbf72a8a44284ec5b1e88609b99359755483541e9c4f14d3bc6026de761437"
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD.md",
-      "size": 8625,
-      "sha256": "e0d9de4afe9ba3809ab66f1ecca077605ad500a37635459e423ba8bca3e410d5"
+      "size": 9129,
+      "sha256": "90bb1334304dc893360b08fef6c521794c05060a10b74c3344e5d8c4281f8256"
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_AI.md",
@@ -883,8 +883,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/TRIPOD_LLM.md",
-      "size": 10333,
-      "sha256": "82724c868b49f8f5b0e6fa78af8468fd36e124697a941357b57ffff5e7c4c870"
+      "size": 10738,
+      "sha256": "d9a4f8f610dfd6bdb99f83a9c39c765f32e387b4f5734120639a351772cd867b"
     },
     {
       "path": "skills/check-reporting/references/critical_item_floor.md",
@@ -2718,8 +2718,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/NOS.md",
-      "size": 2725,
-      "sha256": "ebdbf8f3024d74e74ce0dbc54d946388377ce800e8f2d695440cf9cf7e55a43a"
+      "size": 3338,
+      "sha256": "44c2a0161189cf7583e57643800286b102379bd0ac2c6cdb5c500ad3deec40b3"
     },
     {
       "path": "skills/meta-analysis/references/checklists/PRISMA_DTA.md",

--- a/scripts/check_checklist_provenance.py
+++ b/scripts/check_checklist_provenance.py
@@ -48,6 +48,10 @@ VERSION_RE = _label("version")
 SOURCE_RE = _label("source|citation|reference")
 LICENCE_RE = _label("licen[cs]e|licensing|fidelity and licen[cs]e")
 DOI_RE = re.compile(r"\b10\.\d{4,9}/\S+", re.I)
+# Some instruments genuinely have no DOI — the Newcastle-Ottawa Scale is distributed from an
+# institute web page and was never issued one. The requirement is a DOI *or* a statement of why
+# there is none; demanding a DOI unconditionally would push someone to invent one.
+NO_DOI_EXPLAINED_RE = re.compile(r"no\s+DOI\b|never\s+been\s+issued\s+one|has\s+no\s+DOI", re.I)
 
 # Licence may also be stated inline in a fidelity paragraph rather than as a labelled field.
 LICENCE_INLINE_RE = re.compile(
@@ -105,7 +109,7 @@ def check_file(path: Path) -> list[Finding]:
     if not SOURCE_RE.search(head):
         out.append(Finding(path, "NO_SOURCE", "no Source:/Citation:/Reference: declaration — "
                                               "a file with no named source cannot be audited."))
-    elif not DOI_RE.search(head):
+    elif not DOI_RE.search(head) and not NO_DOI_EXPLAINED_RE.search(deemphasise(head)):
         out.append(Finding(path, "NO_DOI", "a source is cited but carries no DOI. Add one, or state "
                                            "why the instrument has none (e.g. a web-only tool)."))
 
@@ -146,13 +150,7 @@ def check_file(path: Path) -> list[Finding]:
 #   * the list may only SHRINK — `--audit-backlog` fails if an entry has become
 #     compliant and was not removed, so it cannot quietly become a rubber stamp
 # ---------------------------------------------------------------------------
-BACKLOG = {
-    "AMSTAR2.md", "ARRIVE_2.md", "CARE.md", "CHEERS_2022.md", "CLAIM_2024.md",
-    "CLEAR.md", "CONSORT.md", "COSMIN_RoB.md",     "DECIDE_AI.md", "GATHER.md", "GRRAS.md", "MI_CLEAR_LLM.md",
-    "NOS.md", "PGS_RS.md", "PRISMA_P.md", "PROBAST_AI.md", "QUADAS_C.md",
-    "RECORD.md", "REMARK.md", "ROBINS_E.md", "ROBIS.md", "ROB_ME.md",
-    "RoB_NMA.md", "SPIRIT.md", "SQUIRE_2.md",     "STARD.md", "STROBE.md", "SWiM.md", "TARGET.md",
-    "TRIPOD.md", "TRIPOD_LLM.md", }
+BACKLOG: set[str] = set()  # emptied: every checklist now declares itself
 
 
 def main() -> int:

--- a/skills/check-reporting/references/checklists/AMSTAR2.md
+++ b/skills/check-reporting/references/checklists/AMSTAR2.md
@@ -4,6 +4,9 @@
 Version: AMSTAR 2 (2017)
 Source: Shea BJ et al. BMJ 2017;358:j4008. doi: 10.1136/bmj.j4008
 
+Licence: *BMJ* — Crossref returns no Creative Commons licence for this article.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (16 items)
 
 ### Items

--- a/skills/check-reporting/references/checklists/ARRIVE_2.md
+++ b/skills/check-reporting/references/checklists/ARRIVE_2.md
@@ -6,6 +6,11 @@
 
 ---
 
+Version: ARRIVE 2.0 (2020) — Essential 10 + Recommended Set
+Source: Percie du Sert N, Hurst V, Ahluwalia A, Alam S, Avey MT, Baker M, et al. The ARRIVE guidelines 2.0: updated guidelines for reporting animal research. *PLoS Biol* 2020;18(7):e3000410 (DOI 10.1371/journal.pbio.3000410).
+Licence: CC0 1.0 (public domain dedication) — confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## How to Use This Checklist
 
 ARRIVE 2.0 has two tiers:

--- a/skills/check-reporting/references/checklists/CARE.md
+++ b/skills/check-reporting/references/checklists/CARE.md
@@ -5,6 +5,10 @@ Version: CARE 2013
 Source: https://www.care-statement.org
 Reference: Gagnier JJ, Kienle G, Altman DG, Moher D, Sox H, Riley D. The CARE guidelines: consensus-based clinical case report guideline development. J Clin Epidemiol 2014;67(1):46-51.
 
+Source: Gagnier JJ, Kienle G, Altman DG, Moher D, Sox H, Riley D, et al. The CARE guidelines: consensus-based clinical case report guideline development. *J Clin Epidemiol* 2014;67(1):46-51 (DOI 10.1016/j.jclinepi.2013.08.003).
+Licence: Crossref returns only an Elsevier text-and-data-mining licence. A CC BY-NC 4.0 claim circulates for the CARE materials; it is **not confirmed** here. Treat as non-open.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (13 topics)
 
 ### Title and Key Words

--- a/skills/check-reporting/references/checklists/CHEERS_2022.md
+++ b/skills/check-reporting/references/checklists/CHEERS_2022.md
@@ -6,6 +6,8 @@ Source: Husereau D, Drummond M, Augustovski F, et al. *BMJ* 2022;376:e067975 (th
 
 Apply when the manuscript is a **health economic evaluation** — a comparative analysis of costs and consequences of two or more courses of action: cost-effectiveness (CEA), cost-utility (CUA), cost-benefit (CBA), or cost-minimisation analysis, whether trial-based or decision-model-based (decision tree, Markov/state-transition, discrete-event simulation), including budget-impact and HTA submissions. For the design/validity review of the same study, pair with the HE1–HE8 domain probes in `peer-review` / `self-review` `references/domain-probes/health_economic_evaluation.md`; for the analysis, with `analyze-stats` `references/analysis_guides/health_economic_evaluation.md`.
 
+Source: Husereau D, Drummond M, Augustovski F, de Bekker-Grob E, Briggs AH, Carswell C, et al. Consolidated Health Economic Evaluation Reporting Standards 2022 (CHEERS 2022) statement. *BMJ* 2022;376:e067975 (DOI 10.1136/bmj-2021-067975).
+
 ## Checklist Items (28 items)
 
 ### Title

--- a/skills/check-reporting/references/checklists/CLAIM_2024.md
+++ b/skills/check-reporting/references/checklists/CLAIM_2024.md
@@ -7,6 +7,9 @@ Reference: Tejani AS, Klontzas ME, Gatti AA, Mongan JT, Moy L, Park SH, Kahn CE 
 
 > Note: The 2024 update replaces "ground truth" with "reference standard" and discourages "validation" in favour of "internal/external testing". Each item is answered Yes / No / Not Applicable with the manuscript location cited.
 
+Licence: © RSNA, open access. Consult RSNA for reuse terms; Crossref returns no Creative Commons licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (44 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/CLEAR.md
+++ b/skills/check-reporting/references/checklists/CLEAR.md
@@ -19,6 +19,8 @@ essential; score a missing essential item as a reporting gap, and a missing [n/e
 justified. CLEAR is written for **hand-crafted radiomics**; for deep-learning pipelines without radiomic
 features, CLAIM 2024 or TRIPOD+AI may fit better (a study that does both should be assessed against both).
 
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items
 
 ### Title

--- a/skills/check-reporting/references/checklists/CONSORT.md
+++ b/skills/check-reporting/references/checklists/CONSORT.md
@@ -7,6 +7,10 @@ Reference: Hopewell S, Chan AW, Collins GS, et al. CONSORT 2025 statement: updat
 
 > Note: CONSORT 2025 supersedes CONSORT 2010. It is a 30-item checklist (seven new items, three revised, one deleted) restructured with a new Open Science section.
 
+Source: Hopewell S, Chan AW, Collins GS, Hróbjartsson A, Moher D, Schulz KF, et al. CONSORT 2025 statement: updated guideline for reporting randomised trials. *BMJ* 2025;389:e081123 (DOI 10.1136/bmj-2024-081123).
+Licence: CC BY 4.0 — confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (30 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/COSMIN_RoB.md
+++ b/skills/check-reporting/references/checklists/COSMIN_RoB.md
@@ -4,6 +4,11 @@ COnsensus-based Standards for the selection of health Measurement INstruments â€
 Reference: Mokkink LB et al. BMC Medical Research Methodology 2020;20:293.
 Website: https://www.cosmin.nl
 
+Version: COSMIN Risk of Bias tool (2018 guideline)
+Source: Prinsen CAC, Mokkink LB, Bouter LM, Alonso J, Patrick DL, de Vet HCW, et al. COSMIN guideline for systematic reviews of patient-reported outcome measures. *Qual Life Res* 2018;27(5):1147-1157 (DOI 10.1007/s11136-018-1798-3).
+Licence: CC BY 4.0 â€” confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 The COSMIN Risk of Bias tool assesses the methodological quality of studies on **reliability** and **measurement error** of outcome measurement instruments (e.g., questionnaires, imaging measurements, lab tests).

--- a/skills/check-reporting/references/checklists/DECIDE_AI.md
+++ b/skills/check-reporting/references/checklists/DECIDE_AI.md
@@ -9,6 +9,8 @@ Reference: Vasey B, et al. Nat Med 2022;28(5):924-933. doi:10.1038/s41591-022-01
 > paraphrases the *intent* of each item and copies no verbatim guideline wording. Complete the
 > official DECIDE-AI checklist for a submission-ready form and cite Vasey et al. 2022.
 
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Naming and scope (read first)
 
 - DECIDE-AI reports the **early-stage (live) clinical evaluation** of an AI decision-support system —

--- a/skills/check-reporting/references/checklists/GATHER.md
+++ b/skills/check-reporting/references/checklists/GATHER.md
@@ -5,6 +5,9 @@ Version: GATHER 2016 (18 items). Source: Stevens GA, Alkema L, Black RE, et al. 
 
 Apply when the manuscript **reports population health estimates produced by a statistical or mathematical model that synthesizes multiple data sources** — Global Burden of Disease (GBD/IHME) analyses and satellite papers, WHO/UN-agency burden estimates, attributable-burden (comparative-risk / population-attributable-fraction) studies, cause-of-death modeling, prevalence/incidence/mortality estimation, disability-adjusted or quality-adjusted life-year estimation, and their forecasts. GATHER is the reporting standard those estimates are held to; it is orthogonal to STROBE/RECORD (which govern primary and routinely-collected-data studies of *individuals*). A single-institution cohort that only **contextualizes** its finding against a published burden number does not itself trigger GATHER, but a paper that **re-estimates or re-projects** burden does. Pair the analytic methods with `/analyze-stats` `references/analysis_guides/burden_decomposition_forecasting.md` (decomposition, joinpoint/AAPC, forecasting, PAF); pair the reproducibility items (15, 17) with `/verify-refs` and the project's data/code-availability discipline.
 
+Source: Stevens GA, Alkema L, Black RE, Boerma JT, Collins GS, Ezzati M, et al. Guidelines for Accurate and Transparent Health Estimates Reporting: the GATHER statement. *Lancet* 2016;388(10062):e19-e23 (DOI 10.1016/S0140-6736(16)30388-9); also *PLoS Med* 2016;13(6):e1002056 (DOI 10.1371/journal.pmed.1002056).
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (18 items)
 
 ### Objectives and funding

--- a/skills/check-reporting/references/checklists/GRRAS.md
+++ b/skills/check-reporting/references/checklists/GRRAS.md
@@ -5,6 +5,9 @@ Version: GRRAS 2011
 Source: https://doi.org/10.1016/j.jclinepi.2010.03.002
 Reference: Kottner J, Audige L, Brorson S, et al. Guidelines for Reporting Reliability and Agreement Studies (GRRAS) were proposed. J Clin Epidemiol. 2011;64(1):96-106. doi:10.1016/j.jclinepi.2010.03.002
 
+Licence: Crossref returns no Creative Commons licence (Elsevier).
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (15 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/MI_CLEAR_LLM.md
+++ b/skills/check-reporting/references/checklists/MI_CLEAR_LLM.md
@@ -23,6 +23,8 @@ disclosing LLM use in manuscript *writing* — for that, see ICMJE/COPE policies
 disclosure feature. MI-CLEAR-LLM supplements, and does not replace, a primary reporting guideline (STARD /
 STARD-AI, CLAIM 2024, or TRIPOD+AI) chosen for the study design.
 
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (8 items)
 
 | # | Item category | What must be reported |

--- a/skills/check-reporting/references/checklists/NOS.md
+++ b/skills/check-reporting/references/checklists/NOS.md
@@ -3,6 +3,11 @@
 Quality assessment tool for non-randomised studies in meta-analyses.
 Reference: Wells GA et al. Ottawa Hospital Research Institute.
 
+Version: Newcastle-Ottawa Scale (current web version)
+Source: Wells GA, Shea B, O'Connell D, Peterson J, Welch V, Losos M, Tugwell P. The Newcastle-Ottawa Scale (NOS) for assessing the quality of nonrandomised studies in meta-analyses. Ottawa Hospital Research Institute. **No DOI: the tool is distributed from the institute's website and has never been issued one.**.
+Licence: No formal licence is published with the tool.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Structure
 
 NOS uses a "star system" (maximum 9 stars) across 3 categories.

--- a/skills/check-reporting/references/checklists/PGS_RS.md
+++ b/skills/check-reporting/references/checklists/PGS_RS.md
@@ -6,6 +6,9 @@ Source: Wand H, Lambert SA, Tamburro C, et al. *Improving reporting standards fo
 
 Apply when the manuscript develops, validates, or applies a **polygenic risk score / polygenic score (PRS / PGS)** as a predictor or risk-stratifier. For the design-validity review of the same study, pair with the PG1–PG8 domain probes in `peer-review` / `self-review` `references/domain-probes/polygenic_risk_score.md`; for the analysis, with `analyze-stats` `analysis_guides/polygenic_risk_score.md`. PGS-RS is a domain extension of the TRIPOD prediction-model reporting principles — for the general prediction-model items also consult `TRIPOD.md` / `TRIPOD_AI.md`.
 
+Source: Wand H, Lambert SA, Tamburro C, Iacocca MA, O'Sullivan JW, Sillari C, et al. Improving reporting standards for polygenic scores in risk prediction studies. *Nature* 2021;591(7849):211-219 (DOI 10.1038/s41586-021-03243-6).
+Licence: Crossref returns only a Springer Nature text-and-data-mining licence; no Creative Commons licence.
+
 ## Checklist Items (22 items)
 
 ### Background

--- a/skills/check-reporting/references/checklists/PRISMA_P.md
+++ b/skills/check-reporting/references/checklists/PRISMA_P.md
@@ -4,6 +4,10 @@
 Version: PRISMA-P 2015
 Source: Shamseer L et al. BMJ 2015;349:g7647.
 
+Source: Shamseer L, Moher D, Clarke M, Ghersi D, Liberati A, Petticrew M, et al. Preferred reporting items for systematic review and meta-analysis protocols (PRISMA-P) 2015: elaboration and explanation. *BMJ* 2015;350:g7647 (DOI 10.1136/bmj.g7647).
+Licence: Crossref returns no Creative Commons licence for this article.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (17 items, 26 sub-items)
 
 ### Administrative Information

--- a/skills/check-reporting/references/checklists/PROBAST_AI.md
+++ b/skills/check-reporting/references/checklists/PROBAST_AI.md
@@ -4,6 +4,10 @@ Prediction model Risk Of Bias ASsessment Tool — updated for AI/ML methods.
 Reference: Moons KGM et al. PROBAST+AI: an updated quality, risk of bias, and applicability assessment tool for prediction models using regression or artificial intelligence methods. BMJ 2025;388:e082505. doi: 10.1136/bmj-2024-082505.
 Website: https://www.probast.org
 
+Version: PROBAST+AI (2025) — 16 development / 18 evaluation signalling questions
+Licence: CC BY-NC 4.0 (non-commercial) — confirmed via Crossref (DOI 10.1136/bmj-2024-082505). Not redistributable verbatim under this repository's MIT licence.
+Verification: the development and evaluation signalling-question counts and the four-step process were checked against the statement and its supplements during this audit.
+
 ## Purpose
 
 PROBAST+AI is the updated version of PROBAST (2019) that extends the original tool to cover prediction models developed using **machine learning and artificial intelligence** methods, in addition to traditional regression-based models. It replaces PROBAST-2019 for all new assessments.

--- a/skills/check-reporting/references/checklists/QUADAS_C.md
+++ b/skills/check-reporting/references/checklists/QUADAS_C.md
@@ -3,6 +3,11 @@
 Quality Assessment of Diagnostic Accuracy Studies — Comparative (extension to QUADAS-2).
 Reference: Yang B et al. Guidance on how to use QUADAS-C. 2021. Available from: https://osf.io/hq8mf/files/
 
+Version: QUADAS-C (2021)
+Source: Yang B, Mallett S, Takwoingi Y, Davenport CF, Hyde CJ, Whiting PF, et al. QUADAS-C: a tool for assessing risk of bias in comparative diagnostic accuracy studies. *Ann Intern Med* 2021;174(11):1592-1599 (DOI 10.7326/M21-2234).
+Licence: *Annals of Internal Medicine* (© American College of Physicians) — no open licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 QUADAS-C is an extension (add-on) to QUADAS-2 for assessing risk of bias in **comparative diagnostic test accuracy studies** — studies comparing two or more index tests in the same population.

--- a/skills/check-reporting/references/checklists/RECORD.md
+++ b/skills/check-reporting/references/checklists/RECORD.md
@@ -6,6 +6,8 @@ Source: Benchimol EI, Smeeth L, Guttmann A, et al. *PLoS Medicine* 2015;12(10):e
 
 Apply when the manuscript is an **observational study conducted using routinely-collected health data** — administrative claims, electronic health records (EHR), disease/population registries, health-administrative or health-checkup databases, or linked versions of these — i.e. data **not collected for the purpose of the specific study**. RECORD extends the base **STROBE** items with reporting specific to secondary-use data: database identity, the codes/algorithms used to define the population and the variables, data linkage and its quality, and the limitations of analysing data collected for another purpose. For a drug safety/effectiveness study in such data, also apply **RECORD-PE**. For the design/validity review of the same study, pair with the RD1–RD8 domain probes in `peer-review` / `self-review` `references/domain-probes/record_routinely_collected_data.md`, and with the observational-confounding probes (`observational_confounding.md`).
 
+Source: Benchimol EI, Smeeth L, Guttmann A, Harron K, Moher D, Petersen I, et al. The REporting of studies Conducted using Observational Routinely-collected health Data (RECORD) statement. *PLoS Med* 2015;12(10):e1001885 (DOI 10.1371/journal.pmed.1001885).
+
 ## Checklist Items (13 items, extending STROBE)
 
 ### Title and Abstract (STROBE item 1)

--- a/skills/check-reporting/references/checklists/REMARK.md
+++ b/skills/check-reporting/references/checklists/REMARK.md
@@ -4,6 +4,10 @@
 Version: REMARK 2005 (McShane et al.), with the 2012 Explanation and Elaboration (Altman et al.)
 Source: In-house faithful summary of the 20 REMARK item intents (own-words paraphrase, not verbatim). McShane LM, Altman DG, Sauerbrei W, Taube SE, Gion M, Clark GM. Br J Cancer 2005;93(4):387-391. Explanation and Elaboration: Altman DG, McShane LM, Sauerbrei W, Taube SE. PLoS Med 2012;9(5):e1001216. Complete the official REMARK instrument for a submission checklist.
 
+Source: McShane LM, Altman DG, Sauerbrei W, Taube SE, Gion M, Clark GM. Reporting recommendations for tumour marker prognostic studies (REMARK). *Br J Cancer* 2005;93(4):387-391. Explanation and elaboration: Altman DG, McShane LM, Sauerbrei W, Taube SE. *PLoS Med* 2012;9(5):e1001216 (DOI 10.1371/journal.pmed.1001216).
+Licence: The *PLoS Medicine* explanation-and-elaboration paper is CC BY 4.0 (confirmed via Crossref); the original *Br J Cancer* statement is not openly licensed.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (20 items)
 
 ### Introduction

--- a/skills/check-reporting/references/checklists/ROBINS_E.md
+++ b/skills/check-reporting/references/checklists/ROBINS_E.md
@@ -4,6 +4,10 @@ Risk Of Bias In Non-randomized Studies — of Exposures.
 Reference: Higgins JPT et al. Environment International 2024;186:108602. doi: 10.1016/j.envint.2024.108602.
 Website: https://www.riskofbias.info/welcome/robins-e-tool
 
+Version: ROBINS-E (2024)
+Licence: CC BY-NC 4.0 (non-commercial) — confirmed via Crossref. Not redistributable verbatim under this repository's MIT licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 ROBINS-E assesses the risk of **material bias** in individual observational studies examining the effect of an **exposure** on an outcome. Designed for follow-up (cohort) studies. Material bias = bias sufficient to affect the direction of the estimated effect or impact the ability to draw conclusions.

--- a/skills/check-reporting/references/checklists/ROBIS.md
+++ b/skills/check-reporting/references/checklists/ROBIS.md
@@ -3,6 +3,11 @@
 Risk Of Bias In Systematic Reviews, version 1.2.
 Reference: Whiting P et al. J Clin Epidemiol 2016;69:225-234.
 
+Version: ROBIS (2016) — 4 domains in 3 phases
+Source: Whiting P, Savović J, Higgins JPT, Caldwell DM, Reeves BC, Shea B, et al. ROBIS: a new tool to assess risk of bias in systematic reviews was developed. *J Clin Epidemiol* 2016;69:225-234 (DOI 10.1016/j.jclinepi.2015.06.005).
+Licence: CC BY 4.0 — confirmed via Crossref. (`LICENSES.md` previously recorded no open licence for ROBIS; that was wrong.)
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 ROBIS assesses the risk of bias **in systematic reviews themselves** (not in individual studies). It evaluates whether the review process was conducted appropriately and whether the conclusions are trustworthy.

--- a/skills/check-reporting/references/checklists/ROB_ME.md
+++ b/skills/check-reporting/references/checklists/ROB_ME.md
@@ -4,6 +4,11 @@ Risk Of Bias due to Missing Evidence in a meta-analysis.
 Reference: Page MJ et al. BMJ 2023;383:e076"; ROB-ME Cribsheet Version 1, October 2023.
 Website: https://www.riskofbias.info/welcome/rob-me-tool
 
+Version: ROB-ME (2023)
+Source: Page MJ, Sterne JAC, Boutron I, Hróbjartsson A, Kirkham JJ, Li T, et al. ROB-ME: a tool for assessing risk of bias due to missing evidence in systematic reviews with meta-analysis. *BMJ* 2023;383:e076754 (DOI 10.1136/bmj-2023-076754).
+Licence: Crossref returns only a BMJ text-and-data-mining policy; no Creative Commons licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 ROB-ME assesses the risk of bias in a **pairwise meta-analysis result** due to missing evidence — encompassing both non-reporting biases (selective reporting of results) and non-publication biases (unpublished studies). It is applied at the synthesis level (not individual study level).

--- a/skills/check-reporting/references/checklists/RoB_NMA.md
+++ b/skills/check-reporting/references/checklists/RoB_NMA.md
@@ -4,6 +4,11 @@ Risk of Bias in Network Meta-Analysis Tool, Version 1 (March 2024).
 Reference: Lunny C et al. Developed by the Knowledge Translation Foundation.
 Website: https://www.riskofbias.info
 
+Version: RoB NMA (2025) — 17 items
+Source: Lunny C, Higgins JPT, White IR, Dias S, Hutton B, Pham B, et al. Risk of Bias in Network Meta-Analysis (RoB NMA) tool. *BMJ* 2025 (DOI 10.1136/bmj-2024-079839).
+Licence: CC BY 4.0 — confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Purpose
 
 The RoB NMA tool identifies potential limitations in the way a **network meta-analysis (NMA)** was conducted, including aspects of how the evidence was assembled that may lead to bias in the NMA's results or conclusions.

--- a/skills/check-reporting/references/checklists/SPIRIT.md
+++ b/skills/check-reporting/references/checklists/SPIRIT.md
@@ -7,6 +7,10 @@ Reference: Chan AW, Hopewell S, Moher D, et al. SPIRIT 2025 statement: updated g
 
 > Note: SPIRIT 2025 supersedes SPIRIT 2013. It is a 34-item checklist (two new items, five revised, five deleted/merged) restructured with a new Open Science section. Use for clinical trial *protocols* (CONSORT is for the completed trial report).
 
+Source: Chan AW, Boutron I, Hopewell S, Moher D, Schulz KF, Collins GS, et al. SPIRIT 2025 statement: updated guideline for protocols of randomised trials. *BMJ* 2025;389:e081477 (DOI 10.1136/bmj-2024-081477).
+Licence: CC BY 4.0 — confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (34 items)
 
 ### Administrative Information

--- a/skills/check-reporting/references/checklists/SQUIRE_2.md
+++ b/skills/check-reporting/references/checklists/SQUIRE_2.md
@@ -5,6 +5,9 @@ Version: SQUIRE 2.0 (2015)
 Source: http://squire-statement.org
 Reference: Ogrinc G, Davies L, Goodman D, Batalden P, Davidoff F, Stevens D. SQUIRE 2.0 (Standards for QUality Improvement Reporting Excellence): revised publication guidelines from a detailed consensus process. BMJ Qual Saf. 2016;25(12):986-992. doi:10.1136/bmjqs-2015-004411
 
+Licence: Crossref returns no Creative Commons licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (18 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/STARD.md
+++ b/skills/check-reporting/references/checklists/STARD.md
@@ -4,6 +4,10 @@
 Version: STARD 2015
 Source: https://www.stard-statement.org
 
+Source: Bossuyt PM, Reitsma JB, Bruns DE, Gatsonis CA, Glasziou PP, Irwig L, et al. STARD 2015: an updated list of essential items for reporting diagnostic accuracy studies. *BMJ* 2015;351:h5527 (DOI 10.1136/bmj.h5527).
+Licence: CC BY 4.0 — confirmed via the PubMed Central record (PMC4623764).
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (30 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/STROBE.md
+++ b/skills/check-reporting/references/checklists/STROBE.md
@@ -4,6 +4,10 @@
 Version: STROBE 2007 (combined checklist for cohort, case-control, and cross-sectional studies)
 Source: https://www.strobe-statement.org
 
+Source: von Elm E, Altman DG, Egger M, Pocock SJ, Gøtzsche PC, Vandenbroucke JP. The Strengthening the Reporting of Observational Studies in Epidemiology (STROBE) statement. *PLoS Med* 2007;4(10):e296 (DOI 10.1371/journal.pmed.0040296).
+Licence: CC BY 4.0 — confirmed via the PubMed Central record (PMC2020495).
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (22 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/SWiM.md
+++ b/skills/check-reporting/references/checklists/SWiM.md
@@ -5,6 +5,9 @@ Version: SWiM 2020
 Source: Campbell M et al. BMJ 2020;368:l6890. doi: 10.1136/bmj.l6890
 Website: https://swim.sphsu.gla.ac.uk/
 
+Licence: CC BY 4.0 — confirmed via Crossref.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (9 items)
 
 ### Reporting Items

--- a/skills/check-reporting/references/checklists/TARGET.md
+++ b/skills/check-reporting/references/checklists/TARGET.md
@@ -4,6 +4,9 @@
 Version: TARGET 2025 (21 items across 6 sections; items 6 and 7 pair the target-trial *specification* with its *emulation* in the data)
 Source: In-house faithful summary of the TARGET item intents (own-words paraphrase, not verbatim). Cashin AG, Hansford HJ, Hernán MA, et al. Transparent Reporting of Observational Studies Emulating a Target Trial: The TARGET Statement. JAMA 2025;334(12):1084-1093. DOI 10.1001/jama.2025.13350. Official checklist: https://target-guideline.org. Complete the official TARGET instrument for a submission checklist. Pairs with the `/design-study` target-trial-emulation design module.
 
+Licence: *JAMA* (© American Medical Association) — no open licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Checklist Items (21 items)
 
 ### Title and Abstract

--- a/skills/check-reporting/references/checklists/TRIPOD.md
+++ b/skills/check-reporting/references/checklists/TRIPOD.md
@@ -4,6 +4,10 @@
 Version: TRIPOD 2015
 Source: Moons KGM et al. Ann Intern Med. 2015;162:55-63. https://www.tripod-statement.org
 
+Source: Collins GS, Reitsma JB, Altman DG, Moons KGM. Transparent reporting of a multivariable prediction model for individual prognosis or diagnosis (TRIPOD). *Ann Intern Med* 2015;162(1):55-63 (DOI 10.7326/M14-0697).
+Licence: *Annals of Internal Medicine* (© American College of Physicians) — no open licence.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Applicability
 
 Items apply to different study types:

--- a/skills/check-reporting/references/checklists/TRIPOD_LLM.md
+++ b/skills/check-reporting/references/checklists/TRIPOD_LLM.md
@@ -15,6 +15,9 @@ Reference: Gallifant J, ..., Bitterman DS. Nat Med 2025;31(1):60-69. doi:10.1038
 > 18 subitems are **task- or design-specific** (marked *task-specific*) and are N/A when that
 > component is absent — justify the N/A.
 
+Licence: The published *Nature Medicine* article returns no Creative Commons licence via Crossref (DOI 10.1038/s41591-024-03425-5); the author-accepted manuscript is CC BY 4.0 through institutional rights retention.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Naming and scope (read first)
 
 - TRIPOD-LLM is an **extension** of the **TRIPOD** family (TRIPOD 2015 → TRIPOD+AI 2024 →

--- a/skills/meta-analysis/references/checklists/NOS.md
+++ b/skills/meta-analysis/references/checklists/NOS.md
@@ -3,6 +3,11 @@
 Quality assessment tool for non-randomised studies in meta-analyses.
 Reference: Wells GA et al. Ottawa Hospital Research Institute.
 
+Version: Newcastle-Ottawa Scale (current web version)
+Source: Wells GA, Shea B, O'Connell D, Peterson J, Welch V, Losos M, Tugwell P. The Newcastle-Ottawa Scale (NOS) for assessing the quality of nonrandomised studies in meta-analyses. Ottawa Hospital Research Institute. **No DOI: the tool is distributed from the institute's website and has never been issued one.**.
+Licence: No formal licence is published with the tool.
+Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+
 ## Structure
 
 NOS uses a "star system" (maximum 9 stars) across 3 categories.


### PR DESCRIPTION
31 files were carrying gaps — no DOI, no licence, or silence about verification. Each now states all four declarations, and the provenance gate's `BACKLOG` is **empty**.

## The facts were not guessed

**Every DOI was resolved through Crossref and confirmed by the title it returned.** Every licence is the Crossref `license` URL or the PMC `<license>` element.

Two candidates failed that check and were replaced with the real articles rather than shipped:

| | Proposed DOI | What it actually was |
|---|---|---|
| TARGET | `10.1001/jama.2025.10692` | **404** |
| RoB NMA | `10.1002/jrsm.1652` | a paper on **Kenward-Roger corrections** |

This is the same discipline that made me abandon bulk DOI resolution in #480: querying Crossref *by bibliography* returned a Who's Who biography for NOS and a code listing for QUADAS-C. Querying *by DOI and checking the title* is the direction that works, because a wrong DOI is immediately obvious.

## Three more bare "Verified" stamps, found by the gate

`GATHER.md`, `QUADAS_C.md`, `REMARK.md` — none found by hand. They now say what was and was not compared.

## Most of these files now say NOT VERIFIED

**32 of 48 have not been compared against their published table, and they now say so in the header.**

That is the point of the exercise. The gate cannot make a checklist correct. It can stop one from implying it has been checked when it has not — which is exactly what `STROBE_MR.md` and `PRISMA_ScR.md` were doing while being wrong in ten ways between them.

## Two licence corrections fell out of the sweep

- **ROBIS is CC BY 4.0.** `LICENSES.md` recorded "no open licence found" in #472. That was wrong; the Crossref record is unambiguous.
- **PROBAST+AI and ROBINS-E are CC BY-NC 4.0** — non-commercial, so in the same position as ROBINS-I: not redistributable verbatim under this repository's MIT licence. Both are now labelled.

## One exception the gate was always meant to have

**An instrument with no DOI may say so.** The Newcastle-Ottawa Scale is distributed from an institute web page and has never been issued one. Demanding a DOI unconditionally is how a checker pressures someone into inventing a fact — the failure this whole audit is about.

## State

| | |
|---|---|
| Checklists declaring version, source, licence, verification | **48 / 48** |
| Provenance backlog | **0** |
| Content-verified against the published table | 16 / 48 |
| Gates | 241 |

## Verification

`python3 scripts/run_ci_mirror.py` — **241/241**, including `--strict` (now with an empty backlog, so every file is blocking), `--audit-backlog`, and the eight-case challenge card.