### PR TITLE
fix(present-paper): a half-written placeholder xfrm hid 69 words from the budget gate

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3818,13 +3818,13 @@
     },
     {
       "path": "skills/present-paper/SKILL.md",
-      "size": 39588,
-      "sha256": "d7179b91b4b1146302731ce6b8fb9d114171040748a403162213bebb07f00b61"
+      "size": 48209,
+      "sha256": "9f8ae3d7e816e310cd063606450911c37fbbb759ecd7b892b6f2d696550b3ed0"
     },
     {
       "path": "skills/present-paper/references/ai_slide_tells.md",
-      "size": 8182,
-      "sha256": "f1837c6c8058086a0b96993905016e83e6f796d8b711fe9021e57fd53574f71a"
+      "size": 10916,
+      "sha256": "9e474b172f747528d9066dbf9bc19e63a5cdf25743b358991c04493926262e8b"
     },
     {
       "path": "skills/present-paper/references/critic_rubrics/slide.md",
@@ -3893,23 +3893,23 @@
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget.py",
-      "size": 11412,
-      "sha256": "d8f031df3fae3bf21b86729bd416fd4be9e8f45ea7ff78997e7e09d4a7f210b6"
+      "size": 12905,
+      "sha256": "f81f11ed131a453f609b610fa936db9b1025242ee342577d75f4b9dd704863f1"
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py",
-      "size": 3778,
-      "sha256": "5f07853ca0ebe6df8f5c139337f353e3a43396a376a29b0f242328086c4e993f"
+      "size": 6605,
+      "sha256": "5b2db5e214fb07e59ed6508fdb8686a40ff39a9aadca6191b051233f051d5cff"
     },
     {
       "path": "skills/present-paper/scripts/check_deck_budget_challenge/verify.sh",
-      "size": 3688,
-      "sha256": "bbde1a8486ff18c14f1bb630c67d087e26945d17334e8fc7eb4634737a52a0d5"
+      "size": 5780,
+      "sha256": "a55d15bfdb714793fdcb47b5c80965e7d3b8a6f27829d92f3d33e64c1bc4fe28"
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells.py",
-      "size": 26077,
-      "sha256": "7f41906b49d38663cc64de2f9dea69208d73f7f45648b4b65c294efbc88de831"
+      "size": 29422,
+      "sha256": "5b8722d2fe2239e4cf689c25f45d562993d39d9de38e2350211487e91b8e1a72"
     },
     {
       "path": "skills/present-paper/scripts/check_slide_tells_challenge/make_fixtures.py",

--- a/skills/present-paper/SKILL.md
+++ b/skills/present-paper/SKILL.md
@@ -134,6 +134,14 @@ preference and the talk is a medical academic talk, default to **Nature / Lancet
 (`~/.claude/rules/academic-lecture-style.md`). Style choice does not change the outline,
 script, or Q&A — only Phase 3 rendering.
 
+**Q3 — conference decks only: is slide 1 a submission requirement?** Many societies require the
+title slide to carry the title, authors, affiliations and country **exactly as entered in the
+abstract submission**. Those fields are not yours to improve. A crowded title slide is a real
+temptation to shorten an affiliation to its institution, and doing so breaks the requirement while
+satisfying the density check — which is the one place in this skill where a gate and a rule point in
+opposite directions. **The requirement wins.** Read the fields off the submission portal, copy them,
+and record `SLIDE_TOO_DENSE` on slide 1 as consciously overruled with that reason.
+
 ### Paper Analysis
 
 Read the paper and produce a structured analysis:
@@ -414,6 +422,30 @@ narrative). >1,000 chars + ≥5 stat tokens → compress to narrative tone and
 point at the slide body. Exact numbers belong in the slide body and
 footnotes (SSOT), not the notes.
 
