### PR TITLE
fix(skills): a detector's precedent should name the failure, not the paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2619,10 +2619,10 @@ below; the release does not wait the usual 14 days because a wrong result is alr
 ### Added
 
 - **`check_density_complaint` (detector 66 -> 67, `/revise`): "too dense" is the one comment you
-  cannot address by adding text.** A DTA meta-analysis was told by four reviewers it was too dense;
-  the point-by-point revision answered each comment by adding a sentence and came back **613 words
-  longer**, every named term higher than before. It took three rounds to land 733 words below where
-  it started. The detector is arithmetic: if the decision letter carries a density/length complaint
+  cannot address by adding text.** A point-by-point revision answers each density comment by adding
+  a sentence and comes back **longer** than the version that drew the complaint, every named term
+  higher than before, and the shrink the letter asked for slips another round away. The detector is
+  arithmetic: if the decision letter carries a density/length complaint
   AND the revised body (Introduction through Discussion, citation markers excluded) did not shrink,
   it fires `DENSITY_COMPLAINT_UNADDRESSED`. With no complaint it stays silent — it is not a
   "shorter is always better" nag. Ships a challenge card reproducing the v_prev -> longer -> shorter
@@ -5254,7 +5254,7 @@ Resolves the meta-analysis project → medsci-skills handoff P1+P2.
 
 New 3-way audit catches the failure mode where in-text Table/Figure citations resolve to a different rendered caption because the build script carries its own legacy SSOT. Internal consistency (Phase 2.5) cannot detect it — both the prose and the build artifact echo their own divergent truths cleanly.
 
-**Precedent:** in a STROBE cohort manuscript, the body cited "Supp Table S4 (sensitivity analysis)" but the rendered DOCX S4 was a different table; S1, S6, S7 mismatched and S8, S9 were cited but absent from the DOCX entirely. Caught only on co-author circulation review.
+**The failure pattern:** the body cites a supplementary table as a sensitivity analysis while the rendered DOCX carries a different table under that number, further supplement numbers mismatch the same way, and some are cited but absent from the DOCX entirely. Caught only on co-author circulation review.
 
 - `skills/write-paper/scripts/check_xref.py` — extracts (a) `(Supplementary )?(Table|Figure)\s+(S?\d+[A-Z]?)` in-text citations, (b) caption definitions from `## Tables` / `## Figures` / `## Supplementary {Tables,Figures}` body sections, (c) rendered DOCX caption paragraphs via python-docx. Emits `qc/xref_audit.json` with status codes `OK | MISSING_DOCX | MISSING_BODY | MISMATCH | UNCITED | NOT_CITED_NO_BODY`. Caption agreement via Jaccard ≥0.40. Panel-letter fallback (`Figure 2A` cite resolves to `Figure 2` caption). `--strict` exits 1 on any P0 finding.
 - `/write-paper` Step 7.6a (new) — runs after Step 7.6 DOCX build, before Step 7.7 final gate. Submission gate; HALT pipeline on non-OK. Routing table for fixes by symptom (body update vs build-script update) — body caption is the SSOT, never the reverse.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,36 @@ MedSci Skills is public. Do not include:
 
 The validator blocklist is intentionally conservative. If it catches a false positive, explain the case in the pull request rather than bypassing the check silently.
 
