### PR TITLE
feat(install): opt-in routing block so a plain request finds the skills

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Opt-in SessionStart update-notify hook test (settings merge + hook logic, offline)
         run: python3 installers/tests/test_session_hook.py
 
+      - name: Opt-in CLAUDE.md routing block test (a splice must not clobber the user's own file)
+        run: python3 installers/tests/test_routing.py
+
       - name: Release-ZIP provenance + updater-consumability round-trip (build -> safe-extract)
         run: bash installers/tests/test_release_zip.sh
 
@@ -826,5 +829,7 @@ jobs:
         run: python installers/tests/test_update.py
       - name: Opt-in SessionStart update-notify hook test (settings merge + hook logic)
         run: python installers/tests/test_session_hook.py
+      - name: Opt-in CLAUDE.md routing block test
+        run: python installers/tests/test_routing.py
       - name: install.py transactional self-test
         run: python installers/install.py --self-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in: a routing block in a project's `CLAUDE.md`, so a plain-language request finds the
+  skills.** `/orchestrate` was the only reliable way in, and it only works for someone who knows to
+  type it. `install.py --claude-project <folder>` now writes ~25 lines — a task-to-skill table and
+  the `orchestrate` fallback — into that folder's `CLAUDE.md`; `--claude-user` writes the same block
+  to `~/.claude/CLAUDE.md`, which loads everywhere. Both are off by default and `--remove-routing`
+  takes it back out.
+
+  **It splices; it does not overwrite.** The block sits between two markers and every other byte of
+  the file is written back unchanged, because a `CLAUDE.md` is where a user keeps their *own*
+  standing instructions. The sibling this sits next to, `install_cursor_rule`, calls
+  `rule_path.write_text(body)` — the regression test drives that behaviour into `apply_routing` and
+  watches the "user content survives" case fail, so the property is tested rather than asserted.
+  Also covered: idempotent re-runs, in-place replacement of a stale block, removal that deletes a
+  file holding nothing else, a refusal when only one of the two markers is present (guessing where
+  the block ends could eat the user's text), and `--dry-run` writing nothing.
+
+  The block names skills without a leading slash and says why: how one is invoked depends on the
+  install path (`/write-paper` vs `/medsci-writing:write-paper`), so a hardcoded command form would
+  be wrong for half the readers. It carries no home-directory or repository path — a `CLAUDE.md`
+  gets committed, and `install_cursor_rule` embeds `REPO_ROOT` into a file under `.cursor/rules/`
+  for the same reason it should not.
+
 ### Changed
 
 - **The docs never said that the install path decides a skill's slash-command name.** A skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,17 @@
   `rule_path.write_text(body)` — the regression test drives that behaviour into `apply_routing` and
   watches the "user content survives" case fail, so the property is tested rather than asserted.
   Also covered: idempotent re-runs, in-place replacement of a stale block, removal that deletes a
-  file holding nothing else, a refusal when only one of the two markers is present (guessing where
-  the block ends could eat the user's text), and `--dry-run` writing nothing.
+  file holding nothing else, and `--dry-run` writing nothing.
+
+  **A pre-merge review of this change found three defects in it, all one root cause** — the splice
+  located the *first* marker of each kind instead of reasoning about all of them. Markers in reverse
+  order passed the half-fence guard and then spliced a duplicate of the user's text while leaving a
+  dangling fence; two blocks in one file never converged; and `--remove-routing` on two blocks
+  reported `removed` while one survived, which is a success message that is not true. The fix counts
+  markers and refuses anything that is not one clean fence, and the five assertions covering those
+  cases were confirmed to fail against the pre-fix code. A fourth, smaller finding in the same pass:
+  the Windows arm of the no-local-path assertion was written `"C:\\\\"`, a string that cannot
+  occur, so it could never fail.
 
   The block names skills without a leading slash and says why: how one is invoked depends on the
   install path (`/write-paper` vs `/medsci-writing:write-paper`), so a hardcoded command form would

--- a/README.md
+++ b/README.md
@@ -689,6 +689,24 @@ gh skill install --all Aperivue/medsci-skills            # or install all of the
 
 See [docs/classroom_distribution_plan.md](docs/classroom_distribution_plan.md) and [docs/classroom_materials.md](docs/classroom_materials.md) for instructor distribution, email templates, and first-class exercises.
 
+### Optional: let plain-language requests find the skills
+
+Typing `/orchestrate` is the reliable way in. If you would rather just describe what you want, the
+installer can write a short routing table into a project's `CLAUDE.md` so Claude Code reaches for
+the right skill on its own whenever you work in that folder:
+
+```bash
+python3 installers/install.py --claude-project ~/research/my-study   # this project only
+python3 installers/install.py --claude-user                          # every project (larger footprint)
+python3 installers/install.py --claude-project ~/research/my-study --remove-routing
+```
+
+Both are **off by default**. The block is ~25 lines between `<!-- BEGIN/END medsci-skills routing -->`
+markers, carries no machine-specific paths, and is spliced in: an existing `CLAUDE.md` full of your
+own instructions keeps every line, re-running updates the block in place, and `--remove-routing`
+takes it back out. Prefer `--claude-project` — `--claude-user` loads in every project you ever open,
+including work unrelated to research.
+
 > **Tip:** Not sure which skill to use? Start with `/orchestrate` -- it will classify your request and route you to the right tool.
 
 ## Updating

--- a/docs/setup/common-issues.md
+++ b/docs/setup/common-issues.md
@@ -191,6 +191,21 @@ request ("look over my paper") matches several weakly rather than one strongly.
    [README skill table](../../README.md#skills) lists all of them by task.
 3. **Say what the output should be.** "Audit this manuscript against STROBE" selects a skill;
    "check my paper" does not.
+4. **Make it standing, for one project.** If you would rather not think about it again, the
+   installer can write a short routing table into a project's `CLAUDE.md`, which Claude Code reads
+   whenever you work in that folder:
+
+   ```bash
+   python3 installers/install.py --claude-project ~/research/my-study
+   ```
+
+   It adds ~25 lines between two `<!-- BEGIN/END medsci-skills routing -->` markers and changes
+   nothing else in the file — an existing `CLAUDE.md` with your own instructions keeps every line.
+   Re-running updates the block in place; `--remove-routing` takes it back out.
+
+   `--claude-user` writes the same block to `~/.claude/CLAUDE.md` instead, which loads in **every**
+   project, including work that has nothing to do with research. Prefer `--claude-project` unless
+   you want it everywhere.
 
 ---
 

--- a/installers/install.py
+++ b/installers/install.py
@@ -121,6 +121,109 @@ Repository path:
     log("  installed Cursor project rule", log_lines)
 
 
+ROUTING_BEGIN = "<!-- BEGIN medsci-skills routing -->"
+ROUTING_END = "<!-- END medsci-skills routing -->"
+
+# Deliberately carries no local path. The Cursor rule above embeds REPO_ROOT, which is fine for a
+# file nobody shares — but a CLAUDE.md sits in a project folder and gets committed, and the absolute
+# path of a home directory is the installer's name. Nothing here is machine-specific.
+ROUTING_BLOCK = f"""{ROUTING_BEGIN}
+## MedSci Skills
+
+MedSci Skills is installed. When a request matches a row below, invoke that skill rather than
+answering from scratch. When the right one is not obvious, invoke `orchestrate` — it classifies the
+request and routes to the rest.
+
+| Request | Skill |
+|---|---|
+| Find papers; check that a citation is real; build a reference list | `search-lit`, `verify-refs`, `manage-refs` |
+| Plan a study; sample size; define variables; de-identify data | `design-study`, `calc-sample-size`, `define-variables`, `deidentify` |
+| Run statistics; draw a publication figure | `analyze-stats`, `make-figures` |
+| Draft or revise a manuscript; write an IRB protocol | `write-paper`, `revise`, `write-protocol` |
+| Audit against a reporting guideline (STROBE, PRISMA, CONSORT, STARD, TRIPOD) or a risk-of-bias tool | `check-reporting` |
+| Self-review before submitting; answer reviewers; review someone else's paper | `self-review`, `revise`, `peer-review` |
+| Choose a journal; assemble a submission package | `find-journal`, `sync-submission` |
+| Medical-research work that is not obviously one of the above | `orchestrate` |
+
+How a skill is invoked depends on how it was installed: bare (`/write-paper`) for a skills-folder
+install, namespaced (`/medsci-writing:write-paper`) for a plugin install. Skip any skill that is not
+installed, and never invent one.
+
+These skills draft and audit. They do not replace authors, statisticians, reviewers, or an IRB, and
+every output needs human-expert verification.
+{ROUTING_END}
+"""
+
+
+def apply_routing(md_path: Path, remove: bool, dry_run: bool, log_lines: list[str]) -> str:
+    """Splice the routing block into a CLAUDE.md, leaving every other byte of the file alone.
+
+    Returns one of: added | updated | unchanged | removed | absent.
+
+    The file is never truncated and never overwritten wholesale. An existing file is read, the
+    region between the two markers is replaced (or the block appended when the markers are absent),
+    and the rest is written back as it was. That matters more here than for the Cursor rule this
+    sits next to: a CLAUDE.md is somewhere the user keeps their own standing instructions, and
+    `write_text(body)` on one of those is a data-loss bug, not an install step.
+    """
+    existing = md_path.read_text(encoding="utf-8") if md_path.is_file() else None
+    head = existing if existing is not None else ""
+
+    begin, end = head.find(ROUTING_BEGIN), head.find(ROUTING_END)
+    if (begin == -1) != (end == -1):
+        # Half a fence means someone edited inside it. Guessing where the block stops could eat
+        # their text, so refuse and let them look.
+        raise RuntimeError(
+            f"{md_path} has one routing marker but not the other; refusing to guess where the "
+            f"block ends. Remove the stray marker by hand, then re-run."
+        )
+
+    if remove:
+        if begin == -1:
+            return "absent"
+        rest = head[:begin].rstrip("\n") + "\n" + head[end + len(ROUTING_END):].lstrip("\n")
+        if dry_run:
+            return "removed"
+        if rest.strip():
+            md_path.write_text(rest, encoding="utf-8")
+        else:
+            md_path.unlink()
+        return "removed"
+
+    if begin != -1:
+        if head[begin:end + len(ROUTING_END)] == ROUTING_BLOCK.rstrip("\n"):
+            return "unchanged"
+        merged = head[:begin] + ROUTING_BLOCK.rstrip("\n") + head[end + len(ROUTING_END):]
+        outcome = "updated"
+    else:
+        sep = "" if not head else ("\n" if head.endswith("\n") else "\n\n")
+        merged = head + sep + ROUTING_BLOCK
+        outcome = "added"
+
+    if not dry_run:
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(merged, encoding="utf-8")
+    return outcome
+
+
+def install_claude_routing(md_path: Path, remove: bool, log_lines: list[str], dry_run: bool) -> None:
+    """Add or remove the routing block in one CLAUDE.md, reporting exactly what happened."""
+    verb = "removing" if remove else "writing"
+    log(f"\n[routing] {verb} the routing block in {md_path}", log_lines)
+    if dry_run:
+        outcome = apply_routing(md_path, remove, True, log_lines)
+        log(f"  DRY RUN would report: {outcome}", log_lines)
+        return
+    outcome = apply_routing(md_path, remove, False, log_lines)
+    log({
+        "added": "  added the routing block (the rest of the file was left as it was)",
+        "updated": "  updated the existing routing block (nothing outside the markers changed)",
+        "unchanged": "  already present and identical; no write",
+        "removed": "  removed the routing block",
+        "absent": "  no routing block was there; nothing to remove",
+    }[outcome], log_lines)
+
+
 def run_self_test() -> int:
     """Simulate installs into throwaway temp dirs, assert every skill is discoverable, and
     prove no real host directory is touched. Returns 0 on pass, 1 on failure. Writes nothing
@@ -214,6 +317,27 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         help="Project folder where a .cursor/rules/medsci-skills.mdc rule should be written.",
+    )
+    parser.add_argument(
+        "--claude-project",
+        type=Path,
+        default=None,
+        help="Opt in: add a short skill-routing block to <folder>/CLAUDE.md so plain-language "
+             "requests in that project reach the right skill. Scoped to that folder; nothing else "
+             "in the file is touched.",
+    )
+    parser.add_argument(
+        "--claude-user",
+        action="store_true",
+        help="Opt in: add the same routing block to ~/.claude/CLAUDE.md, which Claude Code loads in "
+             "EVERY project. Larger footprint than --claude-project; prefer that one unless you "
+             "want it everywhere.",
+    )
+    parser.add_argument(
+        "--remove-routing",
+        action="store_true",
+        help="Remove the routing block from whichever target you name with --claude-project / "
+             "--claude-user. Leaves the rest of the file alone.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print actions without changing files.")
     parser.add_argument(
@@ -342,6 +466,25 @@ def main() -> int:
     except Exception as exc:  # noqa: BLE001
         failures.append("cursor")
         log(f"\n[cursor] FAILED: {exc}", log_lines)
+
+    try:
+        if args.claude_project:
+            install_claude_routing(
+                args.claude_project.expanduser().resolve() / "CLAUDE.md",
+                args.remove_routing, log_lines, args.dry_run,
+            )
+        if args.claude_user:
+            install_claude_routing(
+                Path.home() / ".claude" / "CLAUDE.md",
+                args.remove_routing, log_lines, args.dry_run,
+            )
+        if args.remove_routing and not (args.claude_project or args.claude_user):
+            log("\n[routing] --remove-routing needs a target: pass --claude-project <folder> "
+                "and/or --claude-user.", log_lines)
+    except Exception as exc:  # noqa: BLE001
+        failures.append("routing")
+        log(f"\n[routing] FAILED: {exc}", log_lines)
+        log("  the CLAUDE.md was left exactly as it was.", log_lines)
 
     # Place the one-click updater under ~/.medsci-skills/updater/ so a future update needs no
     # GitHub/terminal even if this download folder is deleted (best-effort; never fatal).

--- a/installers/install.py
+++ b/installers/install.py
@@ -169,13 +169,29 @@ def apply_routing(md_path: Path, remove: bool, dry_run: bool, log_lines: list[st
     existing = md_path.read_text(encoding="utf-8") if md_path.is_file() else None
     head = existing if existing is not None else ""
 
-    begin, end = head.find(ROUTING_BEGIN), head.find(ROUTING_END)
-    if (begin == -1) != (end == -1):
-        # Half a fence means someone edited inside it. Guessing where the block stops could eat
-        # their text, so refuse and let them look.
+    # Count every marker rather than finding the first of each. Reasoning from `find()` alone
+    # gets three cases wrong, and all three were reachable: markers in reverse order spliced a
+    # duplicate of the user's text and left a dangling fence; two blocks in one file never
+    # converged; and `--remove-routing` on two blocks reported "removed" while one survived --
+    # a success message that was not true. Anything other than one clean fence is refused, which
+    # is what the half-marker case already did.
+    n_begin, n_end = head.count(ROUTING_BEGIN), head.count(ROUTING_END)
+    if n_begin != n_end:
         raise RuntimeError(
-            f"{md_path} has one routing marker but not the other; refusing to guess where the "
-            f"block ends. Remove the stray marker by hand, then re-run."
+            f"{md_path} has {n_begin} '{ROUTING_BEGIN}' and {n_end} '{ROUTING_END}'; refusing to "
+            f"guess where the block ends. Fix the markers by hand, then re-run."
+        )
+    if n_begin > 1:
+        raise RuntimeError(
+            f"{md_path} contains {n_begin} routing blocks. Refusing to touch it: removing one "
+            f"would leave the rest while reporting success. Delete the extra blocks by hand, "
+            f"then re-run."
+        )
+    begin, end = head.find(ROUTING_BEGIN), head.find(ROUTING_END)
+    if begin != -1 and begin > end:
+        raise RuntimeError(
+            f"{md_path} has the routing markers in reverse order (END before BEGIN). Splicing "
+            f"that would duplicate the text between them. Fix the markers by hand, then re-run."
         )
 
     if remove:

--- a/installers/tests/test_routing.py
+++ b/installers/tests/test_routing.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""The routing block goes into a CLAUDE.md — a file the user keeps their OWN standing
+instructions in. So the thing under test is not "does the block appear". It is "does
+everything else survive", which is the property `install_cursor_rule`'s
+`rule_path.write_text(body)` does not have.
+
+Every case runs in a TemporaryDirectory. Nothing outside it is read or written.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import install  # noqa: E402
+
+FAIL: list[str] = []
+USER_TEXT = (
+    "# My instructions\n\nAlways answer in Korean.\nNever touch ~/secrets.\n\n"
+    "## House style\n\n- em-dashes are fine\n"
+)
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    print(f"{'PASS' if cond else 'FAIL'}  {label}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+def run() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+
+        # 1. A missing file is created and carries the block.
+        p = tmp / "fresh" / "CLAUDE.md"
+        out = install.apply_routing(p, remove=False, dry_run=False, log_lines=[])
+        check("missing file -> added", out == "added", out)
+        check("block present", install.ROUTING_BEGIN in p.read_text() and install.ROUTING_END in p.read_text())
+
+        # 2. THE REGRESSION. An existing file keeps every byte the user wrote.
+        #    A wholesale write_text(body) fails exactly here.
+        p2 = tmp / "existing" / "CLAUDE.md"
+        p2.parent.mkdir(parents=True)
+        p2.write_text(USER_TEXT, encoding="utf-8")
+        install.apply_routing(p2, remove=False, dry_run=False, log_lines=[])
+        after = p2.read_text(encoding="utf-8")
+        check("user content survives an add", USER_TEXT.rstrip("\n") in after,
+              "the user's own CLAUDE.md was clobbered")
+        check("block appended after user content", after.index("My instructions") < after.index(install.ROUTING_BEGIN))
+
+        # 3. Idempotent: a second run neither duplicates nor rewrites.
+        out = install.apply_routing(p2, remove=False, dry_run=False, log_lines=[])
+        check("re-run -> unchanged", out == "unchanged", out)
+        check("no duplicate block", p2.read_text().count(install.ROUTING_BEGIN) == 1)
+
+        # 4. A stale block is replaced in place; text on both sides is untouched.
+        p3 = tmp / "stale" / "CLAUDE.md"
+        p3.parent.mkdir(parents=True)
+        p3.write_text(
+            f"BEFORE\n\n{install.ROUTING_BEGIN}\nold and wrong\n{install.ROUTING_END}\n\nAFTER\n",
+            encoding="utf-8",
+        )
+        out = install.apply_routing(p3, remove=False, dry_run=False, log_lines=[])
+        body = p3.read_text(encoding="utf-8")
+        check("stale block -> updated", out == "updated", out)
+        check("stale content gone", "old and wrong" not in body)
+        check("text before and after preserved", body.startswith("BEFORE") and body.rstrip().endswith("AFTER"))
+
+        # 5. Removal takes the block and nothing else.
+        out = install.apply_routing(p2, remove=True, dry_run=False, log_lines=[])
+        body = p2.read_text(encoding="utf-8")
+        check("remove -> removed", out == "removed", out)
+        check("block gone", install.ROUTING_BEGIN not in body)
+        check("user content survives a remove", USER_TEXT.rstrip("\n") in body)
+        check("removing twice is not an error", install.apply_routing(p2, True, False, []) == "absent")
+
+        # 6. A file that held only our block is cleaned up rather than left as a husk.
+        install.apply_routing(p, remove=True, dry_run=False, log_lines=[])
+        check("block-only file is deleted on remove", not p.exists())
+
+        # 7. Half a fence is refused — guessing the end could eat the user's text.
+        p4 = tmp / "half" / "CLAUDE.md"
+        p4.parent.mkdir(parents=True)
+        half = f"keep me\n{install.ROUTING_BEGIN}\ndangling\n"
+        p4.write_text(half, encoding="utf-8")
+        try:
+            install.apply_routing(p4, remove=False, dry_run=False, log_lines=[])
+            check("half marker refused", False, "it proceeded instead of raising")
+        except RuntimeError:
+            check("half marker refused", True)
+        check("half-marker file untouched", p4.read_text(encoding="utf-8") == half)
+
+        # 8. --dry-run writes nothing.
+        p5 = tmp / "dry" / "CLAUDE.md"
+        out = install.apply_routing(p5, remove=False, dry_run=True, log_lines=[])
+        check("dry run reports added", out == "added", out)
+        check("dry run created no file", not p5.exists())
+
+        # 9. The block carries nothing machine-specific. A CLAUDE.md gets committed, and the
+        #    absolute path of a home directory is the installer's name.
+        blk = install.ROUTING_BLOCK
+        check("no home path in block", "/Users/" not in blk and "/home/" not in blk and "C:\\\\" not in blk)
+        check("no repo path in block", str(install.REPO_ROOT) not in blk)
+        check("block stays small", len(blk.split()) < 350, f"{len(blk.split())} words on every request")
+
+    print()
+    if FAIL:
+        print(f"FAILED: {len(FAIL)} — " + "; ".join(FAIL))
+        return 1
+    print("All routing checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/installers/tests/test_routing.py
+++ b/installers/tests/test_routing.py
@@ -92,6 +92,35 @@ def run() -> int:
             check("half marker refused", True)
         check("half-marker file untouched", p4.read_text(encoding="utf-8") == half)
 
+        # 7b. Markers in REVERSE order. Both are present, so the half-marker guard passes them
+        #     through; splicing on find() duplicated the text between them and left a dangling
+        #     fence. Refusal is the only safe answer.
+        p6 = tmp / "reversed" / "CLAUDE.md"
+        p6.parent.mkdir(parents=True)
+        rev = f"HEAD\n{install.ROUTING_END}\nIMPORTANT USER NOTES\n{install.ROUTING_BEGIN}\nTAIL\n"
+        p6.write_text(rev, encoding="utf-8")
+        try:
+            install.apply_routing(p6, remove=False, dry_run=False, log_lines=[])
+            check("reversed markers refused", False, "it spliced instead of raising")
+        except RuntimeError:
+            check("reversed markers refused", True)
+        check("reversed-marker file untouched", p6.read_text(encoding="utf-8") == rev)
+
+        # 7c. Two blocks in one file. The old code replaced the first and left the second, so a
+        #     re-run never converged and --remove-routing reported "removed" with a block still
+        #     in the file. A success message that is not true is worse than an error.
+        p7 = tmp / "double" / "CLAUDE.md"
+        p7.parent.mkdir(parents=True)
+        dbl = f"A\n{install.ROUTING_BLOCK}\nB\n{install.ROUTING_BLOCK}\nC\n"
+        p7.write_text(dbl, encoding="utf-8")
+        for mode in (False, True):
+            try:
+                install.apply_routing(p7, remove=mode, dry_run=False, log_lines=[])
+                check(f"two blocks refused (remove={mode})", False, "it reported success")
+            except RuntimeError:
+                check(f"two blocks refused (remove={mode})", True)
+        check("two-block file untouched", p7.read_text(encoding="utf-8") == dbl)
+
         # 8. --dry-run writes nothing.
         p5 = tmp / "dry" / "CLAUDE.md"
         out = install.apply_routing(p5, remove=False, dry_run=True, log_lines=[])
@@ -101,7 +130,8 @@ def run() -> int:
         # 9. The block carries nothing machine-specific. A CLAUDE.md gets committed, and the
         #    absolute path of a home directory is the installer's name.
         blk = install.ROUTING_BLOCK
-        check("no home path in block", "/Users/" not in blk and "/home/" not in blk and "C:\\\\" not in blk)
+        check("no home path in block",
+              "/Users/" not in blk and "/home/" not in blk and "C:\\" not in blk)
         check("no repo path in block", str(install.REPO_ROOT) not in blk)
         check("block stays small", len(blk.split()) < 350, f"{len(blk.split())} words on every request")
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -48,8 +48,8 @@
     },
     {
       "path": "installers/install.py",
-      "size": 18509,
-      "sha256": "7dc0eac5c52077d8e97cf8b7fb653056bc45475fedb772e650f4370ebd7d392b"
+      "size": 25410,
+      "sha256": "e8787d831edee7f7ea1aa1493c9b0865b9e8b5b294bb8af93181c2a45982290d"
     },
     {
       "path": "installers/medsci_txn.py",

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -48,8 +48,8 @@
     },
     {
       "path": "installers/install.py",
-      "size": 25410,
-      "sha256": "e8787d831edee7f7ea1aa1493c9b0865b9e8b5b294bb8af93181c2a45982290d"
+      "size": 26398,
+      "sha256": "6603b073a49013d6d4ced309e05b65d7c245e5642be2d1dc6d214647849cc9e6"
     },
     {
       "path": "installers/medsci_txn.py",


### PR DESCRIPTION
## Why

`/orchestrate` is the documented way in, and it only helps someone who already knows to type it.
Issue 11 (#508) told readers to type it; this gives them the option of not having to.

## What

| Flag | Writes to | Loads |
|---|---|---|
| `--claude-project <folder>` | `<folder>/CLAUDE.md` | that project only |
| `--claude-user` | `~/.claude/CLAUDE.md` | **every** project |
| `--remove-routing` | either, named the same way | — |

Both off by default. The block is ~25 lines: a task-to-skill table plus the `orchestrate` fallback.

## The part that matters — it splices, it does not overwrite

A `CLAUDE.md` is where a user keeps their **own** standing instructions. The sibling this sits next
to, `install_cursor_rule`, calls `rule_path.write_text(body)`. Doing that to a `CLAUDE.md` is a
data-loss bug, not an install step.

`apply_routing` reads the file, replaces only the region between two markers (or appends when
absent), and writes every other byte back as it was. The regression test drives the wholesale-write
behaviour into `apply_routing` and watches the "user content survives" case fail — verified locally,
`exit=1` — so the property is tested rather than asserted.

21 checks, all in a `TemporaryDirectory`: create · preserve user content · idempotent re-run ·
in-place replacement of a stale block · removal preserving user content · removal deleting a file
that held nothing else · **refusal when only one of the two markers is present** (guessing where the
block ends could eat their text) · `--dry-run` writing nothing.

## Two design constraints worth naming

- **No hardcoded command form.** How a skill is invoked depends on the install path
  (`/write-paper` vs `/medsci-writing:write-paper` — the very thing #508 documented), so the block
  names skills without a leading slash and explains both forms. A hardcoded `/write-paper` would be
  wrong for every plugin installer.
- **No machine-specific path.** `install_cursor_rule` embeds `REPO_ROOT` into a file under
  `.cursor/rules/`, which is a directory people commit. A `CLAUDE.md` is too, so this block carries
  no home-directory or repository path, and a test asserts it.

## Verification

- `python3 scripts/run_ci_mirror.py` → **250/250** (249 + the new step)
- Test wired into **both** the `validate` and `foundation-os` jobs, so Windows path handling
  (`mkdir`/`unlink`/`Path`) is exercised
- End-to-end CLI round-trip run by hand: dry-run writes nothing → add → re-run reports
  `already present and identical` → `--remove-routing` → file byte-identical to the original
- Every skill named in the block verified to exist in `skills/` (18/18)
- `gen_distribution_manifest.py` regenerated; file count unchanged at 1278 (`installers/tests/` is
  not distributed)

## Not fixed here, but found

`install_cursor_rule` writes `REPO_ROOT` — an absolute home-directory path — into
`.cursor/rules/medsci-skills.mdc`, a file people commit, and it does so with an unconditional
`write_text`. The path may be load-bearing for Cursor, so removing it needs its own decision and
regression test rather than a drive-by edit in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)