### PR TITLE
fix(meta-analysis,check-reporting): QUADAS-3 phases 1-2 are protocol work, not risk-of-bias work

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -628,8 +628,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 41090,
-      "sha256": "6f932d046b9e5c2e2968c047b84cb4f981478604e4f74208b5f1ca01244d2b4e"
+      "size": 41742,
+      "sha256": "b57ffd0bab3807cbe8f8c456a9af045c3fd41bd17d2d934abb7fe4fbc1ced03d"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -2698,8 +2698,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 45502,
-      "sha256": "2f2947e7fb73b25b96690f78f9871b239c060ef3fd382c4bb039152ec4210d91"
+      "size": 46982,
+      "sha256": "b10cb9ab372858792bcddcc6675c3c2c0d3211b3e5283b9874b1bdc7e931cfde"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -140,6 +140,14 @@ user specification.
 | Educational / QI study | SQUIRE 2.0 | -- |
 | Generative AI **images ARE the study object** (realism / real-vs-synthetic reader study / model-vs-model quality) | (no single guideline -- assemble) | see decision aid below |
 
+> **QUADAS-3 has two protocol-stage phases, and this skill usually runs too late for them.**
+> Phase 1 (state the synthesis question) and phase 2 (define the **ideal test accuracy trial**
+> each judgement is made against) are review-level and belong in the protocol, alongside the
+> review-specific guidance for answering each signalling question. Reaching them for the first
+> time during manuscript QC means writing the comparator after seeing the results.
+> If they are missing, say so as a limitation rather than reconstructing them — and route the
+> protocol work to `/meta-analysis` Phase 1. Phases 3–6 are what a QC pass can genuinely run.
+
 **Rules:**
 - If the study involves AI/ML, always apply the AI extension in addition to the base guideline.
   - **Exception — TRIPOD**: TRIPOD+AI 2024 (Collins et al., BMJ 2024) is a complete rewrite, not an addendum to TRIPOD 2015 (Moons et al., Ann Intern Med 2015). For non-AI prediction models, use TRIPOD 2015 only. For AI/ML prediction models, use TRIPOD+AI 2024 only. Do NOT apply both simultaneously.

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -80,7 +80,19 @@ Auto-detect type from the research question or accept user specification.
    - DTA: PIRD (Population, Index test, Reference standard, Diagnosis)
    - Intervention: PICO (Population, Intervention, Comparator, Outcome)
 
-2. **Define eligibility criteria**:
+2. **DTA only — do QUADAS-3 phases 1 and 2 now, not at risk-of-bias time**:
+   QUADAS-3's first two phases are **review-level and belong in the protocol**:
+   phase 1 states the **synthesis question(s)** (population, index test(s), target
+   condition — a review may have more than one), and phase 2 defines the **ideal test
+   accuracy trial** for each: objective, participants, index test(s), definition of the
+   target condition, analysis. Every later risk-of-bias and applicability judgement is
+   made against that trial.
+   Write the review-specific guidance for answering each signalling question here too,
+   with clinical **and** methodological input, and publish it as a web appendix.
+   Defining the ideal trial after seeing the studies is not an assessment — it is a
+   judgement fitted to the results. See `references/checklists/QUADAS3.md`.
+
+3. **Define eligibility criteria**:
    - Study design (cross-sectional DTA, cohort, RCT, etc.)
    - Population characteristics
    - Index test / intervention specifics
@@ -88,26 +100,26 @@ Auto-detect type from the research question or accept user specification.
    - Outcome measures (Se/Sp for DTA; effect size for intervention)
    - Exclusion criteria with justification
 
-3. **Plan the search**:
+4. **Plan the search**:
    - Minimum 3 databases: PubMed, Embase, and Cochrane CENTRAL (add Scopus, Web of Science as needed)
    - Draft Boolean search strategy using PIRD/PICO components
    - Grey literature plan (conference abstracts, trial registries)
    - Language restrictions (state explicitly)
    - Date range with justification
 
-4. **Plan RoB assessment**:
+5. **Plan RoB assessment**:
    - Select tool based on type (see table above)
    - State number of independent assessors (minimum 2)
    - Plan for disagreement resolution (consensus, third reviewer)
 
-5. **Plan synthesis**:
+6. **Plan synthesis**:
    - DTA: bivariate random-effects model (Reitsma) or HSROC (Rutter & Gatsonis)
    - Intervention: random-effects (DerSimonian-Laird or REML)
    - Heterogeneity assessment plan
    - Subgroup / sensitivity analysis plan
    - Publication bias assessment plan
 
