### PR TITLE
docs(peer-review,self-review,check-reporting): three judgements that could be answered without evidence

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -628,8 +628,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 41742,
-      "sha256": "b57ffd0bab3807cbe8f8c456a9af045c3fd41bd17d2d934abb7fe4fbc1ced03d"
+      "size": 43252,
+      "sha256": "6a7cc1d829f42be42a8c57e52bbf29b40daa61dc669745fd268d4b83f8e8f43f"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -3373,8 +3373,8 @@
     },
     {
       "path": "skills/peer-review/SKILL.md",
-      "size": 51094,
-      "sha256": "5971df020a89d5bafffdd3c729d0a24cefae0f5cf6bc9cd059b550667d76af68"
+      "size": 51910,
+      "sha256": "fa96bed959cde9ca66d37311da8832cad5de30de2f4bab00c7d24dbb8fc392f4"
     },
     {
       "path": "skills/peer-review/references/aczel_2021_reviewer2_patterns.md",
@@ -3553,8 +3553,8 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_calibration/recommendation_calibration.md",
-      "size": 4405,
-      "sha256": "a00496308fb805e2ace48de023cef8f0373fb8262f0b9c49b6075f45f9fbb1e7"
+      "size": 7152,
+      "sha256": "65a10ae731c12aa55729e8f6cbb2db316b98c639bbb9b0910323709e4549f890"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/AJR.md",
@@ -4568,8 +4568,8 @@
     },
     {
       "path": "skills/self-review/references/panel_review_template.md",
-      "size": 15095,
-      "sha256": "f9c084e950602ec88f7465dc953ed2309148cab37a3bef5f1b4c80deca2707a4"
+      "size": 16949,
+      "sha256": "8cb34e24a3e94c658ba59565fb413c137f005ab282a870edbb15e37bd43e9b9a"
     },
     {
       "path": "skills/self-review/references/phases/confounding_completeness.md",

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -212,6 +212,27 @@ For each item, record:
 - **Location**: Section name and paragraph or approximate position (e.g., "Methods, paragraph 3")
 - **Notes**: What was found (if PRESENT/PARTIAL) or what should be added (if MISSING)
 
+**What is appraised is the source paper's reporting — never your convenience in using it.** This
+holds for every instrument here, reporting checklists and risk-of-bias / quality tools alike, and it
+is easiest to lose in a systematic review, where you read each paper *in order to extract from it*.
+An item asking "are the results clearly reported?" is not asking "were they reported in the unit my
+pool needs".
+
+A reviewer scoring a case-series quality tool marked four papers down on the outcome-reporting item
+because their analysis unit did not match the pool's — treatment-level results against a
+patient-level denominator. A second assessor's correction was one sentence, *that is a limit of our
+extraction, not a defect in their reporting*, and all four scores went back up. Single-scorer
+appraisal is where this happens, because there is nobody to say it.
+
+So: if a downgrade's stated reason turns on a **denominator, an analysis unit, a subgroup you needed
+and they did not report separately, or a format you could not parse**, it is an extraction note, not
+a scoring reason. Record it in a separate **extraction-note** column and restore the score.
+
+Both belong in the table. An extraction limitation is a real constraint on *your* synthesis and often
+belongs in your limitations paragraph — it just is not evidence about the paper being appraised, and
+folding it into the score makes the appraisal unreproducible: another assessor with a different pool
+would score the same paper differently.
+
 ### Step 4b: Section Boundary Check
 
 In addition to checklist items, verify that:

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -169,6 +169,18 @@ gate. It prevents a valid issue list from under-weighting contribution and prior
 3. **Weak novelty**: Is the work hard to distinguish from close prior AI/LLM extraction or validation
    papers, or does it omit the baseline needed to show that the proposed adaptation adds value?
 
+**These take evidence, not opinions.** Answered from the manuscript's own framing they fail in one
+direction only — toward the revision tier. Three rules, with the incident, in
+`references/reviewer_calibration/recommendation_calibration.md`:
+
+- **3 answered "no"** must name what was checked: the validation status of each component
+  (composition of individually established parts is engineering, not a finding) and the tools already
+  delivering the claimed output.
+- **2 answered "no"** may not rest on the clinical need. The need is a fact about the world; the
+  question is this artifact's pathway to a decision.
+- **If the Phase 2 task-formulation audit fired, 3 defaults to YES** unless separately evidenced —
+  a contribution whose measured task differs from its claimed task has not been demonstrated.
+
 If 2 and 3 both hold, do not default to Major Revision simply because the review is constructive. In the
 confidential comments, state that the manuscript has a priority/contribution problem in addition to the
 fixable technical issues, and calibrate the recommendation toward the journal's stronger option (for

--- a/skills/peer-review/references/reviewer_calibration/recommendation_calibration.md
+++ b/skills/peer-review/references/reviewer_calibration/recommendation_calibration.md
@@ -20,6 +20,43 @@ fixable technical issues, and calibrate the recommendation toward the journal's 
 example, reject/resubmission where that tier exists). If only 1 holds and the value/novelty case is strong,
 Major Revision remains appropriate.
 