+### Ship the mechanism, keep the coordinates out
+
+A gate here is expected to say which failure it exists for — a detector validated only against
+fixtures authored beside it has no severity, and naming the failure is what gives it any. That is
+worth keeping. What does not belong in a public file is the arithmetic identifying **which paper**
+the failure happened to.
+
+The blocklist cannot help you here: it matches tokens — names, IDs, paths, emails — and a sentence
+like *"the revision came back 613 words longer and it took three rounds"* contains none. It is
+still the most identifying line on the page, because those numbers occur in exactly one manuscript.
+
+So write the precedent as a **failure pattern**, in the present tense, with the mechanism intact
+and the coordinates removed:
+
+| Keep | Drop |
+|---|---|
+| What goes wrong, and why the obvious check misses it | Word counts, version labels (`v18`, `v2.0.38`), before/after count pairs |
+| The study type, when it changes the failure | Effect sizes, p-values, E-values, κ, AUC from a real analysis |
+| Which artifacts disagree with which | Round numbers, reviewer counts, dates, journal names |
+| The detection move that finds it | An outcome — accepted, rejected, withdrawn, desk-rejected |
+
+Two more places the coordinates travel to, both easy to miss:
+
+- **Test fixtures.** A fixture that reuses a real effect-size pair publishes it. Renumber it — but
+  preserve the property the fixture exists to test (a planted arithmetic error must stay wrong),
+  and re-run the owning test afterwards to prove the detector still fires.
+- **Commit messages and PR bodies.** These are separate storage from the file. A commit that
+  removes a line and then quotes it in its own message has published it, and neither is
+  editable afterwards. Describe the class, never the string.
+
 ## Language Policy
 
 MedSci Skills is **English-canonical**. Write skill mechanics and prose in English so that any

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -1293,8 +1293,8 @@
     },
     {
       "path": "skills/fill-icmje-coi/SKILL.md",
-      "size": 9997,
-      "sha256": "033425065ed9a7429b071e6e2310fdf0666a8a3993a448eb53c9f239c578dc12"
+      "size": 9954,
+      "sha256": "8aa0c34d18e197b0b21ec35c6e53e40c8f5ca3b610ae801441352b99be6968f6"
     },
     {
       "path": "skills/fill-icmje-coi/scripts/fill_icmje_coi.py",
@@ -1933,8 +1933,8 @@
     },
     {
       "path": "skills/intake-project/SKILL.md",
-      "size": 8531,
-      "sha256": "8e4edebfb2b971edf69289d62b4c880321ed2ef9c4f2480c0788ebba9c08ebfc"
+      "size": 8479,
+      "sha256": "c65caf5bcdc53d522c049ea7cb3a48faa8bf2f11bd6a440794d3c4077e951a92"
     },
     {
       "path": "skills/intake-project/skill.yml",
@@ -2698,8 +2698,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 47005,
-      "sha256": "7d9c05842e8835ee72afc71d8f87beb5a3dcab799d3e11965c60edbbc8c67d0d"
+      "size": 46945,
+      "sha256": "ad348da8d8ea24843239ddf7f2e4455101d18ffca23281d1c48e8c3e3ad79487"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2783,8 +2783,8 @@
     },
     {
       "path": "skills/meta-analysis/references/phase4_extraction_detail.md",
-      "size": 11216,
-      "sha256": "ab7a10591f6c6c49e70ad6ba68061fcb5ed0d9435b8fdb8746f7042e31a39220"
+      "size": 11224,
+      "sha256": "d6888235230a53ecc829dd73ef48dfa561cb71467d794a2f6896b486d1787051"
     },
     {
       "path": "skills/meta-analysis/references/phase4_km_composite.md",
@@ -3623,8 +3623,8 @@
     },
     {
       "path": "skills/peer-review/scripts/check_review_boxes.py",
-      "size": 8897,
-      "sha256": "5ddf3ea77569a6ad6b22e7b6ee1a912f9ea36c1c147f7f61cfdf4b2b4d3afcb9"
+      "size": 8941,
+      "sha256": "9ff6d2a02191e9a7dafa039ce5d3b37d7b7395960c59f89e779caab38bd9e94c"
     },
     {
       "path": "skills/peer-review/scripts/check_review_length.py",
@@ -4258,8 +4258,8 @@
     },
     {
       "path": "skills/revise/SKILL.md",
-      "size": 32218,
-      "sha256": "2d207cbad97f2b725d4ddb42d0f23c9fecb805163eb5c31148b30ea465549a0f"
+      "size": 32212,
+      "sha256": "4733786ab5f53316d041ec8ec721ad05a41c9e0366856d1622189ba3132984c2"
     },
     {
       "path": "skills/revise/references/r2r_voice.md",
@@ -4544,7 +4544,7 @@
     {
       "path": "skills/self-review/references/exemplar_findings/estimand_drift_posthoc_primary.md",
       "size": 2179,
-      "sha256": "44dba78272478ff96e0edaee1837832ed9367be00a829dfc4395b6f18816fda6"
+      "sha256": "e9f41030329aa02b6bc3db7910fa26e57f59c8c0ae75349bf3df64a4d996248d"
     },
     {
       "path": "skills/self-review/references/exemplar_findings/over_adjustment_collider.md",
@@ -4573,18 +4573,18 @@
     },
     {
       "path": "skills/self-review/references/phases/confounding_completeness.md",
-      "size": 5344,
-      "sha256": "051f2b066d2d708b161c1e97d666d9e214d128f1413a9c4822f0333e748bda14"
+      "size": 5305,
+      "sha256": "23101938c07c6d8d5ac14e81c007db35b3b4d5e7922238cf6e36fd719565b629"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5a2_design_power.md",
-      "size": 4353,
-      "sha256": "2df5c97fcbb77fb867fd24b116b5e8349f218e3abf5221c4282157f7b2475470"
+      "size": 4301,
+      "sha256": "79183f2ffe7e53733c2680fbb2c00a102538bd2902d49e18314d7e2f1de390ec"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5a_source_fidelity.md",
-      "size": 5989,
-      "sha256": "565eb2ee2f2eaa0be92f04ab2781c5b3ede5d716c9e5caa40b1fea82f87b53ff"
+      "size": 5983,
+      "sha256": "bd781081c756c439bc0f1207adafeab43e3fa8d03a06c3cf8ed459b7805a0297"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5b_screening_counts.md",
@@ -4603,8 +4603,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5f_claim_artifact.md",
-      "size": 12382,
-      "sha256": "c4e83d109e67ca331de1c1f0ee514457426d2be6c6a4fbe56ed0be2a6fc45b25"
+      "size": 12351,
+      "sha256": "dad54cf52b05507df05e48346e0b2aec78c7239ff91f370b8be6c4d71f762b2d"
     },
     {
       "path": "skills/self-review/references/phases/phase2_6_panel.md",
@@ -4999,7 +4999,7 @@
     {
       "path": "skills/self-review/scripts/check_paren_spans.py",
       "size": 6462,
-      "sha256": "bb6ba881fba0c026cae4087d954e6f954be9c9325bfaa4210e4d7ff02310524d"
+      "sha256": "62f44ba1dd11dc4e396b94fe16f82a2d9dd4cae4554d2e7d119aadea9713cc06"
     },
     {
       "path": "skills/self-review/scripts/check_perspective_structure.py",
@@ -6303,8 +6303,8 @@
     },
     {
       "path": "skills/write-paper/references/phase7_integrity_audits.md",
-      "size": 12540,
-      "sha256": "53adeb794576bc580bd34b0173b14cf2483396e25cde12051903145426fd91e3"
+      "size": 12521,
+      "sha256": "9c0ea2eb972af505101c90af5a4bca6ce442ec6bdfc90b2b7ec9b9c4164f60d6"
     },
     {
       "path": "skills/write-paper/references/phase7_polish_detail.md",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -628,8 +628,8 @@
     },
     {
       "path": "skills/check-reporting/SKILL.md",
-      "size": 43252,
-      "sha256": "6a7cc1d829f42be42a8c57e52bbf29b40daa61dc669745fd268d4b83f8e8f43f"
+      "size": 43221,
+      "sha256": "7ea44b9b6c93e4215324dc153e6febb8595c973ba96c4cf40db56a0d255036d0"
     },
     {
       "path": "skills/check-reporting/references/LICENSES.md",
@@ -2613,8 +2613,8 @@
     },
     {
       "path": "skills/manage-refs/references/check_xref_symptoms.md",
-      "size": 4501,
-      "sha256": "4d0da877aca64367cbf13fa8b1008f39b0f258648a5e2a955ca5b8fc8915236f"
+      "size": 4520,
+      "sha256": "06ded0bd36fb8b10166a84705c20769d972fc2d2815c44272df3ffba8700b0e5"
     },
     {
       "path": "skills/manage-refs/scripts/_vendor_citation_writer.py",
@@ -2663,8 +2663,8 @@
     },
     {
       "path": "skills/manage-refs/scripts/check_xref.py",
-      "size": 31099,
-      "sha256": "13d89487a740fdac9b55f6f92d8228fea2c7ae4b8d1c32f96bab3616be8a5b32"
+      "size": 31128,
+      "sha256": "c1d7d8f99d948f2d381c2be2bb13539c2ec8b3a56bd57485271155223e692fa8"
     },
     {
       "path": "skills/manage-refs/scripts/fill_journal_abbrev.py",
@@ -2698,8 +2698,8 @@
     },
     {
       "path": "skills/meta-analysis/SKILL.md",
-      "size": 46982,
-      "sha256": "b10cb9ab372858792bcddcc6675c3c2c0d3211b3e5283b9874b1bdc7e931cfde"
+      "size": 47005,
+      "sha256": "7d9c05842e8835ee72afc71d8f87beb5a3dcab799d3e11965c60edbbc8c67d0d"
     },
     {
       "path": "skills/meta-analysis/references/LICENSES.md",
@@ -2778,8 +2778,8 @@
     },
     {
       "path": "skills/meta-analysis/references/phase3_screening_detail.md",
-      "size": 11123,
-      "sha256": "c1d5f06b86b5913312b08944517f1a99ca873d2bc65b4b35799059605aa3bff7"
+      "size": 10964,
+      "sha256": "e959ae080e6d789f92224920214d32a0ff7580e4a50b7e51bb6a5e8b6177f7b8"
     },
     {
       "path": "skills/meta-analysis/references/phase4_extraction_detail.md",
@@ -4258,8 +4258,8 @@
     },
     {
       "path": "skills/revise/SKILL.md",
-      "size": 32217,
-      "sha256": "a6694b2dac943f65ae0690085ae2951bb9107f42ba429b668829d63bdc154a51"
+      "size": 32218,
+      "sha256": "2d207cbad97f2b725d4ddb42d0f23c9fecb805163eb5c31148b30ea465549a0f"
     },
     {
       "path": "skills/revise/references/r2r_voice.md",
@@ -4273,8 +4273,8 @@
     },
     {
       "path": "skills/revise/scripts/check_density_complaint.py",
-      "size": 8754,
-      "sha256": "243975bbdd2c25e0950f9b9a3b196b99f61e36ead5ba239f9db35749cd5cfd89"
+      "size": 8646,
+      "sha256": "1b3653ad34699b60a40deaee4669f8794160baa2656620a5aa851d8fa11237ed"
     },
     {
       "path": "skills/revise/scripts/check_response_claims.py",
@@ -4303,8 +4303,8 @@
     },
     {
       "path": "skills/revise/scripts/density_complaint_challenge/verify.sh",
-      "size": 3238,
-      "sha256": "5aea8d11e97a7ccd88bcce7196bca0ce020776f6e80233e42c39f2e007370093"
+      "size": 3125,
+      "sha256": "148db1c0a3eca89d47aade8f5a06bcbcb16861d3b4861b8c5f66fbe8e6ccd2f4"
     },
     {
       "path": "skills/revise/skill.yml",
@@ -4588,8 +4588,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5b_screening_counts.md",
-      "size": 7753,
-      "sha256": "35ade6925477a93dd67f827d4b55f971fa12523a9eff5e0a990f421ae00faa32"
+      "size": 7661,
+      "sha256": "f22785378cac3e91f3a64deae4b343a5efdd3d422776bf355c5297d2a0668873"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5c_reference_scans.md",
@@ -4598,8 +4598,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5d_xref_qc.md",
-      "size": 5639,
-      "sha256": "5a574035962626a5a758a335906414c709f2d5cb04b3ac5c5e7dfefa7ba6f8b5"
+      "size": 5649,
+      "sha256": "1aca5552fe697001196b548861abb8b0aaf5e784b60dbd081afdd80eece90d52"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5f_claim_artifact.md",
@@ -4628,8 +4628,8 @@
     },
     {
       "path": "skills/self-review/scripts/_frontmatter.py",
-      "size": 2411,
-      "sha256": "129e1785593629dd63e2b4a264e8cadb034e41ed058cdfe784375e3f765cb5de"
+      "size": 2390,
+      "sha256": "71884a59df74d847ad256021ee2738dd6eaa4c52fc508dd6fade15f41fc8dac3"
     },
     {
       "path": "skills/self-review/scripts/_prose.py",
@@ -6308,8 +6308,8 @@
     },
     {
       "path": "skills/write-paper/references/phase7_polish_detail.md",
-      "size": 19696,
-      "sha256": "ca5d6c1c900d9ef0b4659d18daabdc3322bba3ecef3ec5955e9dc76de958f7e9"
+      "size": 19687,
+      "sha256": "b1d44d8f0cbb0a2d0384de05fa9c0f624dc1ca53450e6ef9e5e0987935ab7782"
     },
     {
       "path": "skills/write-paper/references/section_guides/discussion.md",

--- a/skills/check-reporting/SKILL.md
+++ b/skills/check-reporting/SKILL.md
@@ -218,11 +218,11 @@ is easiest to lose in a systematic review, where you read each paper *in order t
 An item asking "are the results clearly reported?" is not asking "were they reported in the unit my
 pool needs".
 
-A reviewer scoring a case-series quality tool marked four papers down on the outcome-reporting item
-because their analysis unit did not match the pool's — treatment-level results against a
-patient-level denominator. A second assessor's correction was one sentence, *that is a limit of our
-extraction, not a defect in their reporting*, and all four scores went back up. Single-scorer
-appraisal is where this happens, because there is nobody to say it.
+A scorer working a case-series quality tool marks a paper down on the outcome-reporting item
+because its analysis unit does not match the pool's — treatment-level results against a
+patient-level denominator. The correction is one sentence, *that is a limit of our extraction, not
+a defect in their reporting*, and the score goes back up. Single-scorer appraisal is where this
+happens, because there is nobody to say it.
 
 So: if a downgrade's stated reason turns on a **denominator, an analysis unit, a subgroup you needed
 and they did not report separately, or a format you could not parse**, it is an extraction note, not

--- a/skills/fill-icmje-coi/SKILL.md
+++ b/skills/fill-icmje-coi/SKILL.md
@@ -34,8 +34,8 @@ directly on `word/document.xml` inside the docx zip and doing literal-string
 replacement — but that requires the target strings to already exist in the
 seed, so the skill ships a pre-filled synthetic seed.
 
-**Precedent:** a multi-author cohort manuscript submission — 6 authors
-auto-filled in ~5 seconds from the synthetic seed with zero Word clicks.
+**Effect:** a full author roster auto-fills in seconds from the synthetic seed, with
+zero Word clicks.
 
 ## Core Principles (Do Not Violate)
 

--- a/skills/intake-project/SKILL.md
+++ b/skills/intake-project/SKILL.md
@@ -128,7 +128,7 @@ For any manuscript project (cohort, MA, RCT, case series), enforce this structur
 - Mid-project cleanup: when `manuscript/` has >3 versioned files or QC docs at top level, reorganize.
 - Before session handoff: reorganize if structure is drifting.
 
-**Precedent:** an STROBE cohort with a mortality endpoint reorganized v1–v6 plus QC docs from the manuscript/ top level so that a reject-retarget path to a different journal requires only `cp -r submission/chest submission/<new_journal>`.
+**Why it pays off:** moving version drafts and QC docs off the `manuscript/` top level makes retargeting a different journal a single `cp -r submission/<journal> submission/<new_journal>`.
 
 ---
 

--- a/skills/manage-refs/references/check_xref_symptoms.md
+++ b/skills/manage-refs/references/check_xref_symptoms.md
@@ -59,10 +59,10 @@ proven), and a caption nobody wrote becomes visible again.
 Internal consistency in `/self-review` Phase 2.5 does NOT catch
 cross-reference defects because both the body prose and the build script
 can echo their own divergent SSOTs cleanly — each looks self-consistent in
-isolation. Precedent: an STROBE cohort manuscript revision — body cited
-"Supplementary Table S4 (a sensitivity-analysis)" but the rendered DOCX S4 was
-a diagnostics table; S1, S6, S7 mismatched and S8, S9 were cited but absent
-from the DOCX entirely. The 3-way matrix between citations, body captions,
+isolation. The failure it misses: the body cites a supplementary table as a
+sensitivity analysis while the rendered DOCX carries a diagnostics table under
+that number, further supplement numbers mismatch the same way, and some are
+cited but absent from the DOCX entirely. The 3-way matrix between citations, body captions,
 and DOCX captions is the only place those drifts surface.
 
 ## Pipeline placement

--- a/skills/manage-refs/scripts/check_xref.py
+++ b/skills/manage-refs/scripts/check_xref.py
@@ -7,11 +7,11 @@ Supplementary Tables / Supplementary Figures point to labels that either
 the manuscript body, or (c) carry a caption text in the rendered DOCX
 that disagrees with the body's caption definition.
 
-Precedent: an STROBE cohort manuscript revision — body cited
-"Supp Table S4 (a sensitivity-analysis)" but the rendered DOCX S4 was
-a diagnostics table; S1, S6, S7 mismatched; S8, S9 cited but absent
-from DOCX. Internal consistency checks did not catch this because the
-build script carried its own legacy SSOT.
+The failure it catches: the body cites a supplementary table as a
+sensitivity analysis while the rendered DOCX carries a diagnostics table
+under that number, further numbers mismatch the same way, and some are
+cited but absent from the DOCX. Internal consistency checks do not catch
+this because the build script carries its own legacy SSOT.
 
 Inputs
 ------

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -210,9 +210,9 @@ document remains the human explanation. Three hard rules:
    from the consensus artifact altogether** — no adjudication was ever recorded. An exclusion is a
    decision; silence is a gap. Never let it settle into narrative-only (why: reference file).
 
-The set algebra, the reconciliation-table template, and the precedent (a manuscript shipped 32/10/46
-where the ID sets said 24/2/54, with four artifacts echoing the same unreconciled prose total) are
-in the reference file.
+The set algebra, the reconciliation-table template, and the failure pattern it exists for (a
+manuscript ships counts the ID sets do not support, with every downstream artifact echoing the same
+unreconciled prose total) are in the reference file.
 
 **3f.5 Pool composition lock (MANDATORY at adjudication freeze).** Once 3f passes, freeze the pool
 into a single source-of-truth YAML that every downstream artifact can be checked against:

--- a/skills/meta-analysis/SKILL.md
+++ b/skills/meta-analysis/SKILL.md
@@ -378,10 +378,10 @@ setting. R and detail in the same reference:
 
 **Goal**: Catch numerical hallucinations that survived the forward pipeline (CSV → .R → manuscript).
 
-**Precedent failure pattern** — treat this as a lived near-miss, not hypothetical:
-> In a revision-era comparative meta-analysis, a safety outcome was reported as "3/45 vs
-> 0/56, p=0.085." The primary-source Table actually recorded "0/45 vs 1/56, p=0.37" —
-> direction reversed. The extraction CSV was correct; the R script's Fisher exact
+**The failure pattern** — treat this as a lived near-miss, not hypothetical:
+> A safety outcome is reported with its arm-level events, and therefore its p-value,
+> direction-reversed relative to what the primary-source Table actually recorded.
+> The extraction CSV is correct; the R script's Fisher exact
 > `matrix()` was hand-typed after a column in the source Table was misread. Internal
 > consistency checks passed because every downstream artifact (Abstract, Discussion,
 > Table, forest caption) echoed the same wrong number. The reversal was caught only on
@@ -432,9 +432,9 @@ setting. R and detail in the same reference:
    - The underlying means/SDs/counts will change even when the effect size looks similar; if the
      effect sizes are byte-identical while the inputs differ, that is the tell. Probability of ≥4
      independent values coinciding to 2 decimals by chance is ≈ (0.01)^4 — essentially zero.
-   - Precedent: a revision-era sensitivity analysis (1-voxel erosion) reported 8 effect-size values
-     (Cohen's dz + f across 4 VOIs) byte-identical to the primary tables while the means/SDs
-     differed — the erosion analysis had not actually been recomputed. Caught only by external QC.
+   - The failure it catches: a sensitivity analysis reports a block of effect-size values
+     byte-identical to the primary tables while the underlying means/SDs differ — the
+     sensitivity analysis was never actually recomputed. Internal consistency cannot see it.
 
 6. **A "fixed" / "resolved" audit note requires re-run evidence, not a claim.**
    - When a prior audit note records a number as `fixed`, `resolved`, or `corrected`, that status is

--- a/skills/meta-analysis/references/phase3_screening_detail.md
+++ b/skills/meta-analysis/references/phase3_screening_detail.md
@@ -92,7 +92,7 @@ ID sets. The Markdown consensus document remains the human explanation.
    | k_bivariate | ... | ... | |T| |
    | k_narrative-only | ... | ... (explicit IDs listed) | (A ∪ C) \ B \ T |
 
-**Precedent incident (a PRISMA-DTA meta-analysis revision):** a late-revision manuscript shipped with k_qualitative = 32 / k_narrative-only = 10 / k_FT-excluded = 46. ID-set reconciliation (performed only after an adversarial audit at post-Stage 4 QC) revealed true counts 24/2/54. An early-draft prose total ("30 → 32 after FLAG consensus") had been carried forward without ever being reconciled against the screening TSV intersected with the consensus spreadsheet; four downstream artifacts echoed the same wrong total. This gate would have caught the drift at the Phase 5 hand-off.
+**The failure pattern:** a late-revision manuscript ships with qualitative / narrative-only / full-text-excluded counts that ID-set reconciliation later moves in every column. An early-draft prose total is carried forward without ever being reconciled against the screening TSV intersected with the consensus spreadsheet, and the downstream artifacts echo the same wrong total back to each other. This gate catches the drift at the Phase 5 hand-off, rather than at a post-Stage 4 audit.
 
 ##### Why `STAGE_TRANSFER_LOSS` needs its own verdict
 
@@ -114,15 +114,14 @@ where the record is already absent.
 `consensus_ids`) as a blocking issue, and splits `narrative_only` into `_adjudicated` (a decision
 exists) and `_unadjudicated` (none does). Only the first is a legitimate category.
 
-**Precedent incident (a single-arm intervention review):** the review reached journal submission
-with 15 studies and was withdrawn by the authors when 5 eligible studies were found **inside its
-own retrieved records** — none were search failures. One had passed both title/abstract screening
-passes and was never entered into the consensus stage; three others sat under an exclusion code
-that contradicted the registered eligibility criteria (single-arm case series were eligible by
-protocol but were coded "not comparative"). A pre-specified sensitivity analysis flipped from
-P = 0.064 to P = 0.033 once the pool was corrected to 18 studies. Note the shape: every count in
-the submitted manuscript reconciled, because each had been recomputed from an artifact the lost
-studies had already dropped out of.
+**The failure pattern:** a review reaches journal submission with eligible studies missing from
+its pool that were sitting **inside its own retrieved records** — none of them search failures. One
+passes both title/abstract screening passes and is never entered into the consensus stage; others
+sit under an exclusion code that contradicts the registered eligibility criteria (a design the
+protocol declared eligible, coded as though it were not). A pre-specified sensitivity analysis can
+cross its own significance threshold once the pool is corrected, which is how much can ride on this.
+Note the shape: every count in the submitted manuscript reconciles, because each was recomputed from
+an artifact the lost studies had already dropped out of.
 
 #### 3f.5 Pool composition lock (MANDATORY at adjudication freeze)
 

--- a/skills/meta-analysis/references/phase4_extraction_detail.md
+++ b/skills/meta-analysis/references/phase4_extraction_detail.md
@@ -68,7 +68,7 @@ Before opening the extraction form: if a senior mentor or collaborator has share
 - Record any reconciled discrepancy in `extraction_consensus_log.md` with a verbatim quote of the AI-draft value and the corrected value with PDF page coordinate.
 - Trust hierarchy for this phase: **SSOT (source PDF + own analysis stdout) > mentor's direct text (email / track-changes) > attached AI-draft**. Do not promote an AI-draft from tier 3 to tier 2.
 
-Precedent (an active meta-analysis project): Ishikawa 2017 "treatment support 5/70 vs no support 12/33" in Claude-drafted directive → source PDF was 35/68 (single arm). Verbatim absorption would have produced a denominator-hallucinated meta-analysis.
+The failure it prevents: an AI-drafted directive presents a study as a two-arm comparison ("x/n vs y/m") when the source PDF reports a single arm with a different denominator entirely. Verbatim absorption would produce a denominator-hallucinated meta-analysis.
 
 #### 4.0.1 AI-assisted extraction suggestions (optional, suggestions not decisions)
 

--- a/skills/peer-review/scripts/check_review_boxes.py
+++ b/skills/peer-review/scripts/check_review_boxes.py
@@ -7,16 +7,16 @@ things go wrong there, and neither is caught by reading the draft.
 
   1. THE RECOMMENDATION LEAKS. The recommendation lives only in the editor's box. SKILL.md
      says the blocks "must never be transposed" and Phase 4 asks for a forbidden-word check,
-     both as prose. A transposition is not hypothetical: on an Editorial Manager form the two
-     boxes were swapped and it was caught only by exporting the submission proof, one step
-     from irreversible. Once submitted, the authors read the recommendation grade and the
+     both as prose. A transposition is not hypothetical: the two boxes sit adjacent on the
+     form, a swap looks unremarkable while you are filling it in, and the last place it can
+     be caught is the submission proof — one step from irreversible. Once submitted, the authors read the recommendation grade and the
      confidential remarks, and the editor gets the author-facing text.
 
   2. THE BOXES ARE THE SAME TEXT. A human writes the editor note at a different altitude from
      the author note: decision-oriented and terse for the editor, developmental and explanatory
      for the authors. Pasting the same sentences into both is a machine tell, and it wastes the
-     attention of the one reader who opens both. Measured on a real draft that had passed every
-     other gate: 21 shared 6-grams, including one clause copied verbatim. Rewriting the editor
+     attention of the one reader who opens both. Calibration: on a draft that had passed every
+     other gate, 21 shared 6-grams, including one clause copied verbatim; rewriting the editor
      block in its own register took it to 3.
 
 Technical phrasing always overlaps a little ("every k and Wilcoxon p in the"), so a small

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -397,10 +397,10 @@ human to eyeball and do **not** fail `--strict`; only a genuinely absent quote d
 
 **If a reviewer called the manuscript too long or too dense, prove the body got shorter.** Answering
 a density comment point-by-point is a trap: each point is answered by adding a sentence, so the
-revision that responds to "shorten this" comes back *longer*. One real revision did exactly that —
-four reviewers said too dense, the point-by-point answer added 613 words, and it took three rounds
-to land at 733 words below where it started. This gate is arithmetic: if the decision letter
-contains a density/length complaint and the revised body did not shrink, it fires.
+revision that responds to "shorten this" comes back *longer*. Revisions do exactly that: the
+point-by-point answer adds words, the shrink the letter asked for slips another round away, and
+nothing in the response letter records that it happened. This gate is arithmetic: if the decision
+letter contains a density/length complaint and the revised body did not shrink, it fires.
 
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/check_density_complaint.py \

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -94,7 +94,7 @@ the locked extraction CSV. The resulting numbers then flow into the response let
 revised manuscript, and regenerated figures, and they can be internally consistent everywhere
 while still being wrong at the source.
 
-**Precedent failure pattern — treat as a lived failure, not hypothetical:**
+**The failure pattern — treat as a lived failure, not hypothetical:**
 > An R1 revision introduced a new comparative-arm analysis script to answer a reviewer
 > request. The Fisher exact matrix was hand-typed from the primary source Table, with an
 > adjacent severity-grade column misread as the event count. The script, the revised

--- a/skills/revise/scripts/check_density_complaint.py
+++ b/skills/revise/scripts/check_density_complaint.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 """"Your paper is too dense" is the one comment you cannot address by adding text.
 
-A real revision, measured straight out of the .docx files of a DTA meta-analysis:
+The failure this gate catches, in the shape it takes:
 
-    v18  submitted       7,172 words  ->  four reviewers: "too dense / shorten / move to supplement"
-    v20  THE revision    7,785 words  ->  +613.  Every named term went UP (kappa 5->6, Deeks 10->11)
-         answering those                    because each comment was answered point-by-point, and
-         comments                           point-by-point response REWARDS adding text.
-    v21  proof revision  6,439 words  ->  -1,346 (733 below the original).  <- the accepted version.
+    previous   as the reviewers saw it  ->  "too dense / shorten / move to supplement"
+    revised    THE revision answering   ->  LONGER.  Every named term goes UP, because each
+               those comments               comment is answered point-by-point, and point-by-point
+                                            response REWARDS adding text.
+    next       the cut version          ->  below where it started.  <- what the letter asked for.
 
-Answering "your text is too dense" comment-by-comment made it denser. It took three rounds to do
-what four reviewers asked in round one, because point-by-point culture rewards showing you addressed
-each comment — and length is the one comment adding text cannot address.
+Answering "your text is too dense" comment-by-comment makes it denser, because point-by-point
+culture rewards showing you addressed each comment — and length is the one comment adding text
+cannot address. The shrink then slips another round away.
 
 This gate is pure arithmetic. If the reviewer comments contain a density/length complaint AND the
 revised manuscript body did not get SHORTER than the previous version, the complaint was not
-addressed — it was made worse. It fires on v20 immediately, and stays silent on v21.
+addressed — it was made worse. It fires on the longer revision immediately, and stays silent on the cut one.
 
 It reads:
   --comments   the reviewer decision letter (where the complaint lives)
@@ -178,10 +178,10 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  reviewer: {c}")
             print(
                 "\n'Too dense' is the one comment you cannot address by adding text, and point-by-point\n"
-                "response rewards adding it. Answering each density comment individually made the last\n"
-                "manuscript that hit this LONGER by 613 words; the accepted version was 733 words below\n"
-                "where it started. Cut, or move detail to the supplement — do not defend length by\n"
-                "adding a paragraph that explains it."
+                "response rewards adding it: answering each density comment individually is how a\n"
+                "revision comes back longer than the version that drew the complaint. Cut, or move\n"
+                "detail to the supplement — do not defend length by adding a paragraph that explains\n"
+                "it."
             )
     return 1 if (fired and a.strict) else 0
 

--- a/skills/revise/scripts/density_complaint_challenge/verify.sh
+++ b/skills/revise/scripts/density_complaint_challenge/verify.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # Deterministic verifier for the density-complaint challenge card.
 #
-# The bug this gate exists to catch is not hypothetical. A DTA meta-analysis was told by four
-# reviewers that it was too dense; the revision answered each comment point-by-point and came back
-# 613 words LONGER, every named term higher than before. It took three rounds to do what the
-# reviewers asked in round one, because point-by-point response rewards adding text and "too long"
-# is the one comment adding text cannot answer.
+# The bug this gate exists to catch is not hypothetical: a revision answers a "too dense" comment
+# point-by-point and comes back LONGER than the version that drew the complaint, every named term
+# higher than before. Point-by-point response rewards adding text, and "too long" is the one
+# comment adding text cannot answer.
 #
-# So the fixtures reproduce that exact arithmetic:
+# So the fixtures reproduce that arithmetic:
 #   v_prev       -> what the reviewers saw
 #   v20_longer   -> answered point-by-point, body got LONGER   -> DENSITY_COMPLAINT_UNADDRESSED
 #   v21_shorter  -> actually cut, body got SHORTER             -> OK

--- a/skills/self-review/references/exemplar_findings/estimand_drift_posthoc_primary.md
+++ b/skills/self-review/references/exemplar_findings/estimand_drift_posthoc_primary.md
@@ -16,7 +16,7 @@ Reporting.
 > report both models coequally, disclose the change in the Abstract and a Limitations
 > paragraph, and lodge the corresponding registration amendment.
 >
-> The reported E-value of 2.79 should also be recomputed from, and attached to, the primary
+> The reported E-value of 3.10 should also be recomputed from, and attached to, the primary
 > estimate (it currently appears to derive from a different model).
 
 ## Severity / category rationale

--- a/skills/self-review/references/phases/confounding_completeness.md
+++ b/skills/self-review/references/phases/confounding_completeness.md
@@ -19,11 +19,11 @@ deterministic gate so the finding lands without the `--panel` cost.
 cross-sectional, health-screening registry) and the central claim is an
 adjusted exposure–outcome association. Skip for RCTs and descriptive studies.
 
-**Precedent failure pattern:**
+**The failure pattern:**
 > A cross-sectional screening-cohort manuscript reported an adjusted association
-> while Table 1 showed uric acid, smoking pack-years, HDL, total cholesterol, and
-> HbA1c all significantly imbalanced across the exposure groups — none of which
-> were in the age/sex/BMI/hypertension/diabetes adjustment set. The single-pass
+> while Table 1 showed several laboratory and lifestyle covariates significantly
+> imbalanced across the exposure groups — none of which were in a
+> demographic-and-comorbidity adjustment set. The single-pass
 > review passed it; only an epidemiology panel reviewer who read the Table 1 CSV
 > against the Methods caught the gap. After refitting with extended adjustment the
 > primary estimate held, but the manuscript had claimed robustness it had not shown.

--- a/skills/self-review/references/phases/phase2_5a2_design_power.md
+++ b/skills/self-review/references/phases/phase2_5a2_design_power.md
@@ -7,9 +7,9 @@ a-priori effect-size assumptions behind them are *computed*, not extracted, so t
 CSV row or source-paper Table to trace to. They routinely escape both the internal-consistency
 check and the source-fidelity audit above.
 
-**Precedent failure pattern:**
-> A pilot study reported a minimum detectable effect of d = 1.67. No standard two-sample method
-> reproduces it (the correct value at the stated n, alpha, and power was about 1.24). It survived
+**The failure pattern:**
+> A pilot study reported a minimum detectable effect that no standard two-sample method
+> reproduces at the stated n, alpha, and power. It survived
 > several review rounds because no committed script computed it — the value had been hand-entered —
 > and one reviewer even cited the figure approvingly. In the same manuscript, a set of future-trial
 > sample sizes was numerically correct but had been produced with an exact noncentral-t tool, while

--- a/skills/self-review/references/phases/phase2_5a_source_fidelity.md
+++ b/skills/self-review/references/phases/phase2_5a_source_fidelity.md
@@ -26,7 +26,7 @@ unrounded values. Fix: report components and the delta at one precision, or foot
 is computed on unrounded values. A higher-precision component pair (`0.703` vs `0.726`) with a 2-dp
 delta is the legitimate unrounded case and is not flagged.
 
-**Precedent failure pattern:**
+**The failure pattern:**
 > A revision-era comparative meta-analysis reported a safety-outcome 2x2 with the
 > arm-level events direction-reversed relative to the primary-source Table. Internal
 > consistency passed because Abstract, Discussion, Table, and the R script all echoed

--- a/skills/self-review/references/phases/phase2_5b_screening_counts.md
+++ b/skills/self-review/references/phases/phase2_5b_screening_counts.md
@@ -14,15 +14,14 @@ separate failure mode: a prior-draft prose total ("30 → 32 after FLAG consensu
 every downstream pass because Abstract, Methods, Results, Discussion, Figure 1 caption, and
 even the supplementary consensus file all cite the same wrong number back to each other.
 
-**Precedent failure pattern (a PRISMA-DTA meta-analysis revision):**
-> A late-revision manuscript reported study counts of k_qualitative = 32, k_narrative-only = 10,
-> k_FT-excluded = 46. An ID-level recount against the screening TSV and consensus sheet (with
-> FLAG additions reconciled) yielded k_qualitative = 24 with only 2 narrative-only studies
-> (k_FT-excluded = 54). The original 32/10/46 figures came from an early-draft assumption that
-> was never reconciled against the ID-level artifacts; downstream files (consensus markdown,
-> supplementary tables, edit plans) propagated the same wrong total. Caught only by an explicit
-> ID-set recount against the screening TSV and consensus spreadsheet, verified independently
-> by an adversarial audit.
+**The failure pattern:**
+> A late-revision manuscript reports a set of study counts — qualitative synthesis,
+> narrative-only, full-text-excluded — that no longer match the screening artifacts. An ID-level
+> recount against the screening TSV and consensus sheet (with FLAG additions reconciled) moves
+> every one of them. The reported figures came from an early-draft assumption that was never
+> reconciled against the ID-level artifacts; downstream files (consensus markdown, supplementary
+> tables, edit plans) then propagated the same wrong total. Nothing but an explicit ID-set
+> recount finds it, because every document agrees with every other document.
 
 **When to run:** any SR/MA manuscript revision, regardless of stage. Run before Phase 3.
 

--- a/skills/self-review/references/phases/phase2_5d_xref_qc.md
+++ b/skills/self-review/references/phases/phase2_5d_xref_qc.md
@@ -27,10 +27,11 @@ build script carries its own legacy SSOT. Internal consistency (Phase 2.5)
 cannot detect it — both the prose and the build artifact echo their own
 divergent truths cleanly.
 
-**Precedent failure pattern (an STROBE cohort manuscript revision):**
-> Body prose cited Supp Table S4 as a sensitivity analysis; the rendered DOCX
-> S4 instead contained a diagnostics table. S1, S6, S7 also mismatched. S8 and S9
-> were cited in the manuscript but absent from the rendered DOCX entirely.
+**The failure pattern:**
+> Body prose cites a supplementary table as a sensitivity analysis; under that
+> number the rendered DOCX carries a diagnostics table instead. Several further
+> supplement numbers mismatch the same way, and two more are cited in the
+> manuscript but absent from the rendered DOCX entirely.
 > Caught only on co-author circulation review.
 
 **When to run:** every manuscript at self-review when a rendered DOCX exists

--- a/skills/self-review/references/phases/phase2_5f_claim_artifact.md
+++ b/skills/self-review/references/phases/phase2_5f_claim_artifact.md
@@ -16,13 +16,13 @@ value, deterministic instances; figure/flow-count reconciliation, Methods-promis
 analysis completeness, and imputation-input integrity are separate subchecks (run
 `/make-figures` legend reconciliation and `/write-paper`'s Methods-promised gate).
 
-**Precedent failure pattern:**
+**The failure pattern:**
 > A manuscript reported a null primary association from a multiple-imputation model
 > and described it as "pre-specified," while the registered primary had been the
 > complete-case model that was significant — the primary had been re-designated after
-> the results were known. In the same paper an E-value of 2.79 was attached to the
-> primary HR of 1.34, but 2.79 does not recompute from 1.34 (it came from a different,
-> non-primary estimate), and a second E-value bounded an exploratory cancer-specific
+> the results were known. In the same paper an E-value was attached to the primary
+> HR but does not recompute from it (it came from a different,
+> non-primary estimate), and a second E-value bounded an exploratory cause-specific
 > hazard, not the headline contrast. None of these tripped the internal-consistency
 > checks; all three are deterministic against the registration and the arithmetic.
 

--- a/skills/self-review/scripts/_frontmatter.py
+++ b/skills/self-review/scripts/_frontmatter.py
@@ -4,9 +4,9 @@ Several `--manuscript` detectors in this skill roll their own body extractor tha
 lines starting with `#`, `|`, `>`, `!`, list markers and code fences. A `---`-fenced YAML
 front-matter block matches none of those, so the `status:`, changelog and build-note lines
 that projects keep at the top of a pandoc manuscript were read as body prose. Two shipped
-detectors fired on it on a live submission: `check_citation_order` reported floats "cited out
-of order" from a `status:` block narrating a display-item renumber, and `check_aphorism_density`
-listed build notes among the manuscript's "very short declaratives".
+detectors fired on it: `check_citation_order` reported floats "cited out of order" from a
+`status:` block narrating a display-item renumber, and `check_aphorism_density` listed build
+notes among the manuscript's "very short declaratives".
 
 `strip_frontmatter` removes exactly the pandoc/YAML front-matter block: an opening `---` fence
 on the FIRST line and its matching closing `---` fence. If the first line is not a fence, or the

--- a/skills/self-review/scripts/check_paren_spans.py
+++ b/skills/self-review/scripts/check_paren_spans.py
@@ -5,8 +5,8 @@ Reducing em-dashes to satisfy a classical-style gate (`" — X — "` appositive
 `(X)`) is a common edit. When a bulk regex pairs two *unrelated* single em-dashes
 across a sentence boundary, it wraps a whole sentence inside one parenthesis:
 
-    "... E-value 2.79 — Sixth, the lean-MASLD subgroup was small — and ..."
-  → "... E-value 2.79 (Sixth, the lean-MASLD subgroup was small) and ..."
+    "... E-value 3.10 — Sixth, the lean-MASLD subgroup was small — and ..."
+  → "... E-value 3.10 (Sixth, the lean-MASLD subgroup was small) and ..."
 
 The result is grammatically broken but **paren-balanced**, so a balance check
 misses it; only a human re-read (or this scan) catches it. This gate flags any

--- a/skills/self-review/tests/fixtures/claim_manuscript.md
+++ b/skills/self-review/tests/fixtures/claim_manuscript.md
@@ -10,7 +10,7 @@ estimate was found to be more favourable.
 ## Results
 
 In the primary model, emphysema was not associated with all-cause mortality. The
-E-value for the primary association (HR 1.34) was 2.79, which we interpret as robust
+E-value for the primary association (HR 1.52) was 3.10, which we interpret as robust
 to unmeasured confounding.
 
 In an exploratory analysis, the E-value for the cancer-specific subdistribution hazard

--- a/skills/self-review/tests/fixtures/claim_manuscript_single_primary.md
+++ b/skills/self-review/tests/fixtures/claim_manuscript_single_primary.md
@@ -1,3 +1,3 @@
 ## Methods
 Model 3 is the single primary model, consistent with the registered analysis plan.
-The E-value for the primary association (HR 1.34) was 2.02.
+The E-value for the primary association (HR 1.52) was 2.41.

--- a/skills/self-review/tests/fixtures/paren_clean.md
+++ b/skills/self-review/tests/fixtures/paren_clean.md
@@ -1,6 +1,6 @@
 # Discussion
 
-The protective association was robust to extended adjustment (E-value 2.79;
+The protective association was robust to extended adjustment (E-value 3.10;
 95% CI 1.10 to 1.52), consistent with prior cohorts (Smith 2022; cf. Doe 2021).
 We confirmed the result in a first-visit sensitivity analysis (n = 3,335). The
 imaging was read by Dr. Smith. See Fig. 2 for the calibration plot.

--- a/skills/self-review/tests/fixtures/paren_corrupt.md
+++ b/skills/self-review/tests/fixtures/paren_corrupt.md
@@ -2,7 +2,7 @@
 
 Our study has several limitations. The protective association was robust to
 extended adjustment, and the residual-confounding bound was reassuring (E-value
-2.79 Sixth, the lean-MASLD subgroup was small and may be underpowered) and the
+3.10 Sixth, the lean-MASLD subgroup was small and may be underpowered) and the
 finding should be interpreted cautiously.
 
 The estimate was stable across sensitivity analyses (this paragraph was wrongly

--- a/skills/self-review/tests/test_claim_artifact.sh
+++ b/skills/self-review/tests/test_claim_artifact.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Regression test for the claim-vs-artifact cross-check (self-review Phase 2.5f).
 # Synthetic fixture reproduces: (a) a primary re-designated at manuscript stage,
-# (b) an E-value (2.79) that does not recompute from its stated primary HR 1.34,
+# (b) an E-value (3.10) that does not recompute from its stated primary HR 1.52,
 # (c) a correctly-arithmetic E-value attached to a non-primary (cancer) estimate.
 # Stdlib-only (python3).
 set -u
@@ -30,7 +30,7 @@ python3 "$SCRIPT" --manuscript "$MAN" --prereg "$PRE" --out "$OUT" --strict >/de
 check "exit 1 under --strict (Major present)" test "$?" -eq 1
 check "JSON artifact written" test -s "$OUT"
 check "PRIMARY_REASSIGNED detected"  has_verdict PRIMARY_REASSIGNED
-check "EVALUE_ARITHMETIC detected (2.79 vs HR 1.34)" has_verdict EVALUE_ARITHMETIC
+check "EVALUE_ARITHMETIC detected (3.10 vs HR 1.52)" has_verdict EVALUE_ARITHMETIC
 check "EVALUE_NON_PRIMARY detected (cancer sHR)"     has_verdict EVALUE_NON_PRIMARY
 
 # Clean case: primary matches prereg, correct primary E-value, no reassignment.
@@ -41,7 +41,7 @@ cat > "$CLEAN" <<'EOF'
 The primary analysis was the association between emphysema and all-cause mortality
 in the complete-case multivariable Cox model.
 ## Results
-The E-value for the primary association (HR 1.34) was 2.02.
+The E-value for the primary association (HR 1.52) was 2.41.
 EOF
 python3 "$SCRIPT" --manuscript "$CLEAN" --prereg "$PRE" --strict >/dev/null 2>&1
 check "exit 0 on clean manuscript (matching primary, correct E-value)" test "$?" -eq 0
@@ -59,7 +59,7 @@ in the complete-case multivariable Cox model. Using the multiple-imputation mode
 the estimation approach was a manuscript-stage analytical decision, disclosed here and
 reported coequally with the pre-specified complete-case analysis.
 ## Results
-The E-value for the primary association (HR 1.34) was 2.02.
+The E-value for the primary association (HR 1.52) was 2.41.
 EOF
 python3 "$SCRIPT" --manuscript "$DISC" --prereg "$PRE" --out "$OUT" --strict >/dev/null 2>&1
 check "exit 0 on honest manuscript-stage disclosure (advisory, not Major)" test "$?" -eq 0

--- a/skills/write-paper/references/phase7_integrity_audits.md
+++ b/skills/write-paper/references/phase7_integrity_audits.md
@@ -13,7 +13,7 @@ the pipeline and route to **Step 7.4a (Audit Recovery Branch)**.
 Citation verification protects against fabricated references; this step protects against
 fabricated numbers. They are different failure modes and Step 7.3 does not catch the latter.
 
-**Precedent failure pattern:**
+**The failure pattern:**
 > A revision-era comparative meta-analysis reached Step 7.3 with 0 citation errors (all
 > PMIDs verified against PubMed) yet carried a silent numerical reversal on a safety
 > outcome — the reported arm-level events were direction-flipped relative to the primary
@@ -33,11 +33,11 @@ fabricated numbers. They are different failure modes and Step 7.3 does not catch
   and percentages. The matrix cells are the authoritative source; headline numbers are
   derivations and must be recomputed from cells via code before prose drafting.
 
-**Precedent failure pattern for the reporting-quality trigger:**
-> A reporting-quality systematic review reported corpus PRESENT at ~61% in v1.0; cell-level
-> recomputation on v1.1 produced ~51% (delta ~10 percentage points). The error survived
+**The failure pattern for the reporting-quality trigger:**
+> A reporting-quality systematic review reports a corpus PRESENT percentage that cell-level
+> recomputation later moves by roughly ten percentage points. The error survives
 > internal consistency because every downstream table, figure caption, and abstract
-> sentence echoed the hand-tallied v1.0 total. Recomputation from matrix cells — not from
+> sentence echoes the same hand-tallied total. Recomputation from matrix cells — not from
 > hand-tallied per-study totals — is the only reliable source for headline numbers.
 
 **Procedure:**

--- a/skills/write-paper/references/phase7_polish_detail.md
+++ b/skills/write-paper/references/phase7_polish_detail.md
@@ -217,9 +217,9 @@ Build the final submission-ready documents from the assembled components:
 Catches the failure mode where in-text Table/Figure citations resolve to the
 wrong rendered caption. Internal consistency (Phase 2.5 of `/self-review`)
 does NOT catch this because both the body prose and the build script can echo
-their own divergent SSOTs cleanly. Precedent: an STROBE cohort manuscript revision —
-body cited "Supplementary Table S4 (a sensitivity-analysis)" but the rendered DOCX S4
-was a diagnostics table; S1, S6, S7 mismatched and S8, S9 were cited but absent from
+their own divergent SSOTs cleanly: the body cites a supplementary table as a
+sensitivity analysis, the rendered DOCX carries a diagnostics table under that number,
+further supplement numbers mismatch the same way, and some are cited but absent from
 the DOCX entirely.
 
 **Run after Step 7.6 DOCX build and before Step 7.7 final gate:**


### PR DESCRIPTION
Detector precedents here were written from real cycles, and several kept the numbers identifying
which paper the failure happened to. Those come out; the mechanism stays. A precedent is what gives
a detector its severity, so each is rewritten in the present tense rather than deleted. Gate
behaviour and thresholds are untouched.

One effect-size pair had also reached seven test fixtures. The replacement pair carries the same
planted defect, and both owning tests were re-run to prove nothing was disarmed —
`EVALUE_ARITHMETIC` and `EVALUE_NON_PRIMARY` still fire.

`CONTRIBUTING.md` gains the rule this class needed: the blocklist matches tokens, and a sentence
naming a word count and a round count contains none of them while still being the most identifying
line on the page. No gate added.

`python3 scripts/run_ci_mirror.py` → 249/249 on each commit. Independent of #505 (dry-run merge: no
conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
