### PR TITLE
fix: honor PDF metadata and select collection font faces

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,10 +27,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python test dependencies
-        run: pip install pyyaml pandas numpy python-pptx python-docx
+        run: pip install pyyaml pandas numpy python-pptx python-docx fonttools
 
-      - name: Install exiftool + poppler (EXIF scan + check_asset_anonymization PDF text/metadata)
-        run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl poppler-utils
+      - name: Install exiftool + poppler + pandoc (artifact and render tests; no TeX)
+        run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl poppler-utils pandoc
 
       - name: "Workflow files parse (a broken one runs ZERO jobs and reports no checks)"
         run: python3 scripts/check_workflow_yaml.py --strict
@@ -411,8 +411,11 @@ jobs:
       - name: Run sync-submission supplement-assembler test (A12)
         run: bash skills/sync-submission/tests/test_assemble_supplement.sh
 
-      - name: Run render-pdf-doc glyph-coverage scan test (A13)
-        run: bash skills/render-pdf-doc/tests/test_glyph_coverage.sh
+      - name: Run render-pdf-doc glyph and render regressions (A13)
+        run: |
+          bash skills/render-pdf-doc/tests/test_glyph_coverage.sh
+          python3 skills/render-pdf-doc/tests/test_font_faces.py
+          python3 skills/render-pdf-doc/tests/test_render_pdf.py
 
       - name: Run author-strategy archetype-classifier test (A14)
         run: bash skills/author-strategy/tests/test_archetype_classifier.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- PDF rendering now honors frontmatter before wrapper/OS defaults for fonts,
+  page geometry, font size, line spacing and link colors. Explicit pandoc overrides
+  remain available. Glyph scans support an explicitly selected TTC/OTC face and
+  report why font coverage could not be checked; different faces are never combined.
+  Synthetic font and pandoc regressions extend the existing render test step.
 - Full-text retrieval no longer treats scattered title words or body/reference mentions
   as a title match. Report schema 2 separates download results from advisory first-page
   title/identifier evidence and records the PDF hash; related versions and incomplete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,9 @@ suite uses synthetic fixtures and needs no private data or network access.
 To run the same gates CI runs, install the test dependencies and run the mirror:
 
 ```bash
-pip install pyyaml pandas numpy python-pptx python-docx
+pip install pyyaml pandas numpy python-pptx python-docx fonttools
+# Also install pandoc, exiftool and poppler with your OS package manager.
+# Render regression tests generate LaTeX with pandoc; CI does not install TeX.
 
 # Runs every gate in the CI `validate` job, in order, locally. The step list is
 # parsed from validate.yml itself, so it can never drift from a hand-copied subset,

--- a/docs/locale_inventory.md
+++ b/docs/locale_inventory.md
@@ -2,7 +2,7 @@
 
 **Status: migration complete (PR1–PR4).** The English-canonical migration has landed — incidental
 Korean prose is translated (PR2) and the Korean-default skills now default to English with opt-in
-`*_ko` variants (PR3). The rows below are the **steady state**: 50 Korean-bearing files, each a
+`*_ko` variants (PR3). The rows below document the Korean-bearing files, each a
 functional locale feature (A), a Korean-jurisdiction mode (A2), a bilingual trigger (D), or an
 opt-in `*_ko`/locale variant. `check_locale_inventory.py --strict` is clean.
 
@@ -64,6 +64,7 @@ Buckets:
 | `skills/define-variables/SKILL.md` | A/D | KNHANES-style dictionary sheet/row example (`5-1.복부초음파 r12`) + bilingual trigger. |
 | `skills/render-pdf-doc/references/pandoc_korean_cheatsheet.md` | A | Korean-PDF rendering reference (the skill renders Korean academic PDFs). +label in PR3. |
 | `skills/render-pdf-doc/references/known_pitfalls.md` | A | Korean-PDF rendering failure-mode demonstrations. +label in PR3. |
+| `skills/render-pdf-doc/tests/test_font_faces.py` | A | Synthetic Hangul glyphs distinguish CJK coverage from Greek coverage across font collection faces. |
 
 ## KEEP — Korean-domain mode (Bucket A2)
 

--- a/docs/skills/render-pdf-doc.md
+++ b/docs/skills/render-pdf-doc.md
@@ -22,13 +22,16 @@
 **Known limitations**
 
 - Output fidelity depends on installed render dependencies (checked by check_deps.sh).
+- Glyph scans cover selected risky classes in one font face; final PDF rendering requires visual verification.
 - Institutional Word forms are out of scope (use fill-protocol).
 
 **Validation**
 
 - `bash scripts/check_deps.sh`
-- `bash scripts/render_pdf.sh <manuscript.md>`
+- `bash scripts/render_pdf.sh -i <manuscript.md>`
 - `bash tests/test_glyph_coverage.sh`
+- `python3 tests/test_font_faces.py`
+- `python3 tests/test_render_pdf.py`
 
 **Evidence** — `bundled_script`
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -4153,8 +4153,8 @@
     },
     {
       "path": "skills/render-pdf-doc/SKILL.md",
-      "size": 9236,
-      "sha256": "97af21fac95af6dcd0e47bc6a547f6413f47d431c74d310174899c36cb86da17"
+      "size": 10667,
+      "sha256": "cb3856e4b0aefb6dd0f038a7c8389620c4b933d381d7ff6f653c1f5246abb16a"
     },
     {
       "path": "skills/render-pdf-doc/references/known_pitfalls.md",
@@ -4168,8 +4168,8 @@
     },
     {
       "path": "skills/render-pdf-doc/scripts/check_deps.sh",
-      "size": 2183,
-      "sha256": "782efdda541c0a84a8d978bb076d43a1d3a026a00b878205dd6d922a197186f6"
+      "size": 2218,
+      "sha256": "587b5890f82890a95647fb7f8b764f8f1c559c2c2806796387b88cfa90c803a7"
     },
     {
       "path": "skills/render-pdf-doc/scripts/infer_colwidths.py",
@@ -4178,18 +4178,18 @@
     },
     {
       "path": "skills/render-pdf-doc/scripts/render_pdf.sh",
-      "size": 3958,
-      "sha256": "b5a9ebcbb25b1ec85577c9864f60f4f363e90f88896903cff48f7626f5b6b95a"
+      "size": 4711,
+      "sha256": "0892681945d7599ca5c4dc5411297f8904a8595efe8f7401004c3dac06d68764"
     },
     {
       "path": "skills/render-pdf-doc/scripts/scan_glyph_coverage.py",
-      "size": 6602,
-      "sha256": "09415f60ef9fd96e4baee36bcd38da36dde604baf0656c436cde9f75fb001a17"
+      "size": 9266,
+      "sha256": "4795edba22e36e1ca28e30588f696628e203a573862e066961648896b7f6699d"
     },
     {
       "path": "skills/render-pdf-doc/skill.yml",
-      "size": 3133,
-      "sha256": "77fe112e5a013d3169290132f9882fbb05b3ebe9317729960582895509c21568"
+      "size": 3329,
+      "sha256": "3d7f542a2fe9a5d0de2e2e462f4177f68424dfbdc6f34a69758d847a954752cd"
     },
     {
       "path": "skills/render-pdf-doc/templates/anchor-doc.md",

--- a/skills/render-pdf-doc/SKILL.md
+++ b/skills/render-pdf-doc/SKILL.md
@@ -44,6 +44,9 @@ Manual fixes work but the same pattern recurs across proposals, briefings, IRB c
 
 ## Dependencies
 
+Python 3 is required by the wrapper. FontTools is optional for the font-file
+coverage check (`python3 -m pip install fonttools`).
+
 ```bash
 # macOS
 brew install pandoc
