### PR TITLE
docs(check-reporting): where QUADAS-C and QUADAS-3 do not slot together, and why C4 is the problem

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -628,8 +628,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 41059,
-      "sha256": "db06fd060469f2215c86e9616800710f288a8ab8c9f5f6f55adf8e0b3054daa0"
+      "size": 41096,
+      "sha256": "2da6526d5b044b483f0b85cfcd913d3f4d85f994009a16dc0d471d134057cc93"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -778,13 +778,13 @@
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS3.md",
-      "size": 9474,
-      "sha256": "61083d6ab470c387c550c631435106a205aec722d968e72452e740ae152bc407"
+      "size": 11822,
+      "sha256": "f6edd64e37a58823007c7f4412f0fad5fbab2c447e03c0697ea0ba6d5860b316"
     },
     {
       "path": "skills/check-reporting/references/checklists/QUADAS_C.md",
-      "size": 9816,
-      "sha256": "6a521a0936960264eb7913a1fa252618c4d5cd88e4085451c04229aa4392519c"
+      "size": 9953,
+      "sha256": "1438ede70887883c4dae2d7a80acf64d37f55f62aab55fa2994868664728c8c4"
     },
     {
       "path": "skills/check-reporting/references/checklists/RECORD.md",
@@ -2743,8 +2743,8 @@
     },
     {
       "path": "skills/meta-analysis/references/checklists/QUADAS3.md",
-      "size": 9474,
-      "sha256": "61083d6ab470c387c550c631435106a205aec722d968e72452e740ae152bc407"
+      "size": 11822,
+      "sha256": "f6edd64e37a58823007c7f4412f0fad5fbab2c447e03c0697ea0ba6d5860b316"
     },
     {
       "path": "skills/meta-analysis/references/checklists/ROBINS_I.md",

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -118,7 +118,7 @@ user specification.
 | Risk of bias (RCTs) | RoB 2 | -- |
 | Risk of bias (non-randomised intervention studies) | ROBINS-I | -- |
 | Risk of bias (non-randomised exposure studies) | ROBINS-E | -- |
-| Risk of bias (comparative DTA studies) | QUADAS-C | **QUADAS-3** (use both; QUADAS-C needs adaptation — see the QUADAS-3 E&E) |
+| Risk of bias (comparative DTA studies) | QUADAS-C | **QUADAS-3** (use both; C4 has no single QUADAS-3 domain — see *Using QUADAS-C with QUADAS-3* in `QUADAS3.md`) |
 | Risk of bias (prediction models) | PROBAST | PROBAST+AI |
 | Risk of bias (systematic reviews) | ROBIS | AMSTAR 2 |
 | Risk of bias (missing evidence in MA) | ROB-ME | -- |

--- a/skills/check-reporting/references/checklists/QUADAS3.md
+++ b/skills/check-reporting/references/checklists/QUADAS3.md
@@ -43,8 +43,43 @@ Condition** (the index-test-to-reference-standard interval), and participant exc
 data and the unit of analysis moved into the new **Analysis** domain.
 
 **Comparative accuracy reviews**: the group recommends using **QUADAS-C in addition to QUADAS-3**
-(`QUADAS_C.md`). QUADAS-C was written against QUADAS-2 and needs adaptation; the QUADAS-3 E&E
-report gives guidance on how.
+(`QUADAS_C.md`). QUADAS-C was written against QUADAS-2 and needs adaptation — see the next section.
+
+## Using QUADAS-C with QUADAS-3
+
+Both tools say to pair them: the QUADAS-3 tool states that "for reviews involving comparative
+accuracy, we recommend using the QUADAS-C tool in addition to QUADAS-3", and the QUADAS group says
+QUADAS-C "cannot be used alone and must be used alongside the main QUADAS tool", now meaning
+QUADAS-3.
+
+**They do not slot together unchanged, and it is worth knowing where before you start.** Each of
+QUADAS-C's four opening questions hard-references a QUADAS-2 question number:
+
+| QUADAS-C | asks whether | referencing | QUADAS-3 counterpart |
+|---|---|---|---|
+| C1.1 | each index test was low risk for this domain | QUADAS-2 **1.4** | Domain 1 **Participants** judgement |
+| C2.1 | 〃 | QUADAS-2 **2.3** | Domain 2 **Index Test** judgement |
+| C3.1 | 〃 | QUADAS-2 **3.3** | Domain 3 **Target Condition** judgement (the domain was renamed from Reference Standard) |
+| C4.1 | 〃 | QUADAS-2 **4.5** | **no single counterpart** |
+
+**C4 is the one that does not map.** QUADAS-C's domain 4 is *Flow and Timing*, and QUADAS-3 split
+that domain: the index-test-to-reference-standard interval became **3.8** inside Target Condition,
+while exclusions, missing data and the unit of analysis became the new **Analysis** domain. So
+QUADAS-C's C4.1 has no one judgement to read, and its C4.2 (interval between the index tests),
+C4.3 (same reference standard for all index tests) and C4.4 (missing data comparable across index
+tests) sit astride two QUADAS-3 domains.
+
+There is a second mismatch of granularity: **QUADAS-3 judges each set of accuracy estimates, while
+QUADAS-C judges a test comparison**, which spans at least two estimates. Decide, and record, which
+estimates a given QUADAS-C assessment is standing on.
+
+> **The authority for this adaptation is the QUADAS-3 E&E report, which this file has not read.**
+> Davenport C, Rutjes A, Mallett S, Tomlinson E, Yang B, et al. QUADAS-3 explanation and
+> elaboration. *Ann Intern Med* 2026;179:e2504943 (DOI 10.7326/ANNALS-25-04943). It is **CC BY**
+> and open access, but every route to it — the ACP site, the Bristol repository landing page, and
+> the handle — returns a bot challenge to automated retrieval, so it was not fetched. The mapping
+> above is **our reading of the two tool documents**, not the E&E's guidance. Read the E&E before
+> relying on it for a review you will publish.
 
 ## The six phases
 

--- a/skills/check-reporting/references/checklists/QUADAS_C.md
+++ b/skills/check-reporting/references/checklists/QUADAS_C.md
@@ -18,8 +18,9 @@ repositories sit behind a browser challenge; the group's own distribution made t
 > that QUADAS-C "cannot be used alone and must be used alongside the main QUADAS tool", and now
 > recommends pairing it with **QUADAS-3** rather than QUADAS-2 — with adaptation, for which the
 > QUADAS-3 E&E document gives guidance. This file documents QUADAS-C as published against
-> QUADAS-2. See **`QUADAS3.md`** for the current base tool, and `QUADAS2.md` for the one this
-> extension was written against.
+> QUADAS-2. See **`QUADAS3.md`** for the current base tool (its *Using QUADAS-C with QUADAS-3*
+> section maps the four Cx.1 questions onto QUADAS-3's domains and shows where **C4 does not map**),
+> and `QUADAS2.md` for the tool this extension was written against.
 
 ## Purpose
 

--- a/skills/meta-analysis/references/checklists/QUADAS3.md
+++ b/skills/meta-analysis/references/checklists/QUADAS3.md
@@ -43,8 +43,43 @@ Condition** (the index-test-to-reference-standard interval), and participant exc
 data and the unit of analysis moved into the new **Analysis** domain.
 
 **Comparative accuracy reviews**: the group recommends using **QUADAS-C in addition to QUADAS-3**
-(`QUADAS_C.md`). QUADAS-C was written against QUADAS-2 and needs adaptation; the QUADAS-3 E&E
-report gives guidance on how.
+(`QUADAS_C.md`). QUADAS-C was written against QUADAS-2 and needs adaptation — see the next section.
+
+## Using QUADAS-C with QUADAS-3
+
+Both tools say to pair them: the QUADAS-3 tool states that "for reviews involving comparative
+accuracy, we recommend using the QUADAS-C tool in addition to QUADAS-3", and the QUADAS group says
+QUADAS-C "cannot be used alone and must be used alongside the main QUADAS tool", now meaning
+QUADAS-3.
+
+**They do not slot together unchanged, and it is worth knowing where before you start.** Each of
+QUADAS-C's four opening questions hard-references a QUADAS-2 question number:
+
+| QUADAS-C | asks whether | referencing | QUADAS-3 counterpart |
+|---|---|---|---|
+| C1.1 | each index test was low risk for this domain | QUADAS-2 **1.4** | Domain 1 **Participants** judgement |
+| C2.1 | 〃 | QUADAS-2 **2.3** | Domain 2 **Index Test** judgement |
+| C3.1 | 〃 | QUADAS-2 **3.3** | Domain 3 **Target Condition** judgement (the domain was renamed from Reference Standard) |
+| C4.1 | 〃 | QUADAS-2 **4.5** | **no single counterpart** |
+
+**C4 is the one that does not map.** QUADAS-C's domain 4 is *Flow and Timing*, and QUADAS-3 split
+that domain: the index-test-to-reference-standard interval became **3.8** inside Target Condition,
+while exclusions, missing data and the unit of analysis became the new **Analysis** domain. So
+QUADAS-C's C4.1 has no one judgement to read, and its C4.2 (interval between the index tests),
+C4.3 (same reference standard for all index tests) and C4.4 (missing data comparable across index
+tests) sit astride two QUADAS-3 domains.
+
+There is a second mismatch of granularity: **QUADAS-3 judges each set of accuracy estimates, while
+QUADAS-C judges a test comparison**, which spans at least two estimates. Decide, and record, which
+estimates a given QUADAS-C assessment is standing on.
+
+> **The authority for this adaptation is the QUADAS-3 E&E report, which this file has not read.**
+> Davenport C, Rutjes A, Mallett S, Tomlinson E, Yang B, et al. QUADAS-3 explanation and
+> elaboration. *Ann Intern Med* 2026;179:e2504943 (DOI 10.7326/ANNALS-25-04943). It is **CC BY**
+> and open access, but every route to it — the ACP site, the Bristol repository landing page, and
+> the handle — returns a bot challenge to automated retrieval, so it was not fetched. The mapping
+> above is **our reading of the two tool documents**, not the E&E's guidance. Read the E&E before
+> relying on it for a review you will publish.
 
 ## The six phases
 


### PR DESCRIPTION
#487 routed QUADAS-C to QUADAS-3 in the selection tables but left the pairing as one line — *"needs adaptation, see the E&E."* That tells a reviewer nothing they can act on, and the specific place it breaks turns out to be derivable from the two tool documents this repository already holds.

## The mapping

Each of QUADAS-C's four opening questions hard-references a **QUADAS-2 question number**:

| QUADAS-C | referencing | QUADAS-3 counterpart |
|---|---|---|
| C1.1 | QUADAS-2 **1.4** | Domain 1 **Participants** judgement |
| C2.1 | QUADAS-2 **2.3** | Domain 2 **Index Test** judgement |
| C3.1 | QUADAS-2 **3.3** | Domain 3 **Target Condition** judgement (renamed from Reference Standard) |
| C4.1 | QUADAS-2 **4.5** | **no single counterpart** |

## C4 is the one that breaks

QUADAS-C's domain 4 is *Flow and Timing* — and **QUADAS-3 split that domain**. The index-test-to-reference-standard interval became **3.8** inside Target Condition; exclusions, missing data and the unit of analysis became the new **Analysis** domain.

So C4.1 has no one judgement to read, and C4.2 (interval between the index tests), C4.3 (same reference standard for all index tests) and C4.4 (missing data comparable across index tests) sit astride two QUADAS-3 domains.

A second mismatch is one of granularity rather than structure: **QUADAS-3 judges each set of accuracy estimates; QUADAS-C judges a test comparison**, which spans at least two. Which estimates a given QUADAS-C assessment stands on has to be decided and recorded.

## What this is not

The authority for the adaptation is the **QUADAS-3 E&E report** (*Ann Intern Med* 2026;179:e2504943, `10.7326/ANNALS-25-04943`), and **this file has not read it.** The E&E is CC BY and open access, but every route — the ACP site, the Bristol repository landing page, and the handle — returns a bot challenge to automated retrieval, which this repository does not complete.

The mapping is therefore labelled in the file as **our reading of the two tool documents**, with the E&E named as the authority to consult before publishing a review that relies on it.

That labelling is the whole point. A mapping presented as the guideline's own would be the same defect class the checklist audit spent this week removing — 11 instruments where somebody's plausible reconstruction had been shipped as the instrument.

**To finish this properly**: one copy of the E&E PDF, the same way GRRAS got finished.

`python3 scripts/run_ci_mirror.py` → 243/243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)