### PR TITLE
fix(check-reporting): GRRAS was 13 of 15 items wrong; the directory is now 49/49 compared

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -713,8 +713,8 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/GRRAS.md",
-      "size": 6589,
-      "sha256": "4eec0fce5d129d6de4a230f6f2ebb207ec55483c059d54133e8adc3fbf6cbf2f"
+      "size": 6359,
+      "sha256": "51ee96c57b9a0447e9d67898adea3186da5b404621e37813047eb869e6a23053"
     },
     {
       "path": "skills/check-reporting/references/checklists/MI_CLEAR_LLM.md",

--- a/skills/check-reporting/references/checklists/GRRAS.md
+++ b/skills/check-reporting/references/checklists/GRRAS.md
@@ -6,75 +6,77 @@ Source: https://doi.org/10.1016/j.jclinepi.2010.03.002
 Reference: Kottner J, Audige L, Brorson S, et al. Guidelines for Reporting Reliability and Agreement Studies (GRRAS) were proposed. J Clin Epidemiol. 2011;64(1):96-106. doi:10.1016/j.jclinepi.2010.03.002
 
 Licence: Crossref returns no Creative Commons licence (Elsevier).
-Verification: **NOT VERIFIED — no accessible copy exists.** GRRAS was published simultaneously in
-*J Clin Epidemiol* 2011;64(1):96-106 and *Int J Nurs Stud* 2011;48(6):661-671, both Elsevier and
-both paywalled. **Two independent open-access indexes agree there is no free copy of either**:
-OpenAlex returns no OA location and Unpaywall returns `is_oa: false` with an empty location list
-for both DOIs. Neither has a PubMed Central record; the EQUATOR page links only to PubMed; the
-GRRAS authors publish no tool document of their own (unlike QUADAS, ROBIS, RoB 2, TRIPOD, NOS and
-CARE, whose own sites carry the instrument). ScienceDirect serves a CAPTCHA to automated retrieval,
-which this audit does not complete.
+Verification: all 15 items were compared against the checklist table of the published article
+(Table 1, *J Clin Epidemiol* 2011;64(1):96-106), read from the article PDF obtained through an
+institutional subscription. The table renders several rows as mirrored glyphs, so each item was
+also recovered independently from the article's own section-3 headings ("Item N: ...") and the two
+readings agreed. **The count matched and almost nothing else did**: 13 of 15 items were wrong.
+Only items 1 and 14 survived. This file previously invented a *Limitations* item that GRRAS does
+not have, and omitted item 2 (name and describe the measurement device) entirely; items 2-13 were
+a different checklist wearing GRRAS's numbering.
 
-**What is confirmed** is only internal: the file declares 15 items and carries 15, numbered 1–15
-with no gaps, across Title/Abstract, Introduction, Methods, Results and Discussion. That says
-nothing about whether they are GRRAS's items — the count matched on GATHER, REMARK and COSMIN
-while the items underneath were wrong.
-
-**To finish this file**: download either article through an institutional subscription and compare
-its checklist table item by item. Until then the items below are an in-house summary, and anything
-you report should be scored against the published instrument.
+The source article is not redistributable (Elsevier, no open licence; **OpenAlex and Unpaywall
+both report no open-access copy of either the *J Clin Epidemiol* or the *Int J Nurs Stud*
+version**). The item text below therefore states what each item asks **in our own words**.
+Complete the official instrument for anything you report.
 
 ## Checklist Items (15 items)
 
-### Title and Abstract
+### Title and abstract
 
 | # | Item | Description |
 |---|------|-------------|
-| 1 | Identification | Identify in title or abstract that the study addresses reliability and/or agreement. Specify the statistic(s) used (e.g., kappa, ICC, Bland-Altman). |
+| 1 | Identification | Make clear in the title or the abstract whether interrater or intrarater **reliability** or **agreement** was the subject of the study. |
 
 ### Introduction
 
 | # | Item | Description |
 |---|------|-------------|
-| 2 | Rationale | Provide the scientific background and rationale for the reliability/agreement study. |
-| 3 | Objectives | State the specific objectives, including any pre-specified hypotheses (e.g., expected level of agreement). |
+| 2 | Measurement device | Name the diagnostic or measurement device under study and describe it explicitly. |
+| 3 | Subject population | Specify the population of subjects (or objects) the study is about. |
+| 4 | Rater population | Specify the population of raters the study is about, where raters are involved. |
+| 5 | Existing knowledge and rationale | Describe what is already known about the reliability and agreement of this measurement, and give the rationale for doing this study. |
 
 ### Methods
 
 | # | Item | Description |
 |---|------|-------------|
-| 4 | Study design | Describe the study design, including: fully crossed vs nested, raters as random or fixed effect, number of measurement occasions. |
-| 5 | Sample | Describe the sample: how subjects were sampled, eligibility criteria, settings and locations, and intended variation in the measurand. |
-| 6 | Measurement methods and devices | Describe the measurement methods and devices used, including any preparation, training, or calibration. |
-| 7 | Raters | Describe the raters: number, relevant qualifications and experience, any rater training specific to the study, and whether raters represent the target population of users. |
-| 8 | Measurement procedure | Describe the measurement procedure: setting, timing, number of measurements per subject, time interval between repeated measurements, and standardization of conditions. |
-| 9 | Order of measurements | State how the order of examination was varied (e.g., randomized order, blinding to previous measurements). |
-| 10 | Statistical methods | State the statistical methods used to estimate reliability and/or agreement, including: software, specific statistical model (e.g., ICC model and type), handling of missing data, methods for estimating CIs, and any additional analyses (e.g., Bland-Altman, SEM, MDC). |
+| 6 | Sample size | Explain how the sample size was arrived at, and state the number of raters, of subjects/objects, and of replicate observations that were decided on. |
+| 7 | Sampling method | Describe how subjects/objects (and raters, where applicable) were sampled. |
+| 8 | Measurement/rating process | Describe how measurements or ratings were carried out — including the time interval between repeated measurements, what clinical information was available to raters, and any blinding. |
+| 9 | Independence | State whether the repeated measurements or ratings were made **independently** of one another. |
+| 10 | Statistical analysis | Describe the statistical analysis. |
 
 ### Results
 
 | # | Item | Description |
 |---|------|-------------|
-| 11 | Sample and raters | Report the number of raters and subjects included in the analysis (and any exclusions). Report relevant demographic and clinical characteristics of the sample. |
-| 12 | Reliability/agreement estimates | Report reliability and/or agreement estimates with confidence intervals or standard errors. For continuous measurements, report LoA or SEM/MDC as applicable. |
-| 13 | Additional analyses | Report results of any additional analyses performed (e.g., effect of rater experience, subgroup analyses, time-trend analysis). |
+| 11 | Numbers actually included | State the number of raters and of subjects/objects that were actually included, and the number of replicate observations actually made. |
+| 12 | Sample characteristics | Describe the characteristics of the raters and of the subjects — for raters, things such as training and experience. |
+| 13 | Reliability and agreement estimates | Report the reliability and/or agreement estimates **together with a measure of statistical uncertainty** (e.g. a confidence interval or standard error). |
 
 ### Discussion
 
 | # | Item | Description |
 |---|------|-------------|
-| 14 | Clinical relevance | Discuss the practical and clinical relevance of the results. Include comparison with previously reported reliability/agreement values, interpretation relative to measurement purpose, and implications for clinical use. |
-| 15 | Limitations | Discuss the limitations of the study, including: spectrum of measurand values, generalizability to other raters/settings, potential sources of bias (e.g., memory effects, learning effects), and any factors that may have inflated or deflated estimates. |
+| 14 | Practical relevance | Discuss the practical relevance of the results. |
 
----
+### Auxiliary material
+
+| # | Item | Description |
+|---|------|-------------|
+| 15 | Detailed results | Provide detailed results where possible — for example as online supplementary material. |
+
+**GRRAS has no Limitations item.** It also has no separate Objectives item; the study's purpose is
+carried by items 3-5. Do not add either when scoring.
 
 ## Notes for Assessors
 
 - GRRAS applies to all reliability and agreement studies, including inter-rater, intra-rater, test-retest, and method-comparison designs across any medical discipline.
 - **Reliability vs Agreement**: These are distinct concepts. Reliability (e.g., ICC, kappa) reflects the ability to distinguish between subjects; agreement (e.g., Bland-Altman limits of agreement, SEM) reflects how close scores are on repeated measurements. A study may report one or both.
-- Item 4 (Study design): The ICC model choice (one-way random, two-way random, two-way mixed) and type (single measures, average measures) must match the study design. Flag mismatches as a Major Comment.
-- Item 7 (Raters): Rater characteristics strongly influence reliability estimates. Studies using expert raters only will overestimate reliability in general clinical practice. Note this if raters are not representative.
-- Item 9 (Order of measurements): Randomization of measurement order is critical for avoiding memory and learning effects. Its absence should be flagged as a limitation.
-- Item 12: For ICC, report the model, type, and definition (consistency vs absolute agreement). For kappa, specify weighted vs unweighted and the weighting scheme. Bare numbers without these specifications are PARTIAL.
+- Item 10 (Statistical analysis): the ICC model (one-way random, two-way random, two-way mixed) and type (single measures, average measures) must match the study design. Flag mismatches as a Major Comment. GRRAS states this item in one line and leaves the detail to the analyst — the article's Table 2 maps statistical methods onto the level of measurement and onto reliability versus agreement.
+- Items 4 and 12 (rater population, rater characteristics): rater characteristics strongly influence reliability estimates. A study using expert raters only will overestimate reliability for general clinical practice. Note it when the raters are not representative of the population item 4 names.
+- Item 9 (Independence) is the one most often skipped, and it is narrow: it asks whether the repeated measurements were made independently — not whether their *order* was randomised. Order randomisation and blinding belong to item 8. Both matter for memory and learning effects; score them where GRRAS puts them.
+- Item 13: for an ICC, report the model, type and definition (consistency vs absolute agreement); for a kappa, whether it is weighted and with which scheme. A bare estimate with no measure of statistical uncertainty fails the item outright, since the uncertainty is part of what item 13 asks for.
 - Common in radiology: inter-reader agreement for measurements (Bland-Altman, ICC), segmentation agreement (Dice, ICC of volumes), and diagnostic classification agreement (kappa, percent agreement).
 - GRRAS is complementary to study-type checklists. For example, a diagnostic accuracy study reporting inter-reader agreement should follow STARD for the main analysis and GRRAS for the agreement component.


### PR DESCRIPTION
GRRAS was the one instrument the audit could not reach. Published only in two paywalled Elsevier journals, with **OpenAlex and Unpaywall independently reporting no open-access copy of either**, no PMC record, and — unlike QUADAS, ROBIS, RoB 2, ROB-ME, TRIPOD, NOS and CARE — **no tool distributed by its own authors**. The file said so and named exactly what it would take. It took one institutional download.

## 13 of 15 items were wrong

Only items 1 and 14 survived. The count matched — 15 declared, 15 present, numbered 1–15 with no gaps — which is the **fourth** time in this audit that a right count sat on top of wrong items, after GATHER, REMARK and COSMIN.

| # | what the file had | what GRRAS asks |
|---|---|---|
| 2 | Rationale | **Name and describe the measurement device** — missing from the file entirely |
| 3 | Objectives | Specify the **subject population** of interest |
| 4 | Study design | Specify the **rater population** of interest |
| 5 | Sample | What is **already known** about reliability/agreement, and the rationale |
| 6 | Measurement methods and devices | **Sample size**, and the number of raters / subjects / replicate observations |
| 7 | Raters | The **sampling method** |
| 9 | Order of measurements | Whether measurements were made **independently** (order and blinding are item 8) |
| 12 | Reliability/agreement estimates | **Sample characteristics** of raters and subjects |
| 13 | Additional analyses | Estimates **with a measure of statistical uncertainty** |
| 15 | Limitations | **Provide detailed results, if possible online** |

**GRRAS has no Limitations item** — the file invented one. It also has no Objectives item, and the file invented one of those at position 3. Conversely the real item 2 was absent. And GRRAS has an **AUXILIARY MATERIAL** section the file did not have at all.

## Method note

The article's Table 1 renders several rows as **mirrored glyphs**, so a naive text extraction yields reversed, space-stripped strings. Each item was therefore recovered **twice** — once by decoding the table, once from the article's own section-3 headings (`Item N: …`) — and the two readings were required to agree before anything was written. Six of the nine mirrored items were independently confirmed verbatim in the body text.

The source is not redistributable (Elsevier, no open licence), so item text states what each item asks in our own words, as with the other closed-licence instruments here.

## Directory state

**49 of 49 compared against a source. None unverified.** The `NOT VERIFIED` tier is now empty, as is the count-only tier.

`python3 scripts/run_ci_mirror.py` → 241/241.

*Note:* this branch is off `main` and will need a rebase on `metadata/distribution_files.json` if #488 lands first — the usual mechanical regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)