### PR TITLE
fix: complete privacy-example cleanup in v5.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [5.26.1] - 2026-09-05
+
+**Hotfix:** published examples retained manuscript-specific details after the privacy cleanup.
+
+### Fixed
+
+- Complete the privacy cleanup of illustrative cover-letter output and citation-order
+  test data and reference-check commentary with synthetic values and neutral prose.
+  The expected arithmetic
+  and citation-order findings are preserved; no detector behavior changes.
+- This patch supersedes v5.26.0. Existing tags and published package versions remain
+  unchanged.
+
 ## [5.26.0] - 2026-09-05
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.26.0"
+version: "5.26.1"
 date-released: "2026-09-05"
 doi: "10.5281/zenodo.20155321"
 identifiers:

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5468,8 +5468,8 @@
     },
     {
       "path": "skills/sync-submission/SKILL.md",
-      "size": 40770,
-      "sha256": "016b88b1d495a094104d7154724632178751f843623683fb8ebe447735ff5557"
+      "size": 40790,
+      "sha256": "45b228823952b028f0ec8160cd3e457f95b37a0a8fe692a09349a49d1e91054a"
     },
     {
       "path": "skills/sync-submission/references/journal_availability_policy.json",
@@ -5828,8 +5828,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/verify_refs.py",
-      "size": 49238,
-      "sha256": "5e631278ab1b38960d6ba1865cc360855fb2d600024fb67a8e3a9c5a82d5ba9c"
+      "size": 49027,
+      "sha256": "289a91883045bbc38d8e16f65d3e858a106edbb3413ecf6e2d723f353b733362"
     },
     {
       "path": "skills/verify-refs/skill.yml",

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.26.0",
+  "version": "5.26.1",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.26.0",
+  "version": "5.26.1",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",

--- a/skills/self-review/tests/fixtures/citation_order_bad.md
+++ b/skills/self-review/tests/fixtures/citation_order_bad.md
@@ -1,24 +1,21 @@
 # Abstract
 
-We report a cohort study. Baseline characteristics are summarized later.
+This is a synthetic document for testing citation order.
 
 # Methods
 
-The reference tier had zero events by design and enters Table 3 descriptively.
-Number-at-risk tables are provided in Table S4, and the endpoint decomposition in
-Table S9. Baseline characteristics by alternative strata appear in Table S16.
+The planned groups are listed in Table 4. Additional setup information is in
+Table S3, and the variable glossary is in Table S1. The example protocol is in Table S8.
 
 # Results
 
-Of the cohort, the eligible adults are described in Table 1; tier-specific rates
-use the denominator roadmap in Table 2. The discrimination metrics are in Table S12,
-and the exploratory model in Table S6. Five-year incidences are in Table 3, and the
-landmark model in Table 4. The returner comparison is in Table S2.
+Group summaries appear in Table 2 and Table 1. Further summaries are in Table S2
+and Table S6. The final comparison appears in Table 3, with an example in Table S4.
 
 # Discussion
 
-The gradient held across sensitivity analyses S1 through S6 (these are analysis-plan
-labels, not supplementary tables). Schematic in Supplementary Figure S1.
+Sensitivity analyses S1 through S6 are analysis-plan labels, not supplementary tables.
+The schematic appears in Supplementary Figure S1.
 
 # References
 
@@ -26,6 +23,6 @@ labels, not supplementary tables). Schematic in Supplementary Figure S1.
 
 # Figure Legends
 
-**Figure 1.** Cohort flow.
+**Figure 1.** Synthetic flow diagram.
 
-**Figure 2.** Tier-stratified curves; numbers at risk in Table S4.
+**Figure 2.** Example comparison; additional details in Table S3.

--- a/skills/self-review/tests/test_citation_order.sh
+++ b/skills/self-review/tests/test_citation_order.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Regression test for the float citation-ORDER gate (journal technical-check pass).
-# Synthetic, PII-free fixtures: a manuscript whose main Tables (3,1,2,4) and
-# supplementary Tables (S4,S9,S16,S12,S6,S2) are cited out of numerical order, and
+# Synthetic, PII-free fixtures: a manuscript whose main Tables (4,2,1,3) and
+# supplementary Tables (S3,S1,S8,S2,S6,S4) are cited out of numerical order, and
 # a clean manuscript where every series is cited in ascending order (incl. a plural
 # list "Tables S4, S5", a back-matter legends block that must be excluded, and a
 # non-float "S1 through S6" sensitivity label that must NOT be parsed as tables).

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -261,18 +261,18 @@ Body words are matched with a 5% tolerance ("approximately N words"
 phrasing). Abstract words tolerate ±5. Reference / table / figure counts
 require exact match.
 