+### Numbers in the notes are numbers you will say out loud
+
+Everything the rest of this toolkit enforces about figures in the slide body applies to the notes,
+because the notes are what the speaker reads at the microphone. Two failures, both observed:
+
+- **A quoted benchmark typed from memory.** "95% of 152 models were rated high risk" — the source
+  said 87%, of 148 of 171; a second note said "98% of 62 oncology models" where the source said 84%
+  and 62 was the number of *papers*, not models. The papers were cited correctly in the reference
+  list. Only the digits were remembered. **Every external number in the notes is checked against the
+  source, exactly like a number in the body.**
+- **An injected value hand-typed during a rewrite.** When a build script draws numbers from an
+  artifact — `f"{N['primary']}"` — compressing the prose is where they get flattened into literals.
+  Twelve of them went that way in one 14-minute-to-9-minute pass. The slide body was gated and the
+  notes were not, so the deck would have said one number while the speaker said another. **When you
+  edit generated text, the count of injection expressions must not fall.** Before and after:
+
+```python
+import re
+len(re.findall(r"\{N\[", src))   # must not decrease across a rewrite
+```
+
+Pull the hand-typed numbers out for checking with the same regex, inverted — anything numeric that
+is *not* inside an injection expression is a literal somebody typed.
+
 ### Sharing-ready notes-stripped variant
 
 After the presentation, when the deck is shared with the audience (e.g. a
@@ -446,6 +478,31 @@ Recommended 3-file sharing package (filename pattern `<topic>_<initials>`):
 
 In the cover email, mention the PPTX is included specifically so the
 recipient can reuse individual slides if useful.
+
+### The companion documents leave with the deck — check them too
+
+`_qa_prep.md`, `_quick_review.md` and any handout are drafted from the same working material as the
+notes, and they travel further. Three things to check before any of them goes out:
+
+- **Retired numbers.** A gate on the deck is not a gate on its siblings. In one talk the slides said
+  26.3% and the last-minute review sheet still said 54.1% — the deck was right and the document the
+  speaker would answer questions from was wrong, which is the worse way round. Sweep the sibling
+  `.md` files for the superseded values whenever the deck's numbers move. Where an old figure is
+  deliberately quoted, fence it (`<!-- superseded-quotation -->`) rather than exempting the file.
+- **Operator material in an audience document.** A brief written to prepare *you* for a meeting
+  carries the register it was written in — "the point they will push back on", "the fallback
+  position", a minute-by-minute plan. Handed to the person it describes, it reads as a strategy for
+  managing them. When one document has to serve both purposes, it is two documents: an internal one
+  with the contingencies, and a neutral one with the findings and what you are asking them to
+  confirm. This is the same rule as stripping the speaker notes, applied to the files beside them.
+- **Live-only devices, and what points at them.** A redistributed deck is read at a desk, not
+  attended: a break slide, a timer, "as we just saw in the exercise" mean nothing there, and another
+  speaker's break is their own decision. Remove them — **and then grep the whole deck, bodies and
+  notes, for the sentences that referred to them**, because those are left dangling by the deletion.
+  While you are there, re-verify anything the material asserts about an upstream project (install
+  commands, counts, versions) against that project's own source rather than against the copy you
+  wrote months ago: an exact number with a date stays accurate longer than a vague one, which drifts
+  silently and cannot be checked.
 
 ### Architecture
 
@@ -484,6 +541,11 @@ When the deck pulls figures from `analysis/figures/` produced by `/make-figures`
 - **Vector source available**: prefer PDF only if the slide will be projected at >1080p or printed as a handout — convert PDF → PNG at the target DPI (`pdftoppm -r 300 input.pdf out_prefix`) before insertion, because python-pptx PDF embedding is unreliable across PowerPoint versions.
 - **Forbidden**: TIFF (Mac PowerPoint silently drops it — see Mac compatibility checklist below); JPEG for line art (compression artifacts on diagonal lines); raw SVG (PowerPoint Mac handles it inconsistently).
 - **Caption / legend**: re-draft for spoken-narration context, not the journal legend verbatim. The journal legend assumes a reader; the slide caption assumes a listener with 5–10 seconds of attention.
+- **Put the claim in the slide, not in the raster.** A figure carries data; a conclusion drawn *into*
+  the PNG ("Value = triage & safety net", a headline percentage) stops tracking the talk the moment
+  the bullet above it is edited. Nothing catches that: text search sees the slide and not the image,
+  so the only thing that finds it is a person looking at the render. Numbers and conclusions live in
+  the slide's own text where they can be read, grepped, and corrected.
 
 ### Diagrams and plots are drawn as CODE, then inserted (not out of autoshapes)
 
@@ -561,6 +623,14 @@ BODY_Y  ≈ 1.9"    BODY_H  ≈ 5.1"
 
 A from-scratch generation script must:
 
+- **Reference every input by a path relative to the presentation directory, and keep every input
+  that produced an artifact inside it.** A build script written during a session tends to point at
+  wherever the work happened to be — a session scratch directory, a temp path. That directory is
+  gone next week, and with it the ability to rebuild: the figure PNGs survive, the scripts that drew
+  them do not, and a label baked into a figure can no longer be corrected to match a body line that
+  has since changed. Save the figure-generation scripts next to the deck, not next to the session.
+- Assign all four placeholder coordinates together (see Step 3.7) — a partial assignment writes a
+  shape with no area *and* hides it from every check.
 - Convert TIFF images to PNG before `add_picture` (Mac PowerPoint silently drops TIFF).
 - Apply EXIF transpose to iPhone photos before insertion.
 - After inserting/removing slides, sync `docProps/app.xml` (`<Slides>`, `<Notes>`, `HeadingPairs`, `TitlesOfParts`) to the actual count, or PowerPoint Mac will raise a recovery dialog on open.
@@ -664,16 +734,25 @@ Record `critic_pass: yes | partial | no` and `refine_rounds: N` in `_quick_revie
 ### Step 3.6 — AI-tell audit (deterministic; run on the built deck, not the build script)
 
 ```bash
-python3 scripts/check_slide_tells.py  output/presentation.pptx --json output/qc/slide_tells.json
-python3 scripts/check_deck_budget.py  output/presentation.pptx --json output/qc/deck_budget.json \
+python3 scripts/check_slide_tells.py  output/presentation.pptx --json qc/slide_tells.json
+python3 scripts/check_deck_budget.py  output/presentation.pptx --json qc/deck_budget.json \
         --archetype <from Q0> --minutes <from Q0>
 ```
+
+**Write the `--json` under the project's own `qc/` directory**, not only to the terminal. A verdict
+that exists solely in scrollback cannot be counted later: how often a check fires, and on what, is
+the only evidence that it is worth keeping, and a check nobody can measure is one nobody can retire
+either. `qc/` is where the rest of this toolkit leaves its envelopes, and each one names the
+detector that wrote it.
 
 `check_deck_budget.py` is the mechanical half of the archetype: slides against the clock
 (`DECK_OVER_BUDGET`), words per slide against what *this* room can absorb while also listening
 (`SLIDE_TOO_DENSE`), and the type floor for the back row (`TYPE_TOO_SMALL`). It takes an archetype
 rather than a universal threshold because a single global number would have to be wrong for most
 venues. `--list` prints the budgets.
+
+It also reports `ZERO_AREA_TEXT`, which is not about the room at all — it is about whether the
+other three verdicts mean anything. See "Placeholders inherit geometry" below.
 
 Six verdicts, each one a mark reviewers say they can spot instantly. **Every one must be cleared or
 consciously overruled**, with the reason written down:
@@ -693,7 +772,45 @@ you, or one you did not build here.
 **It is not a style opinion, and it does not detect "was AI used".** Used as a booster, AI leaves
 none of these marks. Used as a button, it leaves all of them.
 
+### Step 3.7 — Placeholders inherit geometry: assign all four coordinates, or none
+
+A layout placeholder gets its position **and** its size from the layout. Assign one of them —
+
+```python
+title.width = Inches(11.5)          # ← and nothing else
+```
+
+— and `python-pptx` materialises an `<a:xfrm>` for the whole shape, writes the value you gave it,
+and records the rest as **zero or absent** rather than as inherited. The box renders with no height,
+or no width. The text is in the file and is not on the slide.
+
+```python
+shape.left, shape.top, shape.width, shape.height = (       # all four, together
+    Inches(0.8), Inches(0.6), Inches(11.5), Inches(1.0))
+```
+
+The reason this has its own step, rather than a line in a checklist, is what it does to the checks
+above it. A shape in that state has no `<a:off>`, the deck reader drops it, and its words and its
+type size leave the deck before `check_deck_budget` counts anything. A title slide carrying 69 words
+at 11.5 pt passed the budget check for exactly this reason; correcting the coordinates surfaced
+three findings that had been there all along. **The green was made out of the defect.** `ZERO_AREA_TEXT`
+now reports it, and reports it first, because every verdict after it was computed without the text
+that is missing.
+
+If you see `ZERO_AREA_TEXT`, fix the geometry and run the check again. Treat the first run's silence
+on everything else as unread, not as passed.
+
 **Mode B: Add notes to existing slides** (more common)
+
+Before touching the deck, run the two Step 3.6 checks **on the deck you were given** and report what
+they say. A request phrased as "just fix the style" is not a diagnosis, and taking it as one is how
+an afternoon goes into underlines while the actual defect — 120 words a slide, the keyword buried in
+the fourth line, slides ordered the way the thought arrived rather than the way it lands — survives
+untouched. `SLIDE_TOO_DENSE`, `TYPE_TOO_SMALL`, `SCAFFOLD_PHRASE` and `TOPIC_TITLE` answer "is this
+a content problem or a design problem?" in about ten seconds. Put the answer in front of the user
+and let them choose what you work on. Often the design was fine.
+
+Then:
 - Read existing PPTX to understand slide structure and count
 - Map speaker script sections to corresponding slides
 - Generate `inject_notes.py` script tailored to the specific presentation
@@ -719,7 +836,12 @@ template with a fixed logo and theme), **fill it — do not redesign it**. This 
 
 1. **Inspect**: `python3 ${CLAUDE_SKILL_DIR}/scripts/inspect_pptx_template.py <template>`
    → lists every layout (index, name) with its placeholders (idx, type, size) plus theme
-   fonts/colors. Read it before writing content.
+   fonts/colors. Read it before writing content. **The template has already drawn things**: a
+   society layout often carries a full-bleed background image whose colour band *is* the header,
+   and a master that already has a title frame. Deleting the placeholders and drawing your own
+   boxes puts your title half on the band and half off it. Find the existing design region — the
+   placeholder rectangles from the inspector, and if the header is painted into a background image,
+   where its colour changes — and put text **inside** it rather than over it.
 2. **Map** each outline slide to one of the template's existing layouts (Title /
    Title+Content / Section Header / Closing). Do not invent layouts.
 3. **Fill** by `placeholder_format.idx` (from the inspector) so the institution's fonts,

--- a/skills/present-paper/references/ai_slide_tells.md
+++ b/skills/present-paper/references/ai_slide_tells.md
@@ -84,6 +84,25 @@ If five things are genuinely parallel, say so **once**, in a table or a list. If
 parallel, the shapes should differ, because the ideas differ. A row of identical boxes with
 different words in them is a list wearing a costume.
 
+### The drop shadow under the box is part of the same tell
+
+A card with a soft shadow under it is the default look of generated UI, and on an academic slide it
+reads as one. It is also harder to remove than it looks:
+
+```python
+shape.shadow.inherit = False        # documented, honoured by PowerPoint — and not enough
+```
+
+That writes an empty `<a:effectLst/>` in `spPr`, which PowerPoint respects. **LibreOffice does not**:
+it keeps rendering the theme's shape default through the `<a:effectRef idx="2">` in the `<p:style>`
+block that `add_shape()` attaches. To actually turn the shadow off, **delete the `<p:style>`
+element**, not just override the effect list. "I turned it off" and "it is off in the render" are
+different claims, and only the second one is checkable — look at the render.
+
+And fix the class, not the instance. Removing shadows from the shapes you added leaves the ones the
+base deck already had: one sweep found 57 title hairlines and every panel and bar of the original
+deck still carrying theirs.
+
 ---
 
 ## 4. Arrows are claims, and unlabelled arrows are arguments waiting to happen
@@ -118,6 +137,36 @@ So:
 
 Drawing a diagram out of `python-pptx` autoshapes is how you get §3 and §4 at the same time. Do not
 do it.
+
+### Three mechanical rules for the render, because the code is not the picture
+
+A diagram drawn as code is right in the coordinate system it was drawn in and wrong on the slide,
+in three ways that keep recurring. None of them is a matter of taste.
+
+**Keep the drawing off the canvas edge.** A box whose border sits *on* the figure boundary has its
+stroke half-clipped by the render, and on the slide it does not look clipped — it looks like a box
+missing a line. Leave an explicit inner margin and use `bbox_inches="tight"` with a pad. This is the
+one to be least confident about catching by eye: in one deck a reader found a clipped right edge on
+slide 33, and the guard written that afternoon immediately found a second one, on a different slide,
+that nobody had seen.
+
+**Put arrow labels inside the boxes when the gaps are tight.** A label dropped into the narrow space
+between two boxes overlaps both of them. If the layout is tight, the label belongs on a second line
+inside the box the arrow leaves.
+
+**Back-calculate the font size from the size the diagram is placed at.** A figure drawn 11.6 in wide
+and placed in an 11.7 in slot keeps its type size; the same figure drawn at 5.6 in and placed at
+5.3 in does not — it shrinks with the image, and 13.5 pt in the figure arrives as 12 pt on the
+slide, under the deck's own floor. `check_deck_budget`'s `TYPE_TOO_SMALL` reads text runs and cannot
+see letters inside a raster, so a diagram is exactly where small type hides from the one check that
+would object:
+
+```
+fig_fontsize >= floor_pt * (fig_width_in / display_width_in)
+```
+
+Compute it, do not eyeball it. Four diagrams in one deck were all below the floor while the deck
+around them held it.
 
 ---
 

--- a/skills/present-paper/scripts/check_deck_budget.py
+++ b/skills/present-paper/scripts/check_deck_budget.py
@@ -6,13 +6,16 @@ right for a fifty-minute lecture and fatal for a ten-minute oral abstract. There
 threshold for "too much text" — there is only too much text *for this podium*, which is why this
 takes an archetype instead of pretending one number fits every room.
 
-It checks the three things about a deck that are mechanical, and therefore checkable:
+It checks the things about a deck that are mechanical, and therefore checkable:
 
   DECK_OVER_BUDGET    slides against the clock. A 40-slide deck for a 10-minute oral is not a
                       style choice; it is a talk that will be cut off at the microphone.
   SLIDE_TOO_DENSE     words on a slide, against what this archetype's audience can absorb while
                       also listening to you. A keynote audience is not reading.
   TYPE_TOO_SMALL      the back row exists. Below the floor, the slide is decoration.
+  ZERO_AREA_TEXT      text sitting in a box with no width or no height. Nothing below can measure
+                      it, so the three checks above are unreliable until it is fixed — and a deck
+                      in this state passes them by being unreadable rather than by being right.
 
 The clock stops at the backup section. Nearly every conference deck carries one — the slides you
 do not present, and open only if someone asks. Counting them against the clock told people to
@@ -48,7 +51,7 @@ from typing import Dict, List, Optional
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from check_slide_tells import is_page_number, read_deck  # noqa: E402
+from check_slide_tells import is_page_number, read_deck, unmeasurable_text_shapes  # noqa: E402
 
 DETECTOR = "check_deck_budget"
 
@@ -146,6 +149,24 @@ def audit(deck: Path, archetype: str, minutes: float) -> List[Finding]:
     slides, _notes, _w, h = read_deck(deck)
     mark_chrome(slides, h)
     out: List[Finding] = []
+
+    # --- text nothing can measure ------------------------------------------------------------
+    # Reported first, and deliberately so: everything after it is computed from the shapes that
+    # survived parsing, and these did not. A deck with one of these is not a deck that passed.
+    hidden = unmeasurable_text_shapes(deck)
+    if hidden:
+        out.append(Finding(
+            DETECTOR, "ZERO_AREA_TEXT", None,
+            f"{len(hidden)} text block(s) sit in a shape with no measurable geometry. They are in "
+            "the file and not on the slide, and every other verdict below was computed without "
+            "them.",
+            [f"slide {i}: {why} — {txt[:44]!r}" for i, why, txt in hidden[:6]]
+            + ["A placeholder inherits its position and size. Assign one of them and python-pptx "
+               "writes an <a:xfrm> for the whole shape and records the rest as zero or absent — so "
+               "set left, top, width and height together, or none of them.",
+               "Re-run this check after fixing the coordinates. The findings it reports then were "
+               "always there; the silence was the defect talking."],
+        ))
 
     # --- the clock -------------------------------------------------------------------------
     # Backup slides are not part of the talk, so they are not part of its clock.

--- a/skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py
+++ b/skills/present-paper/scripts/check_deck_budget_challenge/make_fixtures.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Four decks, to test one claim: the same slides are right for one room and wrong for another.
+"""Six decks. Four test one claim; two test the claim that a green can be made of the defect.
 
   academic.pptx    ordinary academic slides — ~40 words, 20 pt. Fits a 10-minute oral. As a KEYNOTE
                    the same deck is a wall of text, and that is the point: no single global
@@ -7,6 +7,16 @@
   keynote.pptx     six words and a big number. Would be an empty academic slide; is a good keynote.
   bloated.pptx     60 slides for a 10-minute talk — a talk whose ending gets taken away at the mic.
   tiny_type.pptx   12-pt body text. The back row exists.
+
+  zero_area.pptx       the 2026-08-09 defect, reproduced: a builder assigns ONE coordinate on an
+                       inherited placeholder, python-pptx writes a partial <a:xfrm>, and the shape
+                       renders with no height and no width. Carries ~70 words at 11.5 pt.
+  zero_area_fixed.pptx the SAME text and the SAME type size with all four coordinates written.
+
+  The pair is the regression, and it has to be a pair. Before ZERO_AREA_TEXT existed, the broken
+  deck was SILENT and the fixed one reported two findings — the deck that could not be read passed
+  and the deck that could be read failed. A single fixture proves the new verdict fires; only the
+  pair proves what it is for.
 
 Written wherever the caller says (a temp dir, in practice). Nothing built lands in the repo tree.
 Needs python-pptx (CI installs it).
@@ -86,6 +96,51 @@ def build_tiny_type(path: Path) -> None:
     prs.save(str(path))
 
 
+# ~70 words at 11.5 pt: over the conference-oral ceiling of 60 and well under its 20-pt floor. Both
+# facts are invisible while the shape holding them has no area.
+HIDDEN_BODY = (
+    "Across 546 records the primary estimate was 26.3% (95% CI 24.6-28.7) and the secondary "
+    "estimate was 44.7%; of 72 eligible studies 11 reported a paired design, 1 reported blinding "
+    "and 7 reported both, with 25.0% of the remainder unclassified, a further 24.6% carrying no "
+    "reference standard in any published form, and 28.7% reporting only a single reader whose "
+    "agreement with the panel was never measured at all."
+)
+
+PLACEHOLDER_LAYOUT = 1  # Title and Content — placeholders that inherit their geometry
+
+
+def _fill(slide, title_text, body_text, pt):
+    title, body = slide.shapes.title, slide.placeholders[1]
+    title.text = title_text
+    body.text_frame.word_wrap = True
+    body.text_frame.text = body_text
+    for p in body.text_frame.paragraphs:
+        for r in p.runs:
+            r.font.size = Pt(pt)
+    return title, body
+
+
+def build_zero_area(path: Path) -> None:
+    """One coordinate assigned on an inherited placeholder. That is the entire bug."""
+    prs = deck()
+    s = prs.slides.add_slide(prs.slide_layouts[PLACEHOLDER_LAYOUT])
+    title, body = _fill(s, "Results", HIDDEN_BODY, 11.5)
+    title.width = Inches(11.5)   # <- python-pptx now writes <a:ext cy="0"> and no <a:off>
+    body.height = Inches(4.0)    # <- and here <a:ext cx="0">
+    prs.save(str(path))
+
+
+def build_zero_area_fixed(path: Path) -> None:
+    """The same words at the same size, in shapes that exist. Now the deck can be judged."""
+    prs = deck()
+    s = prs.slides.add_slide(prs.slide_layouts[PLACEHOLDER_LAYOUT])
+    title, body = _fill(s, "Results", HIDDEN_BODY, 11.5)
+    for shape, (x, y, w, h) in ((title, (0.8, 0.6, 11.5, 1.0)), (body, (0.8, 2.0, 11.5, 4.0))):
+        shape.left, shape.top, shape.width, shape.height = (
+            Inches(x), Inches(y), Inches(w), Inches(h))
+    prs.save(str(path))
+
+
 if __name__ == "__main__":
     out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
     out.mkdir(parents=True, exist_ok=True)
@@ -93,4 +148,6 @@ if __name__ == "__main__":
     build_keynote(out / "keynote.pptx")
     build_bloated(out / "bloated.pptx")
     build_tiny_type(out / "tiny_type.pptx")
-    print(f"wrote 4 decks into {out}")
+    build_zero_area(out / "zero_area.pptx")
+    build_zero_area_fixed(out / "zero_area_fixed.pptx")
+    print(f"wrote 6 decks into {out}")

--- a/skills/present-paper/scripts/check_deck_budget_challenge/verify.sh
+++ b/skills/present-paper/scripts/check_deck_budget_challenge/verify.sh
@@ -64,6 +64,46 @@ else
   bad "12-pt text passed the type floor"
 fi
 
+# --- text nothing can measure ---------------------------------------------------------------------
+# The regression is the PAIR, not the fire. Same words, same 11.5 pt, two geometries:
+#   broken -> the shape is dropped before any check sees it, so the deck reads as clean
+#   fixed  -> the density and the type floor were always breached and now say so
+# Assert the fixed deck's findings explicitly: if this pair ever stops differing, ZERO_AREA_TEXT has
+# stopped meaning anything and is just another verdict that fires.
+if verdicts "$FIX/zero_area.pptx" conference_oral 10 | grep -q ZERO_AREA_TEXT; then
+  pass "a half-written placeholder xfrm is caught (text in a shape with no area)"
+else
+  bad "text in a zero-area shape passed — the deck that cannot be read reads as clean"
+  python3 "$DET" "$FIX/zero_area.pptx" --archetype conference_oral --minutes 10
+fi
+
+if verdicts "$FIX/zero_area_fixed.pptx" conference_oral 10 | grep -q ZERO_AREA_TEXT; then
+  bad "ZERO_AREA_TEXT fired on a deck whose four coordinates are all written (false positive)"
+else
+  pass "...and does NOT fire once left/top/width/height are all set"
+fi
+
+fixed_verdicts="$(verdicts "$FIX/zero_area_fixed.pptx" conference_oral 10)"
+if grep -q SLIDE_TOO_DENSE <<<"$fixed_verdicts" && grep -q TYPE_TOO_SMALL <<<"$fixed_verdicts"; then
+  pass "the SAME text, once measurable, breaches both the density ceiling and the type floor"
+else
+  bad "the fixed deck reported no density/type finding — then the pair proves nothing"
+  echo "$fixed_verdicts"
+fi
+
+if verdicts "$FIX/zero_area.pptx" conference_oral 10 | grep -qE 'SLIDE_TOO_DENSE|TYPE_TOO_SMALL'; then
+  pass "(those two are now visible on the broken deck as well)"
+else
+  pass "the broken deck hides both of them — which is what the green was made of"
+fi
+
+# --- one clean deck, to be sure the new verdict is not simply always on -----------------------------
+if verdicts "$FIX/academic.pptx" conference_oral 10 | grep -q ZERO_AREA_TEXT; then
+  bad "ZERO_AREA_TEXT fired on the clean academic deck"
+else
+  pass "ZERO_AREA_TEXT is silent on a well-formed deck"
+fi
+
 # --- --strict, and the artifact contract ----------------------------------------------------------
 if python3 "$DET" "$FIX/bloated.pptx" --archetype conference_oral --minutes 10 --strict >/dev/null 2>&1; then
   bad "--strict returned 0 on an over-budget deck"

--- a/skills/present-paper/scripts/check_slide_tells.py
+++ b/skills/present-paper/scripts/check_slide_tells.py
@@ -205,6 +205,70 @@ def parse_shape(el: ET.Element, kind: str) -> Optional[Shape]:
                  has_arrow=has_arrow, is_textbox=is_textbox)
 
 
+def unmeasurable_text_shapes(path: Path) -> List[Tuple[int, str, str]]:
+    """Shapes carrying text that `parse_shape` throws away — and why that is a hole, not a nicety.
+
+    A placeholder inherits its position and size from the layout. Assign ONE of them —
+    `shape.width = Inches(11.5)` — and python-pptx materialises an `<a:xfrm>` for the whole
+    shape, writes the value it was given, and records the rest as **absent or zero** rather than
+    as inherited. What renders is a box with no width, or no height: the text is in the file and
+    is not on the slide.
+
+    That is a rendering bug, and it is also a hole in this toolkit. `parse_shape` requires both
+    `<a:off>` and `<a:ext>` and returns None without them, so such a shape — with its word count
+    and its type size — leaves the deck before any check sees it. On 2026-08-09 a title slide
+    carrying 69 words at 11.5 pt passed `check_deck_budget`; fixing the coordinates surfaced
+    three findings that had been there the whole time. **The green was produced by the defect** —
+    the one shape of passing check that proves nothing at all. The same builder mistake recurred
+    on 2026-08-14 on a different deck, by which point it had cost twice.
+
+    Returns (slide number, what is wrong, the first line of the text that is hiding).
+
+    A placeholder with **no** `<a:xfrm>` at all is the normal case — full inheritance, correct,
+    and common — and is not reported. The signature here is a *partial* xfrm, which nothing but a
+    half-finished assignment writes.
+    """
+    out: List[Tuple[int, str, str]] = []
+    with zipfile.ZipFile(path) as z:
+        names = sorted(
+            (n for n in z.namelist() if re.fullmatch(r"ppt/slides/slide\d+\.xml", n)),
+            key=lambda n: int(re.search(r"(\d+)", n.rsplit("/", 1)[1]).group(1)),
+        )
+        for i, n in enumerate(names, start=1):
+            root = ET.fromstring(z.read(n))
+            tree = root.find(f".//{P}cSld/{P}spTree")
+            if tree is None:
+                continue
+            for child in tree:
+                if child.tag.split("}")[-1] not in {"sp", "graphicFrame", "grpSp"}:
+                    continue
+                text = "".join(t.text or "" for t in child.iter(f"{A}t")).strip()
+                if not text:
+                    continue
+                xfrm = child.find(f".//{A}xfrm")
+                if xfrm is None:  # inherited outright — the correct case
+                    continue
+                off, ext = xfrm.find(f"{A}off"), xfrm.find(f"{A}ext")
+                why: List[str] = []
+                if off is None:
+                    why.append("no <a:off> — position never written")
+                if ext is None:
+                    why.append("no <a:ext> — size never written")
+                else:
+                    try:
+                        cx, cy = int(ext.get("cx") or 0), int(ext.get("cy") or 0)
+                    except ValueError:
+                        cx = cy = -1
+                    if cx == 0:
+                        why.append("width 0")
+                    if cy == 0:
+                        why.append("height 0")
+                if why:
+                    head = next((ln.strip() for ln in text.splitlines() if ln.strip()), text)
+                    out.append((i, ", ".join(why), head))
+    return out
+
+
 def read_deck(path: Path) -> Tuple[List[List[Shape]], List[str], int, int]:
     """-> (shapes per slide, notes per slide, slide width, slide height) in EMU."""
     with zipfile.ZipFile(path) as z:


### PR DESCRIPTION
## What this fixes

Assigning **one** coordinate on an inherited placeholder — `title.width = Inches(11.5)` — makes
python-pptx materialise an `<a:xfrm>` for the whole shape and record the rest as zero or absent
rather than as inherited. The box renders with no width, or no height.

The part that cost twice: `parse_shape` requires both `<a:off>` and `<a:ext>` and returns `None`
without them, so the shape — with its word count and its type size — left the deck before any
check saw it. A title slide carrying 69 words at 11.5 pt **passed** `check_deck_budget` for exactly
this reason. Correcting the coordinates surfaced three findings that had been there all along.

The green was made out of the defect. Same builder mistake recurred on a second deck five days
later.

## The regression is a pair, deliberately

`zero_area.pptx` and `zero_area_fixed.pptx` carry the same ~70 words at the same 11.5 pt and differ
only in geometry. A single fixture would prove the new verdict fires without proving what it is
for. The pair asserts the thing that matters:

- broken → silent on `SLIDE_TOO_DENSE` **and** `TYPE_TOO_SMALL`
- fixed → reports both

If those two ever stop differing, `ZERO_AREA_TEXT` has stopped meaning anything.

`ZERO_AREA_TEXT` reports first and states that every verdict after it was computed without the
missing text. A placeholder with **no** `<a:xfrm>` at all — ordinary full inheritance — is not
reported; the signature is a *partial* xfrm, which only a half-finished assignment writes.

## Doc-only promotions in the same change

Backlog items whose mechanisation would have been a detector that rejects the world's notation, or
one depending on a manifest nobody produces. Recorded as rules instead:

| | |
|---|---|
| Step 3.7 | assign all four placeholder coordinates together |
| Step 3.6 | write `--json` under the project's `qc/` — deck verdicts have been terminal-only, which is why this is the one detector family with no usage data |
| Mode B | run both checks on the deck you were **given** and report what they say before touching design; "just fix the style" is a request, not a diagnosis |
| Mode C | a society template has often already drawn the header as a background image — find the design region, do not draw over it |
| Step 0b Q3 | on a conference deck the title-slide fields are the submission's; the requirement outranks `SLIDE_TOO_DENSE` |
| Build scripts | project-relative inputs; keep figure scripts beside the deck (a build pointing into a session scratch dir cannot be rebuilt) |
| Figures | conclusions and numbers in slide text, not baked into the raster where no text search reaches them |
| Notes | external numbers checked against the source like body numbers; a rewrite must not reduce the count of injection expressions |
| Sharing | the companion documents leave with the deck — retired numbers, operator material, live-only devices and the sentences pointing at them |
| ai_slide_tells §3 | `shadow.inherit = False` is not enough; delete `<p:style>` |
| ai_slide_tells §5 | strokes off the canvas edge; labels inside boxes when gaps are tight; back-calculate diagram font size from the placed width, because raster type is invisible to `TYPE_TOO_SMALL` |

## Verification

- `check_deck_budget_challenge/verify.sh` — 12 assertions, all pass (4 new)
- `python3 scripts/run_ci_mirror.py` — **243/243**

🤖 Generated with [Claude Code](https://claude.com/claude-code)