### PR TITLE
fix(install): the routing splice claimed to preserve the file and did not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The routing splice claimed to preserve the user's file and did not.** An independent Codex
+  review of the feature below found six defects in it. Four were real losses and are fixed here; the
+  other two are answered rather than coded around.
+
+  The docstring said the file "is never truncated" while the code called `Path.write_text`, which
+  opens in `w` mode and truncates before writing — an interrupted install left a zero-byte
+  `CLAUDE.md`, and the error handler then logged *"the CLAUDE.md was left exactly as it was"*, which
+  is the false-success report this feature was built to avoid. Writes now go through
+  `medsci_txn.atomic_write_bytes` (extracted from `atomic_write_json`, so the repo keeps one fsync
+  implementation) and land with `os.replace`, so that log line is now true.
+
+  `--remove-routing` called `unlink()` on a path that may be a **symlink**, deleting the user's link
+  while the block stayed in the file it pointed at. The splice now resolves through to the target and
+  never deletes a link.
+
+  Removal ran `rstrip` over the head, so a file ending in two newlines came back with one — the
+  user's own blank line. And the whole file was read and rewritten as text, so `read_text`'s
+  universal-newline translation silently rewrote every line of a **CRLF** file. Reads are now
+  `read_bytes`, the block is emitted with the file's own line ending, and add-then-remove returns the
+  original bytes.
+
+  The atomic rewrite introduced a hazard of its own that the review did not have to catch: replacing
+  a file loses its mode, so a `chmod 600` `CLAUDE.md` would have been widened. The mode is now
+  re-applied, following `update._write_settings`.
+
+  **The tests are why this was invisible.** They asserted preservation with a substring check, which
+  cannot see a collapsed blank line, a rewritten line ending, or a changed mode. They now compare
+  bytes. Eleven of the new assertions were confirmed to fail against the previous release, and the
+  mode assertion against an atomic write without the chmod step.
+
+  Not fixed, and stated instead: a file with **no trailing newline** gains one and removal does not
+  take it back (nothing records that the newline was ours); two installers racing on one file can
+  still lose an update, though neither can now corrupt it; and a `CLAUDE.md` that already contains
+  our exact marker pair has that region replaced — the block now says so inside itself.
+
+  Found and deferred: `install_cursor_rule` has the same unconditional `write_text` and embeds an
+  absolute home path into `.cursor/rules/`, a directory people commit. That needs its own change,
+  because whether Cursor requires the path is an open question.
+
 ### Added
 
 - **Opt-in: a routing block in a project's `CLAUDE.md`, so a plain-language request finds the