+## The three questions take evidence, not opinions
+
+Answering "no" to 2 or 3 is a claim about the literature and about the artifact. Answered from the
+manuscript's own framing, it is the manuscript grading itself — and it fails in one direction only,
+toward the revision tier.
+
+**Condition 3 ("weak novelty") may not be answered *no* without naming what was checked.** At minimum:
+
+- **Per component.** A study assembling two or more established parts — an off-the-shelf model, a
+  standard pipeline, a published score — must be assessed component by component. *Composition of
+  individually validated components is engineering, not a finding*, unless the composition itself
+  yields something neither component gives. Where every component is separately established, the
+  burden shifts: the manuscript must show what the combination produces that its parts do not.
+- **Existing products.** Name the tools or commercial systems already delivering the claimed output,
+  or state that a search for them found none. "I am not aware of one" is not that search.
+
+**Condition 2 ("speculative value") may not be answered *no* by asserting the clinical need.** That the
+problem matters is a fact about the world; condition 2 asks about *this artifact's* pathway to a
+decision, a workflow change, or a downstream validation. A strong need with no pathway is exactly the
+case the condition exists to catch.
+
+**Wiring: a task-formulation mismatch feeds condition 3.** If the task-formulation audit found that the
+*claimed* task and the *measured* task differ, then the contribution as claimed has not been
+demonstrated — so **condition 3 defaults to YES (weak novelty) unless separately evidenced against the
+prior art.** Without this, an audit finding and a "the contribution is real" answer sit in the same QC
+log four lines apart and nothing notices.
+
+**Why this is here.** A review recorded, four lines apart: *task-formulation audit: mismatch found —
+claimed = objective replacement of a subjective assessment; measured = a distribution conditioned on
+that same subjective assessment*, and *weak novelty NO (the contribution is real) → Major Revision
+correct*. Condition 3 had been answered by citing the very claim the audit had just invalidated;
+condition 2 from the clinical need rather than the artifact. Neither answer cited anything. The
+co-reviewer wrote ~180 words, all on priority — each component already validated, commercial tools
+already delivering the output — and the editor **rejected outright**, two tiers below the
+recommendation. The technical review was the stronger of the two on execution and still landed in the
+wrong tier, because the gate that was supposed to price contribution accepted an unsourced answer.
+
 **Fixable vs unfixable tier-domination**: separate defects that a revision can repair (extraction errors,
 missing supplementary, a mislabeled table, an over-claiming sentence) from defects that cannot be repaired
 within the current submission (poolability of incommensurable studies, a broken construct, an invalid

--- a/skills/self-review/references/panel_review_template.md
+++ b/skills/self-review/references/panel_review_template.md
@@ -236,3 +236,33 @@ Concern families the classifier recognizes: `search_screening`, `design_leakage`
 type is unknown, the axis-coverage check is skipped (the monoculture and lens-collapse
 checks still run). The gate never penalizes genuine consensus — only full reviewer
 redundancy (`LENS_COLLAPSE`) or panel-level concentration (`FAMILY_MONOCULTURE`).
+
+### What a same-substrate panel cannot check: claims about other papers
+
+`SUBSTRATE_MONOCULTURE` says the panel is not independent. It does not say **where** the
+dependence bites, and that turns out to be specific rather than diffuse.
+
+Findings grounded in the manuscript's **own numbers** are checkable by any lens — the table is
+right there, and a reviewer sharing the drafter's substrate can still add the column up.
+Findings about **what another paper says** are not. There the reviewer inherits the drafter's
+reading of a source it never reopens, and every lens inherits the same one.
+
+A four-reviewer panel plus an editor lens, all sharing the drafter's substrate, cleared **two
+false characterisations of cited papers**. Its own roster had `SUBSTRATE_MONOCULTURE` recorded as
+an open finding, so the *risk* was known; what was not known is that the failures concentrate
+exactly there. A different-substrate pass caught one in a single run by opening the sources'
+enrolment criteria, and a senior co-author caught the other by reading the anchor paper's stated
+conclusion.
+
+**Roster rule.** Route these claim types by construction to a **non-drafter substrate or a
+human**:
+
+- Introduction premises about the state of the literature
+- Descriptions of comparator or prior studies — design, population, what they concluded
+- "No prior study has…" / "this is the first…" statements
+- Any sentence whose truth depends on a document the panel did not open
+
+**When the whole panel shares the drafter's substrate, the editor synthesis reports this class as
+`UNCHECKED`, not as reviewed.** That is the entire change, and it is deliberately cheap: it adds
+no reviewer and finds no new defect. It stops the panel claiming coverage it did not have — which
+is what let two false characterisations through with a clean panel report attached to them.


### PR DESCRIPTION
Three harvest candidates, one shape. Each sits where the skill asks for a **judgement**, each
accepted an answer with nothing behind it, and each failed in **one direction only** — the
comfortable one.

No new gates. All three are rules; the detector count is unchanged.

## 1. `/peer-review` Phase 2F — the contribution gate took its answer from the manuscript's framing

Conditions 2 and 3 were unsourced yes/no questions. One review's QC log recorded, **four lines
apart**:

> `task-formulation audit: mismatch found — claimed = objective replacement of a subjective
> assessment; measured = a distribution conditioned on that same subjective assessment`

> `weak novelty NO (the contribution is real) → Major Revision correct`

Condition 3 had been answered by citing the claim the audit had just invalidated; condition 2 from
the clinical *need* rather than the artifact. The co-reviewer wrote ~180 words, all on priority —
each component already validated, commercial tools already delivering the output — and the **editor
rejected outright, two tiers below the recommendation.** The technical review was the stronger of
the two on execution and still landed in the wrong tier.

| now | |
|---|---|
| 3 answered "no" | must name per-component validation status (composition of individually established parts is engineering, not a finding) **and** the products already delivering the claimed output |
| 2 answered "no" | may not rest on the clinical need — the need is a fact about the world; the question is this artifact's pathway |
| task-formulation audit fired | **3 defaults to YES** unless separately evidenced — the audit and the gate can no longer contradict each other silently |

## 2. `/self-review` panel — `SUBSTRATE_MONOCULTURE` said the panel was not independent, not *where*

The dependence is specific, not diffuse. Findings grounded in the manuscript's **own numbers** are
checkable by any lens — the table is right there. Findings about **what another paper says** are
not: the reviewer inherits the drafter's reading of a source it never reopens, and every lens
inherits the same one.

A four-reviewer panel plus an editor lens, all on the drafter's substrate, cleared **two false
characterisations of cited papers**. The roster had `SUBSTRATE_MONOCULTURE` recorded as an open
finding, so the *risk* was known — that the failures **concentrate** there was not. A
different-substrate pass caught one by opening the sources' enrolment criteria; a senior co-author
caught the other by reading the anchor paper's stated conclusion.

Literature-characterisation claims now route to a non-drafter substrate or a human, and a wholly
same-substrate panel reports that class as **`UNCHECKED`, not as reviewed**. It adds no reviewer and
finds no defect — it stops the panel claiming coverage it did not have, which is what let two false
characterisations through *with a clean panel report attached*.

## 3. `/check-reporting` Step 4 — an instrument appraises the source paper, not our convenience

Four papers were marked down on a case-series outcome-reporting item because their **analysis unit
did not match the pool's** (treatment-level results against a patient-level denominator). A second
assessor's correction was one sentence — *that is a limit of our extraction, not a defect in their
reporting* — and all four scores went back up. Single-scorer appraisal is where this happens,
because nobody is there to say it.

A downgrade whose reason turns on a **denominator, an analysis unit, a subgroup they did not report
separately, or a format that would not parse** is an *extraction note*, not a scoring reason. It
belongs in the table — it constrains **our** synthesis and often belongs in the limitations
paragraph — but folding it into the score makes the appraisal **unreproducible**: another assessor
with a different pool would score the same paper differently.

Written **instrument-generally on purpose**: the tool in the incident is not among the 49 vendored
checklists, so a tool-specific note would be a claim this repo cannot check.

## Verification

- `check_phase_budget.py --strict` — every section within budget, **0 exempt**
- `python3 scripts/run_ci_mirror.py` — **249/249**

🤖 Generated with [Claude Code](https://claude.com/claude-code)