### PR TITLE
test(lit-sync): the citekey-provenance detector had 210 lines and no test; both now exist

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -430,6 +430,12 @@ jobs:
       - name: Run checklist-provenance challenge (a bare "Verified" claim must fail)
         run: bash scripts/checklist_provenance_challenge/verify.sh
 
+      - name: Run citekey-provenance challenge (a composed citekey must be caught)
+        run: bash skills/lit-sync/tests/citekey_provenance_challenge.sh
+
+      - name: Run citekey-provenance self-test (mutate the detector; the card must FAIL)
+        run: bash skills/lit-sync/tests/citekey_provenance_challenge_selftest.sh
+
       - name: Run lit-sync poll-logic test
         run: bash skills/lit-sync/tests/test_poll_logic.sh
 

--- a/docs/skills/lit-sync.md
+++ b/docs/skills/lit-sync.md
@@ -28,6 +28,8 @@
 
 - `confirm refs.bib mtime refreshed via Better BibTeX`
 - `zotero_find_duplicates after sync`
+- `bash skills/lit-sync/tests/citekey_provenance_challenge.sh`
+- `bash skills/lit-sync/tests/citekey_provenance_challenge_selftest.sh`
 
 **Evidence** — `manual_workflow`
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1963,8 +1963,8 @@
     },
     {
       "path": "skills/lit-sync/skill.yml",
-      "size": 2780,
-      "sha256": "a04d160e9fc6382c783940b737c9d9348db45e34ea80c69ef905be0a3c357e34"
+      "size": 2919,
+      "sha256": "516cb1ea69464e76b5868500d04429f5ea40e428be2ecbf54214fd888040984e"
     },
     {
       "path": "skills/ma-scout/SKILL.md",

--- a/skills/lit-sync/skill.yml
+++ b/skills/lit-sync/skill.yml
@@ -52,4 +52,6 @@ known_limitations:
 validation_commands:
   - "confirm refs.bib mtime refreshed via Better BibTeX"
   - "zotero_find_duplicates after sync"
+  - "bash skills/lit-sync/tests/citekey_provenance_challenge.sh"
+  - "bash skills/lit-sync/tests/citekey_provenance_challenge_selftest.sh"
 evidence_surface: manual_workflow

--- a/skills/lit-sync/tests/citekey_provenance_challenge.sh
+++ b/skills/lit-sync/tests/citekey_provenance_challenge.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Challenge card for skills/lit-sync/scripts/check_citekey_provenance.py.
+#
+# Run with no argument from CI; pass a path to point it at a mutated copy (see the
+# self-test below, which is how this card earns the right to be believed).
+#
+# The script decides whether a literature note's citekey is real. Its verdicts are what a
+# user acts on, and its --strict exit code is what a gate acts on. Both are asserted here
+# against a fixture built at runtime, so the card carries no committed vault to drift.
+#
+# The boundary that matters and is easy to get wrong: --strict fails on INVENTED only.
+# UNRESOLVED and FILENAME are reported but do not fail — a paper that was never added to
+# the library is not the same defect as a citekey that was composed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${1:-$HERE/../scripts/check_citekey_provenance.py}"
+[ -f "$SCRIPT" ] || { echo "cannot find check_citekey_provenance.py at $SCRIPT"; exit 2; }
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"; PASS=$((PASS+1))
+  else printf '  FAIL  %s (expected %s, got %s)\n' "$1" "$2" "$3"; FAIL=$((FAIL+1)); fi
+}
+
+note() { # note <path> <citekey-or-empty> <doi-or-empty> <notetype>
+  mkdir -p "$(dirname "$1")"
+  {
+    echo "---"
+    [ -n "$2" ] && echo "citekey: \"$2\""
+    [ -n "$3" ] && echo "doi: \"$3\""
+    echo "notetype: $4"
+    echo "---"
+    echo
+    echo "body"
+  } > "$1"
+}
+
+# ---------------------------------------------------------------- fixture
+VAULT="$WORK/vault"
+BIB="$WORK/refs.bib"
+cat > "$BIB" <<'BIB'
+@article{realKey2020,
+  title = {A real entry},
+  doi = {10.1000/real},
+}
+@article{otherKey2021,
+  title = {Another real entry},
+  doi = {10.1000/other},
+}
+BIB
+
+note "$VAULT/realKey2020.md"      "realKey2020" "10.1000/real"     literature  # OK
+note "$VAULT/wrongName.md"        "otherKey2021" "10.1000/other"   literature  # FILENAME
+note "$VAULT/composedKey2021.md"  "composedKey2021" "10.1000/other" literature # INVENTED (doi resolves)
+note "$VAULT/neverAdded2019.md"   "neverAdded2019" "10.1000/absent" literature # UNRESOLVED
+note "$VAULT/noKey.md"            "" "10.1000/real"                literature  # NO_CITEKEY
+note "$VAULT/concept.md"          "notAKey" ""                     concept     # skipped: not literature
+note "$VAULT/.trash/hidden.md"    "alsoNotAKey" ""                 literature  # skipped: dot-path
+
+OUT="$WORK/out.txt"
+python3 "$SCRIPT" --vault "$VAULT" --bib "$BIB" --json "$WORK/audit.json" > "$OUT" 2>&1
+rc=$?
+check "exit 0 without --strict" 0 "$rc"
+
+count() { python3 -c "
+import json,sys
+d=json.load(open('$WORK/audit.json'))
+print(d['counts'].get('$1',0))
+"; }
+
+check "OK counted once"          1 "$(count OK)"
+check "FILENAME counted once"    1 "$(count FILENAME)"
+check "INVENTED counted once"    1 "$(count INVENTED)"
+check "UNRESOLVED counted once"  1 "$(count UNRESOLVED)"
+check "NO_CITEKEY counted once"  1 "$(count NO_CITEKEY)"
+
+total=$(python3 -c "
+import json; d=json.load(open('$WORK/audit.json')); print(sum(d['counts'].values()))
+")
+check "non-literature and dot-path notes skipped" 5 "$total"
+
+sugg=$(python3 -c "
+import json
+d=json.load(open('$WORK/audit.json'))
+print(next(r['suggested_citekey'] for r in d['findings'] if r['verdict']=='INVENTED'))
+")
+check "INVENTED names the real key from the DOI" "otherKey2021" "$sugg"
+
+# ------------------------------------------------- --strict fires on INVENTED
+python3 "$SCRIPT" --vault "$VAULT" --bib "$BIB" --strict > /dev/null 2>&1
+check "--strict exits 1 when INVENTED present" 1 "$?"
+
+# --------------------------------- --strict does NOT fire without INVENTED
+VAULT2="$WORK/vault2"
+note "$VAULT2/realKey2020.md"    "realKey2020" "10.1000/real"      literature  # OK
+note "$VAULT2/neverAdded2019.md" "neverAdded2019" "10.1000/absent" literature  # UNRESOLVED
+note "$VAULT2/wrongName.md"      "otherKey2021" "10.1000/other"    literature  # FILENAME
+python3 "$SCRIPT" --vault "$VAULT2" --bib "$BIB" --strict > /dev/null 2>&1
+check "--strict exits 0 for UNRESOLVED/FILENAME alone" 0 "$?"
+
+# ------------------------------------------------------------ input guards
+python3 "$SCRIPT" --vault "$WORK/does-not-exist" --bib "$BIB" > /dev/null 2>&1
+check "missing vault exits 2" 2 "$?"
+
+python3 "$SCRIPT" --vault "$VAULT" > /dev/null 2>&1
+check "no --bib and no --live exits 2" 2 "$?"
+
+: > "$WORK/empty.bib"
+python3 "$SCRIPT" --vault "$VAULT" --bib "$WORK/empty.bib" > /dev/null 2>&1
+check "empty library exits 2 instead of condemning every note" 2 "$?"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/skills/lit-sync/tests/citekey_provenance_challenge_selftest.sh
+++ b/skills/lit-sync/tests/citekey_provenance_challenge_selftest.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Self-test for the citekey-provenance challenge card.
+#
+# A card that passes proves it RAN. It proves nothing about whether it would catch a
+# defect. So: mutate the detector five ways, each removing a behaviour the card claims to
+# assert, and require the card to FAIL every time. If any mutation slips through green,
+# the card is blind on that axis and this exits 1.
+#
+# The five mutations are the mistakes this detector is actually exposed to:
+#   1. --strict fails on UNRESOLVED too      (a paper never added != a composed citekey)
+#   2. the empty-library guard is dropped    (an empty .bib condemns every note, saying nothing)
+#   3. the notetype filter is dropped        (concept notes get judged as literature notes)
+#   4. the DOI suggestion is disabled        (INVENTED silently degrades to UNRESOLVED)
+#   5. the filename check is dropped         (a note whose filename disagrees reads as OK)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CARD="$HERE/citekey_provenance_challenge.sh"
+SRC="$HERE/../scripts/check_citekey_provenance.py"
+[ -f "$CARD" ] || { echo "missing card: $CARD"; exit 2; }
+[ -f "$SRC" ]  || { echo "missing detector: $SRC"; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+python3 - "$SRC" "$CARD" "$WORK" <<'PY'
+import pathlib, subprocess, sys
+
+src_path, card, work = sys.argv[1], sys.argv[2], sys.argv[3]
+src = pathlib.Path(src_path).read_text(encoding="utf-8")
+
+MUTATIONS = {
+    "--strict fires on UNRESOLVED too": (
+        'if args.strict and counts["INVENTED"]:',
+        'if args.strict and (counts["INVENTED"] or counts["UNRESOLVED"]):',
+    ),
+    "empty-library guard removed": (
+        "        return 2\n\n    rows = []",
+        "        pass\n\n    rows = []",
+    ),
+    "notetype filter removed": (
+        'if field(fm, "notetype") != "literature":\n            continue',
+        "if False:\n            continue",
+    ),
+    "DOI suggestion disabled": (
+        'suggestion = doi_to_key.get(doi, "") if doi else ""',
+        'suggestion = ""',
+    ),
+    "filename check removed": (
+        'verdict = "OK" if path.stem == citekey else "FILENAME"',
+        'verdict = "OK"',
+    ),
+}
+
+# The card must pass against the real detector, or the mutations below prove nothing.
+real = subprocess.run(["bash", card, src_path], capture_output=True, text=True)
+if real.returncode != 0:
+    print("FAIL: the card does not pass against the unmutated detector")
+    print(real.stdout[-2000:])
+    sys.exit(1)
+print("  PASS  card is green against the real detector")
+
+blind = []
+for label, (old, new) in MUTATIONS.items():
+    n = src.count(old)
+    if n != 1:
+        print(f"  FAIL  {label}: anchor matched {n} time(s) — the detector changed, "
+              "so this self-test no longer tests what it claims")
+        blind.append(label)
+        continue
+    mutant = pathlib.Path(work) / "mutant.py"
+    mutant.write_text(src.replace(old, new), encoding="utf-8")
+    r = subprocess.run(["bash", card, str(mutant)], capture_output=True, text=True)
+    if r.returncode == 0:
+        print(f"  FAIL  {label}: the card stayed GREEN — it is blind on this axis")
+        blind.append(label)
+    else:
+        fired = sum(1 for l in r.stdout.splitlines() if l.strip().startswith("FAIL"))
+        print(f"  PASS  {label}: card failed as it must ({fired} assertion(s) fired)")
+
+if blind:
+    print(f"\n{len(blind)} mutation(s) went undetected: {', '.join(blind)}")
+    sys.exit(1)
+print(f"\nall {len(MUTATIONS)} mutations caught")
+PY


### PR DESCRIPTION
`check_citekey_provenance.py` shipped in #478 with no test, no challenge card and no CI wiring. `check_test_wiring.py` could not catch that — it asks whether *existing* tests run, not whether a script has one. So the detector that decides whether a literature note's citekey is real had never been run against a known answer.

## The challenge card

Builds its fixture at runtime (7 notes + a `.bib`), so nothing committed here can drift. 13 assertions: all five verdicts (OK, FILENAME, INVENTED, UNRESOLVED, NO_CITEKEY) counted exactly once; both skip rules (`notetype != literature`, dot-paths); that INVENTED recovers the real key from the note's DOI; and four exit codes.

Two of those are the ones worth having:

- **`--strict` fails on INVENTED only.** A paper never added to the library (UNRESOLVED) and a filename disagreeing with a real key (FILENAME) are reported but do not fail. Widening that to UNRESOLVED would make the gate fire on ordinary in-progress work — it is exactly the boundary a later edit would blur.
- **An empty library exits 2.** The script's own comment says why: with no keys every note reads as unresolved, *"which says nothing."* The guard existed and had never been exercised.

## The self-test is the point

A card that passes proves it **ran**. It proves nothing about whether it would catch a defect — the lesson this repo keeps relearning. So the self-test mutates the detector five ways, each removing a behaviour the card claims to assert, and requires the card to **FAIL** every time:

| mutation | result |
|---|---|
| `--strict` fires on UNRESOLVED too | caught (1 assertion) |
| empty-library guard removed | caught (1) |
| `notetype` filter removed | caught (2) |
| DOI suggestion disabled | caught (4) |
| filename check removed | caught (2) |

A mutation that stayed green would be reported as a blind axis. The self-test also refuses to run if an anchor no longer matches, so a future refactor cannot leave it silently testing nothing.

## What this did not find

**The detector needed no change.** It was correct — the `--strict` boundary and the empty-library guard were both already right. It was simply unverified, which is a different problem with the same remedy.

Wired into `validate.yml` (241 → 243 gates) and lit-sync's `validation_commands`. `python3 scripts/run_ci_mirror.py` → 243/243, with both new gates observed running at 133 and 134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)