### PR TITLE
fix: the rule against publishing coordinates was publishing a pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5227,7 +5227,7 @@ Lessons from senior meta-analysis mentor circulation feedback promoted into glob
 - **Global rules (5 files)** under `~/.claude/rules/`:
   - `manuscript-style-classical.md` (new) — 11-item style policy: `## **METHODS**` heading, abstract sub-headers `**Objectives:**`, eligibility numbered list, no `§` symbol, no AI Disclosure paragraph in body, em-dash <25, Vancouver 6+ et al., ORCID one-per-line, table header punctuation, British/American per journal.
   - `senior-mentor-circulation.md` (new) — mandatory `8_Review_Comments/` folder layout, 1차 source preservation, 1:1 verification, mentor README (per-mentor preference accumulation).
-  - `ai-drafted-document-policy.md` (new) — verbatim absorption forbidden when senior mentors attach AI-drafted documents; `_DO_NOT_USE_VERBATIM` filename suffix mandatory; trust hierarchy SSOT > mentor direct text > AI-draft. Motivation: 2026-04-12 Ishikawa 2017 denominator hallucination (5/70 vs 12/33 → real 35/68).
+  - `ai-drafted-document-policy.md` (new) — verbatim absorption forbidden when senior mentors attach AI-drafted documents; `_DO_NOT_USE_VERBATIM` filename suffix mandatory; trust hierarchy SSOT > mentor direct text > AI-draft. Motivation: an AI-drafted directive presented a single-arm study as a two-arm comparison, with a denominator that did not exist in the source.
   - `data-integrity.md` — one-line augmentation cross-linking the AI-drafted policy.
   - `agent-skill-routing.md` — new "Cross-cutting 룰 (Manuscript / 회람)" table referencing the six rule files.
 
@@ -5241,7 +5241,7 @@ Lessons from senior meta-analysis mentor circulation feedback promoted into glob
 
 - **`/meta-analysis` Phase 4.0 — AI-drafted starting document gate**:
   - `skills/meta-analysis/SKILL.md` — new sub-step at the top of Phase 4 (Data Extraction) requiring `_DO_NOT_USE_VERBATIM` filename suffix and source-PDF re-verification of every per-study N, denominator, event count, and effect estimate carried over from a senior mentor's AI-drafted directive. Trust hierarchy: SSOT > mentor direct text > AI-draft (never promote tier 3 to tier 2).
-  - Cross-links `~/.claude/rules/ai-drafted-document-policy.md` (motivation: 2026-04-12 Ishikawa 2017 denominator hallucination caught at SSOT re-verification).
+  - Cross-links `~/.claude/rules/ai-drafted-document-policy.md` (motivation: a denominator hallucination in an AI-drafted directive, caught at SSOT re-verification).
 
 - **`/check-reporting prisma` Step 4d — PRISMA Figure 1 arithmetic & cross-reference audit**:
   - `skills/check-reporting/scripts/check_prisma_figure.py` (new) — extracts PRISMA numbers from manuscript body and Figure 1 source, runs 4 arithmetic equations (`screened = identified - duplicates`, etc.) and a body↔figure 1:1 cross-reference, emits `qc/prisma_figure_audit.json` + table. Exits 1 on any MISMATCH.
@@ -5517,8 +5517,8 @@ triggers even in non-skill workflows.
 A real incident during a revision run exposed that the citation-safety pipeline did not have
 a symmetric counterpart for numerical claims. Citations were verified end-to-end against
 PubMed (0 fabricated refs), while a hand-typed `matrix()` in a revision-era R script silently
-reversed a Fisher exact 2x2 ("3/45 vs 0/56, p=0.085" where the source said "0/45 vs 1/56,
-p=0.37"). Every internal consistency check passed because every artifact echoed the same
+reversed a Fisher exact 2x2, flipping the arm-level events and therefore the p-value relative
+to what the source Table recorded. Every internal consistency check passed because every artifact echoed the same
 wrong number. Detection required an explicitly requested second-pass audit with random
 sampling against the primary paper.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,8 +166,10 @@ worth keeping. What does not belong in a public file is the arithmetic identifyi
 the failure happened to.
 
 The blocklist cannot help you here: it matches tokens — names, IDs, paths, emails — and a sentence
-like *"the revision came back 613 words longer and it took three rounds"* contains none. It is
-still the most identifying line on the page, because those numbers occur in exactly one manuscript.
+naming a word count and a round count contains none of them. It is still the most identifying line
+on the page, because that pair of numbers occurs in exactly one manuscript. (Note what this
+paragraph does not do: quote one. A rule that illustrates itself with a real example publishes the
+example.)
 
 So write the precedent as a **failure pattern**, in the present tense, with the mechanism intact
 and the coordinates removed:

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4578,8 +4578,8 @@
     },
     {
       "path": "skills/self-review/references/phases/phase2_5a2_design_power.md",
-      "size": 4301,
-      "sha256": "79183f2ffe7e53733c2680fbb2c00a102538bd2902d49e18314d7e2f1de390ec"
+      "size": 4310,
+      "sha256": "de68080a1d7987ea835e93475fd01b809c1750d4c9e242fcbf4f94d63d98d74e"
     },
     {
       "path": "skills/self-review/references/phases/phase2_5a_source_fidelity.md",

--- a/skills/self-review/references/phases/phase2_5a2_design_power.md
+++ b/skills/self-review/references/phases/phase2_5a2_design_power.md
@@ -30,7 +30,7 @@ check and the source-fidelity audit above.
 
 3. **Recompute independently** with a standard tool, then classify:
    - **Not reproducible by any standard method** → likely a calculation error (Major; P0 if it
-     is a headline claim). This is the d = 1.67-vs-1.24 case above.
+     is a headline claim). This is the minimum-detectable-effect case above.
    - **Reproducible only by a method the committed script does not implement** (e.g. the
      manuscript value is noncentral-t but the script is a normal approximation) → provenance /
      method drift. The number may be correct, but update the committed code so it reproduces the


### PR DESCRIPTION
Two leftovers from #505/#506.

The `CONTRIBUTING` rule added in #506 illustrated itself with a live example — the exact kind of
number pair it tells you not to write. A rule that demonstrates itself with real material publishes
it, which is the mistake #504 made in its own commit message. It now describes the shape instead.

The second is a back-reference: a later step pointed at "the <numbers> case above" after the case
above had been rewritten. Cleaning a passage does not clean what points at it. Three CHANGELOG
entries held earlier copies and are rewritten the same way.

On method: this sweep was the union of every removed string, run repo-wide including CHANGELOG, in
one pass. The five before it each used a different subset and each reported clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)