### PR TITLE
fix(install): the Cursor rule put the installer's home path in a committed file

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Opt-in CLAUDE.md routing block test (a splice must not clobber the user's own file)
         run: python3 installers/tests/test_routing.py
 
+      - name: Cursor project-rule test (no machine path in a file people commit; atomic write)
+        run: python3 installers/tests/test_cursor_rule.py
+
       - name: Release-ZIP provenance + updater-consumability round-trip (build -> safe-extract)
         run: bash installers/tests/test_release_zip.sh
 
@@ -831,5 +834,7 @@ jobs:
         run: python installers/tests/test_session_hook.py
       - name: Opt-in CLAUDE.md routing block test
         run: python installers/tests/test_routing.py
+      - name: Cursor project-rule test
+        run: python installers/tests/test_cursor_rule.py
       - name: install.py transactional self-test
         run: python installers/install.py --self-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Fixed
 
+- **The Cursor project rule embedded the installer's home directory into a file people commit.**
+  `install_cursor_rule` wrote `REPO_ROOT` — an absolute path naming the user who ran the installer —
+  into `<project>/.cursor/rules/medsci-skills.mdc`, and `.cursor/rules/` is a directory that goes
+  into git. It was also pointing at the wrong place: `docs/host_compatibility.md` already records
+  that this rule is **legacy for discovery**, because Cursor reads `~/.claude/skills/` and
+  `~/.agents/skills/` directly. The path was therefore leaking something while steering nothing, so
+  the rule now names those two installed locations and `orchestrate` as the entry point.
+
+  It also wrote with `Path.write_text`, the same truncate-then-write that the CLAUDE.md splice was
+  fixed for. This file is ours to replace, but a half-written one after an interrupt is nobody's; it
+  now goes through `medsci_txn.atomic_write_bytes` and keeps the destination's mode.
+
+  Four of the new assertions fail against the previous release. The one that matters most is the
+  repository-path check — the generic home-path check passes in CI, where the checkout is not under
+  a home directory, and would only have fired on a real user's machine.
+
+
+### Fixed
+
 - **The routing splice claimed to preserve the user's file and did not.** An independent Codex
   review of the feature below found six defects in it. Four were real losses and are fixed here; the
   other two are answered rather than coded around.

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ gh skill install --all Aperivue/medsci-skills            # or install all of the
 
 - Claude Code: skills are copied to `~/.claude/skills/` (also read by GitHub Copilot and Cursor).
 - Codex: skills are copied to `~/.agents/skills/` (also read by Cursor and GitHub Copilot).
-- Cursor: no separate step needed — Cursor reads `~/.claude/skills/` and `~/.agents/skills/` directly. The installer can still write an optional `.cursor/rules/` steering rule with `--cursor-project`.
+- Cursor: no separate step needed — Cursor reads `~/.claude/skills/` and `~/.agents/skills/` directly. The installer can still write an optional `.cursor/rules/` steering rule with `--cursor-project`; it carries no machine-specific path, so it is safe to commit.
 - See [`docs/host_compatibility.md`](docs/host_compatibility.md) for the verified per-host install paths and their official sources.
 - Windows users do not need WSL for the basic classroom workflow. Use WSL only for advanced reproducible Linux toolchains.
 

--- a/installers/install.py
+++ b/installers/install.py
@@ -86,38 +86,55 @@ def copy_skills(target: str, dest: Path, log_lines: list[str], dry_run: bool) ->
 
 
 def install_cursor_rule(project: Path, log_lines: list[str], dry_run: bool) -> None:
-    rules_dir = project / ".cursor" / "rules"
-    rule_path = rules_dir / "medsci-skills.mdc"
-    body = f"""---
+    """Write the optional Cursor steering rule into <project>/.cursor/rules/medsci-skills.mdc.
+
+    Two things this deliberately does NOT do any more:
+
+    * It does not embed the repository path. `.cursor/rules/` is a directory people commit, and the
+      absolute path of a home directory is the installer's name, so it travelled into shared repos.
+      It was also pointing at the wrong place: per docs/host_compatibility.md this rule is legacy
+      for discovery -- Cursor reads `~/.claude/skills/` and `~/.agents/skills/` directly -- so the
+      rule steers, and the skills are found where they are installed rather than in a checkout.
+    * It does not call `Path.write_text`, which opens in "w" mode and truncates before writing. This
+      file is ours to replace, but a half-written one after an interrupt is nobody's.
+    """
+    rule_path = project / ".cursor" / "rules" / "medsci-skills.mdc"
+    body = """---
 description: Use MedSci Skills for medical research writing, literature search, statistics, figures, and submission workflows.
 alwaysApply: false
 ---
 
 # MedSci Skills
 
-When the user asks for medical research workflows, inspect the relevant
-`skills/<skill-name>/SKILL.md` file in this repository before acting.
+This file is written by the MedSci Skills installer and is replaced whenever it runs.
+
+When the user asks for a medical research workflow, use the installed MedSci skill rather than
+answering from scratch. Cursor reads them from `~/.claude/skills/` and `~/.agents/skills/`; open the
+relevant `<skill-name>/SKILL.md` before acting.
 
 Start with these entry points:
 
-- `skills/search-lit/SKILL.md` for literature search and verified citations
-- `skills/analyze-stats/SKILL.md` for statistical tables and analysis code
-- `skills/make-figures/SKILL.md` for publication figures
-- `skills/write-paper/SKILL.md` for manuscript sections
-- `skills/check-reporting/SKILL.md` for reporting guideline audits
+- `orchestrate` — unsure which one fits; it classifies the request and routes
+- `search-lit` — literature search and verified citations
+- `analyze-stats` — statistical tables and analysis code
+- `make-figures` — publication figures
+- `write-paper` — manuscript sections
+- `check-reporting` — reporting-guideline audits
 
-Use small single-skill tasks first. Avoid running the full end-to-end pipeline
-unless the user explicitly asks and provides the required project files.
-
-Repository path:
-`{REPO_ROOT}`
+Prefer small single-skill tasks. Do not run the full end-to-end pipeline unless the user asks for it
+and provides the required project files.
 """
     log(f"\n[cursor] writing project rule to {rule_path}", log_lines)
     if dry_run:
         log("  DRY RUN write Cursor rule", log_lines)
         return
-    rules_dir.mkdir(parents=True, exist_ok=True)
-    rule_path.write_text(body, encoding="utf-8")
+    prev_mode = os.stat(rule_path).st_mode & 0o777 if rule_path.is_file() else None
+    medsci_txn.atomic_write_bytes(rule_path, body.encode("utf-8"))
+    if prev_mode is not None:
+        try:
+            os.chmod(rule_path, prev_mode)
+        except OSError:
+            pass
     log("  installed Cursor project rule", log_lines)
 
 

--- a/installers/tests/test_cursor_rule.py
+++ b/installers/tests/test_cursor_rule.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""`.cursor/rules/medsci-skills.mdc` is written into a project folder, and that folder is usually a
+git repository. So the two properties worth testing are the ones that survive a `git add`: the file
+must carry nothing machine-specific, and writing it must not be able to leave a half-written file
+behind.
+
+The version this replaces embedded `REPO_ROOT` -- the absolute path of the installing user's home
+directory -- and wrote with `Path.write_text`, which opens in "w" mode and truncates first.
+
+Every case runs in a TemporaryDirectory. Nothing outside it is read or written.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import install  # noqa: E402
+import medsci_txn  # noqa: E402
+
+FAIL: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    print(f"{'PASS' if cond else 'FAIL'}  {label}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAIL.append(label)
+
+
+def run() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        proj = Path(td) / "project"
+        proj.mkdir()
+        rule = proj / ".cursor" / "rules" / "medsci-skills.mdc"
+
+        install.install_cursor_rule(proj, [], dry_run=False)
+        check("rule written", rule.is_file())
+        body = rule.read_text(encoding="utf-8")
+
+        # The reason this test exists. `.cursor/rules/` gets committed; a home path in it is the
+        # installer's name travelling into a shared repository.
+        check("no home path in the rule",
+              "/Users/" not in body and "/home/" not in body and "C:\\" not in body,
+              body[:200])
+        check("no repository path in the rule", str(install.REPO_ROOT) not in body)
+        # It must still be a usable Cursor rule, not just an empty file that passes the scan.
+        check("frontmatter intact", body.startswith("---") and "alwaysApply:" in body)
+        check("points at where Cursor actually reads skills",
+              "~/.claude/skills/" in body and "~/.agents/skills/" in body)
+        check("names orchestrate as the entry point", "orchestrate" in body)
+
+        # Idempotent: a second run produces the same bytes.
+        first = rule.read_bytes()
+        install.install_cursor_rule(proj, [], dry_run=False)
+        check("re-run produces identical bytes", rule.read_bytes() == first)
+
+        # Mode is preserved (POSIX only -- on Windows os.chmod moves the read-only bit and nothing
+        # else, so the assertion could not tell preserved from widened; skipped out loud).
+        if os.name != "posix":
+            print("SKIP  rule mode preserved (POSIX modes are not meaningful on this platform)")
+        else:
+            os.chmod(rule, 0o600)
+            install.install_cursor_rule(proj, [], dry_run=False)
+            check("rule mode preserved", (os.stat(rule).st_mode & 0o777) == 0o600,
+                  oct(os.stat(rule).st_mode & 0o777))
+
+        # An interrupted write must leave the previous file intact, not a truncated one.
+        before = rule.read_bytes()
+        real_replace = medsci_txn.os.replace
+
+        def boom(*_a, **_k):
+            raise OSError("simulated interruption")
+
+        medsci_txn.os.replace = boom
+        try:
+            install.install_cursor_rule(proj, [], dry_run=False)
+            check("interrupted write raises", False, "it returned normally")
+        except OSError:
+            check("interrupted write raises", True)
+        finally:
+            medsci_txn.os.replace = real_replace
+        check("interrupted write left the rule byte-identical", rule.read_bytes() == before)
+        leftovers = sorted(q.name for q in rule.parent.iterdir())
+        check("interrupted write left no temp file behind",
+              leftovers == ["medsci-skills.mdc"], str(leftovers))
+
+        # --dry-run writes nothing at all.
+        proj2 = Path(td) / "dry"
+        proj2.mkdir()
+        install.install_cursor_rule(proj2, [], dry_run=True)
+        check("dry run created nothing", not (proj2 / ".cursor").exists())
+
+    print()
+    if FAIL:
+        print(f"FAILED: {len(FAIL)} — " + "; ".join(FAIL))
+        return 1
+    print("All Cursor-rule checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -48,8 +48,8 @@
     },
     {
       "path": "installers/install.py",
-      "size": 28830,
-      "sha256": "04f51767d3a19f50fe4262252d93248857fb00cb7840b12c7d6a2d83d52d791c"
+      "size": 29970,
+      "sha256": "199df3eee9b08f37b798305496fd994591b15ab18c8594bb0691b6850cfbd432"
     },
     {
       "path": "installers/medsci_txn.py",


### PR DESCRIPTION
Deferred from #510 with an open question attached. The repo's own docs answered it.

## The leak

`install_cursor_rule` wrote `REPO_ROOT` — an absolute path naming whoever ran the installer — into
`<project>/.cursor/rules/medsci-skills.mdc`. **`.cursor/rules/` is a directory people commit**, so a
`--cursor-project` install could carry the installer's home path into a shared repository.

## The open question, answered by `docs/host_compatibility.md:32`

> the optional `.cursor/rules/medsci-skills.mdc` project rule is now **legacy**: Cursor reads
> `~/.claude/skills` and `~/.agents/skills` directly … the rule remains a convenience for
> **steering, not a requirement**

So the path was **not load-bearing** — it pointed at a checkout Cursor never consults, while leaking
something real. That is what made this safe to change rather than a guess. The rule now names the two
locations Cursor actually reads, plus `orchestrate` as the entry point.

## Same truncate-then-write as #510

It also used `Path.write_text`. This file is ours to replace, unlike a `CLAUDE.md`, but a
half-written one after an interrupt is nobody's — it now goes through
`medsci_txn.atomic_write_bytes` and preserves the destination's mode.

## Verification

- `installers/tests/test_cursor_rule.py` — new, wired into **both** the `validate` and
  `foundation-os` jobs
- **4 assertions fail against the previous release.** The load-bearing one is the
  repository-path check: the generic home-path check passes in CI, where the checkout is not under a
  home directory, and would only have fired on a real user's machine — worth naming, because a
  green home-path check here proves less than it looks like it does
- `python3 scripts/run_ci_mirror.py` → **251/251**
- `apply_routing`, `install_claude_routing`, `_write_preserving_mode` and `_dominant_newline`
  verified AST-identical to `main` — only `install_cursor_rule` changed

## One thing worth recording

The first version of this change spliced on the wrong end anchor and **silently deleted
`ROUTING_BEGIN` / `ROUTING_END` / `ROUTING_BLOCK`**, which sat between `install_cursor_rule` and the
next constant. The CI mirror caught it (`NameError`), the definitions were restored verbatim from
`main`, and the four neighbouring functions were then AST-compared against `main` to prove nothing
else had moved. Same shape as the serial-merge hazard already recorded for this repo: a
regex/offset splice that drops a neighbour and still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)