### PR TITLE
docs: the install path decides a skill's slash-command name, and nothing said so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **The docs never said that the install path decides a skill's slash-command name.** A skill
+  installed as a plugin is invoked under its plugin's namespace (`/medsci-analysis:analyze-stats`);
+  the same skill installed into `~/.claude/skills/` by the `npx`, `gh skill`, classroom, or manual
+  paths is invoked bare (`/analyze-stats`). The README showed the namespaced form in the plugin
+  section and the bare form everywhere else, and never connected them — so a reader who followed the
+  plugin path had every other page of the documentation naming a command their install does not
+  have. Reported from a live workshop, where it read as a broken install rather than a second
+  correct name.
+
+  `docs/setup/common-issues.md` gains the mapping as issue 11, with how to switch, and the FAQ and
+  the README plugin section point at it.
+
+  The same section answers the question asked alongside it: **why a plain-language request starts no
+  skill.** A skill is selected by matching the request against that skill's description, so a broad
+  ask ("look over my paper") matches many weakly instead of one strongly. `/orchestrate` is the
+  documented answer and was not findable from the symptom.
+
 ## [5.25.0] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Install a single category and invoke its skills under that namespace:
 
 All nine plugins share the same repository source, so this groups and enables skills by category — it is not a partial download. The marketplace tracks `main`, so a plugin's version is its git commit.
 
+**Note the name.** A skill installed as a plugin is invoked under its plugin's namespace (`/medsci-analysis:analyze-stats`); the same skill installed into the skills folder by the `npx`, `gh skill`, classroom, or manual paths is invoked bare (`/analyze-stats`). Both run the same skill — press `/` and use Tab completion rather than typing the long form.
+
 **Want just one capability?** Two skills are also published as focused standalone repos (generated mirrors; this repo stays the source of truth), each installable on its own with `/plugin marketplace add Aperivue/<repo>`:
 
 - [`Aperivue/verify-refs`](https://github.com/Aperivue/verify-refs) — catch fabricated/mismatched citations (PubMed + CrossRef).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,6 +69,15 @@ biology, and it is not an autonomous research agent. It is one physician-researc
 clinical-manuscript pipeline with integrity gates (see
 [`ROADMAP.md`](../ROADMAP.md) for the scope boundary).
 
+## Why is my slash command `/medsci-analysis:analyze-stats` instead of `/analyze-stats`?
+
+Because the install path decides the name. Skills installed **as a plugin** are prefixed
+with their plugin's name; skills installed into the **skills folder** (`npx medsci-skills
+install`, `gh skill install`, the classroom installer, or `installers/install.py`) are
+invoked bare. Both run the same skill. See
+[common setup issues](setup/common-issues.md#11-a-skills-slash-command-is-longer-than-the-docs-show-or-a-plain-prompt-starts-no-skill)
+for how to switch, and what to do when a plain-language request starts no skill at all.
+
 ## Is it free and open-source?
 
 Yes — MIT licensed (see [`LICENSE`](../LICENSE); note any per-file carve-outs noted

--- a/docs/setup/common-issues.md
+++ b/docs/setup/common-issues.md
@@ -152,6 +152,48 @@ Or in OneDrive settings, exclude the `medsci-skills` folder from sync.
 
 ---
 
+## 11. A skill's slash command is longer than the docs show, or a plain prompt starts no skill
+
+Two different things, often reported together.
+
+### The name is namespaced: `/medsci-analysis:analyze-stats`, not `/analyze-stats`
+
+**Cause**: not a fault — the install path decides the name. Claude Code prefixes a skill
+that arrives inside a plugin with that plugin's name.
+
+| How you installed | Where skills land | What you type |
+|---|---|---|
+| `/plugin install medsci-analysis@medsci-skills` | plugin cache | `/medsci-analysis:analyze-stats` |
+| `npx medsci-skills install` | `~/.claude/skills/` | `/analyze-stats` |
+| `gh skill install --all Aperivue/medsci-skills` | `~/.claude/skills/` | `/analyze-stats` |
+| Classroom installer, or `python3 installers/install.py` | `~/.claude/skills/` | `/analyze-stats` |
+
+Both forms run the same skill. If the long name is only a typing problem, press `/` and use
+Tab completion rather than reinstalling.
+
+**To get the short names**: open `/plugin` and remove the MedSci plugins you enabled, then
+install by one of the folder paths above and restart Claude Code.
+Keeping both is supported but means every skill is listed twice — once namespaced, once bare —
+so pick one.
+
+### Typing a request in plain language starts no skill
+
+**Cause**: a skill is selected by matching your request against that skill's own description.
+With the full bundle installed there are dozens of descriptions to choose between, and a broad
+request ("look over my paper") matches several weakly rather than one strongly.
+
+**Fix**, in order of effort:
+
+1. **Use `/orchestrate`.** It exists for exactly this: it classifies the request and routes to
+   the right skill, or chains several for a multi-step task. It is the documented entry point —
+   if you remember one command, remember this one.
+2. **Name the skill.** `/self-review`, `/check-reporting`, `/verify-refs` — the
+   [README skill table](../../README.md#skills) lists all of them by task.
+3. **Say what the output should be.** "Audit this manuscript against STROBE" selects a skill;
+   "check my paper" does not.
+
+---
+
 ## Still Stuck?
 
 1. Run `/setup-medsci` inside Claude Code — it prints a diagnostic checklist with the specific failure point.


### PR DESCRIPTION
## What

A skill installed **as a plugin** is invoked under its plugin's namespace
(`/medsci-analysis:analyze-stats`). The same skill installed into `~/.claude/skills/` by the
`npx`, `gh skill`, classroom, or manual paths is invoked **bare** (`/analyze-stats`).

The README showed the namespaced form exactly once — inside the plugin section — and the bare
form on every other page, and never said the two were the same skill under two install paths.
A reader who followed the plugin path therefore had the rest of the documentation naming
commands their install does not have.

Reported from a live workshop, where it presented as a broken install rather than as a second
correct name.

The same session asked the question that arrives with it: **why does typing a plain-language
request start no skill?** Selection matches the request against each skill's own description,
so a broad ask ("look over my paper") matches many weakly instead of one strongly.
`/orchestrate` is the documented answer and was not reachable from the symptom.

## Changes

| File | Change |
|---|---|
| `docs/setup/common-issues.md` | New issue **11** — install-path→command-name table, how to switch, and the plain-prompt case |
| `docs/faq.md` | Short entry pointing at it (the FAQ had nothing on invocation at all) |
| `README.md` | One paragraph in the plugin section contrasting the two naming forms at the point of choice |
| `CHANGELOG.md` | `[Unreleased] → Changed` |

Docs only. No skill, detector, or count changes.

## Verification

- `python3 scripts/run_ci_mirror.py` → **249/249 gates pass**
- `python3 scripts/gen_distribution_manifest.py` → no diff (docs are not hashed into it)
- Relative links and the GitHub anchor slug checked by hand; `README.md#skills` resolves to the
  existing `## Skills` heading
- No unverified commands documented — the plugin-removal step points at `/plugin` rather than
  asserting a flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)