@@ -69,7 +72,7 @@ so `xelatex` can read as `[MISS]` even after install. Both `check_deps.sh` and
 `render_pdf.sh` now auto-probe that location; if `xelatex` still isn't found, add the
 directory to your `PATH` (or run from the *MiKTeX Console → Settings*-configured shell).
 The Windows CJK/main font default is **Malgun Gothic** (preinstalled); override per document
-via frontmatter, or with `--font` / `--cjk-font`.
+via frontmatter, or set fallbacks with `--font` / `--cjk-font`.
 
 ## Workflow
 
@@ -116,10 +119,16 @@ Or one-shot:
 bash scripts/render_pdf.sh -i input.md -o output.pdf --infer-colwidths
 ```
 
+Frontmatter wins over wrapper defaults, including `--font` / `--cjk-font`.
+Missing fields use the wrapper or OS defaults. This also applies to `geometry`,
+`fontsize`, `linestretch` and `colorlinks` (including `false`). Explicit pandoc
+`-V` / `-M` arguments after `--` still override frontmatter; for example,
+`-- -V fontsize=10pt`. The wrapper logs font **fallbacks**, not the final fonts.
+
 ### Step 3.5 — Scientific-symbol + CJK glyph scan (before render)
 
-xelatex **silently drops** any character the chosen font does not cover — the PDF
-renders with the glyph simply missing, no error or warning. Academic markdown
+xelatex can finish successfully with missing glyphs; warnings may appear in the
+render log. Academic markdown
 routinely carries glyphs a default Latin font misses: transition arrows (→ ↑ ↓),
 math operators (− ≤ ≥ ± √ ∪ × ≈ ≠), stats Greek (κ μ σ β), bullets/marks (• ★ ✓),
 and CJK. Scan the source first so a silent drop is caught before it ships:
@@ -128,10 +137,24 @@ and CJK. Scan the source first so a silent drop is caught before it ships:
 python3 scripts/scan_glyph_coverage.py input.md --strict
 # real cmap check when you have the font file + fonttools:
 python3 scripts/scan_glyph_coverage.py input.md --font "/path/to/body.otf" --strict
+# TTC/OTC collections require the zero-based face index used by the renderer:
+python3 scripts/scan_glyph_coverage.py input.md --font "/path/to/body.ttc" --font-index 0 --strict --json glyphs.json
 ```
 
 It groups the risky glyphs by class (advisory), or — with `--font` + `fonttools`
