### PR TITLE
Checklist fidelity 13/N: six count-only checks, recorded as count-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,19 @@
 
   **241 gates** (was 238).
 
+### Changed
+
+- **Six checklists gain a partial verification record — item count checked, item text not — and say
+  so in those words.** SWiM (9), CHEERS 2022 (28), CLEAR (58), GATHER (18), REMARK (20) and
+  CONSORT 2025 (30) each match the count their own statement gives, confirmed against the PubMed
+  Central record.
+
+  **They are not marked verified**, and the header says why: *a matching count is not evidence that
+  the items would match*. STARD carried the right count of 30 while omitting two items, collapsing
+  three sub-item pairs and inventing a fourth (#483). Recording a count check as verification would
+  be the same false stamp this audit spent its whole length removing — the difference is that this
+  time the temptation was mine.
+
 ### Fixed
 
 - **STARD 2015 was missing two items and had invented a sub-item split.** Extracted from the

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -663,8 +663,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/CHEERS_2022.md",
-      "size": 8294,
-      "sha256": "e381939bf6b857a06ad2404a2d3371875a5e39d73dda40b4565bd22fd4aa1b92"
+      "size": 8785,
+      "sha256": "fc78fbed277fa82dd0700e372d7f6f8d7e7fa6637db4be13e07cf958dffa69f7"
     },
     {
       "path": "skills/check-reporting/references/checklists/CLAIM_2024.md",
@@ -673,13 +673,13 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/CLEAR.md",
-      "size": 7970,
-      "sha256": "5811cdba2c7c0e1834c8d2438b3fb383a6a1961a30f108c72331f22d66b8a12c"
+      "size": 8273,
+      "sha256": "fdd8b4f20c33f51d738680b8431af94cde164d9495be1766e077e971196f79c1"
     },
     {
       "path": "skills/check-reporting/references/checklists/CONSORT.md",
-      "size": 7079,
-      "sha256": "6f93c173e37fa31abeaa70a709ed984af32ed0d4eac13178ac8e904a367b8955"
+      "size": 7385,
+      "sha256": "c6076444e3af376c22bbf9cfb0cd196256b90560b96790eb8ad5a2b2dcc85426"
     },
     {
       "path": "skills/check-reporting/references/checklists/CONSORT_AI.md",
@@ -708,8 +708,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/GATHER.md",
-      "size": 6772,
-      "sha256": "f4d1bc97326864035988f21f3a64ad5dc003c58a399e34a82507c6d732a50972"
+      "size": 7074,
+      "sha256": "71cd717281705685af77b6b75bc5eefe9183b9a2f350b20bb45cd21d40a272e1"
     },
     {
       "path": "skills/check-reporting/references/checklists/GRRAS.md",
@@ -788,8 +788,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/REMARK.md",
-      "size": 6692,
-      "sha256": "6186d680d1dda3f426ea00685e577ac78661caeb4d49bd65b83c2e83c96610d0"
+      "size": 6995,
+      "sha256": "5cc74ca8eb56289213d3c19042e083989dde89d4cee9ccaf1974d3537b9e87a0"
     },
     {
       "path": "skills/check-reporting/references/checklists/ROBINS_E.md",
@@ -863,8 +863,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/SWiM.md",
-      "size": 3752,
-      "sha256": "046c4331ce92aa0bf7775d169737a6b517dc72b99cd445e210cf6acaf3b19d40"
+      "size": 4048,
+      "sha256": "c75ae57ec109bdbdcfbce4e8c5ae1e79039f11b66eef729ef2477f0c2b8150ce"
     },
     {
       "path": "skills/check-reporting/references/checklists/TARGET.md",

--- a/skills/check-reporting/references/checklists/CHEERS_2022.md
+++ b/skills/check-reporting/references/checklists/CHEERS_2022.md
@@ -3,6 +3,11 @@
 **Consolidated Health Economic Evaluation Reporting Standards 2022**
 Version: CHEERS 2022 (28 items; replaces CHEERS 2013).
 Source: Husereau D, Drummond M, Augustovski F, et al. *BMJ* 2022;376:e067975 (the CHEERS 2022 statement), co-published simultaneously across BMJ, *Value in Health*, *PharmacoEconomics*, *Int J Technol Assess Health Care* and others. CC BY 4.0. https://www.equator-network.org/reporting-guidelines/cheers/ · ISPOR CHEERS Task Force.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement presents “the new CHEERS 2022 28-item checklist”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 Apply when the manuscript is a **health economic evaluation** — a comparative analysis of costs and consequences of two or more courses of action: cost-effectiveness (CEA), cost-utility (CUA), cost-benefit (CBA), or cost-minimisation analysis, whether trial-based or decision-model-based (decision tree, Markov/state-transition, discrete-event simulation), including budget-impact and HTA submissions. For the design/validity review of the same study, pair with the HE1–HE8 domain probes in `peer-review` / `self-review` `references/domain-probes/health_economic_evaluation.md`; for the analysis, with `analyze-stats` `references/analysis_guides/health_economic_evaluation.md`.
 

--- a/skills/check-reporting/references/checklists/CLEAR.md
+++ b/skills/check-reporting/references/checklists/CLEAR.md
@@ -19,7 +19,11 @@ essential; score a missing essential item as a reporting gap, and a missing [n/e
 justified. CLEAR is written for **hand-crafted radiomics**; for deep-learning pipelines without radiomic
 features, CLAIM 2024 or TRIPOD+AI may fit better (a study that does both should be assessed against both).
 
-Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement says “with its 58 items, the CLEAR checklist…”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 ## Checklist Items
 

--- a/skills/check-reporting/references/checklists/CONSORT.md
+++ b/skills/check-reporting/references/checklists/CONSORT.md
@@ -9,7 +9,11 @@ Reference: Hopewell S, Chan AW, Collins GS, et al. CONSORT 2025 statement: updat
 
 Source: Hopewell S, Chan AW, Collins GS, Hróbjartsson A, Moher D, Schulz KF, et al. CONSORT 2025 statement: updated guideline for reporting randomised trials. *BMJ* 2025;389:e081123 (DOI 10.1136/bmj-2024-081123).
 Licence: CC BY 4.0 — confirmed via Crossref.
-Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement says CONSORT 2025 “consists of a 30-item checklist”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 ## Checklist Items (30 items)
 

--- a/skills/check-reporting/references/checklists/GATHER.md
+++ b/skills/check-reporting/references/checklists/GATHER.md
@@ -6,7 +6,11 @@ Version: GATHER 2016 (18 items). Source: Stevens GA, Alkema L, Black RE, et al. 
 Apply when the manuscript **reports population health estimates produced by a statistical or mathematical model that synthesizes multiple data sources** — Global Burden of Disease (GBD/IHME) analyses and satellite papers, WHO/UN-agency burden estimates, attributable-burden (comparative-risk / population-attributable-fraction) studies, cause-of-death modeling, prevalence/incidence/mortality estimation, disability-adjusted or quality-adjusted life-year estimation, and their forecasts. GATHER is the reporting standard those estimates are held to; it is orthogonal to STROBE/RECORD (which govern primary and routinely-collected-data studies of *individuals*). A single-institution cohort that only **contextualizes** its finding against a published burden number does not itself trigger GATHER, but a paper that **re-estimates or re-projects** burden does. Pair the analytic methods with `/analyze-stats` `references/analysis_guides/burden_decomposition_forecasting.md` (decomposition, joinpoint/AAPC, forecasting, PAF); pair the reproducibility items (15, 17) with `/verify-refs` and the project's data/code-availability discipline.
 
 Source: Stevens GA, Alkema L, Black RE, Boerma JT, Collins GS, Ezzati M, et al. Guidelines for Accurate and Transparent Health Estimates Reporting: the GATHER statement. *Lancet* 2016;388(10062):e19-e23 (DOI 10.1016/S0140-6736(16)30388-9); also *PLoS Med* 2016;13(6):e1002056 (DOI 10.1371/journal.pmed.1002056).
-Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement says GATHER “comprises a checklist of 18 items”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 ## Checklist Items (18 items)
 

--- a/skills/check-reporting/references/checklists/REMARK.md
+++ b/skills/check-reporting/references/checklists/REMARK.md
@@ -6,7 +6,11 @@ Source: In-house faithful summary of the 20 REMARK item intents (own-words parap
 
 Source: McShane LM, Altman DG, Sauerbrei W, Taube SE, Gion M, Clark GM. Reporting recommendations for tumour marker prognostic studies (REMARK). *Br J Cancer* 2005;93(4):387-391. Explanation and elaboration: Altman DG, McShane LM, Sauerbrei W, Taube SE. *PLoS Med* 2012;9(5):e1001216 (DOI 10.1371/journal.pmed.1001216).
 Licence: The *PLoS Medicine* explanation-and-elaboration paper is CC BY 4.0 (confirmed via Crossref); the original *Br J Cancer* statement is not openly licensed.
-Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement discusses “the 20 items in the REMARK checklist”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 ## Checklist Items (20 items)
 

--- a/skills/check-reporting/references/checklists/SWiM.md
+++ b/skills/check-reporting/references/checklists/SWiM.md
@@ -6,7 +6,11 @@ Source: Campbell M et al. BMJ 2020;368:l6890. doi: 10.1136/bmj.l6890
 Website: https://swim.sphsu.gla.ac.uk/
 
 Licence: CC BY 4.0 — confirmed via Crossref.
-Verification: **NOT VERIFIED.** The items below have not been compared against the published table. They are an in-house summary; complete the official instrument for anything you report.
+Verification: **PARTIAL — item count only.** The number of items here matches the published
+statement (the statement describes “the nine SWiM reporting items”), checked against its PubMed Central record. The **item text has not been
+compared**, and a matching count is not evidence that it would match: STARD carried the right
+count of 30 while omitting two items, collapsing three sub-item pairs and inventing a fourth.
+Complete the official checklist for anything you report.
 
 ## Checklist Items (9 items)
 


### PR DESCRIPTION
SWiM (9), CHEERS 2022 (28), CLEAR (58), GATHER (18), REMARK (20) and CONSORT 2025 (30) each match the item count their own statement gives, confirmed against the PubMed Central record.

## They are not marked verified

The header on each says why:

> A matching count is not evidence that the items would match.

**STARD carried the right count of 30** while omitting two items, collapsing three sub-item pairs and inventing a fourth (#483). Recording a count check as verification would be the same false stamp this audit has spent its whole length removing — `STROBE_MR.md` and `PRISMA_ScR.md` in #475/#477, then `GATHER.md`, `QUADAS_C.md` and `REMARK.md` caught by the gate in #482.

The difference this time is that the temptation was mine: I had six cheap confirmations in hand and the obvious move was to call them verified.

## State

| | |
|---|---|
| Item-level verified against the published table | 18 / 48 |
| Count-level checked only, and labelled as such | **6 / 48** |
| Explicitly NOT VERIFIED | 24 / 48 |
| Declaring version, source, licence, verification | 48 / 48 |
| Provenance backlog | 0 |
| Gates | 241 |

## Verification

`python3 scripts/run_ci_mirror.py` — **241/241 gates pass**.