### PR TITLE
Fix rendered slide checks and consistency-linter controls

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -479,10 +479,14 @@ jobs:
         run: bash skills/present-paper/scripts/check_diagram_edges_challenge/verify.sh
 
       - name: "Run measured-overflow challenge (no render supplied -> exit 2, never a silent pass)"
-        run: bash skills/present-paper/scripts/check_text_overflow_challenge/verify.sh
+        run: |
+          bash skills/present-paper/scripts/check_text_overflow_challenge/verify.sh
+          python3 skills/present-paper/tests/test_overflow_pdf.py
 
       - name: Run present-paper builder chrome test (the old eyebrow-everywhere default must be CAUGHT)
-        run: python3 skills/present-paper/tests/test_builder_no_chrome.py
+        run: |
+          python3 skills/present-paper/tests/test_builder_no_chrome.py
+          python3 skills/present-paper/tests/test_builder_layout.py
 
       - name: Run present-paper speaker-notes markdown test
         run: python3 skills/present-paper/tests/test_speaker_notes_markdown.py
@@ -509,7 +513,9 @@ jobs:
         run: bash skills/manage-refs/tests/test_csl_render.sh
 
       - name: Run polish-language consistency-linter challenge
-        run: bash skills/polish-language/scripts/lint_challenge/verify.sh
+        run: |
+          bash skills/polish-language/scripts/lint_challenge/verify.sh
+          python3 skills/polish-language/tests/test_consistency_controls.py
 
       - name: "Run polish-language numeral-designator test (\"type 2 diabetes\" is not \"type two\")"
         run: bash skills/polish-language/tests/test_numeral_designators.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- Presentation overflow checks now request line coordinates from poppler instead of
+  silently treating word-only output as a clean measurement. Real-PDF regression
+  tests run in the existing CI step. The Nature/Lancet builder uses readable
+  outline/glossary text and native bullets, reserves space for wrapped headings
+  and captions, and supports choosing installed fonts without rewriting content.
+  Font-check success no longer implies the fonts are installed at the venue.
+- Consistency linting no longer reports a single COVID-19 spelling as mixed, splits
+  numeric/hyphenated abbreviations into partial tokens, or treats grammatical
+  follow-up/follow up and long-term/in the long term pairs as spelling drift.
+  Synthetic US/UK normal controls supplement the existing seeded-error challenge.
 - PDF rendering now honors frontmatter before wrapper/OS defaults for fonts,
   page geometry, font size, line spacing and link colors. Explicit pandoc overrides
   remain available. Glyph scans support an explicitly selected TTC/OTC face and

--- a/docs/skills/polish-language.md
+++ b/docs/skills/polish-language.md
@@ -17,7 +17,7 @@
 **Safety boundaries**
 
 - Edits style only; never alters numeric values, p-values, units, citations, or scientific meaning.
-- Deterministic linter is the authority for mechanical issues; no edit without user approval.
+- Linter findings remain advisory and need contextual review; no edit without user approval.
 
 **Known limitations**
 
@@ -28,6 +28,7 @@
 
 - `python3 scripts/lint_consistency.py <manuscript.md>`
 - `bash scripts/lint_challenge/verify.sh  # deterministic, network-free`
+- `python3 tests/test_consistency_controls.py`
 - `python3 scripts/lint_figure_locale.py --manuscript <manuscript.md> --figures-dir <figures/>`
 - `bash scripts/lint_figure_locale_challenge/verify.sh  # deterministic, network-free`
 
@@ -37,7 +38,7 @@
 
 **Scripts** (`skills/polish-language/scripts/`):
 
-- `lint_challenge/` (4 files)
+- `lint_challenge/` (6 files)
 - `lint_consistency.py`
 - `lint_figure_locale.py`
 - `lint_figure_locale_challenge/` (2 files)

--- a/docs/skills/present-paper.md
+++ b/docs/skills/present-paper.md
@@ -26,6 +26,7 @@
 - Font portability is a blocklist of platform-bundled faces. A font absent from it may still be missing at the venue; embedding, or a PDF, is the only guarantee.
 - A per-slide script is required, not a topic. Given only a topic, the deck comes out generic in the way every reviewer can see -- the skill asks for the narrative instead of inventing one.
 - It does not draw diagrams from autoshapes: flows and mechanisms are rendered as code (matplotlib / Graphviz) and inserted, because an unlabelled arrow is read differently by every person in the room.
+- The Nature/Lancet defaults target academic profiles; larger-type venues need adaptation. Capacity limits do not guarantee text fit or acceptable density.
 - Mac OOXML quirks require the bundled compatibility checks; not every host renders identically.
 
 **Validation**
@@ -41,6 +42,8 @@
 - `bash scripts/check_font_portability_challenge/verify.sh`
 - `bash scripts/check_diagram_edges_challenge/verify.sh`
 - `bash scripts/check_text_overflow_challenge/verify.sh`
+- `python3 tests/test_overflow_pdf.py`
+- `python3 tests/test_builder_layout.py`
 - `python3 scripts/strip_notes_for_sharing.py before sharing`
 
 **Evidence** — `bundled_script`

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -3688,13 +3688,23 @@
     },
     {
       "path": "skills/polish-language/SKILL.md",
-      "size": 7649,
-      "sha256": "27c9d79d48c6b4b3e5a840e30962c4e731f8486e9dab75c16ac70d6067bc4c76"
+      "size": 7709,
+      "sha256": "db2a3d7705c611185daed6d363d606cbda11b5e041bc84c41a61c5b28dc45058"
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/expected/report.txt",
       "size": 1032,
       "sha256": "bf7be677cd12d583fd958468a6e5ee7f08493cc5fd01a4f7c27af3770331da66"
+    },
+    {
+      "path": "skills/polish-language/scripts/lint_challenge/fixture/consistent_uk.md",
+      "size": 524,
+      "sha256": "1b77ed2c859da126ce1aa6a8557d180e8e845c97271b2b898ca718df10e3de0c"
+    },
+    {
+      "path": "skills/polish-language/scripts/lint_challenge/fixture/consistent_us.md",
+      "size": 763,
+      "sha256": "3bd1ce288b08e27296dd67a5a2ad1261e61e1219344c3e2c59b9070e8f6ccda4"
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/fixture/manuscript.md",
@@ -3703,18 +3713,18 @@
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/problem.md",
-      "size": 2169,
-      "sha256": "69037c9d85cf1a29a77dc77cd61e879b9a6befcec945b808d71468fff4278490"
+      "size": 2949,
+      "sha256": "df7c892a1131d76ee2f7614b465e0d677d09d595492eef2ece4f21bd9ff36583"
     },
     {
       "path": "skills/polish-language/scripts/lint_challenge/verify.sh",
-      "size": 615,
-      "sha256": "31ddc7fb64ac2f9180cdfa6a6ee15a29844c2e9c0955b83250b2c1b62f9e8fa6"
+      "size": 1132,
+      "sha256": "6b3faa91892bb4651795e4943b04171ef87e6162acce58a65390446e14251560"
     },
     {
       "path": "skills/polish-language/scripts/lint_consistency.py",
-      "size": 15665,
-      "sha256": "f380439fae1fd41b966862957ca4232467a1d1701dd5a19c35c1864b3df9aea2"
+      "size": 16136,
+      "sha256": "cc892d682ea4ccd648effb1facf8d404503d9c5d89b2cf954acfedd12a967857"
     },
     {
       "path": "skills/polish-language/scripts/lint_figure_locale.py",
@@ -3733,8 +3743,8 @@
     },
     {
       "path": "skills/polish-language/skill.yml",
-      "size": 2033,
-      "sha256": "1a513a7d532d5a335acd6fa91566a551b5dc17d6ba3021f9d39a52848a7df571"
+      "size": 2081,
+      "sha256": "aff8fcd8108ca1df38de11ce594005dfa94baec8947e14dba9214538e77b1eaa"
     },
     {
       "path": "skills/preprocess-imaging/SKILL.md",
@@ -3828,8 +3838,8 @@
     },
     {
       "path": "skills/present-paper/SKILL.md",
-      "size": 53093,
-      "sha256": "d94632764cd473f79ccf594bb6ecbd49bc270447a81d1f9cfce3d1d43701bbea"
+      "size": 54313,
+      "sha256": "f57f6bfcfdf4a016defcce34732e264c7ac11258f825e1244c681d0d6a52db5d"
     },
     {
       "path": "skills/present-paper/references/ai_slide_tells.md",
@@ -3898,8 +3908,8 @@
     },
     {
       "path": "skills/present-paper/references/slide_visual_styles/nature_lancet.md",
-      "size": 9116,
-      "sha256": "fd70cbe0edbc39b05a8c6f53da5637913c15182aeb4878983615a77af20c5846"
+      "size": 10721,
+      "sha256": "7f6bc69354220de042a8074d00e5e015972f232384efda72587208fbacd078e6"
     },
     {
       "path": "skills/present-paper/references/spoken_notes_and_bilingual.md",
@@ -3943,8 +3953,8 @@
     },
     {
       "path": "skills/present-paper/scripts/check_font_portability.py",
-      "size": 15788,
-      "sha256": "192f7107e47364ebe14e6db287d4e3c91b62d6c24391ac5669532f0461695c98"
+      "size": 15874,
+      "sha256": "182a214f32f4f9c73b7e4717d334cd81e94da77c78bc660a7367d69921451528"
     },
     {
       "path": "skills/present-paper/scripts/check_font_portability_challenge/make_fixtures.py",
@@ -3973,18 +3983,18 @@
     },
     {
       "path": "skills/present-paper/scripts/check_text_overflow.py",
-      "size": 11729,
-      "sha256": "211a6fd3b73d5d8b107f24648db2b0de5628ae6f52c7331253ec9f7664d8179b"
+      "size": 12150,
+      "sha256": "c0dde521a02b7f3d495a627003430c29eae199cd8fa4e1c5be4f778b32ff6c5b"
     },
     {
       "path": "skills/present-paper/scripts/check_text_overflow_challenge/make_fixtures.py",
-      "size": 4169,
-      "sha256": "6f9d577e43f10ad6f9d98bfa3d8a02f0cf1bb8a5b7c722c11054363dacf39b67"
+      "size": 4162,
+      "sha256": "473b8a58e8fefc62c1d3cf0f974aeb1b7ca1ddb3bb31abf2aa7ec612bded3fdd"
     },
     {
       "path": "skills/present-paper/scripts/check_text_overflow_challenge/verify.sh",
-      "size": 4013,
-      "sha256": "77366b614425a859c09942b233a9616b21bd1f33c50fdf20d5ca25a18eba837e"
+      "size": 4126,
+      "sha256": "5467d119389fb9b2787d18b5f67283c804cd22a5b112c3c82ece55f6ed720269"
     },
     {
       "path": "skills/present-paper/scripts/extract_pdf_figures.py",
@@ -4018,13 +4028,13 @@
     },
     {
       "path": "skills/present-paper/skill.yml",
-      "size": 3238,
-      "sha256": "6d45223886fa651661d13afbe18a8cd80907f11cbe1afadd94656630a83729ba"
+      "size": 3482,
+      "sha256": "28d8a5a32fc4a0c5ab63c7a506911e3c022a1b8c77ecccef350298b1755d0e37"
     },
     {
       "path": "skills/present-paper/templates/build_pptx_nature_lancet.py",
-      "size": 30327,
-      "sha256": "8a08bb4e981c76aa8b3d262037c7456dc4eab2ef12c809a26297c85be9508f6e"
+      "size": 32525,
+      "sha256": "9e14b3845d961d3bb9ab12bffc9709414ac1b517b08c345a85556868a619afb3"
     },
     {
       "path": "skills/profile-imaging/SKILL.md",

--- a/skills/polish-language/SKILL.md
+++ b/skills/polish-language/SKILL.md
@@ -127,7 +127,7 @@ A deterministic, network-free challenge card lives in
 `expected/report.txt` + `verify.sh`):
 
 ```bash
-bash scripts/lint_challenge/verify.sh   # PASS = 10 seeded issues across 7 categories
+bash scripts/lint_challenge/verify.sh   # PASS = 11 seeded issues across 8 categories + 2 clean controls
 ```
 
 ## What This Skill Does NOT Do