-— reports which are genuinely absent from the font's cmap. If risky glyphs are
+— reports which are absent from one face's preferred Unicode cmap. It never
+combines coverage across collection faces. The report includes the selected
+face index and PostScript name; choose the face that matches the rendered font.
+A missing dependency, unreadable font, missing face selection or invalid index
+is reported as `font_checked: false` with a reason in `font_check`.
+An empty `missing_in_font` list then means **unverified**, not full coverage.
+The default mode remains advisory (exit 0); `--strict` exits 1 when risky glyphs
+are unverified or missing. ASCII-only input still exits 0 with an unavailable
+font, with `font_checked: false` visible.
+
+This checks only the listed risky character classes and the selected cmap;
+it does not verify shaping, fallback fonts, math fonts or final PDF glyphs.
+If risky glyphs are
 present, ensure `mainfont`/`CJKmainfont` cover them (a CJK-capable font such as
 *Apple SD Gothic Neo* / *Noto Sans CJK* usually covers arrows + Hangul but can
 still miss the true-minus `−` U+2212 and `★`). **The DOCX is authoritative; the

--- a/skills/render-pdf-doc/scripts/check_deps.sh
+++ b/skills/render-pdf-doc/scripts/check_deps.sh
@@ -36,6 +36,7 @@ esac
 
 check "pandoc" command -v pandoc
 check "xelatex" command -v xelatex
+check "python3" command -v python3
 
 case "$(uname -s)" in
   Darwin)

--- a/skills/render-pdf-doc/scripts/render_pdf.sh
+++ b/skills/render-pdf-doc/scripts/render_pdf.sh
@@ -12,7 +12,8 @@
 #   - Output path = <input>.pdf
 #   - geometry = margin=0.85in, fontsize = 11pt (override via frontmatter)
 #
-# The frontmatter in input.md takes precedence over CLI/auto-detected defaults.
+# Frontmatter overrides wrapper/OS defaults. Explicit pandoc -V/-M arguments
+# after -- retain pandoc's normal precedence over frontmatter.
 
 set -euo pipefail
 
@@ -33,8 +34,8 @@ Options:
   -i  Input markdown
   -o  Output PDF (default: <input>.pdf)
   --infer-colwidths     Run scripts/infer_colwidths.py on a temp copy first
-  --font NAME           mainfont (default: OS-detected)
-  --cjk-font NAME       CJKmainfont (default: OS-detected)
+  --font NAME           mainfont fallback when absent from frontmatter (default: OS-detected)
+  --cjk-font NAME       CJKmainfont fallback when absent from frontmatter (default: OS-detected)
   -h | --help           Help
 
 Pass-through: any args after '--' go directly to pandoc.
@@ -99,27 +100,40 @@ esac
 
 command -v pandoc >/dev/null || { echo "ERROR: pandoc not installed" >&2; exit 3; }
 command -v xelatex >/dev/null || { echo "ERROR: xelatex not installed (install mactex / texlive-xetex / MiKTeX)" >&2; exit 3; }
+command -v python3 >/dev/null || { echo "ERROR: python3 not installed" >&2; exit 3; }
 
 WORK="$INPUT"
-TMPDIR=""
+RENDER_TMP="$(mktemp -d)"
+trap 'rm -rf "$RENDER_TMP"' EXIT
 if [[ "$INFER_COLWIDTHS" == "1" ]]; then
-  TMPDIR="$(mktemp -d)"
-  trap 'rm -rf "$TMPDIR"' EXIT
-  WORK="$TMPDIR/$(basename "$INPUT")"
+  WORK="$RENDER_TMP/$(basename "$INPUT")"
   python3 "$SCRIPT_DIR/infer_colwidths.py" "$INPUT" --out "$WORK"
 fi
 