--- a/README.md
+++ b/README.md
@@ -702,9 +702,10 @@ python3 installers/install.py --claude-project ~/research/my-study --remove-rout
 ```
 
 Both are **off by default**. The block is ~25 lines between `<!-- BEGIN/END medsci-skills routing -->`
-markers, carries no machine-specific paths, and is spliced in: an existing `CLAUDE.md` full of your
-own instructions keeps every line, re-running updates the block in place, and `--remove-routing`
-takes it back out. Prefer `--claude-project` — `--claude-user` loads in every project you ever open,
+markers and carries no machine-specific paths. It is spliced in, not written over: an existing
+`CLAUDE.md` keeps its bytes outside the markers — line endings and file permissions included — the
+write is atomic so an interrupted run cannot leave a truncated file, re-running updates the block in
+place, and `--remove-routing` takes it back out. Prefer `--claude-project` — `--claude-user` loads in every project you ever open,
 including work unrelated to research.
 
 > **Tip:** Not sure which skill to use? Start with `/orchestrate` -- it will classify your request and route you to the right tool.

--- a/installers/install.py
+++ b/installers/install.py
@@ -151,23 +151,72 @@ installed, and never invent one.
 
 These skills draft and audit. They do not replace authors, statisticians, reviewers, or an IRB, and
 every output needs human-expert verification.
+
+Everything between the two markers above and below is managed by the MedSci Skills installer and is
+replaced or removed wholesale when it runs. Put your own notes outside them.
 {ROUTING_END}
 """
 
 
-def apply_routing(md_path: Path, remove: bool, dry_run: bool, log_lines: list[str]) -> str:
-    """Splice the routing block into a CLAUDE.md, leaving every other byte of the file alone.
+LF = "\n"
+CRLF = "\r\n"
 
-    Returns one of: added | updated | unchanged | removed | absent.
 
-    The file is never truncated and never overwritten wholesale. An existing file is read, the
-    region between the two markers is replaced (or the block appended when the markers are absent),
-    and the rest is written back as it was. That matters more here than for the Cursor rule this
-    sits next to: a CLAUDE.md is somewhere the user keeps their own standing instructions, and
-    `write_text(body)` on one of those is a data-loss bug, not an install step.
+def _dominant_newline(text: str) -> str:
+    """Which line ending this file already uses, so the block matches it instead of mixing."""
+    crlf = text.count(CRLF)
+    return CRLF if crlf > text.count(LF) - crlf else LF
+
+
+def _write_preserving_mode(path: Path, text: str, newline: str) -> None:
+    """Atomically replace `path`, keeping the permissions it already had.
+
+    The mode step mirrors update._write_settings: a user who ran `chmod 600` on their CLAUDE.md
+    should not have it widened to the umask default as a side effect of an install.
     """
-    existing = md_path.read_text(encoding="utf-8") if md_path.is_file() else None
-    head = existing if existing is not None else ""
+    prev_mode = os.stat(path).st_mode & 0o777 if path.is_file() else None
+    medsci_txn.atomic_write_bytes(path, text.encode("utf-8"))
+    if prev_mode is not None:
+        try:
+            os.chmod(path, prev_mode)
+        except OSError:
+            pass
+
+
+def apply_routing(md_path: Path, remove: bool, dry_run: bool, log_lines: list[str]) -> str:
+    """Splice the routing block into a CLAUDE.md. Returns: added | updated | unchanged | removed | absent.
+
+    What is actually guaranteed, because the first version of this docstring claimed more than the
+    code delivered and an external review said so:
+
+    * **The write is atomic.** Content goes to a temp file beside the target and is `os.replace`d
+      into position (medsci_txn.atomic_write_bytes), so an interrupted run leaves the previous file
+      intact. The previous version called `Path.write_text`, which opens in "w" mode and therefore
+      truncates before writing -- an interrupt there left a zero-byte CLAUDE.md.
+    * **Bytes outside the two markers are preserved, line endings included.** The file is read with
+      `read_bytes` and decoded here, so nothing on the path performs universal-newline translation;
+      a CRLF file stays CRLF, and the block is emitted with the file's own line ending rather than
+      mixing one in.
+    * **Permissions are preserved.**
+
+    The one thing it does NOT preserve, stated rather than hidden: a file with no trailing newline
+    gains one, and removal does not take it back. The newline is needed to put the block on its own
+    line, and nothing in the file records that it was ours.
+
+    A CLAUDE.md is where a user keeps their own standing instructions. Anything less than the above
+    is a data-loss bug, not an install step.
+    """
+    # A symlinked CLAUDE.md must be edited through to its target: `os.replace` onto the link would
+    # replace the link itself with a regular file, and unlinking it would delete the user's link
+    # while leaving the block sitting in the file it pointed at.
+    linked = md_path.is_symlink()
+    target = md_path.resolve() if linked else md_path
+
+    raw = target.read_bytes() if target.is_file() else None
+    head = raw.decode("utf-8") if raw is not None else ""
+    nl = _dominant_newline(head)
+    block = ROUTING_BLOCK if nl == LF else ROUTING_BLOCK.replace(LF, nl)
+    region = block[: -len(nl)]  # the block without its own trailing newline
 
     # Count every marker rather than finding the first of each. Reasoning from `find()` alone
     # gets three cases wrong, and all three were reachable: markers in reverse order spliced a
@@ -197,28 +246,31 @@ def apply_routing(md_path: Path, remove: bool, dry_run: bool, log_lines: list[st
     if remove:
         if begin == -1:
             return "absent"
-        rest = head[:begin].rstrip("\n") + "\n" + head[end + len(ROUTING_END):].lstrip("\n")
+        # Exact slice. The previous version ran rstrip("\n") + "\n" over the head, which silently
+        # collapsed the user's own blank lines: "KEEP\n\n" came back as "KEEP\n".
+        tail = head[end + len(ROUTING_END):]
+        if tail.startswith(nl):
+            tail = tail[len(nl):]
+        rest = head[:begin] + tail
         if dry_run:
             return "removed"
-        if rest.strip():
-            md_path.write_text(rest, encoding="utf-8")
+        if rest.strip() or linked or not target.is_file():
+            _write_preserving_mode(target, rest, nl)
         else:
-            md_path.unlink()
+            target.unlink()
         return "removed"
 
     if begin != -1:
-        if head[begin:end + len(ROUTING_END)] == ROUTING_BLOCK.rstrip("\n"):
+        if head[begin:end + len(ROUTING_END)] == region:
             return "unchanged"
-        merged = head[:begin] + ROUTING_BLOCK.rstrip("\n") + head[end + len(ROUTING_END):]
+        merged = head[:begin] + region + head[end + len(ROUTING_END):]
         outcome = "updated"
     else:
-        sep = "" if not head else ("\n" if head.endswith("\n") else "\n\n")
-        merged = head + sep + ROUTING_BLOCK
+        merged = (head if not head or head.endswith(nl) else head + nl) + block
         outcome = "added"
 
     if not dry_run:
-        md_path.parent.mkdir(parents=True, exist_ok=True)
-        md_path.write_text(merged, encoding="utf-8")
+        _write_preserving_mode(target, merged, nl)
     return outcome
 
 

--- a/installers/medsci_txn.py
+++ b/installers/medsci_txn.py
@@ -84,15 +84,33 @@ def assert_contained(path: Path, container: Path) -> None:
 
 # ---------------------------------------------------------------- json io
 
-def atomic_write_json(path: Path, obj) -> None:
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Replace `path` with `data`, atomically: a reader sees either the old file or the whole new
+    one, never a half-written or truncated file.
+
+    Extracted from `atomic_write_json` so there is one fsync implementation in the repo rather than
+    two. The caller that forced the split writes a user's CLAUDE.md, where the alternative --
+    `Path.write_text`, which opens in "w" mode and truncates before writing -- turns an interrupted
+    install into a lost file.
+
+    Bytes, not text: the caller decides the encoding and the line endings, so nothing here can
+    translate a CRLF file into an LF one on the way through.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
-    data = (json.dumps(obj, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
-    with open(tmp, "wb") as f:
-        f.write(data)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, path)
+    try:
+        with open(tmp, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        # Leave nothing behind: the destination is still whatever it was before this call.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
     # fsync the directory so the rename is durable.
     try:
         dfd = os.open(str(path.parent), os.O_RDONLY)
@@ -102,6 +120,10 @@ def atomic_write_json(path: Path, obj) -> None:
             os.close(dfd)
     except (OSError, AttributeError):
         pass  # directory fsync unsupported (e.g. Windows) — os.replace is still atomic.
+
+
+def atomic_write_json(path: Path, obj) -> None:
+    atomic_write_bytes(path, (json.dumps(obj, indent=2, ensure_ascii=False) + "\n").encode("utf-8"))
 
 
 def read_json_strict(path: Path):

--- a/installers/tests/test_routing.py
+++ b/installers/tests/test_routing.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""The routing block goes into a CLAUDE.md — a file the user keeps their OWN standing
+"""The routing block goes into a CLAUDE.md -- a file the user keeps their OWN standing
 instructions in. So the thing under test is not "does the block appear". It is "does
-everything else survive", which is the property `install_cursor_rule`'s
-`rule_path.write_text(body)` does not have.
+everything else survive, byte for byte".
+
+The first version of this file asserted preservation with `USER_TEXT.rstrip("\\n") in after`.
+A substring test cannot see a collapsed blank line, a CRLF rewritten to LF, or a changed file
+mode -- and an external review found exactly those defects sitting under a green suite. The
+assertions here compare bytes.
 
 Every case runs in a TemporaryDirectory. Nothing outside it is read or written.
 """
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -15,12 +20,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import install  # noqa: E402
+import medsci_txn  # noqa: E402
 
 FAIL: list[str] = []
 USER_TEXT = (
     "# My instructions\n\nAlways answer in Korean.\nNever touch ~/secrets.\n\n"
-    "## House style\n\n- em-dashes are fine\n"
+    "## House style\n\n- em-dashes are fine\n\n"
 )
+BARE_LF = b"\n"
+CRLF_B = b"\r\n"
 
 
 def check(label: str, cond: bool, detail: str = "") -> None:
@@ -29,9 +37,22 @@ def check(label: str, cond: bool, detail: str = "") -> None:
         FAIL.append(label)
 
 
-def run() -> int:
+def outside(raw: bytes, nl: bytes = BARE_LF) -> bytes:
+    """The file's bytes with the managed region removed, so the rest can be compared exactly."""
+    b = raw.find(install.ROUTING_BEGIN.encode())
+    e = raw.find(install.ROUTING_END.encode())
+    if b == -1:
+        return raw
+    tail = raw[e + len(install.ROUTING_END.encode()):]
+    if tail.startswith(nl):
+        tail = tail[len(nl):]
+    return raw[:b] + tail
+
+
+def run() -> int:  # noqa: PLR0915 - a flat list of cases reads better than nested helpers
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
+        original = USER_TEXT.encode()
 
         # 1. A missing file is created and carries the block.
         p = tmp / "fresh" / "CLAUDE.md"
@@ -39,96 +60,181 @@ def run() -> int:
         check("missing file -> added", out == "added", out)
         check("block present", install.ROUTING_BEGIN in p.read_text() and install.ROUTING_END in p.read_text())
 
-        # 2. THE REGRESSION. An existing file keeps every byte the user wrote.
-        #    A wholesale write_text(body) fails exactly here.
+        # 2. THE REGRESSION. An existing file keeps every byte the user wrote -- not "contains
+        #    the text somewhere", but byte-identical outside the managed region.
         p2 = tmp / "existing" / "CLAUDE.md"
         p2.parent.mkdir(parents=True)
-        p2.write_text(USER_TEXT, encoding="utf-8")
+        p2.write_bytes(original)
         install.apply_routing(p2, remove=False, dry_run=False, log_lines=[])
-        after = p2.read_text(encoding="utf-8")
-        check("user content survives an add", USER_TEXT.rstrip("\n") in after,
-              "the user's own CLAUDE.md was clobbered")
-        check("block appended after user content", after.index("My instructions") < after.index(install.ROUTING_BEGIN))
+        after = p2.read_bytes()
+        check("user bytes survive an add (exact)", outside(after) == original,
+              f"{outside(after)!r} != {original!r}")
+        check("block appended after user content",
+              after.index(b"My instructions") < after.index(install.ROUTING_BEGIN.encode()))
 
         # 3. Idempotent: a second run neither duplicates nor rewrites.
         out = install.apply_routing(p2, remove=False, dry_run=False, log_lines=[])
         check("re-run -> unchanged", out == "unchanged", out)
         check("no duplicate block", p2.read_text().count(install.ROUTING_BEGIN) == 1)
 
-        # 4. A stale block is replaced in place; text on both sides is untouched.
+        # 4. A stale block is replaced in place; bytes on both sides are untouched.
         p3 = tmp / "stale" / "CLAUDE.md"
         p3.parent.mkdir(parents=True)
-        p3.write_text(
-            f"BEFORE\n\n{install.ROUTING_BEGIN}\nold and wrong\n{install.ROUTING_END}\n\nAFTER\n",
-            encoding="utf-8",
+        stale_outside = b"BEFORE\n\nAFTER\n"
+        p3.write_bytes(
+            b"BEFORE\n\n" + install.ROUTING_BEGIN.encode() + b"\nold and wrong\n"
+            + install.ROUTING_END.encode() + b"\nAFTER\n"
         )
         out = install.apply_routing(p3, remove=False, dry_run=False, log_lines=[])
-        body = p3.read_text(encoding="utf-8")
         check("stale block -> updated", out == "updated", out)
-        check("stale content gone", "old and wrong" not in body)
-        check("text before and after preserved", body.startswith("BEFORE") and body.rstrip().endswith("AFTER"))
+        check("stale content gone", b"old and wrong" not in p3.read_bytes())
+        check("bytes around a replaced block are exact", outside(p3.read_bytes()) == stale_outside,
+              f"{outside(p3.read_bytes())!r}")
 
-        # 5. Removal takes the block and nothing else.
+        # 5. ROUND TRIP. add -> remove must return the original bytes. The old removal ran
+        #    rstrip + "\n" over the head, so b"KEEP\n\n" came back as b"KEEP\n".
+        for shape in (b"KEEP\n\n", b"KEEP\n", b"A\n\n\nB\n\n", b"# T\n\n- a\n- b\n"):
+            p4 = tmp / "rt" / "CLAUDE.md"
+            p4.parent.mkdir(parents=True, exist_ok=True)
+            p4.write_bytes(shape)
+            install.apply_routing(p4, remove=False, dry_run=False, log_lines=[])
+            install.apply_routing(p4, remove=True, dry_run=False, log_lines=[])
+            check(f"round trip is byte-exact for {shape!r}", p4.read_bytes() == shape,
+                  f"got {p4.read_bytes()!r}")
+
+        # 6. The one documented exception: a file with no trailing newline gains one, and removal
+        #    does not take it back. Asserted so it stays a decision rather than a surprise.
+        p5 = tmp / "nonl" / "CLAUDE.md"
+        p5.parent.mkdir(parents=True)
+        p5.write_bytes(b"KEEP")
+        install.apply_routing(p5, remove=False, dry_run=False, log_lines=[])
+        install.apply_routing(p5, remove=True, dry_run=False, log_lines=[])
+        check("documented: a missing trailing newline is added and kept",
+              p5.read_bytes() == b"KEEP\n", f"got {p5.read_bytes()!r}")
+
+        # 7. CRLF. read_text() translated these to LF and wrote them back that way, silently
+        #    rewriting every line of a Windows user's file.
+        p6 = tmp / "crlf" / "CLAUDE.md"
+        p6.parent.mkdir(parents=True)
+        crlf = b"# Mine\r\n\r\nUse R.\r\n"
+        p6.write_bytes(crlf)
+        install.apply_routing(p6, remove=False, dry_run=False, log_lines=[])
+        body = p6.read_bytes()
+        check("CRLF bytes outside the block are preserved", outside(body, CRLF_B) == crlf,
+              f"{outside(body, CRLF_B)!r}")
+        bare = body.count(BARE_LF) - body.count(CRLF_B)
+        check("the block itself introduces no bare LF", bare == 0, f"{bare} bare LF")
+        install.apply_routing(p6, remove=True, dry_run=False, log_lines=[])
+        check("CRLF round trip is byte-exact", p6.read_bytes() == crlf, f"got {p6.read_bytes()!r}")
+
+        # 8. An interrupted write must leave the previous file intact. Path.write_text opened in
+        #    "w" mode and truncated first, so an interrupt there produced a zero-byte CLAUDE.md.
+        p7 = tmp / "atomic" / "CLAUDE.md"
+        p7.parent.mkdir(parents=True)
+        p7.write_bytes(original)
+        real_replace = medsci_txn.os.replace
+
+        def boom(*_a, **_k):
+            raise OSError("simulated interruption")
+
+        medsci_txn.os.replace = boom
+        try:
+            install.apply_routing(p7, remove=False, dry_run=False, log_lines=[])
+            check("interrupted write raises", False, "it returned normally")
+        except OSError:
+            check("interrupted write raises", True)
+        finally:
+            medsci_txn.os.replace = real_replace
+        check("interrupted write left the file byte-identical", p7.read_bytes() == original,
+              f"got {p7.read_bytes()!r}")
+        leftovers = sorted(q.name for q in p7.parent.iterdir())
+        check("interrupted write left no temp file behind", leftovers == ["CLAUDE.md"], str(leftovers))
+
+        # 9. Permissions survive. A user who ran chmod 600 should not have it widened by an install.
+        p8 = tmp / "mode" / "CLAUDE.md"
+        p8.parent.mkdir(parents=True)
+        p8.write_bytes(original)
+        os.chmod(p8, 0o600)
+        install.apply_routing(p8, remove=False, dry_run=False, log_lines=[])
+        check("file mode preserved", (os.stat(p8).st_mode & 0o777) == 0o600,
+              oct(os.stat(p8).st_mode & 0o777))
+
+        # 10. A symlinked CLAUDE.md is edited through to its target. Deleting the link would remove
+        #     the user's link and leave the block in the file it pointed at -- wrong twice.
+        shared = tmp / "shared.md"
+        shared.write_bytes(install.ROUTING_BLOCK.encode())
+        linkdir = tmp / "linked"
+        linkdir.mkdir()
+        link = linkdir / "CLAUDE.md"
+        try:
+            link.symlink_to(shared)
+        except (OSError, NotImplementedError):
+            print("SKIP  symlink cases (symlinks unavailable on this platform)")
+        else:
+            out = install.apply_routing(link, remove=True, dry_run=False, log_lines=[])
+            check("symlink remove -> removed", out == "removed", out)
+            check("the symlink itself still exists", link.is_symlink())
+            check("the block is gone from the symlink target",
+                  install.ROUTING_BEGIN not in shared.read_text())
+
+        # 11. Removal takes the block and nothing else.
         out = install.apply_routing(p2, remove=True, dry_run=False, log_lines=[])
-        body = p2.read_text(encoding="utf-8")
         check("remove -> removed", out == "removed", out)
-        check("block gone", install.ROUTING_BEGIN not in body)
-        check("user content survives a remove", USER_TEXT.rstrip("\n") in body)
+        check("user bytes survive a remove (exact)", p2.read_bytes() == original,
+              f"got {p2.read_bytes()!r}")
         check("removing twice is not an error", install.apply_routing(p2, True, False, []) == "absent")
 
-        # 6. A file that held only our block is cleaned up rather than left as a husk.
+        # 12. A regular file that held only our block is cleaned up rather than left as a husk.
         install.apply_routing(p, remove=True, dry_run=False, log_lines=[])
         check("block-only file is deleted on remove", not p.exists())
 
-        # 7. Half a fence is refused — guessing the end could eat the user's text.
-        p4 = tmp / "half" / "CLAUDE.md"
-        p4.parent.mkdir(parents=True)
-        half = f"keep me\n{install.ROUTING_BEGIN}\ndangling\n"
-        p4.write_text(half, encoding="utf-8")
+        # 13. Half a fence is refused -- guessing the end could eat the user's text.
+        p9 = tmp / "half" / "CLAUDE.md"
+        p9.parent.mkdir(parents=True)
+        half = f"keep me\n{install.ROUTING_BEGIN}\ndangling\n".encode()
+        p9.write_bytes(half)
         try:
-            install.apply_routing(p4, remove=False, dry_run=False, log_lines=[])
+            install.apply_routing(p9, remove=False, dry_run=False, log_lines=[])
             check("half marker refused", False, "it proceeded instead of raising")
         except RuntimeError:
             check("half marker refused", True)
-        check("half-marker file untouched", p4.read_text(encoding="utf-8") == half)
+        check("half-marker file untouched", p9.read_bytes() == half)
 
-        # 7b. Markers in REVERSE order. Both are present, so the half-marker guard passes them
-        #     through; splicing on find() duplicated the text between them and left a dangling
-        #     fence. Refusal is the only safe answer.
-        p6 = tmp / "reversed" / "CLAUDE.md"
-        p6.parent.mkdir(parents=True)
-        rev = f"HEAD\n{install.ROUTING_END}\nIMPORTANT USER NOTES\n{install.ROUTING_BEGIN}\nTAIL\n"
-        p6.write_text(rev, encoding="utf-8")
+        # 14. Markers in REVERSE order. Both are present, so the half-marker guard passes them
+        #     through; splicing on find() duplicated the text between them.
+        p10 = tmp / "reversed" / "CLAUDE.md"
+        p10.parent.mkdir(parents=True)
+        rev = f"HEAD\n{install.ROUTING_END}\nIMPORTANT USER NOTES\n{install.ROUTING_BEGIN}\nTAIL\n".encode()
+        p10.write_bytes(rev)
         try:
-            install.apply_routing(p6, remove=False, dry_run=False, log_lines=[])
+            install.apply_routing(p10, remove=False, dry_run=False, log_lines=[])
             check("reversed markers refused", False, "it spliced instead of raising")
         except RuntimeError:
             check("reversed markers refused", True)
-        check("reversed-marker file untouched", p6.read_text(encoding="utf-8") == rev)
+        check("reversed-marker file untouched", p10.read_bytes() == rev)
 
-        # 7c. Two blocks in one file. The old code replaced the first and left the second, so a
-        #     re-run never converged and --remove-routing reported "removed" with a block still
-        #     in the file. A success message that is not true is worse than an error.
-        p7 = tmp / "double" / "CLAUDE.md"
-        p7.parent.mkdir(parents=True)
-        dbl = f"A\n{install.ROUTING_BLOCK}\nB\n{install.ROUTING_BLOCK}\nC\n"
-        p7.write_text(dbl, encoding="utf-8")
+        # 15. Two blocks in one file. The old code replaced the first and left the second, so
+        #     --remove-routing reported "removed" with a block still in the file.
+        p11 = tmp / "double" / "CLAUDE.md"
+        p11.parent.mkdir(parents=True)
+        dbl = f"A\n{install.ROUTING_BLOCK}\nB\n{install.ROUTING_BLOCK}\nC\n".encode()
+        p11.write_bytes(dbl)
         for mode in (False, True):
             try:
-                install.apply_routing(p7, remove=mode, dry_run=False, log_lines=[])
+                install.apply_routing(p11, remove=mode, dry_run=False, log_lines=[])
                 check(f"two blocks refused (remove={mode})", False, "it reported success")
             except RuntimeError:
                 check(f"two blocks refused (remove={mode})", True)
-        check("two-block file untouched", p7.read_text(encoding="utf-8") == dbl)
+        check("two-block file untouched", p11.read_bytes() == dbl)
 
-        # 8. --dry-run writes nothing.
-        p5 = tmp / "dry" / "CLAUDE.md"
-        out = install.apply_routing(p5, remove=False, dry_run=True, log_lines=[])
+        # 16. --dry-run writes nothing.
+        p12 = tmp / "dry" / "CLAUDE.md"
+        out = install.apply_routing(p12, remove=False, dry_run=True, log_lines=[])
         check("dry run reports added", out == "added", out)
-        check("dry run created no file", not p5.exists())
+        check("dry run created no file", not p12.exists())
 
-        # 9. The block carries nothing machine-specific. A CLAUDE.md gets committed, and the
-        #    absolute path of a home directory is the installer's name.
+        # 17. The block carries nothing machine-specific. A CLAUDE.md gets committed, and the
+        #     absolute path of a home directory is the installer's name.
         blk = install.ROUTING_BLOCK
         check("no home path in block",
               "/Users/" not in blk and "/home/" not in blk and "C:\\" not in blk)

--- a/installers/tests/test_routing.py
+++ b/installers/tests/test_routing.py
@@ -151,13 +151,20 @@ def run() -> int:  # noqa: PLR0915 - a flat list of cases reads better than nest
         check("interrupted write left no temp file behind", leftovers == ["CLAUDE.md"], str(leftovers))
 
         # 9. Permissions survive. A user who ran chmod 600 should not have it widened by an install.
-        p8 = tmp / "mode" / "CLAUDE.md"
-        p8.parent.mkdir(parents=True)
-        p8.write_bytes(original)
-        os.chmod(p8, 0o600)
-        install.apply_routing(p8, remove=False, dry_run=False, log_lines=[])
-        check("file mode preserved", (os.stat(p8).st_mode & 0o777) == 0o600,
-              oct(os.stat(p8).st_mode & 0o777))
+        #    POSIX only, and skipped out loud rather than silently: on Windows os.chmod toggles the
+        #    read-only attribute and nothing else, so st_mode reports 0o666 whatever we set. An
+        #    assertion that cannot distinguish a preserved mode from a widened one there would be a
+        #    green light with no meaning behind it.
+        if os.name != "posix":
+            print("SKIP  file mode preserved (POSIX modes are not meaningful on this platform)")
+        else:
+            p8 = tmp / "mode" / "CLAUDE.md"
+            p8.parent.mkdir(parents=True)
+            p8.write_bytes(original)
+            os.chmod(p8, 0o600)
+            install.apply_routing(p8, remove=False, dry_run=False, log_lines=[])
+            check("file mode preserved", (os.stat(p8).st_mode & 0o777) == 0o600,
+                  oct(os.stat(p8).st_mode & 0o777))
 
         # 10. A symlinked CLAUDE.md is edited through to its target. Deleting the link would remove
         #     the user's link and leave the block in the file it pointed at -- wrong twice.

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -48,13 +48,13 @@
     },
     {
       "path": "installers/install.py",
-      "size": 26398,
-      "sha256": "6603b073a49013d6d4ced309e05b65d7c245e5642be2d1dc6d214647849cc9e6"
+      "size": 28830,
+      "sha256": "04f51767d3a19f50fe4262252d93248857fb00cb7840b12c7d6a2d83d52d791c"
     },
     {
       "path": "installers/medsci_txn.py",
-      "size": 17498,
-      "sha256": "13da36ce2a07f8c0880dcf44dabc9867ae32b7f6388fa695a63a7a0dedd08f3d"
+      "size": 18454,
+      "sha256": "7634cdaf1189b7ad4928c1333badb46d79c5d57ec6403f2dea7f7ab75f7fef00"
     },
     {
       "path": "installers/session_update_check.py",


### PR DESCRIPTION
An independent Codex review of #509 (merged `main` @ `c393809`) found **six defects** in it. Four
were real losses and are fixed here; two are answered rather than coded around.

## What was wrong

| # | Defect | Fix |
|---|---|---|
| 1 | Docstring said "never truncated"; code called `Path.write_text`, which opens in `w` mode and **truncates first**. An interrupt left a zero-byte `CLAUDE.md` — and the handler then logged *"the CLAUDE.md was left exactly as it was"* | Atomic write via `medsci_txn.atomic_write_bytes` + `os.replace`. That log line is now true |
| 6 | `--remove-routing` called `unlink()` on a path that may be a **symlink** — deleting the user's link while the block stayed in the target | Resolve through to the target; never delete a link |
| 3 | Removal ran `rstrip` over the head, collapsing the user's own blank lines | Exact slice; add→remove returns the original bytes |
| 4 | The file was read and rewritten as text, so universal-newline translation **silently rewrote every line of a CRLF file** | `read_bytes`; block takes the file's own line ending |

Answered, not coded around: **#2** (no lock) — the atomic write removes the corrupted-file outcome;
a lost update between two racing installers remains, and is stated. **#5** (exact marker collision) —
the block now says inside itself that the region is managed.

## Reuse, not reinvention

`medsci_txn.atomic_write_json` already had the right pattern (temp beside target → `fsync` →
`os.replace` → directory `fsync`) and was unusable only because it hard-coded `json.dumps`. Its body
is extracted into `atomic_write_bytes`; `atomic_write_json` now calls it. One fsync implementation in
the repo, and the existing 19 `test_txn.py` assertions still pass, so the refactor is guarded.

## A hazard the review did not have to catch

Replacing a file loses its mode, so the atomic rewrite would have widened a `chmod 600` `CLAUDE.md`
to 644. Mode is re-applied after the replace, following `update._write_settings`.

## The tests are why this was invisible

Preservation was asserted with `USER_TEXT.rstrip("\n") in after`. **A substring check cannot see a
collapsed blank line, a rewritten line ending, or a changed mode.** Codex correctly reported 0 of 26
assertions as *decorative* — they were falsifiable — but weaker than the claim they defended, which
is how #3 and #4 passed under a green suite.

They now compare bytes. Discriminating power was verified rather than assumed:

- **11 of the new assertions fail against the previous release** (`c393809`) — covering byte
  preservation, the blank-line round trip, CRLF, the interrupted write, and the symlink case.
- The mode assertion fails against an atomic write with the `chmod` step removed.

## Verification

- `installers/tests/test_routing.py` → **40/40**, and `test_txn.py` → 19/19
- `python3 scripts/run_ci_mirror.py` → **250/250**
- End-to-end CLI on a **CRLF file with `chmod 600`**: add → `--remove-routing` → `cmp` reports
  **byte-identical**, mode still `600`, no temp files left behind
- `gen_distribution_manifest.py` regenerated

## Deferred on purpose

`install_cursor_rule` carries the same unconditional `write_text` **and** embeds an absolute home
path into `.cursor/rules/` — a directory people commit, so an installer's username can reach a
shared repo. It needs its own PR, because whether Cursor requires that path is an open question and
bundling it would mix a verified fix with an investigation. Recorded in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)