### PR TITLE
fix(peer-review): a round number and a date are a reviewing timeline

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3563,13 +3563,13 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/EURE.md",
-      "size": 2934,
-      "sha256": "b5adbd2bc617efe3500daf12df03ca2d06ce66265a663541a71e6c29decdc94f"
+      "size": 2883,
+      "sha256": "f39641698ebeec91328872ada36d7c06c9c838bb9857a915d7635e599f2dce04"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/INSI.md",
-      "size": 1872,
-      "sha256": "4a933d32363ad566f2054c740c9c93bc1cc3a8e924f3b050ce59dc9408e3c2f5"
+      "size": 1870,
+      "sha256": "70d73a0b51ce3e15bcc0ccd9a3a9379c9e6d3a4fe03eba8777dd9cc495245d8a"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/KJR.md",
@@ -3578,13 +3578,13 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/README.md",
-      "size": 4752,
-      "sha256": "470b0bbd324f7203c3cef4805283ff32599e7936bb78234ab78ca2ab7ac39730"
+      "size": 5254,
+      "sha256": "6bd85fecf935552a53e5d64797e0381a6af27765c7f2c28faa79773a2f96a1b4"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/RYAI.md",
-      "size": 4813,
-      "sha256": "a23c19c19261305f7f088ca4235e5385ab715b28f1d33c41d01753a6ad39289c"
+      "size": 4776,
+      "sha256": "144f9fb659961827ce34db79c7f5335097296530000edd029d291b756c0f9b01"
     },
     {
       "path": "skills/peer-review/scripts/check_pdf_injection.py",

--- a/skills/peer-review/references/reviewer_profiles/EURE.md
+++ b/skills/peer-review/references/reviewer_profiles/EURE.md
@@ -38,12 +38,12 @@ Use INSI-style base; substitute journal name and scorecard fields when confirmed
 
 ## Confirmed Form Fields
 
-**Verified against:** two submitted-review confirmation PDFs, rounds R1 and R2. Last updated: 2026-08-06.
+**Verified against:** a completed review form. Last updated: 2026-08.
 
 This list previously said "from a recent reviewer invitation", and that was the defect: an
 invitation advertises the review, it is not the form you fill in. One field carried over from it —
 **ORCID Reviewer Credit** — does not exist on the scorecard at all (zero occurrences of the string
-in either confirmation PDF; it is an account-level setting). It had been copied into a submission
+on the form; it is an account-level setting). It had been copied into a submission
 checklist as a field to answer before the PDFs were compared.
 
 Editorial Manager scorecard differs from INSI H/M/L base. Actual fields:

--- a/skills/peer-review/references/reviewer_profiles/INSI.md
+++ b/skills/peer-review/references/reviewer_profiles/INSI.md
@@ -12,7 +12,7 @@ Rating scale: High / Medium / Low
 1. Interest
 2. Innovation
 3. Importance
-4. Language editing — categorical. Editorial Manager dropdown labels (verified against an R1 confirmation PDF, 2026-05-16): "No (minor)" / "Yes (minor)" / "Yes (major)". The profile previously listed these as "No minor editing needed" / "Yes minor editing needed" / "Yes major editing needed"; the portal uses the parenthesized short form. Semantics: "No (minor)" = best/most favorable (well written, only minor polish possible); "Yes (minor)" = minor editing needed; "Yes (major)" = major editing needed.
+4. Language editing — categorical. Editorial Manager dropdown labels (verified against a completed review form, 2026-05): "No (minor)" / "Yes (minor)" / "Yes (major)". The profile previously listed these as "No minor editing needed" / "Yes minor editing needed" / "Yes major editing needed"; the portal uses the parenthesized short form. Semantics: "No (minor)" = best/most favorable (well written, only minor polish possible); "Yes (minor)" = minor editing needed; "Yes (major)" = major editing needed.
 
 ## Additional Required Fields
 

--- a/skills/peer-review/references/reviewer_profiles/README.md
+++ b/skills/peer-review/references/reviewer_profiles/README.md
@@ -31,7 +31,7 @@ expensive, and it has now happened twice on two different journals.
   reviewer was told to pick the non-existent option and had to report back from the portal. Filed,
   then observed a second time two weeks later, still uncorrected.
 - Another profile listed **ORCID Reviewer Credit** under *Confirmed Form Fields*. It is not a