@@ -142,9 +142,9 @@ bash scripts/lint_challenge/verify.sh   # PASS = 10 seeded issues across 7 categ
 
 ## Anti-Hallucination
 
-- The deterministic linter (`lint_consistency.py`) is the authority for
-  mechanical issues; never report consistency problems it did not surface, and
-  never claim a fix was applied without re-running it.
+- Report deterministic findings as linter findings, and other observations as
+  editorial suggestions. The fixed rules do not resolve every grammar or journal
+  preference; triage flags in context. Never claim a fix without re-running the linter.
 - Clarity edits are constrained to wording. Numbers, p-values, effect sizes,
   units, citations, and claims are copied verbatim — if an edit would change
   any of them, it is out of scope and must be skipped.

--- a/skills/polish-language/scripts/lint_challenge/fixture/consistent_uk.md
+++ b/skills/polish-language/scripts/lint_challenge/fixture/consistent_uk.md
@@ -1,0 +1,9 @@
+# Synthetic methods example
+
+Computed tomography (CT) was used for acquisition. CT images were reviewed.
+The analysis characterised tumour size and modelled the association.
+The organisation optimised colour labels without changing the characteristics.
+Follow-up lasted 12 months. We will follow up with the study team.
+Long-term monitoring continued; the protocol remained stable in the long term.
+Measurements ranged from 5–10 mm. The group comparison yielded p < 0.001.
+Figure 2 shows the workflow for type 2 diabetes.

--- a/skills/polish-language/scripts/lint_challenge/fixture/consistent_us.md
+++ b/skills/polish-language/scripts/lint_challenge/fixture/consistent_us.md
@@ -1,0 +1,12 @@
+# Synthetic methods example
+
+Computed tomography (CT) was used for acquisition. CT images were reviewed.
+Magnetic resonance imaging (MRI) was used for confirmation. MRI findings were recorded.
+The analysis characterized tumor size and modeled the association.
+The organization optimized color labels without changing the characteristics.
+Follow-up lasted 12 months. We will follow up with the study team.
+Long-term monitoring continued; the protocol remained stable in the long term.
+Coronaviruses were discussed in a background section on coronavirus disease 2019 (COVID-19).
+COVID-19 terminology was consistent throughout the document.
+Measurements ranged from 5–10 mm. The group comparison yielded P < 0.001.
+Figure 2 shows the workflow for type 2 diabetes.

--- a/skills/polish-language/scripts/lint_challenge/problem.md
+++ b/skills/polish-language/scripts/lint_challenge/problem.md
@@ -11,9 +11,9 @@ unit. `/humanize` explicitly does **not** do general copy-editing (it only
 removes AI tells), and `/check-reporting` checks guideline items, not house
 style — so none of the existing skills caught these.
 
-## What the new gate does
+## What the linter does
 
-`scripts/lint_consistency.py` deterministically reports (never rewrites) seven
+`scripts/lint_consistency.py` deterministically reports (never rewrites) eight
 families of inconsistency with line numbers and a per-category + total count.
 It changes no text, numbers, or citations — it is advisory input for a
 human/LLM polish pass.
@@ -26,13 +26,25 @@ UK-dominant doc), numeric range (`5-10`), p-values (`p` vs `P`, impossible
 `P = 0.000`), hyphenation (follow-up/followup, healthcare/health care),
 small number (`3 patients`), unit (`5mg`).
 
