### PR TITLE
feat(scripts): gate that a domain-probe module declares the probes it contains

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,6 +105,12 @@ jobs:
       - name: "Run check_named_skills_exist.py (a skill may not send you to a skill that does not exist)"
         run: python3 scripts/check_named_skills_exist.py --strict
 
+      - name: "Run check_probe_declaration.py (a module must declare the probes it contains)"
+        run: python3 scripts/check_probe_declaration.py --strict
+
+      - name: "Run probe-declaration challenge (restore each defect; the gate must FAIL)"
+        run: bash scripts/probe_declaration_challenge/verify.sh
+
       - name: Run check_domain_probe_sync.py (vendored domain probes must be byte-identical)
         run: python3 scripts/check_domain_probe_sync.py --strict
 

--- a/scripts/check_probe_declaration.py
+++ b/scripts/check_probe_declaration.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""A domain-probe module must declare the probes it actually contains.
+
+Four modules were found under-declaring themselves: `ai_overclaiming` carried AO0-AO7 and
+its title said AO0-AO6; `sr_ma` carried P0-P19, its title said P0-P17, and its body still
+called itself "an 11-probe checklist (P1-P11)". Six probes sat below a title that told a
+reviewer they were not there.
+
+That is the same defect the vendored-checklist audit spent a week removing from other
+people's instruments -- a file whose declaration does not match its contents -- and it is
+worse here, because the title is the scope a reviewer takes on trust when they load the
+module. SKILL.md happened to hold the correct range; the module a reviewer actually reads
+held the stale one.
+
+This gate compares three things per module and requires them to agree:
+
+  1. the range declared in the H1 title, e.g. `# ... probes (AO0-AO7)`
+  2. the probe IDs actually defined in the body (a bolded ID at the start of a line)
+  3. the count declared in any "N-probe checklist" phrase, if the body has one
+
+It also reports a gap in the numbering. A gap is not automatically wrong -- a retired probe
+may be deliberately skipped -- but it must be visible, because silently closing one
+renumbers every probe after it, and reviewers cite probes by number.
+
+Notation: the title may use an en dash or a hyphen, and may repeat the prefix on the right
+(`AO0-AO7`) or not (`AO0-7`). Accepting only one spelling is this repository's most common
+detector defect, so all four forms parse.
+
+Stdlib only. Usage:
+    python3 scripts/check_probe_declaration.py [--strict] [--dir DIR]
+
+Exit 0 when every module agrees with itself (with --strict, 1 on any violation; 2 on a
+read error or an empty scan).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DIR = ROOT / "skills" / "peer-review" / "references" / "domain-probes"
+
+# `# Survival / Prognostic Model probes (S1-S9)` -- en dash or hyphen, prefix optional on
+# the right-hand side.
+TITLE_RE = re.compile(
+    r"^#\s+.*\((?P<pref>[A-Z]{1,3})(?P<lo>\d{1,2})\s*[–—-]\s*(?P=pref)?(?P<hi>\d{1,2})\)\s*$",
+    re.M,
+)
+# A probe is DEFINED where its bolded ID opens a line; elsewhere it is only referenced, and
+# a reference must not be able to fill a gap.
+DEF_RE = re.compile(r"^\**\s*\*\*([A-Z]{1,3})(\d{1,2})\b", re.M)
+# "A 7-probe checklist", "plus an 11-probe checklist"
+COUNT_RE = re.compile(r"\b(?:an?|plus an?)\s+(\d{1,2})-probe checklist\b", re.I)
+# Several modules number a gate probe zero and exclude it from the count -- "a 7-probe
+# checklist (AO1-AO7, with AO0 as a gate)", "gate (P0) plus a 19-probe checklist". That is
+# the repository's own convention, so the count check has to know it; a checker that only
+# accepts its own preferred spelling is this repository's most common detector defect, and
+# the first draft of THIS gate reported both of those modules as wrong.
+GATE_PROBE_RE = re.compile(r"\b(?:with\s+)?[A-Z]{1,3}0\b[^.\n]{0,40}\bas a gate\b|\bgate\s*\([A-Z]{1,3}0\)", re.I)
+
+
+def check(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    problems: list[str] = []
+
+    title = TITLE_RE.search(text)
+    if not title:
+        # Not every reference file is a probe module; only complain when one clearly is.
+        if DEF_RE.search(text):
+            problems.append("has probe definitions but no `# ... (X1-X9)` range in its H1 title")
+        return problems
+
+    pref, lo, hi = title["pref"], int(title["lo"]), int(title["hi"])
+    nums = sorted({int(n) for p, n in DEF_RE.findall(text) if p == pref})
+    if not nums:
+        problems.append(f"title declares {pref}{lo}-{pref}{hi} but no {pref}n probe is defined")
+        return problems
+
+    if nums[0] != lo or nums[-1] != hi:
+        problems.append(
+            f"title declares {pref}{lo}-{pref}{hi}, body defines {pref}{nums[0]}-{pref}{nums[-1]}"
+            f" -- {len([n for n in nums if not lo <= n <= hi])} probe(s) outside the declared range"
+        )
+
+    gaps = [n for n in range(nums[0], nums[-1] + 1) if n not in nums]
+    if gaps:
+        problems.append(
+            f"numbering gap: {', '.join(f'{pref}{g}' for g in gaps)} not defined. "
+            "Keep the gap and say why, or the numbers after it shift and citations break"
+        )
+
+    declared = COUNT_RE.search(text)
+    if declared:
+        n = int(declared[1])
+        has_gate = bool(GATE_PROBE_RE.search(text)) and nums[0] == 0
+        allowed = {len(nums)} | ({len(nums) - 1} if has_gate else set())
+        if n not in allowed:
+            expected = f"{len(nums)}" + (f" (or {len(nums) - 1} excluding the gate probe)" if has_gate else "")
+            problems.append(
+                f'body says "{n}-probe checklist" but {len(nums)} probes are defined -- expected {expected}'
+            )
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dir", type=Path, default=DEFAULT_DIR)
+    ap.add_argument("--strict", action="store_true", help="exit 1 on any violation")
+    args = ap.parse_args()
+
+    if not args.dir.is_dir():
+        print(f"error: not a directory: {args.dir}", file=sys.stderr)
+        return 2
+
+    files = sorted(args.dir.glob("*.md"))
+    if not files:
+        # An empty scan passes every assertion while checking nothing.
+        print(f"error: no .md modules found in {args.dir}", file=sys.stderr)
+        return 2
+
+    print("=" * 41)
+    print(" Probe Declaration (title vs contents)")
+    print("=" * 41)
+    try:
+        shown = args.dir.relative_to(ROOT)
+    except ValueError:
+        # --dir may point outside the repo (the challenge card builds fixtures in a tmpdir).
+        shown = args.dir
+    print(f"  scanned: {len(files)} module(s) in {shown}")
+
+    violations = 0
+    for f in files:
+        try:
+            problems = check(f)
+        except OSError as exc:
+            print(f"error: cannot read {f}: {exc}", file=sys.stderr)
+            return 2
+        for p in problems:
+            violations += 1
+            print(f"  {f.name}: {p}")
+
+    print()
+    if violations:
+        print(f"PROBE_DECLARATION_DRIFT: {violations} violation(s).")
+        print("A module's title is the scope a reviewer takes on trust. Fix the title, the")
+        print("body count, or the missing probe -- whichever is actually wrong.")
+        return 1 if args.strict else 0
+
+    print(f"OK: all {len(files)} module(s) declare the probes they contain.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_declaration_challenge/verify.sh
+++ b/scripts/probe_declaration_challenge/verify.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Challenge card for check_probe_declaration.py.
+#
+# A green gate proves it RAN. These fixtures are built at runtime and each carries exactly
+# one defect the gate claims to catch, so a green run against a broken module is reported
+# here rather than discovered in a review.
+#
+# The last case is the one that bit the gate's own first draft: the repository numbers a
+# gate probe zero and excludes it from the "N-probe checklist" count. A checker that only
+# accepts its own preferred spelling is this repository's most common detector defect, and
+# this card pins that convention so a later edit cannot quietly drop it.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${1:-$HERE/../check_probe_declaration.py}"
+[ -f "$GATE" ] || { echo "cannot find check_probe_declaration.py at $GATE"; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+check() { if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"; PASS=$((PASS+1));
+          else printf '  FAIL  %s (expected %s, got %s)\n' "$1" "$2" "$3"; FAIL=$((FAIL+1)); fi }
+
+run() { # run <dir> -> exit code of the gate in --strict mode
+  python3 "$GATE" --dir "$1" --strict > /dev/null 2>&1; echo $?
+}
+
+mk() { # mk <dir> <file> <body>
+  mkdir -p "$1"; printf '%s\n' "$3" > "$1/$2"
+}
+
+CLEAN='# Example probes (EX1–EX3)
+
+A 3-probe checklist for the thing.
+
+**EX1 — first**: body.
+
+**EX2 — second**: body.
+
+**EX3 — third**: body.'
+
+# ------------------------------------------------------------------ the happy path
+mk "$WORK/clean" ex.md "$CLEAN"
+check "a self-consistent module passes" 0 "$(run "$WORK/clean")"
+
+# ------------------------------------------------- title under-declares its contents
+mk "$WORK/under" ex.md "${CLEAN/EX1–EX3/EX1–EX2}"
+check "title declaring fewer probes than exist fails" 1 "$(run "$WORK/under")"
+
+# -------------------------------------------------- title over-declares its contents
+mk "$WORK/over" ex.md "${CLEAN/EX1–EX3/EX1–EX9}"
+check "title declaring more probes than exist fails" 1 "$(run "$WORK/over")"
+
+# ------------------------------------------------------------ stale body count
+mk "$WORK/count" ex.md "${CLEAN/A 3-probe/A 5-probe}"
+check "stale \"N-probe checklist\" count fails" 1 "$(run "$WORK/count")"
+
+# ------------------------------------------------------------ numbering gap
+mk "$WORK/gap" ex.md "$(printf '%s' "$CLEAN" | grep -v 'EX2 — second')"
+check "a numbering gap is reported" 1 "$(run "$WORK/gap")"
+
+# ------------------------------------------ probes present but no declared range
+mk "$WORK/notitle" ex.md '# Example probes
+
+**EX1 — first**: body.'
+check "probe definitions with no declared range fail" 1 "$(run "$WORK/notitle")"
+
+# --------------------------------- hyphen and prefix-less range must both parse
+mk "$WORK/hyphen" ex.md "${CLEAN/EX1–EX3/EX1-EX3}"
+check "a hyphen range parses (not only an en dash)" 0 "$(run "$WORK/hyphen")"
+mk "$WORK/short" ex.md "${CLEAN/EX1–EX3/EX1–3}"
+check "a prefix-less range parses (EX1–3)" 0 "$(run "$WORK/short")"
+
+# ------------------------- the repo's gate-probe convention must NOT be flagged
+mk "$WORK/gateprobe" ex.md '# Example probes (EX0–EX3)
+
+A 3-probe checklist (EX1–EX3, with EX0 as a gate) for the thing.
+
+**EX0 — gate**: body.
+
+**EX1 — first**: body.
+
+**EX2 — second**: body.
+
+**EX3 — third**: body.'
+check "gate probe excluded from the count is accepted" 0 "$(run "$WORK/gateprobe")"
+
+# ------------------------------------------------------------ input guards
+mkdir -p "$WORK/empty"
+check "an empty directory exits 2, not 0" 2 "$(run "$WORK/empty")"
+check "a missing directory exits 2" 2 "$(run "$WORK/does-not-exist")"
+
+# --------------------------------- without --strict a violation still exits 0
+python3 "$GATE" --dir "$WORK/under" > /dev/null 2>&1
+check "without --strict a violation exits 0 (repo convention)" 0 "$?"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
#494 found four modules under-declaring themselves — `ai_overclaiming` carried **AO0–AO7** under a title saying AO0–AO6; `sr_ma` carried **P0–P19** under P0–P17 while its body still called itself *"an 11-probe checklist (P1–P11)"*. **Six probes sat below a title telling a reviewer they were not there.** Nothing would have caught it — the four were found by hand, while doing something else.

This is the vendored-checklist audit's defect class — a file whose declaration does not match its contents — inside our own artifacts. Worse here, because the title is the scope a reviewer takes on trust when they load the module.

## What it checks

Three things per module, required to agree:

1. the range in the **H1 title** — `# … probes (AO0–AO7)`
2. the probe IDs **actually defined** — a bolded ID opening a line, so a mere reference elsewhere cannot fill a gap
3. the count in any **"N-probe checklist"** phrase

It also reports **numbering gaps**. A gap may be deliberate — a retired probe — but silently closing one renumbers every probe after it, and reviewers cite probes by number.

## Two defects in the gate itself, both found by its challenge card rather than by me

**It flagged two correct modules.** The first draft reported `ai_overclaiming` and `sr_ma` as wrong when they were right: both use the repository's own convention of numbering a gate probe zero and excluding it from the count — *"a 7-probe checklist (AO1–AO7, with AO0 as a gate)"*. A checker that accepts only its own preferred spelling is this repository's most common detector defect, and **the gate written to catch declaration drift walked straight into it.** The convention is now understood, and pinned by a card case so a later edit cannot quietly drop it.

**`--dir` outside the repo crashed** on `relative_to(ROOT)`. Every fixture the card builds lives in a tmpdir, so the card failed on its own happy path and surfaced it immediately.

## The card

12 assertions: both directions of range mismatch, stale body count, numbering gap, missing declaration, hyphen **and** prefix-less range spellings, the gate-probe convention, an empty directory exiting 2 rather than passing vacuously, and that a violation without `--strict` still exits 0 per repo convention.

**Regressed against the real thing, not only fixtures**: restoring all four original titles makes the gate report exactly those four and exit 1.

```
ai_overclaiming.md: title declares AO0-AO6, body defines AO0-AO7 -- 1 probe(s) outside the declared range
clinical_prediction_model.md: title declares CP1-CP4, body defines CP1-CP6 -- 2 probe(s) outside
observational_confounding.md: title declares O1-O17, body defines O1-O18 -- 1 probe(s) outside
sr_ma.md: title declares P0-P17, body defines P0-P19 -- 2 probe(s) outside
```

243 → **245** gates. `python3 scripts/run_ci_mirror.py` → 245/245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)