### PR TITLE
chore(release): v5.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [5.25.0] - 2026-08-17
+
 ### Added
 
 - **`/obsidian-paper-vault` — a folder of PDFs becomes an Obsidian vault.** The reference

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.24.0"
-date-released: "2026-07-31"
+version: "5.25.0"
+date-released: "2026-08-17"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.24.0",
+  "version": "5.25.0",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.24.0",
+  "version": "5.25.0",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",


### PR DESCRIPTION
Rolls up the work accumulated since v5.24.0 (2026-07-31).

**36 CHANGELOG entries**, led by:

- `/obsidian-paper-vault` — a folder of PDFs becomes an Obsidian vault
- `/preprocess-imaging` — `check_normalizer_domain.py`
- `/meta-analysis` — where published radiology SR/MAs actually fail PRISMA 2020, and the binary-outcome specification Cochrane says to avoid

## Scope

Version synchronised across the three declaring files; `CHANGELOG [Unreleased]` closed as `[5.25.0]`.

| file | 5.24.0 → 5.25.0 |
|---|---|
| `CITATION.cff` | ✅ (+ `date-released`) |
| `package.json` | ✅ |
| `metadata/distribution_manifest.json` | ✅ regenerated |

No skill content changes in this PR — it is the version bump only.

Local mirror: **249/249**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