+# --metadata-file supplies defaults that document metadata can override. -V,
+# -M, and a --defaults file's metadata would override the document instead.
+# JSON is accepted by pandoc; serialize arguments without interpolating code.
+python3 - "$MAINFONT" "$CJKFONT" > "$RENDER_TMP/metadata.json" <<'PY'
+import json
+import sys
+
+json.dump({
+    "mainfont": sys.argv[1],
+    "CJKmainfont": sys.argv[2],
+    "geometry": "margin=0.85in",
+    "fontsize": "11pt",
+    "linestretch": "1.25",
+    "colorlinks": True,
+}, sys.stdout)
+PY
+
 ARGS=(
   --pdf-engine=xelatex
-  -V "mainfont=${MAINFONT}"
-  -V "CJKmainfont=${CJKFONT}"
-  -V "geometry:margin=0.85in"
-  -V "fontsize=11pt"
-  -V "linestretch=1.25"
-  -V "colorlinks=true"
+  --metadata-file "$RENDER_TMP/metadata.json"
   -o "$OUTPUT"
 )
 
-echo "[render_pdf] in=$INPUT out=$OUTPUT mainfont='$MAINFONT' CJK='$CJKFONT' infer=$INFER_COLWIDTHS" >&2
+echo "[render_pdf] in=$INPUT out=$OUTPUT infer=$INFER_COLWIDTHS" >&2
+echo "[render_pdf] font fallbacks: mainfont='$MAINFONT' CJK='$CJKFONT'; frontmatter overrides fallbacks, explicit pandoc -V/-M overrides frontmatter" >&2
 pandoc "${ARGS[@]}" ${EXTRA[@]+"${EXTRA[@]}"} "$WORK"
 echo "[render_pdf] ok → $OUTPUT" >&2

--- a/skills/render-pdf-doc/scripts/scan_glyph_coverage.py
+++ b/skills/render-pdf-doc/scripts/scan_glyph_coverage.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Scientific-symbol + CJK glyph-coverage scanner for xelatex PDF builds.
 
-xelatex **silently drops** a character the chosen font does not cover — the PDF
-renders with the glyph simply missing, no error. Academic markdown routinely
+xelatex can finish successfully with missing glyphs (warnings may be in the log).
+Academic markdown routinely
 carries glyphs a default Latin font misses: transition arrows (→ ↑ ↓ ↔), math
 operators (− ≤ ≥ ± √ ∪ × ≈ ≠), stats Greek (κ μ σ β χ), bullets/marks (• ★ ✓),
 and CJK. This scans the SOURCE markdown, groups the risky non-ASCII glyphs it
@@ -15,14 +15,16 @@ derive_) so the catalog glob does not count it; it is a render-time QA helper.
 
 INPUT
   markdown   one or more .md files (positional).
-  --font     optional path to the .ttf/.otf that will render the body; with
+  --font     optional path to the .ttf/.otf/.ttc/.otc that will render the body; with
              `fonttools` installed, glyphs absent from its cmap are reported as
              MISSING (the real coverage check). Without it, the scan is advisory
              (presence by class — verify your mainfont/CJKmainfont covers them).
+  --font-index  required zero-based face index for a collection; one face is
+                checked, never the union of different faces' glyphs.
 
 OUTPUT
   stdout report and, with --json, an artifact:
-    {files, classes{name:[chars]}, missing_in_font[], summary}
+    {files, classes{name:[chars]}, font_checked, font_check, missing_in_font[], summary}
   Exit 1 (with --strict) when risky glyphs are present AND no font verified them,
   or when --font is given and any glyph is genuinely missing from it.
 
@@ -34,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import struct
 import sys
 import unicodedata
 from pathlib import Path
@@ -81,47 +84,85 @@ def scan(paths: list[Path]) -> dict:
     return {"classes": classes, "chars": sorted(all_chars)}
 
 
-def font_missing(chars: list[str], font_path: Path) -> tuple[list[str], bool]:
-    """Return (missing_chars, checked). checked=False if fonttools/font unavailable."""
+def check_font(chars: list[str], font_path: Path, font_index: int | None = None) -> dict:
+    """Inspect one face's preferred Unicode cmap; an unavailable check is explicit.
+
+    Cmap coverage does not establish shaping, fallback-font selection, or whether
+    the renderer used this font. Inspect the rendered PDF separately.
+    """
+    result = {"status": "unavailable", "reason": None, "face_index": font_index,
+              "face_name": None, "n_faces": None, "missing": []}
     try:
         from fontTools.ttLib import TTFont  # type: ignore
-    except Exception:
-        return [], False
-    if not font_path.is_file():
-        sys.stderr.write(f"WARN: --font not found: {font_path}\n")
-        return [], False
+    except ImportError:
+        return dict(result, reason="fonttools_unavailable")
     try:
-        font = TTFont(str(font_path))
-        cmap = set()
-        for t in font["cmap"].tables:
-            cmap.update(t.cmap.keys())
-    except Exception as e:
-        sys.stderr.write(f"WARN: could not read font cmap: {e}\n")
-        return [], False
-    return [c for c in chars if ord(c) not in cmap], True
+        with font_path.open("rb") as source:
+            header = source.read(12)
+        collection = header[:4] == b"ttcf"
+        n_faces = struct.unpack(">I", header[8:12])[0] if collection else 1
+        result["n_faces"] = n_faces
+        if collection and font_index is None:
+            return dict(result, reason="face_selection_required")
+        face_index = 0 if font_index is None else font_index
+        if not 0 <= face_index < n_faces:
+            return dict(result, reason="font_index_out_of_range")
+        result["face_index"] = face_index
+        with TTFont(str(font_path), fontNumber=face_index, lazy=True) as font:
+            cmap = font.getBestCmap()
+            if cmap is None:
+                return dict(result, reason="unicode_cmap_unavailable")
+            if "name" in font:
+                result["face_name"] = (font["name"].getDebugName(6)
+                                       or font["name"].getDebugName(4))
+            missing = [c for c in chars if cmap.get(ord(c), ".notdef") == ".notdef"]
+    except FileNotFoundError:
+        return dict(result, reason="font_not_found")
+    except Exception:
+        return dict(result, reason="font_unreadable")
+    return dict(result, status="checked", missing=missing)
+
+
+def font_missing(chars: list[str], font_path: Path,
+                 font_index: int | None = None) -> tuple[list[str], bool]:
+    """Compatibility wrapper returning (missing_chars, checked)."""
+    result = check_font(chars, font_path, font_index)
+    return result["missing"], result["status"] == "checked"
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Scientific-symbol + CJK glyph-coverage scanner.")
     ap.add_argument("markdown", nargs="+", help="markdown file(s) to scan")
-    ap.add_argument("--font", help="path to body font (.ttf/.otf) — checks real cmap if fonttools present")
+    ap.add_argument("--font", help="font file (.ttf/.otf/.ttc/.otc); fonttools required for cmap check")
+    ap.add_argument("--font-index", type=int, help="zero-based face index (required for collections)")
     ap.add_argument("--json", help="write JSON artifact")
     ap.add_argument("--strict", action="store_true",
                     help="exit 1 if risky glyphs are present and unverified, or genuinely missing from --font")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args()
+    if args.font_index is not None and (not args.font or args.font_index < 0):
+        ap.error("--font-index requires --font and a nonnegative integer")
 
     res = scan([Path(m) for m in args.markdown])
     classes = res["classes"]
-    missing, checked = ([], False)
+    font_check = {"status": "not_requested", "reason": "no_font_supplied",
+                  "face_index": None, "face_name": None, "n_faces": None, "missing": []}
     if args.font:
-        missing, checked = font_missing(res["chars"], Path(args.font))
+        font_check = check_font(res["chars"], Path(args.font), args.font_index)
+    missing = font_check.pop("missing")
+    checked = font_check["status"] == "checked"
+    if args.font and not checked:
+        sys.stderr.write(f"WARN: font_checked=false: {font_check['reason']}\n")
+        if font_check["reason"] == "face_selection_required":
+            sys.stderr.write(f"Select --font-index 0..{font_check['n_faces'] - 1} "
+                             "to match the face used by the renderer.\n")
 
     n_risky = sum(sum(d.values()) for d in classes.values())
     out = {
         "files": args.markdown,
         "classes": {k: sorted(v) for k, v in classes.items()},
         "font_checked": checked,
+        "font_check": font_check,
         "missing_in_font": sorted(missing),
         "summary": {"n_risky_glyphs": n_risky, "n_classes": len(classes),
                     "n_missing_in_font": len(missing)},
@@ -137,11 +178,14 @@ def main() -> int:
         if not classes:
             print("  (no risky non-ASCII glyphs found)")
         if checked:
+            print(f"\nfont face {font_check['face_index']}: {font_check['face_name'] or '(unnamed)'}")
             print(f"\nfont cmap checked: {len(missing)} glyph(s) MISSING from the font"
                   + (f": {' '.join(missing)}" if missing else ""))
         elif classes:
             print("\nADVISORY: risky glyphs present; verify mainfont/CJKmainfont cover them "
                   "(pass --font with fonttools for a real cmap check). DOCX is authoritative.")
+        if not checked:
+            print(f"\nfont_checked=false ({font_check['reason']})")
 
     if args.json:
         Path(args.json).parent.mkdir(parents=True, exist_ok=True)

--- a/skills/render-pdf-doc/skill.yml
+++ b/skills/render-pdf-doc/skill.yml
@@ -51,9 +51,12 @@ safety_boundaries:
   - "Does not hand-type CSV data into tables (numerical-safety)."
 known_limitations:
   - "Output fidelity depends on installed render dependencies (checked by check_deps.sh)."
+  - "Glyph scans cover selected risky classes in one font face; final PDF rendering requires visual verification."
   - "Institutional Word forms are out of scope (use fill-protocol)."
 validation_commands:
   - "bash scripts/check_deps.sh"
-  - "bash scripts/render_pdf.sh <manuscript.md>"
+  - "bash scripts/render_pdf.sh -i <manuscript.md>"
   - "bash tests/test_glyph_coverage.sh"
+  - "python3 tests/test_font_faces.py"
+  - "python3 tests/test_render_pdf.py"
 evidence_surface: bundled_script

--- a/skills/render-pdf-doc/tests/test_font_faces.py
+++ b/skills/render-pdf-doc/tests/test_font_faces.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Synthetic TTF, CFF/OTF and TTC regressions; no system fonts or network needed."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from fontTools.fontBuilder import FontBuilder
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+from fontTools.ttLib import TTCollection, TTFont
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/scan_glyph_coverage.py"
+
+
+def build_font(path, chars, name, cff=False):
+    builder = FontBuilder(1000, isTTF=not cff)
+    mapping = {ord(c): f"uni{ord(c):04X}" for c in chars}
+    order = [".notdef", *mapping.values()]
+    builder.setupGlyphOrder(order)
+    builder.setupCharacterMap(mapping)
+    glyphs = {}
+    for glyph in order:
+        pen = T2CharStringPen(600, None) if cff else TTGlyphPen(None)
+        pen.moveTo((50, 0))
+        pen.lineTo((550, 0))
+        pen.lineTo((550, 700))
+        pen.closePath()
+        glyphs[glyph] = pen.getCharString() if cff else pen.glyph()
+    if cff:
+        builder.setupCFF(name, {"FullName": name, "FamilyName": name,
+                               "Weight": "Regular"}, glyphs, {})
+    else:
+        builder.setupGlyf(glyphs)
+    builder.setupHorizontalMetrics({g: (600, 50) for g in order})
+    builder.setupHorizontalHeader(ascent=800, descent=-200)
+    builder.setupNameTable({"familyName": name, "styleName": "Regular",
+                            "psName": name, "fullName": name})
+    builder.setupOS2(sTypoAscender=800, sTypoDescender=-200,
+                    usWinAscent=800, usWinDescent=200)
+    builder.setupPost()
+    builder.setupMaxp()
+    builder.save(path)
+
+
+class FontFaces(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        build_font(self.root / "greek.ttf", "κ", "SyntheticGreek")
+        build_font(self.root / "cjk.ttf", "가", "SyntheticCJK")
+        build_font(self.root / "both.otf", "κ가", "SyntheticBoth", cff=True)
+        with TTCollection() as collection:
+            collection.fonts = [TTFont(self.root / "greek.ttf"),
+                                TTFont(self.root / "cjk.ttf")]
+            collection.save(self.root / "faces.ttc")
+
+    def run_scan(self, font=None, index=None, text="κ가", strict=True, no_site=False):
+        source = self.root / "source.md"
+        source.write_text(text, encoding="utf-8")
+        report = self.root / "report.json"
+        args = [sys.executable, *(["-S"] if no_site else []), str(SCRIPT),
+                str(source), "--json", str(report), "--quiet"]
+        if strict:
+            args += ["--strict"]
+        if font:
+            args += ["--font", str(self.root / font)]
+        if index is not None:
+            args += ["--font-index", str(index)]
+        result = subprocess.run(args, capture_output=True, text=True)
+        return result, json.loads(report.read_text())
+
+    def test_standalone_ttf_missing_and_covered(self):
+        result, report = self.run_scan("greek.ttf")
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertTrue(report["font_checked"])
+        self.assertEqual(report["missing_in_font"], ["가"])
+        self.assertEqual(report["font_check"]["face_name"], "SyntheticGreek")
+        self.assertEqual(self.run_scan("greek.ttf", text="κ")[0].returncode, 0)
+
+    def test_real_cff_otf(self):
+        self.assertEqual((self.root / "both.otf").read_bytes()[:4], b"OTTO")
+        result, report = self.run_scan("both.otf")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(report["font_checked"])
+        self.assertEqual(report["missing_in_font"], [])
+
+    def test_collection_never_unions_faces(self):
+        for index, missing, name in [(0, "가", "SyntheticGreek"), (1, "κ", "SyntheticCJK")]:
+            with self.subTest(index=index):
+                result, report = self.run_scan("faces.ttc", index)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertTrue(report["font_checked"])
+                self.assertEqual(report["missing_in_font"], [missing])
+                self.assertEqual(report["font_check"]["face_index"], index)
+                self.assertEqual(report["font_check"]["face_name"], name)
+                self.assertEqual(report["font_check"]["n_faces"], 2)
+        self.assertEqual(self.run_scan("faces.ttc", 0, text="κ")[0].returncode, 0)
+        self.assertEqual(self.run_scan("faces.ttc", 1, text="κ")[0].returncode, 1)
+
+    def test_face_selection_required_even_if_file_renamed(self):
+        (self.root / "renamed.bin").write_bytes((self.root / "faces.ttc").read_bytes())
+        for filename in ("faces.ttc", "renamed.bin"):
+            result, report = self.run_scan(filename)
+            self.assertEqual(result.returncode, 1)
+            self.assertFalse(report["font_checked"])
+            self.assertEqual(report["font_check"]["reason"], "face_selection_required")
+            self.assertIn("font_checked=false", result.stderr)
+            self.assertIn("--font-index 0..1", result.stderr)
+
+    def test_bad_index_cannot_silently_select_another_face(self):
+        for filename, index in [("faces.ttc", 2), ("greek.ttf", 1)]:
+            result, report = self.run_scan(filename, index)
+            self.assertEqual(result.returncode, 1)
+            self.assertFalse(report["font_checked"])
+            self.assertEqual(report["font_check"]["reason"], "font_index_out_of_range")
+
+    def test_missing_corrupt_and_truncated_fonts(self):
+        (self.root / "corrupt.ttf").write_bytes(b"not a font")
+        (self.root / "truncated.ttc").write_bytes(b"ttcf")
+        for filename, reason in [("absent.ttf", "font_not_found"),
+                                 ("corrupt.ttf", "font_unreadable"),
+                                 ("truncated.ttc", "font_unreadable")]:
+            result, report = self.run_scan(filename)
+            self.assertEqual(result.returncode, 1)
+            self.assertFalse(report["font_checked"])
+            self.assertEqual(report["font_check"]["reason"], reason)
+
+    def test_missing_fonttools_has_machine_readable_reason(self):
+        result, report = self.run_scan("greek.ttf", no_site=True)
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(report["font_checked"])
+        self.assertEqual(report["font_check"]["reason"], "fonttools_unavailable")
+
+    def test_no_unicode_cmap_is_unavailable(self):
+        with TTFont(self.root / "greek.ttf") as font:
+            font["cmap"].tables = []
+            font.save(self.root / "no-cmap.ttf")
+        result, report = self.run_scan("no-cmap.ttf")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["font_check"]["reason"], "unicode_cmap_unavailable")
+        self.assertFalse(report["font_checked"])
+
+    def test_preferred_unicode_cmap_not_union_of_subtables(self):
+        with TTFont(self.root / "greek.ttf") as font:
+            for table in font["cmap"].tables:
+                if table.platformID == 3:
+                    table.cmap = {}
+            font.save(self.root / "conflicting-cmaps.ttf")
+        result, report = self.run_scan("conflicting-cmaps.ttf", text="κ")
+        self.assertEqual(result.returncode, 1)
+        self.assertTrue(report["font_checked"])
+        self.assertEqual(report["missing_in_font"], ["κ"])
+
+    def test_advisory_and_plain_ascii_exit_contract(self):
+        self.assertEqual(self.run_scan()[0].returncode, 1)
+        self.assertEqual(self.run_scan(text="ASCII only")[0].returncode, 0)
+        result, report = self.run_scan("faces.ttc", strict=False)
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(report["font_checked"])
+        result, report = self.run_scan("faces.ttc", text="ASCII only")
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(report["font_checked"])
+
+    def test_index_usage_errors(self):
+        for args in [("--font-index", "0"),
+                     ("--font", "unused.ttf", "--font-index", "-1")]:
+            result = subprocess.run([sys.executable, str(SCRIPT), "unused.md", *args],
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--font-index requires", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/render-pdf-doc/tests/test_render_pdf.py
+++ b/skills/render-pdf-doc/tests/test_render_pdf.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Exercise wrapper precedence through real pandoc LaTeX output, without TeX.
+
+A failing xelatex stub satisfies the wrapper's dependency lookup. It must never
+execute: these tests stop at LaTeX generation; they do not certify a rendered PDF.
+"""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/render_pdf.sh"
+FRONTMATTER = '''---
+mainfont: Frontmatter Body
+CJKmainfont: Frontmatter CJK
+geometry:
+  - paperwidth=180mm
+  - paperheight=240mm
+  - margin=30mm
+fontsize: 12pt
+linestretch: 1.6
+colorlinks: false
+---
+
+Body text.
+
+| Label | Longer description |
+|-------|--------------------|
+| A | Some example content |
+'''
+
+
+class RenderPrecedence(unittest.TestCase):
+    def setUp(self):
+        self.assertIsNotNone(shutil.which("pandoc"), "Install pandoc to run render regressions")
+        self.temp = tempfile.TemporaryDirectory(prefix="render test ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        stub = self.bin / "xelatex"
+        stub.write_text("#!/bin/sh\necho 'ERROR: TeX must not execute in this test' >&2\nexit 93\n")
+        stub.chmod(0o755)
+        self.transient = self.root / "transient"
+        self.transient.mkdir()
+        self.env = dict(os.environ, PATH=str(self.bin) + os.pathsep + os.environ["PATH"],
+                        TMPDIR=str(self.transient))
+
+    def render(self, text, wrapper=(), extra=()):
+        source = self.root / "input file.md"
+        source.write_text(text, encoding="utf-8")
+        original = source.read_bytes()
+        output = self.root / "output file.tex"
+        result = subprocess.run(["bash", str(SCRIPT), "-i", str(source), "-o", str(output),
+                                 *wrapper, "--", "-s", "-t", "latex", *extra],
+                                env=self.env, capture_output=True, text=True)
+        self.assertEqual(source.read_bytes(), original, "Source bytes must be preserved")
+        self.assertEqual(list(self.transient.iterdir()), [], "Temporary files must be removed")
+        return result, output.read_text() if output.exists() else ""
+
+    def assert_frontmatter(self, tex):
+        self.assertIn("12pt,", tex)
+        self.assertIn(r"\setmainfont[]{Frontmatter Body}", tex)
+        self.assertIn(r"\setCJKmainfont[]{Frontmatter CJK}", tex)
+        self.assertIn(r"\usepackage[paperwidth=180mm,paperheight=240mm,margin=30mm]{geometry}", tex)
+        self.assertIn(r"\setstretch{1.6}", tex)
+        self.assertNotIn("colorlinks=true", tex)
+        self.assertNotIn("margin=0.85in", tex)
+        self.assertNotIn("Fallback Body", tex)
+
+    def test_frontmatter_beats_wrapper_and_os_defaults(self):
+        for wrapper in [(), ("--font", "Fallback Body", "--cjk-font", "Fallback CJK")]:
+            with self.subTest(wrapper=wrapper):
+                result, tex = self.render(FRONTMATTER, wrapper)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assert_frontmatter(tex)
+                self.assertIn("font fallbacks:", result.stderr)
+
+    def test_defaults_fill_missing_metadata(self):
+        result, tex = self.render("Body text.\n", ("--font", "Fallback Body", "--cjk-font", "Fallback CJK"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for value in ("11pt,", r"\setmainfont[]{Fallback Body}",
+                      r"\setCJKmainfont[]{Fallback CJK}", "margin=0.85in",
+                      r"\setstretch{1.25}", "colorlinks=true"):
+            self.assertIn(value, tex)
+
+    def test_partial_frontmatter_keeps_other_defaults(self):
+        result, tex = self.render("---\nfontsize: 12pt\n---\n\nBody.\n",
+                                  ("--font", "Fallback Body", "--cjk-font", "Fallback CJK"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("12pt,", tex)
+        self.assertIn(r"\setmainfont[]{Fallback Body}", tex)
+        self.assertIn("margin=0.85in", tex)
+
+    def test_explicit_pandoc_arguments_still_override(self):
+        result, tex = self.render(FRONTMATTER, extra=("-V", "mainfont=Explicit Body",
+            "-V", "CJKmainfont=Explicit CJK", "-V", "fontsize=10pt",
+            "-V", "geometry=margin=20mm", "-M", "linestretch=1.1"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for value in (r"\setmainfont[]{Explicit Body}", r"\setCJKmainfont[]{Explicit CJK}",
+                      "10pt,", r"\usepackage[margin=20mm]{geometry}", r"\setstretch{1.1}"):
+            self.assertIn(value, tex)
+        self.assertNotIn("Frontmatter Body", tex)
+
+    def test_inferred_table_preserves_frontmatter_and_source(self):
+        result, tex = self.render(FRONTMATTER, ("--infer-colwidths", "--font", "Fallback Body"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_frontmatter(tex)
+        self.assertIn(r"\begin{longtable}", tex)
+
+    def test_failed_pandoc_propagates_failure_and_cleans_temp(self):
+        result, _ = self.render(FRONTMATTER, ("--infer-colwidths",), ("--invalid-render-test-option",))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("[render_pdf] ok", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PDF renders previously ignored frontmatter for fonts and page layout because wrapper defaults were passed as higher-priority pandoc variables. Supply those defaults through a metadata file so document settings win, while preserving explicit pandoc overrides and cleaning temporary files on success or failure.

Glyph coverage checks now require a selected face for TTC/OTC collections, report the selected face and explicit reasons for unavailable coverage, and inspect the preferred Unicode cmap without combining different faces. Existing advisory/strict exit behavior and result fields remain available. Cmap coverage still does not certify final PDF rendering.

Validation:
- 17 new synthetic-font and real-pandoc regression tests, plus the existing glyph test.
- Local before/after PDF verification of custom paper size, margins, body font and point size; visual inspection and a system TTC smoke check.
- Full validate-job mirror: 251 steps. New regressions share the existing render step; CI adds FontTools and Pandoc, not TeX.

Documentation, dependency checks and distribution hashes are updated. No new manuscript detector, release tag or version bump.