-  scorecard field at all — zero occurrences in either round's confirmation PDF; it is an
+  scorecard field at all — zero occurrences on the form; it is an
   account-level setting. It reached a submission checklist as a field to answer.
 
 Both entries came from the same place: **a review invitation, or the author guidelines.** An
@@ -43,9 +43,14 @@ nothing in this directory used to say so.
 1. **Source of truth is a completed form or its confirmation PDF** — never the invitation, never the
    author guidelines. Guidelines describe the journal's policy; the form is the journal's software.
 2. **Every form-field list carries an evidence pointer**, or it may not be called *confirmed*:
-   `Verified against {R1/R2/…} confirmation PDF, {YYYY-MM-DD}`. **Date and round only — never the
-   manuscript ID** (Design Principle 3: the set of manuscripts a reviewer has handled can identify
-   the reviewer).
+   `Verified against a completed review form, {YYYY-MM}`. **Evidence class and month only.**
+   Never the manuscript ID, and — added 2026-08-17 — never the round, the count, or the day.
+   Design Principle 3 says the set of manuscripts a reviewer has handled can identify the
+   reviewer; so does the set of *reviews*. A round number and a day-precision date say how many
+   reviews were done and when, which is a reviewing timeline, and correlating five profiles
+   rebuilds it. Worse, a day-precision date is a join key: an ID scrubbed from this file survives
+   in already-published package versions, and a shared date links the two back together. The month
+   carries the staleness signal a date exists for; nothing else here needs to.
 3. **A confirmation PDF cannot verify a dropdown.** It carries no form widgets, so the *contents* of
    a recommendation or rating menu are not recoverable from it. Verifying an option list means
    rendering the live page as an image. Until that is done, mark the list partially verified and

--- a/skills/peer-review/references/reviewer_profiles/RYAI.md
+++ b/skills/peer-review/references/reviewer_profiles/RYAI.md
@@ -54,7 +54,7 @@ The Daily-practice field is easily left as Yes by a portal default selection or 
 ## Recommendation Options
 
 **⚠ PARTIALLY VERIFIED — transcribe the list from the form before you use it.**
-**Verified against:** the live form, rendered (one R1 and one later invitation). Last updated: 2026-08-05.
+**Verified against:** the live form, rendered. Last updated: 2026-08.
 
 This section previously listed four options as fact, including **"Accept with Minor Revision"**.
 That label **is not on the form.** A reviewer was told to select it, reached the portal, and had


### PR DESCRIPTION
The evidence pointers #499 added to this directory were the right idea, and they carried more than
the idea needs.

> `Verified against: two submitted-review confirmation PDFs, rounds R1 and R2. Last updated: 2026-08-06.`

That tells a reader **how many** reviews were done, **at which stage**, and **on what day**. Across
five profiles it correlates into a reviewing timeline — and none of it is what a user of this skill
came for. They came for what the form asks.

## The join key

A day-precision date is worse than it looks. #499 removed a manuscript ID from one of these files
and left the date it was read on. **The ID survives in already-published package versions**, so
anyone holding one has the ID, this file has the date, and the same date links them back together.

Scrubbing an identifier is not finished while its coordinates remain.

## What changed

| | before | after |
|---|---|---|
| `EURE.md` | two … PDFs, rounds R1 and R2, `2026-08-06` | a completed review form, `2026-08` |
| `INSI.md` | an R1 confirmation PDF, `2026-05-16` | a completed review form, `2026-05` |
| `RYAI.md` | one R1 and one later invitation, `2026-08-05` | the live form, rendered, `2026-08` |
| `README.md` | rule: `{R1/R2/…} + {YYYY-MM-DD}` | rule: evidence class + `{YYYY-MM}` |

The README is the part that matters. It **prescribed** the shape, so every future profile would
have rebuilt it. It now prescribes evidence class plus month and says why — including the join-key
mechanism, so the next person to relax it knows what they are relaxing.

Provenance itself is kept: a profile that does not say what it was read off is a claim. That is
#499's finding and it stands. The month carries the staleness signal a date exists for.

## Not touched

- **The form contents.** Every dropdown label, scorecard item and caveat is unchanged. The diff is
  21 lines and all of it is provenance.
- **Which journals have profiles.** Journal-level reviewing is ordinary to disclose — Publons and
  ORCID publish it — and the profiles existing is the skill. Removing them would be scrubbing past
  the point of any benefit.

Local mirror: **249/249**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