-6. **Generate PROSPERO registration document**:
+7. **Generate PROSPERO registration document**:
    - Read `${CLAUDE_SKILL_DIR}/references/PROSPERO_template.md` for field-by-field guidance
    - Generate all fields with word counts (stay within limits per field)
    - Structure: title, review question, PICO, searches, data collection, outcomes, synthesis, subgroups, stage, affiliation
@@ -306,6 +318,11 @@ analysis excluding one of the pair. Cross-links: `/peer-review` Phase 2A P1 + P2
 
 **Goal**: Guide structured RoB assessment with the appropriate tool.
 
+**DTA**: this phase runs QUADAS-3 **phases 3–6** (flow diagram, identify the estimates to
+assess, assess, overall judgement). Phases 1–2 — the synthesis question and the ideal test
+accuracy trial — were written in Phase 1 above. If they were not, stop and write them before
+judging anything; they are the comparator every judgement is made against.
+
 Select tool based on meta-analysis type (see table above), then read the corresponding checklist:
 
 | Tool | Checklist File |
@@ -438,7 +455,7 @@ occurred inside a "minor" revision-era re-analysis.
 **Goal**: Assess certainty of the body of evidence.
 
 For DTA meta-analysis, apply GRADE-DTA framework:
-1. Risk of bias (from QUADAS-2)
+1. Risk of bias (from QUADAS-3, or QUADAS-2 for a legacy review)
 2. Indirectness (applicability concerns)
 3. Inconsistency (heterogeneity)
 4. Imprecision (wide CIs, small sample)
@@ -633,7 +650,8 @@ de-scaffolding, self-contained reproducible analysis scripts, sidecar re-sync, m
 | Standard funnel plot for DTA | Inappropriate | Use Deeks' funnel plot |
 | I-squared only for heterogeneity | Doesn't capture threshold effect | Use prediction region on SROC |
 | Missing GRADE | Common omission in DTA MA | Apply GRADE-DTA. If <4 studies, assess each domain narratively and state the limitation explicitly |
-| Partial verification bias | Inflates sensitivity | Assess in QUADAS-2 Flow & Timing domain |
+| Partial verification bias | Inflates sensitivity | QUADAS-3 **3.2** (target condition assessed in all participants). QUADAS-3 has no Flow & Timing domain — that was QUADAS-2 |
+| Differential verification bias | Distorts both Se and Sp | QUADAS-3 **3.3** (target condition assessed the same way in all participants) |
 | Unevaluable results excluded | Biases accuracy estimates | Report intent-to-diagnose analysis |
 
 ---


### PR DESCRIPTION
QUADAS-3 was routed into both skills in #487, but only at the point where risk of bias gets assessed. **Two of its six phases do not belong there.**

Phase 1 states the review's synthesis question(s); phase 2 defines the **ideal test accuracy trial** that every later judgement is measured against. Both are review-level, and the E&E says to do them at the protocol stage together with the review-specific guidance for answering each signalling question.

Reaching them for the first time when the studies are already in hand means writing the comparator **after seeing the results**. That is the same failure as choosing a primary estimand once the estimates are visible, and the tool cannot detect it afterwards.

## Routing

- **`/meta-analysis` Phase 1 (Protocol Development)** now carries QUADAS-3 phases 1–2 as a DTA step, with the tailoring guidance and the instruction to publish it as a web appendix.
- **`/meta-analysis` Phase 5** now says it runs QUADAS-3 phases **3–6**, and to stop and write phases 1–2 first if the protocol lacks them.
- **`/check-reporting`** records that a manuscript-QC pass usually arrives too late for phases 1–2: if they are missing, report it as a limitation rather than reconstructing them, and send the protocol work to `/meta-analysis` Phase 1.

## Two stale QUADAS-2 references, fixed while here

Both in `/meta-analysis`:

- the GRADE-DTA step still sourced risk of bias *"from QUADAS-2"*
- the DTA pitfalls table sent partial verification bias to the **"QUADAS-2 Flow & Timing domain"** — a domain **QUADAS-3 does not have**

Per the E&E, partial verification is item **3.2** and differential verification item **3.3**, both in Target Condition. The table now names both biases and both items. (Checked against the E&E text rather than inferred — the last inference in this area turned out wrong, see #492.)

`python3 scripts/run_ci_mirror.py` → 243/243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)