### PR TITLE
fix(peer-review,contribute): a reviewer profile is a claim until it says what it was read off

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -993,8 +993,8 @@
     },
     {
       "path": "skills/contribute/scripts/check_contribution_safety.py",
-      "size": 11153,
-      "sha256": "4620801b7ce5e42b3de15fa069b0a46d2b0d113140609b3fa950de7f8773ad27"
+      "size": 12681,
+      "sha256": "23bd34f33304b5d9fabf8aff5d60dea6ba5452f07f5399d78ab620bad505dc7a"
     },
     {
       "path": "skills/contribute/scripts/contribution_prefs.py",
@@ -3563,13 +3563,13 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/EURE.md",
-      "size": 2452,
-      "sha256": "cfec6a4f45ee4cd09b0404e249ab948b031148e1f95bad00e8cd3641178652de"
+      "size": 2934,
+      "sha256": "b5adbd2bc617efe3500daf12df03ca2d06ce66265a663541a71e6c29decdc94f"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/INSI.md",
-      "size": 1878,
-      "sha256": "4081a8688e91c2d5f674158a387708294fd9d64867988086bcfd2a63ff0a08f2"
+      "size": 1872,
+      "sha256": "4a933d32363ad566f2054c740c9c93bc1cc3a8e924f3b050ce59dc9408e3c2f5"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/KJR.md",
@@ -3578,13 +3578,13 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/README.md",
-      "size": 2149,
-      "sha256": "fd234df85bc35eece551abf8d74dce7c35630c23228c0c16a555fcbfd1868606"
+      "size": 4752,
+      "sha256": "470b0bbd324f7203c3cef4805283ff32599e7936bb78234ab78ca2ab7ac39730"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/RYAI.md",
-      "size": 3171,
-      "sha256": "2f548ccbe1ee101bf6630b4d363f15e4df0750a350788b26f177490496be74f6"
+      "size": 4813,
+      "sha256": "a23c19c19261305f7f088ca4235e5385ab715b28f1d33c41d01753a6ad39289c"
     },
     {
       "path": "skills/peer-review/scripts/check_pdf_injection.py",

--- a/scripts/check_precedent.py
+++ b/scripts/check_precedent.py
@@ -45,7 +45,19 @@ STRUCTURAL = [
     re.compile(r"screening_consensus_final\.md"),
     re.compile(r"fulltext_screening_final\.tsv"),
     re.compile(r"VIF\s+Diag"),
+    # A journal submission ID (LETTERS-D-YY-NNNNN, with or without an RN revision suffix).
+    # `/contribute` has blocked this shape from CONTRIBUTIONS since it shipped, rated major, on the
+    # grounds that a manuscript under review is confidential and its ID identifies it. Nothing
+    # applied the same rule to the repository's OWN files, and one had been sitting in a shipped
+    # reviewer profile: the toolkit held contributors to a standard it did not hold itself to.
+    # See also reviewer_profiles/README.md, which now requires round + date and forbids the ID.
+    re.compile(r"\b[A-Z]{2,6}(?:-[A-Z])?-\d{2}-\d{3,6}(?:R\d{1,2})?\b"),
 ]
+
+# A published DOI can end in the same shape (Annals of Internal Medicine mints
+# `10.7326/ANNALS-25-02104`), and a vendored checklist citing its own source is not a disclosure.
+# A DOI is public by definition; a submission ID is the opposite.
+DOI_SUFFIX = re.compile(r"\b10\.\d{4,9}/\S*$")
 
 _HERE = Path(__file__).resolve().parent
 # Paths are overridable via env for testing (so regression tests can exercise
@@ -92,8 +104,9 @@ def line_ngrams(line: str) -> set[str]:
 def scan_text(text: str, hashes: set[str]) -> tuple[int, str] | None:
     for lineno, line in enumerate(text.splitlines(), 1):
         for rx in STRUCTURAL:
-            m = rx.search(line)
-            if m:
+            for m in rx.finditer(line):
+                if DOI_SUFFIX.search(line[:m.start()]):
+                    continue
                 return lineno, m.group(0)
         if hashes:
             for gram in line_ngrams(line):

--- a/skills/contribute/scripts/check_contribution_safety.py
+++ b/skills/contribute/scripts/check_contribution_safety.py
@@ -83,9 +83,32 @@ APPROVAL_ID = re.compile(
     re.I,
 )
 
-# A submission ID: LETTERS-D-YY-NNNNN, LETTERS-YY-NNNN, etc. A manuscript under review is
-# confidential; leaking its ID in a public commit is a real disclosure.
-MANUSCRIPT_ID = re.compile(r"\b[A-Z]{2,6}(?:-[A-Z])?-\d{2}-\d{3,6}\b")
+# A submission ID: LETTERS-D-YY-NNNNN, LETTERS-YY-NNNN, and the revision forms LETTERS-D-YY-NNNNNR1.
+# A manuscript under review is confidential; leaking its ID in a public commit is a real disclosure.
+#
+# This got both directions wrong at once, which is worth keeping in view because it is this repo's
+# most common detector defect wearing a new hat:
+#
+#   MISSED  the revision suffix. `\d{3,6}\b` cannot match a five-digit serial followed by `R1`
+#           (R is a word character, so there is no boundary), so EVERY revised ID was invisible.
+#           Revised IDs are the ones a reviewer handles most, and one had been sitting in a shipped
+#           reviewer profile in this repository. Writing the offending literal here would have put
+#           it straight back into a public file -- the repo's own precedent gate caught that too.
+#   FIRED   `10.7326/ANNALS-25-02104` — a published DOI. Annals of Internal Medicine mints DOIs in
+#           exactly this shape, so the vendored QUADAS-3 checklist citing its own source tripped a
+#           MAJOR finding.
+#
+# So: accept the revision suffix, and do not read a DOI as a submission ID. A DOI is public by
+# definition; a submission ID is the opposite.
+MANUSCRIPT_ID = re.compile(r"\b[A-Z]{2,6}(?:-[A-Z])?-\d{2}-\d{3,6}(?:R\d{1,2})?\b")
+
+# `10.7326/ANNALS-25-02104`, `doi.org/10.…` — the registrant's own suffix, not a submission.
+_DOI_CONTEXT = re.compile(r"\b10\.\d{4,9}/\S*$")
+
+
+def _is_doi_suffix(line: str, start: int) -> bool:
+    """Is the match the tail of a DOI rather than a submission ID?"""
+    return bool(_DOI_CONTEXT.search(line[:start]))
 
 LOCAL_PATH = re.compile(r"(?:/Users/|/home/|C:\\Users\\)(?!(?:runner|user|you|username|<)\b)[\w.-]+")
 
@@ -148,8 +171,11 @@ def scan_text(text: str, source: str) -> list[dict]:
             add("INSTITUTION", i, line, m.group(0), "institution")
         if (m := APPROVAL_ID.search(line)):
             add("APPROVAL_ID", i, line, m.group(0), "approval")
-        if (m := MANUSCRIPT_ID.search(line)):
+        for m in MANUSCRIPT_ID.finditer(line):
+            if _is_doi_suffix(line, m.start()):
+                continue  # a published DOI, not a manuscript under review
             add("MANUSCRIPT_ID", i, line, m.group(0), "submission_id")
+            break
         if (m := LOCAL_PATH.search(line)):
             add("LOCAL_PATH", i, line, m.group(0), "home_dir")
 

--- a/skills/contribute/tests/test_contribution_safety.sh
+++ b/skills/contribute/tests/test_contribution_safety.sh
@@ -37,10 +37,18 @@ cat > "$TMP/leaky.md" <<'MD'
 The pipeline failed on patient MRN 4471903 during the review.
 Subject 880101-1234567 was excluded after chart review.
 Approved under IRB 2024-0451 at Severance Hospital.
-I was reviewing EURE-D-26-00203 when this happened.
 Prof. Alan Poe suggested the change; reach me at a.poe@hospital.or.kr.
 Output was written to /Users/apoe/manuscripts/draft.docx.
 MD
+
+# The submission ID is ASSEMBLED, never written out: a file whose job is to carry identifier-shaped
+# strings must not carry one as a literal, or the repo's own precedent gate flags the test that
+# proves the gate works. Two forms, because the plain one shipped working and the revision one --
+# the form a reviewer actually handles -- did not: `\d{3,6}\b` cannot match `00203R2` (R is a word
+# character), so every revised ID was invisible until 2026-08-15.
+J=EURE; Y=26
+printf 'I was reviewing %s-D-%s-00203 when this happened.\n' "$J" "$Y" >> "$TMP/leaky.md"
+printf 'and %s-D-%s-00203R2 the round after that.\n' "$J" "$Y" >> "$TMP/leaky.md"
 
 # --- an ordinary, entirely publishable contribution -------------------------------------------
 cat > "$TMP/clean.md" <<'MD'
@@ -73,6 +81,35 @@ assert r["safe_to_send"] is False
 assert all(f["advice"] for f in r["findings"])
 PY
 ck "MRN, national ID, IRB, manuscript ID, name, path all caught" 0 "$?"
+
+# 1b) BOTH submission-ID forms, because only one of them used to work.
+#
+# The plain form was caught from the day this shipped. The revision form was not: `\d{3,6}\b`
+# cannot match `00203R2`, since R is a word character and there is no boundary before it. Revised
+# IDs are the ones a reviewer handles most, and one had been sitting in a shipped reviewer profile
+# in this repository while the scanner reported the file clean.
+python3 - "$TMP/leaky.json" <<'PY'
+import json, sys
+found = {f["match"] for f in json.load(open(sys.argv[1]))["findings"]
+         if f["verdict"] == "MANUSCRIPT_ID"}
+assert any(x.endswith("00203") for x in found), f"plain submission ID missed: {found}"
+assert any(x.endswith("R2") for x in found), f"REVISED submission ID missed: {found}"
+PY
+ck "both the plain and the revised submission-ID forms are caught" 0 "$?"
+
+# 1c) ...and a published DOI is not a manuscript under review.
+#
+# Annals of Internal Medicine mints DOIs shaped exactly like a submission ID
+# (10.7326/ANNALS-25-02104), so the vendored QUADAS-3 checklist citing its own source drew a MAJOR
+# finding. A DOI is public by definition; flagging one teaches the author to ignore this scanner.
+cat > "$TMP/doi.md" <<'MD'
+# Vendored checklist provenance
+
+Source: *Ann Intern Med* 2026;179(4):548-555 (DOI 10.7326/ANNALS-25-02104), and the
+Explanation & Elaboration paper at https://doi.org/10.7326/ANNALS-25-04943.
+MD
+python3 "$S" --text "$TMP/doi.md" --quiet > /dev/null 2>&1
+ck "a published DOI is not read as a submission ID" 0 "$?"
 
 # 2) THE FALSE-POSITIVE GUARD: an ordinary journal profile must sail through
 python3 "$S" --text "$TMP/clean.md" --quiet > /dev/null 2>&1

--- a/skills/peer-review/references/reviewer_profiles/EURE.md
+++ b/skills/peer-review/references/reviewer_profiles/EURE.md
@@ -36,23 +36,30 @@ Use INSI-style base; substitute journal name and scorecard fields when confirmed
 - ESR Key Points required in accepted manuscripts — reviewers can suggest strengthening these.
 - Transfer authorization common (to Springer Nature portfolio).
 
-## Confirmed Form Fields (from a recent EURE reviewer invitation)
+## Confirmed Form Fields
+
+**Verified against:** two submitted-review confirmation PDFs, rounds R1 and R2. Last updated: 2026-08-06.
+
+This list previously said "from a recent reviewer invitation", and that was the defect: an
+invitation advertises the review, it is not the form you fill in. One field carried over from it —
+**ORCID Reviewer Credit** — does not exist on the scorecard at all (zero occurrences of the string
+in either confirmation PDF; it is an account-level setting). It had been copied into a submission
+checklist as a field to answer before the PDFs were compared.
 
 Editorial Manager scorecard differs from INSI H/M/L base. Actual fields:
 
 1. **Recommendation** (top dropdown): Accept / Minor Revision / Major Revision / Reject (transfer allowed) / Reject
 2. **Transfer Authorization** (2 questions): Yes/No for (a) identifying info transfer, (b) original review transfer. Default Yes/Yes.
-3. **ORCID Reviewer Credit**: Yes/No.
-4. **Level of interest** (4 options):
+3. **Level of interest** (4 options):
    - An exceptional article
    - An article of importance in its field
    - An article whose findings are important to those with closely related research interests
    - An article of limited interest
-5. **Quality of written English** (3 options):
+4. **Quality of written English** (3 options):
    - Not suitable for publication unless extensively edited
    - Needs some language corrections before being published
    - Acceptable
-6. **Declaration of competing interests**: free-text field, ≤300 chars. Standard "I declare that I have no competing interests." accepted.
+5. **Declaration of competing interests**: free-text field, ≤300 chars. Standard "I declare that I have no competing interests." accepted.
 
 Author-facing comments follow the invitation's 4-section scheme:
 1. Comment on study design

--- a/skills/peer-review/references/reviewer_profiles/INSI.md
+++ b/skills/peer-review/references/reviewer_profiles/INSI.md
@@ -12,7 +12,7 @@ Rating scale: High / Medium / Low
 1. Interest
 2. Innovation
 3. Importance
-4. Language editing — categorical. Editorial Manager dropdown labels (verified 2026-05-16 on INSI-D-26-00015R1 confirmation PDF): "No (minor)" / "Yes (minor)" / "Yes (major)". The profile previously listed these as "No minor editing needed" / "Yes minor editing needed" / "Yes major editing needed"; the portal uses the parenthesized short form. Semantics: "No (minor)" = best/most favorable (well written, only minor polish possible); "Yes (minor)" = minor editing needed; "Yes (major)" = major editing needed.
+4. Language editing — categorical. Editorial Manager dropdown labels (verified against an R1 confirmation PDF, 2026-05-16): "No (minor)" / "Yes (minor)" / "Yes (major)". The profile previously listed these as "No minor editing needed" / "Yes minor editing needed" / "Yes major editing needed"; the portal uses the parenthesized short form. Semantics: "No (minor)" = best/most favorable (well written, only minor polish possible); "Yes (minor)" = minor editing needed; "Yes (major)" = major editing needed.
 
 ## Additional Required Fields
 

--- a/skills/peer-review/references/reviewer_profiles/README.md
+++ b/skills/peer-review/references/reviewer_profiles/README.md
@@ -19,12 +19,50 @@ Canonical per-journal reviewer formatting profiles. Consumed by both the OSS `pe
 3. **OSS-safe** — no PII, no specific reviewer identity, no manuscript content, **no manuscript IDs**, **no specific editor names**, no topic-level hints that could identify a past review. Under COPE reviewer confidentiality obligations, publishing the set of manuscripts a reviewer has handled can itself identify the reviewer. Keep personal precedent logs in a private store (e.g., `~/.claude/skills/peer-review/`) — never commit them here.
 4. **Parallel to find-journal / write-paper profiles** — same directory-of-markdown pattern used elsewhere in medsci-skills.
 
+## A form field is a claim until you say what you read it off
+
+These profiles are trusted precisely because they are specific: a reviewer reads the recommendation
+options here and picks one without opening the portal first. That is what makes a wrong entry
+expensive, and it has now happened twice on two different journals.
+
+- A profile listed **"Accept with Minor Revision"** as a recommendation option. The live form does
+  not have that label, and its minor-revision tier is **two** options — final approval *by Editor*
+  versus *by this reviewer*, a real decision about whether the paper returns to the reviewer. The
+  reviewer was told to pick the non-existent option and had to report back from the portal. Filed,
+  then observed a second time two weeks later, still uncorrected.
+- Another profile listed **ORCID Reviewer Credit** under *Confirmed Form Fields*. It is not a
+  scorecard field at all — zero occurrences in either round's confirmation PDF; it is an
+  account-level setting. It reached a submission checklist as a field to answer.
+
+Both entries came from the same place: **a review invitation, or the author guidelines.** An
+invitation advertises the review. The form is what you fill in. They are not the same document, and
+nothing in this directory used to say so.
+
+**Rules:**
+
+1. **Source of truth is a completed form or its confirmation PDF** — never the invitation, never the
+   author guidelines. Guidelines describe the journal's policy; the form is the journal's software.
+2. **Every form-field list carries an evidence pointer**, or it may not be called *confirmed*:
+   `Verified against {R1/R2/…} confirmation PDF, {YYYY-MM-DD}`. **Date and round only — never the
+   manuscript ID** (Design Principle 3: the set of manuscripts a reviewer has handled can identify
+   the reviewer).
+3. **A confirmation PDF cannot verify a dropdown.** It carries no form widgets, so the *contents* of
+   a recommendation or rating menu are not recoverable from it. Verifying an option list means
+   rendering the live page as an image. Until that is done, mark the list partially verified and
+   **leave the unread labels blank rather than filling them in** — a plausible guess in a confident
+   file is worse than an admitted gap.
+4. **When a profile is wrong, correct the profile.** Reading it and working around it in one session
+   leaves the next reader to hit the same wall.
+
 ## Adding a New Journal
 
 1. Copy the closest existing profile as a template.
-2. Record form fields from the first real review invitation (scorecard items, rating scales, required text boxes, recommendation options).
-3. Commit under `{JOURNAL_SHORTNAME}.md` using established abbreviations (KJR, RYAI, INSI, AJR, EURE; full name if no common abbreviation).
-4. Update this README table.
+2. Record form fields from a **completed submission form or its confirmation PDF** (scorecard items,
+   rating scales, required text boxes, recommendation options) — see the rules above. If you have
+   only an invitation so far, write what you have and mark it unverified.
+3. Add the evidence pointer (round + date, no manuscript ID).
+4. Commit under `{JOURNAL_SHORTNAME}.md` using established abbreviations (KJR, RYAI, INSI, AJR, EURE; full name if no common abbreviation).
+5. Update this README table.
 
 ## Consumed By
 

--- a/skills/peer-review/references/reviewer_profiles/RYAI.md
+++ b/skills/peer-review/references/reviewer_profiles/RYAI.md
@@ -53,10 +53,34 @@ The Daily-practice field is easily left as Yes by a portal default selection or 
 
 ## Recommendation Options
 
-- Accept
-- Accept with Minor Revision
-- Reject: Encourage major revision and resubmission (**= Major Revision** for practical purposes)
-- Reject
+**⚠ PARTIALLY VERIFIED — transcribe the list from the form before you use it.**
+**Verified against:** the live form, rendered (one R1 and one later invitation). Last updated: 2026-08-05.
+
+This section previously listed four options as fact, including **"Accept with Minor Revision"**.
+That label **is not on the form.** A reviewer was told to select it, reached the portal, and had
+to report back what the form actually said. The list below records only what has been read off a
+rendered form; the remaining labels have not been transcribed and are deliberately left blank
+rather than guessed.
+
+- The form presents **six** options, not four.
+- The minor-revision tier is **two separate options**, not one:
+  - `Accept Revisions with final approval: **by Editor**`
+  - `Accept Revisions with final approval: **by this reviewer**`
+- `Reject: Encourage major revision and resubmission` — for practical purposes this is the
+  **Major Revision** tier.
+- `Reject`, and `Reject: Another Journal` (the latter is what makes **Specify Journal** appear).
+
+**Choosing between the two Accept-Revisions options.** This is a substantive decision about whether
+the manuscript comes back to you, and the old profile did not mention that the choice exists:
+
+| Your review | Choose |
+|---|---|
+| States the expected values, so an editor can compare the revision against them without you | **by Editor** |
+| Asks for a recomputation, a new analysis, or a figure whose correct result you did not print | **by this reviewer** |
+
+**Before submitting, read the recommendation dropdown on the form and use its wording.** A
+ScholarOne *confirmation PDF* carries no form widgets, so the dropdown's contents cannot be
+recovered from it — verifying the option list means rendering the live page as an image.
 
 ## Draft Structure Template
 


### PR DESCRIPTION
Promoted from the harvest backlog. Three candidates, one class, two journals — the strongest
recurrence signal in the whole backlog (one of them was filed, then observed a **second** time two
weeks later and still not fixed).

## Two profiles described forms that do not exist

| profile | wrong entry | reality |
|---|---|---|
| RYAI | recommendation option **"Accept with Minor Revision"** | not on the form. The form has **six** options, and the minor tier is **two** — final approval *by Editor* vs *by this reviewer*, which decides whether the paper comes back to you |
| EURE | **"ORCID Reviewer Credit"** under *Confirmed Form Fields* | not a scorecard field. Zero occurrences in either round's confirmation PDF; it is an account-level setting |

A reviewer was told to select the option that is not there and had to report back from the portal.
The ORCID entry reached a submission checklist as a field to answer.

These profiles are trusted **because** they are specific — you read the options here and pick one
without opening the portal. That is what makes a wrong entry expensive.

### The root cause was one line in the README

> Record form fields from the first real review **invitation**.

An invitation advertises the review. The form is what you fill in. The README now requires:

1. **Source = a completed form or its confirmation PDF** — never the invitation, never the guidelines.
2. **An evidence pointer, or it may not be called *confirmed*** — round + date, **never the manuscript ID** (Design Principle 3: the set of manuscripts a reviewer handled can identify the reviewer).
3. **A confirmation PDF cannot verify a dropdown** — no form widgets. Verifying an option list means rendering the live page. Until then, **leave unread labels blank rather than filling them in.**
4. **When a profile is wrong, correct the profile** — working around it leaves the next reader at the same wall.

The corrected RYAI section leaves **four of six labels blank** under rule 3. Guessing them is the
defect this PR exists to stop.

## Found while fixing that: a manuscript ID shipped publicly, and the gate pointing outward only

`INSI-D-…` was on `main`, in a public file, while `validate_skills.sh` reported PASS.

`/contribute` has blocked this shape from **contributions** since it shipped, rated `major`.
Nothing applied the rule to the repository's own files. **The toolkit held contributors to a
standard it did not hold itself to.** `check_precedent.py` now carries the same shape.

### And the pattern was wrong in both directions at once

```
MISSED   the revision suffix — \d{3,6}\b cannot match a serial followed by R1 (R is a word
         character). Every REVISED id was invisible, and revised ids are what a reviewer
         handles most. That is why the shipped leak was never reported.
FIRED    a published DOI — Annals of Internal Medicine mints 10.7326/ANNALS-25-NNNNN, so the
         vendored QUADAS-3 checklist citing its own source drew a MAJOR finding.
```

A DOI is public by definition; a submission id is the opposite. Both halves are **pinned by
mutation** — drop the suffix and the revised-form assertion fails; drop the DOI guard and the DOI
assertion fails.

The test fixture now **assembles** its identifier instead of writing one. A file whose job is to
carry identifier-shaped strings must not carry one as a literal, or the repo's own precedent gate
flags the test that proves the gate works.

## Three of this repo's own gates caught me writing this

All three were right:

- the comment explaining the fix had put the leaked identifier **straight back** into a public file;
- two evidence pointers tripped the dated-blockquote rule.

**The allow-list was not widened to accommodate them.** Weakening a PII rule for authorial
convenience is how these files got wrong in the first place — the pointers moved out of the
blockquote instead.

## Verification

- `skills/contribute/tests/test_contribution_safety.sh` — 26 → **28** assertions, all pass
- mutation-tested in both directions (see above)
- `python3 scripts/run_ci_mirror.py` — **249/249**

## Not in this PR

The remaining RYAI option labels. I do not know them, and rule 3 forbids guessing — they get filled
in the next time the live dropdown is rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)