### PR TITLE
test(lit-sync): give the poll-logic scenarios enough timing slack to survive a loaded machine

### DIFF
--- a/skills/lit-sync/tests/test_poll_logic.sh
+++ b/skills/lit-sync/tests/test_poll_logic.sh
@@ -78,14 +78,24 @@ echo "Phase 2.5 polling regression (4 scenarios)"
 echo "  Tmpdir: $TMP"
 echo
 
+# Timing slack. The poller reads `date +%s`, so both START and the `>= TIMEOUT`
+# comparison are whole seconds: the deadline can fire up to ~1s early on top of any
+# sleep overshoot. Each scenario therefore needs its write and its deadline several
+# seconds apart, not one or two.
+#
+# Widening a DETECT scenario's window costs no runtime — it exits the moment it sees
+# the mtime change, so the window is only a deadline. Narrowing a TIMEOUT scenario's
+# window shortens it. The slack column is the gap these margins buy.
+#
+#                                              window  write_at   slack
 # 1. BBT write within window → detect
-run_scenario "detect-within-window" 10 3 0
+run_scenario "detect-within-window" 10 3 0   #     10         3      7s
 # 2. No write, short window → timeout
-run_scenario "timeout-silent" 3 none 1
+run_scenario "timeout-silent" 3 none 1       #      3      none     n/a
 # 3. BBT debounce, late-but-within write → detect
-run_scenario "debounce-late" 10 8 0
+run_scenario "debounce-late" 14 8 0          #     14         8      6s
 # 4. Slow BBT, write outside window → timeout (Phase 2.5 fallback prompt)
-run_scenario "slow-bbt-timeout" 4 8 1
+run_scenario "slow-bbt-timeout" 2 8 1        #      2         8      6s
 
 echo
 echo "Summary: $PASS passed, $FAIL failed"


### PR DESCRIPTION
`test_poll_logic.sh` has been carried in HANDOFF as flaky under local load for several sessions. This does not claim to fix that — see below — but it removes a fragility that is measurable from the source either way.

## The margin

`debounce-late` writes at 8s against a 10s deadline. Two seconds of nominal slack, and the poller spends up to about one of them on arithmetic: it reads `date +%s`, so **both `START` and the `>= TIMEOUT` comparison are whole seconds** and the deadline can fire ~1s early. Whatever the sleeps overshoot comes out of what's left. `slow-bbt-timeout` is the mirror image — it needs the deadline to arrive *before* the write, and had 4s.

| scenario | window | write_at | slack before | after |
|---|---|---|---|---|
| detect-within-window | 10 | 3 | 7s | 7s |
| timeout-silent | 3 | none | n/a | n/a |
| **debounce-late** | 10 → **14** | 8 | **2s** | **6s** |
| **slow-bbt-timeout** | 4 → **2** | 8 | 4s | **6s** |

**This costs no runtime.** A detect scenario exits the moment it sees the mtime change, so its window is only a deadline; a timeout scenario runs its window then waits for the writer either way. Measured: **22.6s after, 22.9s before.**

Both scenarios still test what their names claim — 3 is still a late write *inside* the window, 4 is still a write that lands *outside* it.

## What this is not

**I could not reproduce the reported flake.** 9 unloaded runs and 3 runs under 2× CPU oversubscription (20 workers on 10 cores) all passed — 12 for 12. Pure CPU spin does not delay `sleep` much, and the original report came from a session running the CI mirror, which contends on process spawning and disk rather than CPU.

So this is not presented as the fix. It removes a sub-second effective margin in a test whose clock has whole-second resolution, which is worth removing on its own terms.

**If the flake returns, capture which scenario failed and with what exit code.** That is the evidence this diagnosis is still missing, and the scenario identity points straight at the cause: a detect scenario failing means the write missed its deadline, a timeout scenario failing means the poller was starved past the write.

Rejected on the way, so the next person doesn't re-walk them:

- *mtime whole-second collapse (`BEFORE == NOW`)* — every write lands ≥3s after the baseline `stat`, so the two always differ.
- *a defect in the polling logic itself* — 12/12 green, and the reported failures moved between scenarios, which points at margins rather than logic.

`python3 scripts/run_ci_mirror.py` → 243/243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)