-Output `qc/cover_letter_drift.json`:
+Example `qc/cover_letter_drift.json` (synthetic values):
 
 ```json
 {
   "submission_safe": false,
-  "truth": {"body_words": 3036, "abstract_words": 319, "references": 12,
+  "truth": {"body_words": 2400, "abstract_words": 210, "references": 10,
             "tables": 3, "figures": 4},
-  "claims": {"body_words": 3790, "abstract_words": 250, "references": 12},
+  "claims": {"body_words": 2800, "abstract_words": 250, "references": 10},
   "drifts": [
-    {"field": "body_words", "truth": 3036, "cover_letter_claim": 3790,
+    {"field": "body_words", "truth": 2400, "cover_letter_claim": 2800,
      "severity": "MAJOR",
-     "note": "|claim - truth| = 754 > tolerance 151"}
+     "note": "|claim - truth| = 400 > tolerance 120"}
   ]
 }
 ```

--- a/skills/verify-refs/scripts/verify_refs.py
+++ b/skills/verify-refs/scripts/verify_refs.py
@@ -735,8 +735,7 @@ def author_cross_check(
     Returns ``(mismatches, notes)``: ``mismatches`` — human-readable mismatch strings
     (empty = clean); ``notes`` — non-mismatch evidence strings (the truncation note).
     This is the sole decision surface behind an AUTHOR MISMATCH status, extracted so
-    the fabricated-co-author path (a real AI-assembled bib once registered 7 of 10
-    fabricated co-author names) has a network-free regression test
+    the fabricated-co-author path has a network-free regression test
     (``tests/test_fabricated_author.sh``). Behaviour is identical to the inline logic
     it replaced in ``verify_record``.
     """
@@ -786,7 +785,7 @@ def verify_record(record: RefRecord, offline: bool, timeout: int,
       1. PubMed efetch (XML full-record) — best (motivation: CrossRef returned a
          wrong given name "Vasileios" vs PubMed efetch authoritative "Victoria";
          also catches AI-generated bib entries with hallucinated #2..#N family
-         names — a real AI-assembled bib registered 7 of 10 fabricated co-author names).
+         names).
       2. CrossRef DOI (fallback when no PMID).
       3. OpenAlex (tertiary; conference proceedings / non-DOI / non-biomedical works
          that PubMed and CrossRef miss — the free analogue of a portal's Scopus pass).
@@ -1037,8 +1036,7 @@ def write_outputs(records: list[RefRecord], project_root: Path, source: Path,
     v1.3.0 (2026-05): full-author cross-check. records[] now carry cited_authors[],
     actual_authors[], and author counts; schema_version bumps to 4. MISMATCH now
     fires on any #2..#N family hallucination or author-count mismatch, not just the
-    first author (motivation: a bib entry with a real first author but 7/10
-    fabricated co-author given names previously passed audit).
+    first author. A correct lead author does not verify the remaining author list.
     """
     qc_dir = project_root / "qc"
     qc_dir.mkdir(parents=True, exist_ok=True)

--- a/skills/verify-refs/tests/test_fabricated_author.sh
+++ b/skills/verify-refs/tests/test_fabricated_author.sh
@@ -3,9 +3,8 @@
 #
 # author_cross_check() is the sole decision surface behind an AUTHOR MISMATCH status
 # (family-by-family + author-count). It is the repo's most trust-critical citation
-# check: a real AI-assembled bib once registered 7 of 10 fabricated co-author names
-# with a correct first author + DOI, and only the family/count cross-check catches
-# that. This test locks the logic so a refactor cannot silently drop the MISMATCH
+# check: a correct first author and DOI can coexist with fabricated co-author
+# names. This test locks the logic so a refactor cannot silently drop the MISMATCH
 # path. Stdlib-only, no network (the pure function is tested in isolation, so no
 # PubMed/CrossRef/OpenAlex call is made).
 set -u


### PR DESCRIPTION
Complete the privacy cleanup of published examples: replace remaining manuscript-specific counts and citation sequences with fresh synthetic data, and remove the related numeric anecdotes from reference-check comments. This hotfix supersedes v5.26.0 without rewriting an existing tag or package version.

The example JSON remains arithmetically consistent and the citation-order fixture still produces the two expected order findings while clean controls pass. Reference-checker executable AST is unchanged after removing docstrings. All 251 local CI-mirror gates pass, including the documented hotfix cadence exemption; no detector behavior or inventory count changes.
