### PR TITLE
fix(peer-review): a correction note should not carry the session it was found in

### DIFF
--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3563,8 +3563,8 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/EURE.md",
-      "size": 2883,
-      "sha256": "f39641698ebeec91328872ada36d7c06c9c838bb9857a915d7635e599f2dce04"
+      "size": 2784,
+      "sha256": "9deb7f135146c97646bbe60196d47b98226cb26d0907045b081a62a76ddc3d63"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/INSI.md",
@@ -3578,13 +3578,13 @@
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/README.md",
-      "size": 5254,
-      "sha256": "6bd85fecf935552a53e5d64797e0381a6af27765c7f2c28faa79773a2f96a1b4"
+      "size": 5021,
+      "sha256": "4e27cb134047238da76a2cb5e25801102e8ddc0ea6de1339a7ecfd07bc303cb7"
     },
     {
       "path": "skills/peer-review/references/reviewer_profiles/RYAI.md",
-      "size": 4776,
-      "sha256": "144f9fb659961827ce34db79c7f5335097296530000edd029d291b756c0f9b01"
+      "size": 4670,
+      "sha256": "377ce54c842aeed6e6ddfcfdeddaf54e59e3cf4156e001a50a5b51c9af8201dc"
     },
     {
       "path": "skills/peer-review/scripts/check_pdf_injection.py",

--- a/skills/peer-review/references/reviewer_profiles/EURE.md
+++ b/skills/peer-review/references/reviewer_profiles/EURE.md
@@ -40,11 +40,10 @@ Use INSI-style base; substitute journal name and scorecard fields when confirmed
 
 **Verified against:** a completed review form. Last updated: 2026-08.
 
-This list previously said "from a recent reviewer invitation", and that was the defect: an
+This list previously gave its source as a reviewer invitation, and that was the defect: an
 invitation advertises the review, it is not the form you fill in. One field carried over from it —
 **ORCID Reviewer Credit** — does not exist on the scorecard at all (zero occurrences of the string
-on the form; it is an account-level setting). It had been copied into a submission
-checklist as a field to answer before the PDFs were compared.
+on the form; it is an account-level setting).
 
 Editorial Manager scorecard differs from INSI H/M/L base. Actual fields:
 

--- a/skills/peer-review/references/reviewer_profiles/README.md
+++ b/skills/peer-review/references/reviewer_profiles/README.md
@@ -23,16 +23,14 @@ Canonical per-journal reviewer formatting profiles. Consumed by both the OSS `pe
 
 These profiles are trusted precisely because they are specific: a reviewer reads the recommendation
 options here and picks one without opening the portal first. That is what makes a wrong entry
-expensive, and it has now happened twice on two different journals.
+expensive, and two entries in this directory were wrong.
 
 - A profile listed **"Accept with Minor Revision"** as a recommendation option. The live form does
   not have that label, and its minor-revision tier is **two** options — final approval *by Editor*
-  versus *by this reviewer*, a real decision about whether the paper returns to the reviewer. The
-  reviewer was told to pick the non-existent option and had to report back from the portal. Filed,
-  then observed a second time two weeks later, still uncorrected.
+  versus *by this reviewer*, a real decision about whether the paper returns to the reviewer.
 - Another profile listed **ORCID Reviewer Credit** under *Confirmed Form Fields*. It is not a
   scorecard field at all — zero occurrences on the form; it is an
-  account-level setting. It reached a submission checklist as a field to answer.
+  account-level setting.
 
 Both entries came from the same place: **a review invitation, or the author guidelines.** An
 invitation advertises the review. The form is what you fill in. They are not the same document, and
@@ -56,8 +54,8 @@ nothing in this directory used to say so.
    rendering the live page as an image. Until that is done, mark the list partially verified and
    **leave the unread labels blank rather than filling them in** — a plausible guess in a confident
    file is worse than an admitted gap.
-4. **When a profile is wrong, correct the profile.** Reading it and working around it in one session
-   leaves the next reader to hit the same wall.
+4. **When a profile is wrong, correct the profile.** Reading it, working around the error and
+   moving on leaves the next reader to hit the same wall.
 
 ## Adding a New Journal
 

--- a/skills/peer-review/references/reviewer_profiles/RYAI.md
+++ b/skills/peer-review/references/reviewer_profiles/RYAI.md
@@ -57,10 +57,9 @@ The Daily-practice field is easily left as Yes by a portal default selection or 
 **Verified against:** the live form, rendered. Last updated: 2026-08.
 
 This section previously listed four options as fact, including **"Accept with Minor Revision"**.
-That label **is not on the form.** A reviewer was told to select it, reached the portal, and had
-to report back what the form actually said. The list below records only what has been read off a
-rendered form; the remaining labels have not been transcribed and are deliberately left blank
-rather than guessed.
+That label **is not on the form.** The list below records only what has been read off a rendered
+form; the remaining labels have not been transcribed and are deliberately left blank rather than
+guessed.
 
 - The form presents **six** options, not four.
 - The minor-revision tier is **two separate options**, not one:


### PR DESCRIPTION
Two reviewer-profile corrections were justified with the circumstances of their discovery. This
keeps the defects and drops the circumstances: under COPE, the set of reviews a person has handled
can identify them, and #504 already dropped the round and the day from the evidence pointers.

Form fields, dropdown labels, scorecard items and all four rules are unchanged — the diff is prose.

`python3 scripts/run_ci_mirror.py` → 249/249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