+`fixture/consistent_us.md` and `fixture/consistent_uk.md` contain normal
+synthetic prose. They combine consistent regional spelling, defined abbreviations,
+spaced units, and grammatical noun/verb pairs. Both must produce zero findings
+under `--strict`; a detector that only catches planted errors is not enough.
+
+`follow-up` (noun/adjective) may coexist with `follow up` (verb), as in the
+[CDC writing guidance](https://www.cdc.gov/nceh/clearwriting/writing-tips/2024/writing-tip-wed-05-22-2024.html).
+The same distinction applies to `long-term` versus `in the long term`.
+The fixed variant lists are advisory; they do not adjudicate every grammar or
+journal-style choice. Numeric/hyphenated uppercase abbreviations such as
+`COVID-19` are kept whole when comparing definitions and uses.
+
 ## Expected
 
 `expected/report.txt` — 11 issues across 8 categories.
 
-## Baseline vs new gate
+## Baseline vs linter
 
-| | Baseline (humanize / check-reporting) | New consistency linter |
+| | Baseline (humanize / check-reporting) | Consistency linter |
 |---|---|---|
 | Abbreviation define-once | not checked | reported |
 | US/UK spelling drift | not checked | reported (minority side) |

--- a/skills/polish-language/scripts/lint_challenge/verify.sh
+++ b/skills/polish-language/scripts/lint_challenge/verify.sh
@@ -14,3 +14,15 @@ else
   echo "FAIL: linter output drifted from expected/report.txt" >&2
   exit 1
 fi
+
+# Normal US and UK prose must also stay quiet, including grammatical noun/verb
+# pairs and a defined numeric/hyphenated abbreviation.
+for variant in us uk; do
+  clean="$(python3 "$LINTER" "$HERE/fixture/consistent_${variant}.md" --strict)"
+  if ! grep -q '^Summary: 0 issue(s) across 0 category(ies)\.$' <<<"$clean"; then
+    echo "FAIL: consistent $variant prose produced findings" >&2
+    printf '%s\n' "$clean" >&2
+    exit 1
+  fi
+  echo "PASS: consistent $variant control has zero findings under --strict."
+done

--- a/skills/polish-language/scripts/lint_consistency.py
+++ b/skills/polish-language/scripts/lint_consistency.py
@@ -85,9 +85,11 @@ SPELLING_US = {
 
 # Hyphenation/terminology variant families (all lowercase match, word-ish).
 HYPHEN_FAMILIES = [
-    ("follow-up", [r"\bfollow-up\b", r"\bfollowup\b", r"\bfollow up\b"]),
+    # The spaced verb "follow up" is grammatical beside the noun "follow-up".
+    # Likewise "in the long term" is not a misspelling of the adjective.
+    ("follow-up", [r"\bfollow-up\b", r"\bfollowup\b"]),
     ("health care", [r"\bhealthcare\b", r"\bhealth care\b", r"\bhealth-care\b"]),
-    ("long-term", [r"\blong-term\b", r"\blongterm\b", r"\blong term\b"]),
+    ("long-term", [r"\blong-term\b", r"\blongterm\b"]),
     ("well-being", [r"\bwell-being\b", r"\bwellbeing\b"]),
     ("decision-making", [r"\bdecision-making\b", r"\bdecision making\b"]),
     ("COVID-19", [r"\bCOVID-19\b", r"\bCOVID19\b", r"\bCovid-19\b"]),
@@ -101,8 +103,10 @@ UNIT_RE = re.compile(
     r"(?<![\w.])(\d+(?:\.\d+)?)(" + "|".join(sorted(UNIT_TOKENS, key=len, reverse=True)) + r")(?![\w])"
 )
 
-ABBR_DEF_RE = re.compile(r"\(([A-Z][A-Z0-9]{1,5})\)")            # (CT), (MRI), (DKA), (COVID)
-ABBR_USE_RE = re.compile(r"(?<![A-Za-z])([A-Z]{2,6})(?![A-Za-z])")  # standalone caps token
+# Keep numeric/hyphenated identifiers whole: a definition of (COVID-19) must
+# match uses of COVID-19, not manufacture an undefined abbreviation "COVID".
+ABBR_DEF_RE = re.compile(r"\(([A-Z][A-Z0-9]{1,5}[0-9]*(?:-[A-Z0-9]{1,6})*)\)")
+ABBR_USE_RE = re.compile(r"(?<![A-Za-z0-9-])([A-Z]{2,6}[0-9]*(?:-[A-Z0-9]{1,6})*)(?![A-Za-z0-9-])")
 NUM_RANGE_RE = re.compile(r"(?<![\w/.\-])(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)(?![\w/.\-])")
 PVAL_RE = re.compile(r"(?<![A-Za-z])([Pp])\s*([=<>])\s*(0?\.\d+|\d+\.\d+|\.\d+)")
 SMALL_NUM_RE = re.compile(r"(?<![\w.=<>+\-/])([1-9])\s+([a-z]{3,})")
@@ -236,10 +240,13 @@ def check_pvalues(lines):
 def check_hyphenation(lines):
     out = []
     for canon, variants in HYPHEN_FAMILIES:
+        # These variants intentionally differ in case. Ignoring case makes a
+        # single COVID-19 occurrence match both patterns and report a false mix.
+        flags = 0 if canon == "COVID-19" else re.I
         present = []
         per_variant = {}
         for vre in variants:
-            vlines = [i for i, line in enumerate(lines, 1) if re.search(vre, line, re.I)]
+            vlines = [i for i, line in enumerate(lines, 1) if re.search(vre, line, flags)]
             if vlines:
                 present.append(vre)
                 per_variant[vre] = vlines

--- a/skills/polish-language/skill.yml
+++ b/skills/polish-language/skill.yml
@@ -29,13 +29,14 @@ forbidden_actions:
 purpose: "Standardize house-style consistency and improve non-native clarity without changing facts, numbers, or citations."
 safety_boundaries:
   - "Edits style only; never alters numeric values, p-values, units, citations, or scientific meaning."
-  - "Deterministic linter is the authority for mechanical issues; no edit without user approval."
+  - "Linter findings remain advisory and need contextual review; no edit without user approval."
 known_limitations:
   - "Spelling/hyphenation families are a fixed list; uncommon variants may be missed."
   - "Small-number and abbreviation heuristics can flag intended author choices — triage with the user."
 validation_commands:
   - "python3 scripts/lint_consistency.py <manuscript.md>"
   - "bash scripts/lint_challenge/verify.sh  # deterministic, network-free"
+  - "python3 tests/test_consistency_controls.py"
   - "python3 scripts/lint_figure_locale.py --manuscript <manuscript.md> --figures-dir <figures/>"
   - "bash scripts/lint_figure_locale_challenge/verify.sh  # deterministic, network-free"
 evidence_surface: bundled_script

--- a/skills/polish-language/tests/test_consistency_controls.py
+++ b/skills/polish-language/tests/test_consistency_controls.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Normal prose controls plus matching failure cases; all inputs are synthetic."""
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SKILL = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL / 'scripts/lint_consistency.py'
+spec = importlib.util.spec_from_file_location('linter', SCRIPT)
+linter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(linter)
+
+
+class ConsistencyControls(unittest.TestCase):
+    def test_normal_us_and_uk_manuscripts_are_clean_and_unchanged(self):
+        for name in ('consistent_us.md', 'consistent_uk.md'):
+            with self.subTest(name=name):
+                path = SKILL / 'scripts/lint_challenge/fixture' / name
+                before = path.read_bytes()
+                run = subprocess.run([sys.executable, str(SCRIPT), str(path), '--strict'],
+                                     capture_output=True, text=True)
+                self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+                self.assertIn('Summary: 0 issue(s) across 0 category(ies).', run.stdout)
+                self.assertEqual(path.read_bytes(), before)
+
+    def test_one_covid_form_is_not_a_mix(self):
+        for text in ('COVID-19', 'COVID19', 'Covid-19', 'COVID-19 and COVID-19'):
+            self.assertEqual(linter.check_hyphenation([text]), [], text)
+
+    def test_actual_covid_spelling_and_case_mixes_still_fire(self):
+        for text in ('COVID-19 and COVID19', 'COVID-19 and Covid-19'):
+            found = linter.check_hyphenation([text])
+            self.assertEqual(len(found), 1)
+            self.assertIn('COVID-19', found[0][1])
+
+    def test_grammatically_distinct_forms_can_coexist(self):
+        self.assertEqual(linter.check_hyphenation([
+            'Follow-up continued. We will follow up with the team.',
+            'Long-term monitoring helps in the long term.']), [])
+
+    def test_closed_form_mixes_still_fire(self):
+        for text in ('Follow-up and followup', 'Long-term and longterm',
+                     'Healthcare and health care'):
+            self.assertEqual(len(linter.check_hyphenation([text])), 1, text)
+
+    def test_defined_numeric_and_hyphenated_abbreviations_remain_whole(self):
+        for abbr in ('CT', 'MRI', 'BRCA1', 'COVID-19', 'COVID19'):
+            self.assertEqual(linter.check_abbreviations([
+                f'Expanded name ({abbr}) was introduced.', f'{abbr} was used.']), [])
+
+    def test_missing_definitions_are_not_hidden(self):
+        found = linter.check_abbreviations(['COVID-19 was discussed.', 'COVID-19 was mentioned again.'])
+        self.assertEqual(found, [(1, '"COVID-19" used 2x but never defined')])
+        self.assertEqual(linter.check_abbreviations(['Expanded name (CT).']),
+                         [(1, '"CT" defined but never used')])
+
+    def test_definition_order_and_duplicate_definition_still_fire(self):
+        found = linter.check_abbreviations(['CT was used.', 'Computed tomography (CT).',
+                                            'Computed tomography (CT) was mentioned again.'])
+        self.assertTrue(any('before its definition' in msg for _, msg in found))
+        self.assertTrue(any('more than once' in msg for _, msg in found))
+
+    def test_designators_and_measurements_are_not_counts(self):
+        self.assertEqual(linter.check_small_numbers([
+            'Figure 2 shows type 2 diabetes. The measurement was 5 mm.']), [])
+        self.assertEqual(len(linter.check_small_numbers(['There were 3 samples.'])), 1)
+
+    def test_a_defect_added_to_normal_prose_changes_strict_exit_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / 'text.md'
+            path.write_text('The value was 5mg.\n', encoding='utf-8')
+            before = path.read_bytes()
+            for extra, expected in [((), 0), (('--strict',), 1)]:
+                run = subprocess.run([sys.executable, str(SCRIPT), str(path), *extra],
+                                     capture_output=True, text=True)
+                self.assertEqual(run.returncode, expected)
+                self.assertIn('insert a space', run.stdout)
+                self.assertEqual(path.read_bytes(), before)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/skills/present-paper/SKILL.md
+++ b/skills/present-paper/SKILL.md
@@ -318,8 +318,15 @@ canonical template libraries:
   Use for **academic lecture multi-paper survey** (template #5). Functions:
   `new_presentation`, `add_title_slide`, `add_toc_slide`, `add_section_divider`,
   `add_transition_slide`, `add_content_slide`, `add_glossary_slide`,
-  `add_closing_slide`, plus `fix_app_xml()` helper. Style spec:
+  `add_closing_slide`, plus `apply_fonts(prs, en=..., ko=...)` and `fix_app_xml()` helpers. Style spec:
   `references/slide_visual_styles/nature_lancet.md`.
+
+The Nature/Lancet defaults use 20 pt body text, subtitles and glossary entries.
+They suit the `conference_oral`, `critique`, `case_anchored`, `didactic` and
+`defence` budget profiles with concise content. `keynote`, `lay_talk` and
+`decision_brief` require larger type and layout adaptation; selecting a profile
+in the checker does not restyle the deck. Outline/glossary capacity bounds do not
+guarantee readable density or text fit. Render the actual content and inspect it.
 
 For lecture decks pulling figures from PDFs (rather than from `/make-figures`
 output), use `${CLAUDE_SKILL_DIR}/scripts/extract_pdf_figures.py` — pdftoppm + PIL
@@ -651,6 +658,11 @@ with a count per font so a 1,000-run body face reads differently from a stray mo
 code lines. It is a blocklist, not an allowlist: a hospital's licensed brand face is not this
 check's business. It exempts fonts the deck **embeds**, and it treats a theme-level default as
 inert until the deck actually contains text of the script that slot serves.
+A pass does not verify font installation or renderer substitution. For the
+Nature/Lancet builder, call `apply_fonts` after adding slides and before saving to
+select installed Latin and East Asian faces without changing text or formatting.
+It does not embed fonts or modify fonts inside images, tables or charts. Verify
+the actual exported PDF's fonts as well as its visible layout.
 
 Two ways to be safe, and both have a cost worth knowing:
 
@@ -853,6 +865,11 @@ on everything else as unread, not as passed.
 
 `python-pptx` will write more text than a box can show and say nothing about it. PowerPoint reveals
 it on the screen, which is where the audience is.
+
+The measured-overflow check uses `pdftotext -bbox-layout` line rectangles. It
+checks bottom edges against the slide and filled blocks; it does not certify all
+intersections, top/right clipping, or text omitted entirely from the PDF export.
+Inspect the render against the slide source, including long captions and titles.
 
 The tempting check is arithmetic — font size × line spacing × lines — and it fails in **both**
 directions. A line-height constant of 1.42 under-estimated CJK line pitch and let a body block cross

--- a/skills/present-paper/references/slide_visual_styles/nature_lancet.md
+++ b/skills/present-paper/references/slide_visual_styles/nature_lancet.md
@@ -34,10 +34,10 @@ single 6pt offset on figure tiles.
 | Role | Font (Latin) | Font (EastAsia / Korean) | Size | Weight |
 |---|---|---|---|---|
 | Slide title | Inter | Pretendard | 28–32 pt | Bold |
-| Subtitle / sentence-headline | Inter | Pretendard | 15–18 pt | Italic |
-| Body bullet (main) | Inter | Pretendard | 18–20 pt | Regular |
-| Body bullet (sub) | Inter | Pretendard | 15–16 pt | Regular |
-| Eyebrow text | Inter | Pretendard | 10–14 pt | Bold, letter-spaced 300–400 |
+| Subtitle | Inter | Pretendard | 20 pt | Italic |
+| Body bullet (main) | Inter | Pretendard | 20 pt (closing: 22 pt) | Regular |
+| Body bullet (sub) | Inter | Pretendard | 20 pt | Regular |
+| Eyebrow text | Inter | Pretendard | 20 pt (outline/closing edge label: 11 pt) | Bold, letter-spaced 300–400 |
 | Section title (divider) | Inter | Pretendard | 48–52 pt | Bold |
 | Transition quote | Inter | Pretendard | 36 pt | Bold |
 | Page-brand footer | Inter | Pretendard | 9 pt | Regular, letter-spaced 300 |
@@ -52,17 +52,35 @@ EastAsia attribute **must** be set on every run that may contain Korean text —
 PowerPoint falls back to Times New Roman otherwise. See
 `~/.claude/rules/pptx-mac-compatibility.md` §6.
 
+The font checker reports known platform-specific faces; a pass does not establish
+that Inter/Pretendard is installed or used by the renderer. To choose installed
+faces without changing text, size, bold or italic formatting, call after adding
+slides and before `prs.save(...)`:
+
+```python
+apply_fonts(prs, en="<installed Latin face>", ko="<installed East Asian face>")
+```
+
+This updates the builder's text runs, native bullet fonts and existing notes. It
+does not install/embed fonts or alter fonts inside images, equations, tables or
+charts. Inspect the exported PDF's actual fonts and its visible line breaks.
+
+The default body sizes match the academic `conference_oral`, `critique`,
+`case_anchored`, `didactic` and `defence` profiles for concise content. They do not
+meet the larger body sizes for `keynote`, `lay_talk` or `decision_brief`; adapt the
+layout and type before using those profiles. A budget pass alone is not a render check.
+
 ## 3. Layout grid (16:9, 13.333" × 7.5")
 
 | Region | Position | Content |
 |---|---|---|
 | Eyebrow | x=0.7", y=0.32", w=8", h=0.4" | **Title + dividers only** — see below |
-| Title | x=0.7", y=0.75", w=12.0", h=1.1" | Slide title + optional subtitle |
-| Hairline | x=0.7", y=2.05", w=0.6", h≈0.02" | Coral hairline (separator) |
-| Body (no figure) | x=0.7", y=2.4", w=12.0", h=4.6" | Bullets full width |
-| Body (with figure) | x=0.7", y=2.4", w=6.8", h=4.6" | Bullets left half |
-| Figure (right half) | x=7.9", y=2.4", w=5.0", h=4.0" | Centered within tile |
-| Figure caption | x=7.9", y=fig+0.10", w=5.0", h=0.6" | "Figure · {caption}" centered |
+| Title | x=0.7", y=0.75", w=12.0", h=1.6" | Slide title + optional subtitle |
+| Hairline | x=0.7", y=2.45", w=0.6", 2.5 pt line | Coral hairline (separator) |
+| Body (no figure) | x=0.7", y=2.7", w=12.0", h=4.3" | Bullets full width |
+| Body (with figure) | x=0.7", y=2.7", w=6.8", h=4.3" | Bullets left half |
+| Figure (right half) | x=7.9", y=2.7", w=5.0", h=3.0" with caption (4.0" without) | Centered within tile |
+| Figure caption | x=7.9", y=fig+0.10", w=5.0", h=1.2" | "Figure · {caption}" centered |
 | Page number | x=12.6", y=7.0", w=0.4", h=0.3" | A bare numeral. Keep it. |
 | Footnote | x=0.7", y=7.05", w=12.0", h=0.35" | Right-aligned source ref (only where there is a source) |
 
@@ -91,19 +109,19 @@ legitimate override — record it, and move on.
 
 ### 4a. Title slide
 - Left navy bar (40k EMU wide × 3.5" tall) at x=0.7"
-- "REVIEW LECTURE" eyebrow (14pt, coral, letter-spaced 300)
+- "REVIEW LECTURE" eyebrow (20pt, coral, letter-spaced 300)
 - 48pt navy bold title
-- 18pt italic subtitle (TEXT_SUB)
-- Bottom block: 16pt bold navy line ("Course · Professor · Date"), 13pt sub line
+- 20pt italic subtitle (TEXT_SUB)
+- Bottom block: 20pt bold navy line ("Course · Professor · Date"), 20pt sub line
   ("Presenter Name · Affiliation"), separated by 2" navy hairline above
 
 ### 4b. Section divider
 - Full-bleed deep navy background (`DIVIDER_BG`)
 - 1.8"-tall coral accent strip at x=1.2", y=3.0", 15k EMU wide
-- "SECTION {N}" 18pt coral eyebrow letter-spaced 400
+- "SECTION {N}" 20pt coral eyebrow letter-spaced 400
 - 52pt white bold section title
 - 20pt italic light-navy (`#C0CBDC`) subtitle
-- Bottom-right "{N} MIN" badge (13pt muted)
+- Bottom-right "{N} MIN" badge (20pt muted)
 
 ### 4c. Transition slide
 - Full-bleed deep navy background
@@ -115,8 +133,10 @@ legitimate override — record it, and move on.
   (left if figure, full-width if no figure) → figure tile (shadow offset 0.06",
   hairline border) → optional figure caption → footnote (right) + page brand (left)
 - Bullet markers:
-  - Main: `▪` (14pt coral bold) + 20pt body text
-  - Sub (lines prefixed with 2 spaces): `—` (15pt muted) + 16pt sub text
+  - Main: native `▪` coral paragraph bullet + 20pt body text
+  - Sub (lines prefixed with 2 spaces): native `–` muted paragraph bullet + 20pt text
+  - Hanging indents keep wrapped lines aligned with the text. Markers are not typed
+    into text runs; bold/italic text remains editable.
 - Inline `**bold**` and `*italic*` markdown is parsed into per-run styling (see
   `pptx-mac-compatibility.md` §4 for the parser pattern)
 
@@ -124,13 +144,17 @@ legitimate override — record it, and move on.
 - Eyebrow "OUTLINE"
 - Title "Outline" + sentence subtitle
 - Coral hairline
-- N rows, each: 22pt coral section number (or `·` for wrap-up), 22pt navy bold section
-  title, 13pt sub-text English summary, 12pt muted time badge (right-aligned). Hairline
-  divider between rows.
+- Up to five rows, each: 22pt coral section number (or `·` for wrap-up), 22pt navy bold section
+  title, 20pt sub-text English summary, 20pt muted time badge (right-aligned). Native
+  line dividers between rows. Longer outlines raise `ValueError` before adding a slide;
+  split them. Keep each title and summary to one line.
 
 ### 4f. Glossary slide (optional, for multidisciplinary audiences)
-- Tier 1 (top, 4–7 items): disease/concept abbreviations with one-line context
-- Tier 2 (bottom, 2-column, 8–12): method/statistics abbreviations with short defs
+- Tier 1 (top, up to 7 items): disease/concept abbreviations with one-line context
+- Tier 2 (bottom, 2-column, up to 12): method/statistics abbreviations with short defs
+- Both tiers use 20pt text. Excess entries raise `ValueError` before adding a slide.
+  Maximum capacity is not a density target: split a crowded glossary even when it
+  fits on the canvas. Wrapped definitions need a rendered review.
 - See `~/.claude/rules/multidisciplinary-presentation.md` §1
 
 ### 4g. Closing slide
@@ -140,7 +164,8 @@ legitimate override — record it, and move on.
 
 ## 5. Figure handling
 
-- Aspect-ratio preserving fit inside the figure tile (5.0" × 4.0" max)
+- Aspect-ratio preserving fit inside the figure tile (5.0" wide, 3.0" high with
+  caption or 4.0" without). The caption has a separate 1.2" band above the footnote.
 - Shadow rectangle (hairline gray) offset +0.06" / +0.06" before image
 - Image border: hairline gray (~6000 EMU)
 - Caption format: `Figure  ·  {caption}` (coral "Figure" eyebrow, italic muted caption)

--- a/skills/present-paper/scripts/check_font_portability.py
+++ b/skills/present-paper/scripts/check_font_portability.py
@@ -338,7 +338,8 @@ def main() -> int:
             indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     if not findings:
-        print("OK: every typeface this deck names is available on both platforms, or embedded.")
+        print("OK: no unembedded platform-specific fonts found in the supported checks. "
+              "Font installation and substitution in the renderer still need verification.")
         return 0
 
     for f in findings:

--- a/skills/present-paper/scripts/check_text_overflow.py
+++ b/skills/present-paper/scripts/check_text_overflow.py
@@ -13,7 +13,7 @@ failure walks straight into the other, and the same trap was hit again five mont
 different direction: sizing a block at font x 1.06 without accounting for the roughly 1.2 leading
 PowerPoint adds on top, so a 21-line list computed to 4.1 in and needed 5.1.
 
-None of that arithmetic is necessary. **The render already knows.** `pdftotext -bbox` gives every
+None of that arithmetic is necessary. **The render already knows.** `pdftotext -bbox-layout` gives every
 line's rectangle in points, and the .pptx gives every shape's rectangle. Two comparisons:
 
     OFF_SLIDE   a line's bottom crosses into the reserved band at the foot of the page, or past it
@@ -91,7 +91,7 @@ def run_pdftotext(pdf: Path) -> str:
             "pdftotext is not on PATH. It ships with poppler (macOS: brew install poppler; "
             "Debian/Ubuntu: apt install poppler-utils).")
     try:
-        return subprocess.run(["pdftotext", "-bbox", str(pdf), "-"],
+        return subprocess.run(["pdftotext", "-bbox-layout", str(pdf), "-"],
                               capture_output=True, text=True, check=True).stdout
     except subprocess.CalledProcessError as exc:
         raise CannotMeasure(f"pdftotext could not read {pdf} ({exc})") from exc
@@ -111,6 +111,11 @@ def parse_bbox(xml: str) -> Dict[int, List[Tuple[float, float, float, float, str
             txt = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(7))).strip()
             pages[cur].append((float(m.group(3)), float(m.group(4)),
                                float(m.group(5)), float(m.group(6)), txt))
+    # Plain -bbox contains words but no line rectangles. Treat that as an
+    # incompatible measurement, not an empty clean slide.
+    for i, page in enumerate(re.finditer(r'<page\b[^>]*>(.*?)</page>', xml, re.S), 1):
+        if re.search(r'<word\b', page.group(1)) and not pages.get(i):
+            raise CannotMeasure("word coordinates have no usable line rectangles; use pdftotext -bbox-layout")
     return pages
 
 
@@ -207,7 +212,7 @@ def main() -> int:
     ap.add_argument("deck", type=Path, help="the .pptx")
     ap.add_argument("--pdf", type=Path, help="the rendered PDF of that same deck (required)")
     ap.add_argument("--bbox-xml", type=Path,
-                    help="a recorded `pdftotext -bbox` output to use instead of running it. "
+                    help="a recorded `pdftotext -bbox-layout` output to use instead of running it. "
                          "Same measurement, same parser, supplied from a file — this is how the "
                          "challenge card stays deterministic without poppler.")
     ap.add_argument("--bottom-reserve-in", type=float, default=0.10,

--- a/skills/present-paper/scripts/check_text_overflow_challenge/make_fixtures.py
+++ b/skills/present-paper/scripts/check_text_overflow_challenge/make_fixtures.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""One deck, and three recorded measurements of it.
+"""One deck, and three synthetic measurements of it.
 
 The detector's whole argument is that the render already knows the answer, so the fixture supplies
-a render — as `pdftotext -bbox` output, which is exactly what the detector reads. Recording the
-measurement rather than producing a PDF keeps the card deterministic and free of poppler and
-LibreOffice, and it exercises the same parser and the same comparison on the same geometry.
+synthetic line rectangles in the `pdftotext -bbox-layout` structure. These are computed
+coordinates, not a recorded renderer export. They exercise the parser and comparisons without
+poppler or LibreOffice. tests/test_overflow_pdf.py separately exercises real poppler output.
 
   deck.pptx        two slides. Slide 1 carries a filled block with a known rectangle.
   clean.xml        every line inside its block and clear of the foot of the slide.

--- a/skills/present-paper/scripts/check_text_overflow_challenge/verify.sh
+++ b/skills/present-paper/scripts/check_text_overflow_challenge/verify.sh
@@ -12,9 +12,10 @@
 # and, of course, it has to catch the two real failures: a line leaving its block, and a line
 # ending in the reserved band at the foot of the slide.
 #
-# WHAT THIS DOES NOT COVER: the `pdftotext` invocation itself. The card supplies a recorded
+# WHAT THIS DOES NOT COVER: the `pdftotext` invocation itself. The card supplies a synthetic
 # measurement so that it needs neither poppler nor LibreOffice; the parser and the comparison it
-# feeds are the same code that runs on a real PDF.
+# feeds are the same code that runs on a real PDF. The existing CI step also runs
+# tests/test_overflow_pdf.py against actual poppler, using tiny controlled PDFs.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 DET="$HERE/../check_text_overflow.py"

--- a/skills/present-paper/skill.yml
+++ b/skills/present-paper/skill.yml
@@ -42,6 +42,7 @@ known_limitations:
   - "Font portability is a blocklist of platform-bundled faces. A font absent from it may still be missing at the venue; embedding, or a PDF, is the only guarantee."
   - "A per-slide script is required, not a topic. Given only a topic, the deck comes out generic in the way every reviewer can see -- the skill asks for the narrative instead of inventing one."
   - "It does not draw diagrams from autoshapes: flows and mechanisms are rendered as code (matplotlib / Graphviz) and inserted, because an unlabelled arrow is read differently by every person in the room."
+  - "The Nature/Lancet defaults target academic profiles; larger-type venues need adaptation. Capacity limits do not guarantee text fit or acceptable density."
   - "Mac OOXML quirks require the bundled compatibility checks; not every host renders identically."
 validation_commands:
   - "unzip the .pptx and confirm 0 markdown-raw notes / 0 TIFF / app.xml counts synced"
@@ -55,5 +56,7 @@ validation_commands:
   - "bash scripts/check_font_portability_challenge/verify.sh"
   - "bash scripts/check_diagram_edges_challenge/verify.sh"
   - "bash scripts/check_text_overflow_challenge/verify.sh"
+  - "python3 tests/test_overflow_pdf.py"
+  - "python3 tests/test_builder_layout.py"
   - "python3 scripts/strip_notes_for_sharing.py before sharing"
 evidence_surface: bundled_script

--- a/skills/present-paper/templates/build_pptx_nature_lancet.py
+++ b/skills/present-paper/templates/build_pptx_nature_lancet.py
@@ -176,6 +176,48 @@ def add_notes(slide, text: str | None) -> None:
             add_styled(p, line, size=13)
 
 
+def apply_fonts(prs: Presentation, *, en: str, ko: str) -> None:
+    """Choose installed fonts for this builder's text and notes before saving.
+
+    Does not install/embed fonts or change sizes. This helper handles text frames
+    produced here, not fonts inside images, equations, tables or charts.
+    """
+    if not en.strip() or not ko.strip():
+        raise ValueError("Both Latin and East Asian font names must be nonempty")
+    for slide in prs.slides:
+        frames = [s.text_frame for s in slide.shapes if s.has_text_frame]
+        if slide.has_notes_slide:
+            frames.append(slide.notes_slide.notes_text_frame)
+        for tf in frames:
+            for p in tf.paragraphs:
+                for font in p._p.iter(f"{{{A_NS}}}buFont"):
+                    font.set("typeface", en)
+                for r in p.runs:
+                    r.font.name = en
+                    rPr = r._r.get_or_add_rPr()
+                    ea = rPr.find(f"{{{A_NS}}}ea")
+                    if ea is None:
+                        ea = etree.SubElement(rPr, f"{{{A_NS}}}ea")
+                    ea.set("typeface", ko)
+
+
+def _bullet(p, text: str, *, sub: bool = False, size: float = 20) -> None:
+    """Native paragraph bullet: wrapped lines align with the text, not the marker."""
+    p.level = 1 if sub else 0
+    pPr = p._p.get_or_add_pPr()
+    pPr.set("marL", str(Inches(0.65 if sub else 0.3)))
+    pPr.set("indent", str(-Inches(0.2)))
+    for child in list(pPr):
+        if etree.QName(child).localname.startswith("bu"):
+            pPr.remove(child)
+    color = etree.SubElement(pPr, f"{{{A_NS}}}buClr")
+    etree.SubElement(color, f"{{{A_NS}}}srgbClr").set(
+        "val", str(COLOR_MUTED if sub else COLOR_HIGHLIGHT))
+    etree.SubElement(pPr, f"{{{A_NS}}}buFont").set("typeface", FONT_EN)
+    etree.SubElement(pPr, f"{{{A_NS}}}buChar").set("char", "–" if sub else "▪")
+    add_styled(p, text, size=size, color=COLOR_TEXT_SUB if sub else COLOR_TEXT)
+
+
 # ============================================================================
 # Presentation initialization
 # ============================================================================
@@ -243,7 +285,7 @@ def add_title_slide(prs: Presentation, *,
     if subtitle:
         p2 = tf.add_paragraph(); p2.alignment = PP_ALIGN.LEFT
         r2 = p2.add_run(); r2.text = subtitle
-        set_run(r2, size=18, italic=True, color=COLOR_TEXT_SUB)
+        set_run(r2, size=20, italic=True, color=COLOR_TEXT_SUB)
 
     if meta_top or meta_bottom:
         _rule(s, x=1.1, y=5.95, w=2.0, color=COLOR_NAVY, pt=1.0)
@@ -356,7 +398,7 @@ def add_content_slide(prs: Presentation, *,
         r = p.add_run(); r.text = eyebrow
         set_run(r, size=20, bold=True, color=COLOR_MUTED, letter_space="300")
 
-    title_box = s.shapes.add_textbox(Inches(0.7), Inches(0.75), Inches(12.0), Inches(1.1))
+    title_box = s.shapes.add_textbox(Inches(0.7), Inches(0.75), Inches(12.0), Inches(1.6))
     ttf = title_box.text_frame; ttf.word_wrap = True
     p = ttf.paragraphs[0]; p.alignment = PP_ALIGN.LEFT
     r = p.add_run(); r.text = title
@@ -365,18 +407,21 @@ def add_content_slide(prs: Presentation, *,
     if subtitle:
         p2 = ttf.add_paragraph(); p2.alignment = PP_ALIGN.LEFT
         r2 = p2.add_run(); r2.text = subtitle
-        set_run(r2, size=15, italic=True, color=COLOR_TEXT_SUB)
+        set_run(r2, size=20, italic=True, color=COLOR_TEXT_SUB)
 
-    _rule(s, x=0.7, y=2.06, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
+    _rule(s, x=0.7, y=2.45, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
     has_fig = figure_path is not None and Path(figure_path).exists()
     if has_fig:
         bullet_w = Inches(6.8)
-        fig_x_in, fig_w_in, fig_h_in = 7.9, 5.0, 4.0
+        # Leave a caption band above the source footer. A long caption still
+        # needs a render; never shrink the text to make it fit.
+        fig_x_in, fig_w_in = 7.9, 5.0
+        fig_h_in = 3.0 if fig_caption else 4.0
     else:
         bullet_w = Inches(12.0)
 
-    bullet_box = s.shapes.add_textbox(Inches(0.7), Inches(2.4), bullet_w, Inches(4.6))
+    bullet_box = s.shapes.add_textbox(Inches(0.7), Inches(2.7), bullet_w, Inches(4.3))
     btf = bullet_box.text_frame; btf.word_wrap = True
     for i, raw in enumerate(bullets):
         p = btf.paragraphs[0] if i == 0 else btf.add_paragraph()
@@ -385,21 +430,12 @@ def add_content_slide(prs: Presentation, *,
         p.line_spacing = 1.25
 
         is_sub = raw.startswith("  ")
-        if is_sub:
-            p.level = 1
-            text = raw[2:]
-            r = p.add_run(); r.text = "— "
-            set_run(r, size=15, color=COLOR_MUTED)
-            add_styled(p, text, size=16, color=COLOR_TEXT_SUB)
-        else:
-            r = p.add_run(); r.text = "▪  "
-            set_run(r, size=14, bold=True, color=COLOR_HIGHLIGHT)
-            add_styled(p, raw, size=20, color=COLOR_TEXT)
+        _bullet(p, raw[2:] if is_sub else raw, sub=is_sub)
 
     if has_fig:
         from PIL import Image as PILImage
-        img = PILImage.open(figure_path)
-        iw, ih = img.size
+        with PILImage.open(figure_path) as img:
+            iw, ih = img.size
         ar = iw / ih  # width / height
         if ar > fig_w_in / fig_h_in:
             w_in = fig_w_in
@@ -409,7 +445,7 @@ def add_content_slide(prs: Presentation, *,
             w_in = fig_h_in * ar
 
         fx_in = fig_x_in + (fig_w_in - w_in) / 2
-        fy_in = 2.4 + (fig_h_in - h_in) / 2
+        fy_in = 2.7 + (fig_h_in - h_in) / 2
 
         shadow = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
                                     Inches(fx_in + 0.06), Inches(fy_in + 0.06),
@@ -424,9 +460,9 @@ def add_content_slide(prs: Presentation, *,
         pic.line.width = Emu(6000)
 
         if fig_caption:
-            cap_y_in = min(fy_in + h_in + 0.10, 6.55)
+            cap_y_in = fy_in + h_in + 0.10
             cap = s.shapes.add_textbox(Inches(fig_x_in), Inches(cap_y_in),
-                                       Inches(fig_w_in), Inches(0.6))
+                                       Inches(fig_w_in), Inches(1.2))
             ctf = cap.text_frame; ctf.word_wrap = True
             cp = ctf.paragraphs[0]; cp.alignment = PP_ALIGN.CENTER
             cr = cp.add_run(); cr.text = "Figure  ·  "
@@ -457,8 +493,11 @@ def add_toc_slide(prs: Presentation, *,
                    notes: str | None = None):
     """Outline slide. `sections` = [(num, title, summary, time_label), ...].
 
-    Use num="·" for non-numbered final entry (e.g., wrap-up).
+    Use num="·" for non-numbered final entry (e.g., wrap-up). Up to five rows;
+    split longer outlines across slides instead of silently placing rows off-slide.
     """
+    if len(sections) > 5:
+        raise ValueError("Outline supports at most five rows; split it across slides")
     s = _blank(prs)
 
     eye = s.shapes.add_textbox(Inches(0.7), Inches(0.32), Inches(8), Inches(0.4))
@@ -473,12 +512,12 @@ def add_toc_slide(prs: Presentation, *,
     if subtitle:
         p2 = tb.text_frame.add_paragraph()
         r2 = p2.add_run(); r2.text = subtitle
-        set_run(r2, size=16, italic=True, color=COLOR_TEXT_SUB)
+        set_run(r2, size=20, italic=True, color=COLOR_TEXT_SUB)
 
     _rule(s, x=0.7, y=2.1, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
-    y_start = 2.5
-    row_h = 0.85
+    y_start = 2.4
+    row_h = 0.9
     for i, (num, sec_title, summary, time_label) in enumerate(sections):
         y = y_start + i * row_h
 
@@ -491,26 +530,25 @@ def add_toc_slide(prs: Presentation, *,
         tb2 = s.shapes.add_textbox(Inches(1.9), Inches(y), Inches(9.5), Inches(row_h))
         tt = tb2.text_frame; tt.word_wrap = True
         p = tt.paragraphs[0]; p.alignment = PP_ALIGN.LEFT
+        p.line_spacing = 1.0
         r = p.add_run(); r.text = sec_title
         set_run(r, size=22, bold=True, color=COLOR_NAVY)
         p.space_after = Pt(2)
         p2 = tt.add_paragraph()
+        p2.line_spacing = 1.0
         r2 = p2.add_run(); r2.text = summary
-        set_run(r2, size=13, color=COLOR_TEXT_SUB)
+        set_run(r2, size=20, color=COLOR_TEXT_SUB)
 
         if time_label:
             time_b = s.shapes.add_textbox(Inches(11.5), Inches(y + 0.1),
                                           Inches(1.5), Inches(0.5))
             p = time_b.text_frame.paragraphs[0]; p.alignment = PP_ALIGN.RIGHT
             r = p.add_run(); r.text = time_label
-            set_run(r, size=12, color=COLOR_MUTED)
+            set_run(r, size=20, color=COLOR_MUTED)
 
         if i < len(sections) - 1:
-            divider = s.shapes.add_shape(MSO_SHAPE.RECTANGLE,
-                                         Inches(0.7), Inches(y + row_h - 0.04),
-                                         Inches(12.0), Emu(6000))
-            divider.fill.solid(); divider.fill.fore_color.rgb = COLOR_HAIRLINE
-            divider.line.fill.background()
+            _rule(s, x=0.7, y=y + row_h - 0.02, w=12.0,
+                  color=COLOR_HAIRLINE, pt=0.5)
 
     if page_brand:
         pf = s.shapes.add_textbox(Inches(0.7), Inches(7.05), Inches(12.0), Inches(0.35))
@@ -536,6 +574,8 @@ def add_glossary_slide(prs: Presentation, *,
 
     See ~/.claude/rules/multidisciplinary-presentation.md §1.
     """
+    if len(tier1) > 7 or len(tier2) > 12:
+        raise ValueError("Glossary supports at most seven main and twelve secondary entries; split it across slides")
     s = _blank(prs)
 
     if eyebrow:  # OFF by default. An eyebrow on every slide is the AI tell —
@@ -552,35 +592,41 @@ def add_glossary_slide(prs: Presentation, *,
 
     _rule(s, x=0.7, y=1.65, w=0.6, color=COLOR_HIGHLIGHT, pt=2.5)
 
+    # Reserve rows for the entries supplied. These are layout slots, not a text-fit
+    # prediction: keep definitions brief and verify the rendered PDF.
+    tier1_h = len(tier1) * 0.36 + 0.1 if tier1 else 0
+    tier2_y = 1.9 + tier1_h + (0.15 if tier1 else 0)
     # Tier 1 — full width
     if tier1:
-        box = s.shapes.add_textbox(Inches(0.7), Inches(1.9), Inches(12.0), Inches(2.3))
+        box = s.shapes.add_textbox(Inches(0.7), Inches(1.9), Inches(12.0), Inches(tier1_h))
         tf = box.text_frame; tf.word_wrap = True
         for i, (abbr, ctx) in enumerate(tier1):
             p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
             p.alignment = PP_ALIGN.LEFT
-            p.space_after = Pt(6)
+            p.space_after = Pt(4)
+            p.line_spacing = 1.0
             r = p.add_run(); r.text = f"{abbr}  "
-            set_run(r, size=15, bold=True, color=COLOR_NAVY)
+            set_run(r, size=20, bold=True, color=COLOR_NAVY)
             r2 = p.add_run(); r2.text = ctx
-            set_run(r2, size=14, color=COLOR_TEXT_SUB)
+            set_run(r2, size=20, color=COLOR_TEXT_SUB)
 
     # Tier 2 — 2-column
     if tier2:
         half = (len(tier2) + 1) // 2
         for col, items in enumerate((tier2[:half], tier2[half:])):
             x_in = 0.7 + col * 6.3
-            box = s.shapes.add_textbox(Inches(x_in), Inches(4.3),
-                                        Inches(6.0), Inches(2.7))
+            box = s.shapes.add_textbox(Inches(x_in), Inches(tier2_y),
+                                        Inches(6.0), Inches(7.0 - tier2_y))
             tf = box.text_frame; tf.word_wrap = True
             for i, (abbr, defn) in enumerate(items):
                 p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
                 p.alignment = PP_ALIGN.LEFT
                 p.space_after = Pt(3)
+                p.line_spacing = 1.0
                 r = p.add_run(); r.text = f"{abbr}  "
-                set_run(r, size=12, bold=True, color=COLOR_NAVY)
+                set_run(r, size=20, bold=True, color=COLOR_NAVY)
                 r2 = p.add_run(); r2.text = defn
-                set_run(r2, size=11, color=COLOR_TEXT_SUB)
+                set_run(r2, size=20, color=COLOR_TEXT_SUB)
 
     if page_brand:
         pb = s.shapes.add_textbox(Inches(0.7), Inches(7.05), Inches(4.0), Inches(0.35))
@@ -620,9 +666,7 @@ def add_closing_slide(prs: Presentation, *,
             p.alignment = PP_ALIGN.LEFT
             p.space_after = Pt(14)
             p.line_spacing = 1.3
-            r = p.add_run(); r.text = "▪  "
-            set_run(r, size=16, bold=True, color=COLOR_HIGHLIGHT)
-            add_styled(p, raw, size=22, color=COLOR_TEXT)
+            _bullet(p, raw, size=22)
 
     if contact:
         cb = s.shapes.add_textbox(Inches(0.7), Inches(6.5), Inches(12.0), Inches(0.5))

--- a/skills/present-paper/tests/test_builder_layout.py
+++ b/skills/present-paper/tests/test_builder_layout.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Exercise every shipped slide builder with synthetic content and existing checks.
+
+Use --write-demo PATH to retain the same deck for a separate renderer-based review.
+The tests inspect PPTX structure; they do not certify how PowerPoint renders it.
+"""
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+from PIL import Image
+from pptx.util import Pt
+
+SKILL = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(SKILL / 'templates'), str(SKILL / 'scripts')]
+import build_pptx_nature_lancet as b
+import check_deck_budget as budget
+
+ACADEMIC = ('conference_oral', 'critique', 'case_anchored', 'didactic', 'defence')
+
+
+def build_demo(path):
+    """All seven builders, including a real image slot, short labels and nested lists."""
+    prs = b.new_presentation()
+    b.add_title_slide(prs, eyebrow='SYNTHETIC EXAMPLE', title='Document processing',
+        subtitle='A demonstration of the slide template', meta_top='Software test',
+        meta_bottom='Example presenter', notes='Preserve **source text** and *formatting*.')
+    b.add_toc_slide(prs, subtitle='Workflow overview', sections=[
+        ('01', 'Inputs', 'Read the source files', '5 min'),
+        ('02', 'Outputs', 'Check the final document', '5 min')])
+    b.add_section_divider(prs, num='01', title='Inputs', subtitle='Text and figures', time_min=5)
+    b.add_transition_slide(prs, question='Which file is current?')
+    b.add_content_slide(prs, title='Inputs remain unchanged', subtitle='Source preservation',
+        bullets=['Keep the **original file**', '  Write outputs to a separate folder',
+                 'Check the final artifact'])
+    with tempfile.TemporaryDirectory() as td:
+        slot = Path(td) / 'slot.png'
+        # An inert image-slot fixture, not an illustrative visual asset.
+        Image.new('RGB', (120, 160), '#e0e0e0').save(slot)
+        b.add_content_slide(prs, title='Output review', bullets=['Read the text', 'Inspect the figure'],
+            figure_path=slot, fig_caption='Synthetic image slot', footnote='Synthetic source')
+    b.add_glossary_slide(prs, tier1=[('SRC', 'Source file'), ('OUT', 'Output file'),
+        ('LOG', 'Run record'), ('VER', 'File version')],
+        tier2=[(f'T{i}', f'Example term {i}') for i in range(8)])
+    b.add_closing_slide(prs, bullets=['Preserve the source', 'Review the output'],
+        contact='Documentation team')
+    prs.save(path)
+    b.fix_app_xml(path)
+    return prs
+
+
+class BuilderCompatibility(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.deck = Path(self.temp.name) / 'deck.pptx'
+        self.prs = build_demo(self.deck)
+
+    def test_every_builder_clears_academic_budget(self):
+        self.assertEqual(len(self.prs.slides), 8)
+        for archetype in ACADEMIC:
+            with self.subTest(archetype=archetype):
+                self.assertEqual(budget.audit(self.deck, archetype, 20), [])
+
+    def test_large_room_profiles_are_not_silently_certified(self):
+        for archetype in ('keynote', 'lay_talk', 'decision_brief'):
+            findings = budget.audit(self.deck, archetype, 20)
+            self.assertIn('TYPE_TOO_SMALL', {f.verdict for f in findings})
+
+    def test_regressing_glossary_type_is_detected(self):
+        for shape in self.prs.slides[6].shapes:
+            if shape.has_text_frame and shape.text.startswith('SRC'):
+                for p in shape.text_frame.paragraphs:
+                    for r in p.runs:
+                        r.font.size = Pt(12)
+        self.prs.save(self.deck)
+        self.assertIn('TYPE_TOO_SMALL', {f.verdict for f in budget.audit(self.deck, 'conference_oral', 20)})
+
+    def test_native_bullets_preserve_content_and_hanging_indent(self):
+        for slide_no, first in [(4, 'Keep the original file'), (7, 'Preserve the source')]:
+            shape = next(s for s in self.prs.slides[slide_no].shapes
+                         if s.has_text_frame and s.text.startswith(first))
+            for p in shape.text_frame.paragraphs:
+                self.assertFalse(p.text.startswith(('▪', '—', '–')))
+                props = p._p.get_or_add_pPr()
+                self.assertIsNotNone(props.find(f'{{{b.A_NS}}}buChar'))
+                margin, indent = int(props.get('marL')), int(props.get('indent'))
+                self.assertLess(indent, 0)
+                self.assertGreater(margin + indent, 0)
+                self.assertTrue(all(r.font.size.pt >= 20 for r in p.runs))
+            if slide_no == 4:
+                self.assertEqual(shape.text_frame.paragraphs[1].level, 1)
+                self.assertTrue(any(r.font.bold and r.text == 'original file'
+                                    for r in shape.text_frame.paragraphs[0].runs))
+
+    def test_fonts_can_change_without_rewriting_text_or_formatting(self):
+        def frames():
+            for slide in self.prs.slides:
+                yield from (s.text_frame for s in slide.shapes if s.has_text_frame)
+                if slide.has_notes_slide:
+                    yield slide.notes_slide.notes_text_frame
+        def snapshot():
+            return [(r.text, r.font.size, r.font.bold, r.font.italic)
+                    for tf in frames() for p in tf.paragraphs for r in p.runs]
+        before = snapshot()
+        b.apply_fonts(self.prs, en='Example Sans', ko='Example CJK')
+        self.assertEqual(snapshot(), before)
+        for tf in frames():
+            for p in tf.paragraphs:
+                for r in p.runs:
+                    self.assertEqual(r.font.name, 'Example Sans')
+                    self.assertEqual(r._r.get_or_add_rPr().find(f'{{{b.A_NS}}}ea').get('typeface'), 'Example CJK')
+                for font in p._p.iter(f'{{{b.A_NS}}}buFont'):
+                    self.assertEqual(font.get('typeface'), 'Example Sans')
+        with self.assertRaises(ValueError):
+            b.apply_fonts(self.prs, en='', ko='Example CJK')
+
+    def test_maximum_outline_and_glossary_stay_on_canvas(self):
+        prs = b.new_presentation()
+        b.add_toc_slide(prs, sections=[(str(i), 'Section', 'Short summary', '5 min') for i in range(5)])
+        b.add_glossary_slide(prs, tier1=[(f'A{i}', 'Main concept') for i in range(7)],
+                             tier2=[(f'B{i}', 'Short definition') for i in range(12)])
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                self.assertGreaterEqual(shape.left, 0)
+                self.assertGreaterEqual(shape.top, 0)
+                self.assertLessEqual(shape.left + shape.width, prs.slide_width)
+                self.assertLessEqual(shape.top + shape.height, prs.slide_height)
+        prs.save(self.deck)
+        # Capacity limits are not a promise of acceptable information density.
+        findings = budget.audit(self.deck, 'conference_oral', 20)
+        self.assertEqual({f.verdict for f in findings}, {'SLIDE_TOO_DENSE'})
+
+    def test_excess_entries_fail_before_creating_a_partial_slide(self):
+        before = len(self.prs.slides)
+        for call in [lambda: b.add_toc_slide(self.prs, sections=[('1', 'Section', '', '')]*6),
+                     lambda: b.add_glossary_slide(self.prs, tier1=[('A', 'Term')]*8),
+                     lambda: b.add_glossary_slide(self.prs, tier2=[('A', 'Term')]*13)]:
+            with self.assertRaisesRegex(ValueError, 'split'):
+                call()
+            self.assertEqual(len(self.prs.slides), before)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3 and sys.argv[1] == '--write-demo':
+        build_demo(Path(sys.argv[2]))
+    else:
+        unittest.main()

--- a/skills/present-paper/tests/test_overflow_pdf.py
+++ b/skills/present-paper/tests/test_overflow_pdf.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Exercise the real poppler command, without needing an office renderer in CI.
+
+The tiny vector PDFs below are controlled measurements, not exports of the PPTX.
+Builder rendering and PowerPoint compatibility still need separate visual review.
+"""
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.util import Inches
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import check_text_overflow as overflow
+
+
+def write_pdf(path, *, baseline=400):
+    """One page, standard Helvetica, one line at a known PDF baseline."""
+    stream = f'BT /F1 20 Tf 72 {baseline} Td (Synthetic text) Tj ET\n'.encode('ascii')
+    objects = [b'<< /Type /Catalog /Pages 2 0 R >>',
+        b'<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+        b'<< /Type /Page /Parent 2 0 R /MediaBox [0 0 960 540] '
+        b'/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+        b'<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+        f'<< /Length {len(stream)} >>\nstream\n'.encode('ascii') + stream + b'endstream']
+    data = bytearray(b'%PDF-1.4\n'); offsets = [0]
+    for i, obj in enumerate(objects, 1):
+        offsets.append(len(data)); data.extend(f'{i} 0 obj\n'.encode('ascii') + obj + b'\nendobj\n')
+    xref = len(data)
+    data.extend(f'xref\n0 {len(offsets)}\n0000000000 65535 f \n'.encode('ascii'))
+    for offset in offsets[1:]:
+        data.extend(f'{offset:010d} 00000 n \n'.encode('ascii'))
+    data.extend(f'trailer\n<< /Size {len(offsets)} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n'.encode('ascii'))
+    path.write_bytes(data)
+
+
+class ActualPDFMeasurement(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(); self.addCleanup(self.temp.cleanup)
+        self.deck = Path(self.temp.name) / 'deck.pptx'
+        self.pdf = Path(self.temp.name) / 'deck.pdf'
+        prs = Presentation(); prs.slide_width = Inches(13.333); prs.slide_height = Inches(7.5)
+        slide = prs.slides.add_slide(prs.slide_layouts[6])
+        # A background and a foreground text box deliberately overlap. The
+        # overlap itself is not clipping and must remain a clean control.
+        card = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(.8), Inches(1.5), Inches(8), Inches(2))
+        card.fill.solid()
+        slide.shapes.add_textbox(Inches(1), Inches(1.7), Inches(7), Inches(1)).text = 'Synthetic text'
+        prs.save(self.deck)
+
+    def measure(self, baseline):
+        write_pdf(self.pdf, baseline=baseline)
+        xml = overflow.run_pdftotext(self.pdf)
+        self.assertIn('<line ', xml)
+        self.assertIn('Synthetic', xml)
+        return overflow.audit(self.deck, xml, .1)
+
+    def test_real_pdf_text_inside_filled_background_is_clean(self):
+        self.assertEqual(self.measure(400), [])
+
+    def test_real_pdf_line_crossing_card_is_reported(self):
+        self.assertEqual({f.verdict for f in self.measure(282)}, {'CARD'})
+
+    def test_real_pdf_line_crossing_bottom_reserve_is_reported(self):
+        self.assertEqual({f.verdict for f in self.measure(6)}, {'OFF_SLIDE'})
+        result = subprocess.run([sys.executable, str(Path(overflow.__file__)), str(self.deck),
+            '--pdf', str(self.pdf), '--strict'], text=True, capture_output=True)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+
+    def test_plain_bbox_is_not_misreported_as_a_clean_measurement(self):
+        write_pdf(self.pdf)
+        xml = subprocess.run(['pdftotext', '-bbox', str(self.pdf), '-'],
+            check=True, text=True, capture_output=True).stdout
+        self.assertIn('<word ', xml)
+        self.assertNotIn('<line ', xml)
+        with self.assertRaisesRegex(overflow.CannotMeasure, 'bbox-layout'):
+            overflow.audit(self.deck, xml, .1)
+
+    def test_blank_page_is_not_a_parser_error(self):
+        self.assertEqual(overflow.parse_bbox('<page width="960" height="540"></page>'), {1: []})
+
+    def test_one_usable_page_does_not_hide_an_incompatible_page(self):
+        xml = ('<page width="960" height="540"><line xMin="1" yMin="2" xMax="3" yMax="4">'
+               '<word>Readable</word></line></page><page width="960" height="540">'
+               '<word xMin="1" yMin="2" xMax="3" yMax="4">Unusable</word></page>')
+        with self.assertRaises(overflow.CannotMeasure):
+            overflow.parse_bbox(xml)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem and change

The slide overflow checker requested `pdftotext -bbox` word coordinates but parsed line rectangles. Actual PDFs could therefore pass without any text being measured. It now requests `-bbox-layout` and rejects word-only measurements that contain no usable lines. The existing recorded-coordinate challenge is identified correctly as synthetic, and the same CI step now tests real poppler output with tiny controlled PDFs.

The Nature/Lancet builder now uses 20 pt body subtitles, sub-bullets, outline summaries/time labels and glossary text. Native paragraph bullets preserve emphasis and align wrapped lines. The content grid leaves space for a wrapped heading and caption; outline/glossary capacity limits reject excess rows before creating a partial slide. An `apply_fonts` helper changes the builder's text, native bullet fonts and notes without rewriting content. Font-check success wording no longer promises font installation or renderer availability.

Consistency linting now keeps numeric/hyphenated abbreviations whole, avoids falsely finding mixed COVID-19 spellings in one occurrence, and permits grammatical follow-up/follow up and long-term/in the long term pairs. Normal synthetic US/UK prose supplements the seeded-error challenge. Style findings remain advisory.

## Validation and limits

- 23 new regression tests, plus the existing seeded 11-issue challenge and two clean controls.
- Bundled LibreOffice rendered 12 synthetic slides covering all seven builders, wrapped text, maximum entry counts and Korean text. All 103 source paragraphs were found in the rendered PDFs; Inter/Pretendard output fonts were verified. An intentionally overflowing control changed from a false pass to `OFF_SLIDE`.
- Full local CI mirror: 251 steps. New tests extend existing steps; no workflow, job or renderer dependency was added.
- Public examples are synthetic. Staged changes and publication text were checked for private identifiers and credentials.

These are existing implementation fixes, not new manuscript gates. Density warnings remain active, larger-type venue profiles require adaptation, and overflow checks do not prove that text was never omitted by a renderer or detect every possible overlap. The rendering review did not use PowerPoint. No release version change.
