### PR TITLE
Verify published release payloads and prepare v5.26.2 hotfix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ name: Release
 #
 # The npm publish step runs only when the `NPM_TOKEN` repo secret is set (a granular/automation token
 # scoped to medsci-skills with publish rights + 2FA bypass), and skips if that version is already on
-# npm, so re-running a tag is safe. It runs AFTER the GitHub Release so an npm hiccup never blocks it.
+# npm, and verifies that the existing payload matches. It runs AFTER the GitHub Release;
+# a later npm failure leaves the ZIP release published and requires recovery.
 #
 # Supply-chain posture (see SECURITY.md "Release integrity & revocation"): the self-updater verifies
 # each download's sha256 against the github.com API digest, which detects transport/asset tampering
@@ -21,7 +22,8 @@ name: Release
 #   * a version-consistency gate (CITATION == package.json == manifest == the pushed tag);
 #   * build-provenance attestation of the ZIP artifacts;
 #   * a post-build check that each ZIP round-trips through the updater's own safe-extract + provenance
-#     validation, so a release can never ship a ZIP the updater would refuse.
+#     validation, selected-source byte comparison and existing privacy scanners;
+#   * downloaded ZIP byte and npm payload comparison after publication.
 
 on:
   push:
@@ -45,6 +47,11 @@ env:
 
 # Least privilege: contents:write to publish the release; id-token + attestations for the build
 # provenance attestation. Nothing else.
+# Serialize recovery runs for the same tag; never cancel a publication midway.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -69,6 +76,32 @@ jobs:
           # compares the tag against the CHECKED-OUT manifest — so a republish must check out the tag
           # or it would validate the wrong tree.
           ref: ${{ inputs.tag || github.ref_name }}
+
+      # Keep verification tools at the workflow commit on recovery runs. The
+      # payload remains the selected tag, including tags predating these checks.
+      - name: Checkout verification tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tools
+          persist-credentials: false
+
+      - name: Resolve the selected release commit
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          test "$SOURCE_SHA" = "$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          echo "SOURCE_SHA=$SOURCE_SHA" >> "$GITHUB_ENV"
+
+      - name: Set up Node for packing and npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install metadata inspection tools
+        run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl poppler-utils
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -96,28 +129,33 @@ jobs:
         run: |
           set -euo pipefail
           BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          python3 scripts/build_classroom_release.py \
+          python3 .release-tools/scripts/build_classroom_release.py --source-root . --output-dir dist \
             --tag "${RELEASE_TAG}" \
-            --git-sha "${GITHUB_SHA}" \
+            --git-sha "${SOURCE_SHA}" \
             --built-at "${BUILT_AT}"
+
+      - name: Pack the exact npm artifact before publication
+        run: |
+          set -euo pipefail
+          npm pack --json --pack-destination dist > dist/npm-pack.json
 
       - name: Verify ZIPs are consumable by the self-updater (provenance + safe-extract round-trip)
         run: |
           set -euo pipefail
           for zip in dist/medsci-skills-classroom-*.zip; do
-            python3 scripts/check_release_zip.py --zip "$zip" \
-              --expect-tag "${RELEASE_TAG}" --require-provenance
+            python3 .release-tools/scripts/check_release_zip.py --zip "$zip" \
+              --expect-tag "${RELEASE_TAG}" --require-provenance \
+              --expect-sha "${SOURCE_SHA}" --source-root . --privacy \
+              --report "${zip%.zip}-verification.json"
           done
 
-      - name: List built artifacts
+      - name: Verify actual npm payload and privacy
         run: |
-          ls -lh dist/
-          echo "---"
-          echo "ZIP contents preview:"
-          for zip in dist/*.zip; do
-            echo "## ${zip}"
-            unzip -l "${zip}" | head -20
-          done
+          set -euo pipefail
+          python3 .release-tools/scripts/check_npm_package_contents.py \
+            --tarball "dist/medsci-skills-${RELEASE_TAG#v}.tgz" \
+            --source-root . --expect-version "${RELEASE_TAG#v}" --privacy \
+            --report dist/npm-verification.json
 
       - name: Attest build provenance of the release ZIPs
         uses: actions/attest-build-provenance@v2
@@ -127,6 +165,7 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         id: notes
         run: |
+          set -euo pipefail
           TAG="${RELEASE_TAG}"
           # Tags are "vX.Y.Z" but CHANGELOG headers are "## [X.Y.Z]" (no leading v).
           # Strip the v so the section is actually found (else notes fall back).
@@ -137,25 +176,33 @@ jobs:
               $0 ~ "^## \\[?"ver"\\]?" { found=1; next }
               found && /^## / { exit }
               found { print }
-            ' CHANGELOG.md > /tmp/release_notes.md
+            ' CHANGELOG.md > dist/release-notes.md
           else
-            echo "Release ${TAG}" > /tmp/release_notes.md
+            echo "Release ${TAG}" > dist/release-notes.md
           fi
 
           # Fallback if CHANGELOG section was empty
-          if [ ! -s /tmp/release_notes.md ]; then
-            echo "Release ${TAG}" > /tmp/release_notes.md
-            echo "" >> /tmp/release_notes.md
-            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> /tmp/release_notes.md
+          if [ ! -s dist/release-notes.md ]; then
+            echo "Release ${TAG}" > dist/release-notes.md
+            echo "" >> dist/release-notes.md
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> dist/release-notes.md
           fi
 
-          echo "Release notes preview:"
-          cat /tmp/release_notes.md
+          # Inspect notes before any preview or public upload; findings never quote values.
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, '.release-tools/scripts')
+          from release_payload import privacy
+          findings, _ = privacy({'release-notes.md': Path('dist/release-notes.md').read_bytes()})
+          if findings:
+              raise SystemExit('Release notes failed privacy inspection')
+          PY
 
       - name: Create GitHub Release with classroom ZIP attached
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Publish the SAME classroom artifacts that were verified (line ~75) and attested (line ~97);
+        # Publish the SAME classroom artifacts that were verified (above) and attested (above);
         # the glob is identical so a release can only ship a ZIP that round-tripped + was attested.
         # Nothing modifies dist/ between those steps and this upload, so the API sha256 the updater
         # later checks covers exactly the verified bytes.
@@ -172,12 +219,12 @@ jobs:
             echo "Release $TAG already exists — updating notes and (re)uploading assets."
             gh release edit "$TAG" \
               --title "MedSci Skills ${TAG}" \
-              --notes-file /tmp/release_notes.md
+              --notes-file dist/release-notes.md
             gh release upload "$TAG" dist/medsci-skills-classroom-*.zip --clobber
           else
             gh release create "$TAG" \
               --title "MedSci Skills ${TAG}" \
-              --notes-file /tmp/release_notes.md \
+              --notes-file dist/release-notes.md \
               dist/medsci-skills-classroom-*.zip
           fi
           # Assert the outcome rather than the command's exit code: a release that ends with no
@@ -189,14 +236,23 @@ jobs:
             exit 1
           fi
 
-      # --- npm publish (last, gated on NPM_TOKEN, idempotent) so a npm issue never blocks the release ---
-      - name: Set up Node for npm publish
-        if: env.HAS_NPM_TOKEN == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+      - name: Download and compare published ZIPs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" --pattern 'medsci-skills-classroom-*.zip' \
+            --dir dist/downloaded
+          for platform in macos windows; do
+            asset="medsci-skills-classroom-${platform}.zip"
+            python3 .release-tools/scripts/check_release_zip.py \
+              --zip "dist/downloaded/$asset" --reference "dist/$asset" \
+              --expect-tag "$RELEASE_TAG" --expect-sha "$SOURCE_SHA" \
+              --require-provenance --source-root . \
+              --report "dist/${platform}-published-verification.json"
+          done
 
+      # npm is published from the already inspected tarball. No second pack.
       - name: Publish to npm (idempotent; npm provenance via OIDC)
         if: env.HAS_NPM_TOKEN == 'true'
         env:
@@ -211,5 +267,22 @@ jobs:
           fi
           # --provenance links the published package to this GitHub Actions build via OIDC
           # (uses the id-token permission already granted above).
-          npm publish --provenance --access public
+          npm publish "./dist/medsci-skills-${VER}.tgz" --ignore-scripts --provenance --access public
           echo "Published medsci-skills@${VER} to npm."
+
+      - name: Download and compare published npm payload
+        if: env.HAS_NPM_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+          python3 .release-tools/scripts/check_npm_package_contents.py \
+            --published-version "${RELEASE_TAG#v}" \
+            --reference "dist/medsci-skills-${RELEASE_TAG#v}.tgz" --source-root . \
+            --report dist/npm-published-verification.json
+
+      - name: Retain successful verification records
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-verification-${{ env.RELEASE_TAG }}
+          path: |
+            dist/*-verification.json
+          retention-days: 30

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,7 +88,9 @@ jobs:
         run: python3 installers/tests/test_cursor_rule.py
 
       - name: Release-ZIP provenance + updater-consumability round-trip (build -> safe-extract)
-        run: bash installers/tests/test_release_zip.sh
+        run: |
+          bash installers/tests/test_release_zip.sh
+          python3 tests/test_release_payloads.py
 
       - name: Run validate_routing_assets.py (SKILL.md asset references must exist)
         run: python3 scripts/validate_routing_assets.py --strict
@@ -818,7 +820,7 @@ jobs:
         run: bash tests/test_npm_package.sh
 
       - name: npm pack content audit (real pack, package/ prefix normalized)
-        run: python3 scripts/check_npm_package_contents.py --real
+        run: python3 scripts/check_npm_package_contents.py --real --privacy
 
   # Cross-platform safety for the transactional installer + updater (PR-1a/PR-1b). Ubuntu-only CI
   # cannot assert macOS/Windows path/journal/os.replace/extraction behavior; this matrix runs the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ## [Unreleased]
 
+## [5.26.2] - 2026-09-06
+
+**Hotfix:** shipped PDF identity and presentation overflow checks could report a match or clean result without measuring the relevant evidence.
+
 ### Fixed
 
+- Inspect the actual npm tarball and classroom ZIPs against the selected release
+  source, including file hashes, existing private-identifier/credential patterns,
+  PDF text and binary/Office metadata. Publish the inspected tarball and download
+  both channels to compare the delivered payload. Recovery runs record the selected
+  tag commit and also verify npm versions that are already published.
+- Replace a contextual comment in an npm-shipped synthetic R fixture with neutral
+  wording. The test computation and expected result are unchanged.
 - Presentation overflow checks now request line coordinates from poppler instead of
   silently treating word-only output as a clean measurement. Real-PDF regression
   tests run in the existing CI step. The Nature/Lancet builder uses readable

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,8 +19,8 @@ authors:
 repository-code: "https://github.com/Aperivue/medsci-skills"
 url: "https://github.com/Aperivue/medsci-skills"
 license: MIT
-version: "5.26.1"
-date-released: "2026-09-05"
+version: "5.26.2"
+date-released: "2026-09-06"
 doi: "10.5281/zenodo.20155321"
 identifiers:
   - description: "Concept DOI (always points to the latest version)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,16 @@ For JOSS readiness, contributions should strengthen open-source practice signals
 
 ## Releasing (maintainers)
 
+Before tagging, run the full local CI mirror and regenerate the distribution manifest.
+The release workflow builds the selected tag, compares the actual ZIP/npm payloads to that
+checkout and runs the existing privacy scanners on the packaged bytes. npm publication uses
+the verified `.tgz`; do not replace it with a fresh directory-based `npm publish`.
+After upload, downloaded ZIP bytes and npm file contents/executable modes must match the
+verified artifacts. Inspect the `release-verification-vX.Y.Z` workflow artifact for hashes and
+coverage; absence of a successful report is not a pass. npm requires `NPM_TOKEN`, and skipped
+npm steps leave that channel unverified. See [SECURITY.md](SECURITY.md#release-integrity--revocation)
+for inspection limits and recovery behavior.
+
 **A release is an event, not a commit.** Merge to `main` continuously — that is what `main` is for —
 and let the work accumulate into something a person would actually want to read about.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,23 @@ What the release pipeline adds to make a published release trustworthy:
   anyone can verify a downloaded asset with `gh attestation verify <zip> --repo Aperivue/medsci-skills`.
 - A **pre-publish round-trip check** (`scripts/check_release_zip.py`) that runs the updater's own
   safe-extract + provenance validation, so a release cannot ship a ZIP the updater would reject.
+- **Selected-source comparison** for both classroom ZIPs and the actual npm tarball:
+  exact file sets and bytes must match the release checkout. The npm CLI must be executable.
+  Recovery runs use verification tools from the workflow commit while recording the selected
+  tag commit in ZIP provenance.
+- **Payload privacy inspection** reuses the existing hashed-identifier, credential and asset
+  metadata scanners. It includes packaged text, extracted PDF text and Office XML/relationships.
+  Missing extraction tools or unreadable assets fail verification. It does not perform OCR or
+  certify the absence of every possible personal identifier; public author attribution remains
+  allowed in root READMEs and one exact synthetic credential fixture is hash-allowlisted.
+- **Post-publication comparison** downloads both ZIPs and requires exact pre-upload bytes.
+  The published npm version must have valid registry SHA-512 integrity and the same file contents
+  and executable modes as the inspected tarball, including when publication is skipped because
+  that version already exists. Only tar/gzip headers may differ. Successful runs retain hash and
+  coverage reports for 30 days. A skipped npm job means that channel was not published or verified.
+
+Post-publication failures require recovery; they do not roll back an already public release.
+These checks apply to runs using the updated workflow, not retroactively to historical releases.
 
 ### If a release is compromised
 

--- a/metadata/distribution_manifest.json
+++ b/metadata/distribution_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "5.26.1",
+  "version": "5.26.2",
   "owned_skills": [
     "academic-aio",
     "add-journal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medsci-skills",
-  "version": "5.26.1",
+  "version": "5.26.2",
   "description": "MedSci Skills — a medical/scientific research skill suite for AI coding agents (Claude Code, Codex, Cursor, Copilot). The npm package is a terminal-friendly installer shortcut; the canonical distribution remains the GitHub repository and the Claude Code plugin marketplace.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Aperivue/medsci-skills#readme",

--- a/scripts/build_classroom_release.py
+++ b/scripts/build_classroom_release.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import subprocess
 import zipfile
 from pathlib import Path
@@ -149,12 +148,25 @@ def build_zip(platform: str, version: str, provenance: dict | None = None) -> Pa
 
 
 def main() -> int:
+    global REPO_ROOT, DIST_DIR, MANIFEST_PATH, TRACKED_FILES
     parser = argparse.ArgumentParser(description="Build classroom release ZIPs.")
     parser.add_argument("--version", default="latest", help="Version label for the ZIP root folder (ignored when --tag is given).")
     parser.add_argument("--tag", default=None, help="Release tag (e.g. v4.7.0). Injects a verified provenance.json and pins the root version.")
-    parser.add_argument("--git-sha", default=None, help="Commit SHA to record in provenance.json (release workflow supplies ${{ github.sha }}).")
+    parser.add_argument("--git-sha", default=None, help="Commit SHA to record in provenance.json (release workflow supplies the checked-out tag commit).")
     parser.add_argument("--built-at", default=None, help="Build timestamp (ISO-8601 UTC) to record in provenance.json.")
+    parser.add_argument('--source-root', type=Path, help='selected release checkout (may differ from the verification tools)')
+    parser.add_argument('--output-dir', type=Path, help='directory reserved for generated release artifacts')
     args = parser.parse_args()
+    if args.source_root:
+        REPO_ROOT = args.source_root.resolve()
+        MANIFEST_PATH = REPO_ROOT / 'metadata/distribution_manifest.json'
+        TRACKED_FILES = _git_tracked_files()
+        if not TRACKED_FILES:
+            parser.error('--source-root must contain tracked release source files')
+    if args.output_dir:
+        DIST_DIR = args.output_dir.resolve()
+        if DIST_DIR == REPO_ROOT or REPO_ROOT.is_relative_to(DIST_DIR):
+            parser.error('--output-dir must not contain the source checkout')
 
     provenance: dict | None = None
     version = args.version
@@ -179,9 +191,8 @@ def main() -> int:
             "built_at": args.built_at or "",
         }
 
-    if DIST_DIR.exists():
-        shutil.rmtree(DIST_DIR)
-    DIST_DIR.mkdir(parents=True)
+    # Only replace the two owned ZIPs; do not delete unrelated caller files.
+    DIST_DIR.mkdir(parents=True, exist_ok=True)
 
     outputs = [build_zip("windows", version, provenance), build_zip("macos", version, provenance)]
     for out in outputs:

--- a/scripts/check_npm_package_contents.py
+++ b/scripts/check_npm_package_contents.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """npm tarball content audit (allowlist/denylist gate).
 
-Parses the file list that `npm pack` would publish and asserts that
+The default mode parses the file list from `npm pack --dry-run` and asserts that
 (1) no private / dev / heavy / copyright-bearing path leaks into the tarball, and
 (2) the required public files are present.
+
+Actual --tarball/--real/--published-version modes also compare every payload file
+against the selected checkout; --privacy inspects text and binary metadata.
 
 This is defense-in-depth on top of the `files` allowlist in package.json: if the
 allowlist is ever loosened, this gate still blocks the dangerous paths.
@@ -20,9 +23,19 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
+import tempfile
+import tarfile
+import base64
+import hashlib
+import re
+import time
+import urllib.request
+import urllib.error
+import urllib.parse
+
+import release_payload as payload
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -104,20 +117,6 @@ def get_file_list(args) -> tuple[list[str], dict[str, int]]:
             sys.stderr.write("Could not locate JSON in npm pack output.\n")
             sys.exit(2)
         data = json.loads(out[start:])
-        if args.real:
-            # `npm pack` (no dry-run) writes a .tgz in the repo root; remove it to avoid churn.
-            entries = data if isinstance(data, list) else [data]
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                tgz = entry.get("filename")
-                if tgz:
-                    tgz_path = REPO_ROOT / tgz
-                    if tgz_path.exists():
-                        try:
-                            tgz_path.unlink()
-                        except OSError:
-                            pass
 
     # npm versions differ: --json may emit a single object instead of an array.
     if isinstance(data, dict):
@@ -150,11 +149,110 @@ def is_denied(p: str) -> bool:
     return False
 
 
+def download_published(version, dest):
+    """Read an exact public version; retry short registry propagation delays."""
+    if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', version):
+        raise payload.PayloadError('published version must be an exact release version')
+    for attempt in range(5):
+        try:
+            request = urllib.request.Request(f'https://registry.npmjs.org/medsci-skills/{version}',
+                                             headers={'Cache-Control': 'no-cache'})
+            with urllib.request.urlopen(request, timeout=15) as response:
+                info = json.loads(response.read(2 * 1024 * 1024))
+            if not isinstance(info, dict) or info.get('name') != 'medsci-skills' or info.get('version') != version:
+                raise payload.PayloadError('registry returned a different package/version')
+            url = info['dist']['tarball']
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme != 'https' or parsed.hostname != 'registry.npmjs.org':
+                raise payload.PayloadError('registry tarball URL is outside the public npm registry')
+            with urllib.request.urlopen(url, timeout=30) as response:
+                final_url = urllib.parse.urlparse(response.geturl())
+                if final_url.scheme != 'https' or final_url.hostname != 'registry.npmjs.org':
+                    raise payload.PayloadError('registry download redirected to a different host')
+                data = response.read(payload.update.MAX_TOTAL_UNCOMPRESSED + 1)
+            if len(data) > payload.update.MAX_TOTAL_UNCOMPRESSED:
+                raise payload.PayloadError('registry tarball exceeds size limit')
+            sri = info['dist'].get('integrity', '').split()
+            sha512 = 'sha512-' + base64.b64encode(hashlib.sha512(data).digest()).decode()
+            if sha512 not in sri:
+                raise payload.PayloadError('registry tarball integrity mismatch or unavailable')
+            dest.write_bytes(data)
+            return
+        except (urllib.error.URLError, TimeoutError):
+            if attempt == 4:
+                raise payload.PayloadError('registry download unavailable after bounded retries')
+            time.sleep(2 ** (attempt + 1))
+
+
+def check_tarball(path, *, source_root, expect_version=None, privacy_check=False,
+                  report_path=None, reference=None):
+    files, modes = payload.tar_files(path)
+    problems = [f'denied npm path: {payload.label(p)}' for p in files if is_denied(p)]
+    problems.extend(payload.compare_source(files, source_root, 'npm'))
+    config = json.loads(files.get('package.json', b'{}'))
+    expected = json.loads((source_root / 'package.json').read_text())
+    if not isinstance(config, dict) or config.get('name') != 'medsci-skills' or config.get('version') != (expect_version or expected['version']):
+        problems.append('npm package identity/version differs from the selected release')
+    if not modes.get('bin/medsci-skills.js', 0) & 0o111:
+        problems.append('npm CLI has no executable bit')
+    if reference is not None:
+        # Registries or npm versions may change gzip/tar headers. Compare payload
+        # paths, bytes and executable modes, not timestamps or compression headers.
+        before, before_modes = payload.tar_files(reference)
+        if files != before or any((modes[p] & 0o111) != (before_modes.get(p, 0) & 0o111) for p in files):
+            problems.append('downloaded npm payload differs from the verified pre-publish payload')
+    counts = None
+    if privacy_check:
+        findings, counts = payload.privacy(files)
+        problems.extend(findings)
+    payload.write_report(report_path, path, files, problems, channel='npm', counts=counts)
+    return problems
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="npm tarball content audit.")
     ap.add_argument("--real", action="store_true", help="Run a real `npm pack` (then delete the tarball).")
     ap.add_argument("--json-file", help="Parse a saved `npm pack --json` file list instead of running npm.")
+    ap.add_argument('--tarball', type=Path, help='inspect an existing tarball without repacking')
+    ap.add_argument('--source-root', type=Path, default=REPO_ROOT, help='selected release checkout')
+    ap.add_argument('--expect-version', help='version to require inside the tarball')
+    ap.add_argument('--privacy', action='store_true', help='inspect actual text and binary metadata')
+    ap.add_argument('--report', type=Path)
+    ap.add_argument('--reference', type=Path, help='verified pre-publish tarball to compare by payload')
+    ap.add_argument('--published-version', help='download and inspect this exact public npm version')
     args = ap.parse_args()
+    if args.report:
+        args.report.unlink(missing_ok=True)
+    if sum(bool(x) for x in (args.tarball, args.json_file, args.real, args.published_version)) > 1:
+        ap.error('--tarball, --json-file, --real and --published-version are mutually exclusive')
+    if any((args.privacy, args.report, args.reference, args.expect_version)) and not (args.tarball or args.real or args.published_version):
+        ap.error('privacy, reports, reference and version checks require actual artifact bytes')
+    if args.tarball or args.real or args.published_version:
+        try:
+            with tempfile.TemporaryDirectory(prefix='npm-audit-') as temp:
+                path = args.tarball
+                if args.published_version:
+                    path = Path(temp) / 'downloaded.tgz'
+                    download_published(args.published_version, path)
+                    args.expect_version = args.published_version
+                if args.real:
+                    proc = subprocess.run(['npm', 'pack', '--json', '--pack-destination', temp],
+                        cwd=args.source_root, capture_output=True, text=True, check=True)
+                    info = json.loads(proc.stdout)
+                    if len(info) != 1:
+                        raise payload.PayloadError('expected one tarball')
+                    path = Path(temp) / info[0]['filename']
+                problems = check_tarball(path, source_root=args.source_root,
+                    expect_version=args.expect_version, privacy_check=args.privacy,
+                    report_path=args.report, reference=args.reference)
+            for problem in problems:
+                print('FAIL: ' + problem, file=sys.stderr)
+            if not problems:
+                print('OK: actual npm payload matches the selected source checkout.')
+            return 1 if problems else 0
+        except (OSError, ValueError, KeyError, TypeError, AttributeError, tarfile.TarError, subprocess.SubprocessError, payload.PayloadError):
+            print('FAIL: npm payload inspection could not complete', file=sys.stderr)
+            return 2
 
     paths, modes = get_file_list(args)
     if not paths:

--- a/scripts/check_release_zip.py
+++ b/scripts/check_release_zip.py
@@ -4,7 +4,8 @@
 This runs the SAME code the updater runs against a downloaded release — `update.safe_extract`
 (per-entry traversal/symlink/zip-bomb rejection + `distribution_files.json` allowlist & per-file
 sha256) and `update.validate_provenance` — so the release workflow cannot publish a ZIP the
-updater would later refuse to install. Offline; stdlib-only.
+updater would later refuse to install. Source comparison is opt-in; privacy inspection
+also requires exiftool and pdftotext for packaged binary assets.
 
 Usage:
     python3 scripts/check_release_zip.py --zip dist/medsci-skills-classroom-macos.zip \
@@ -26,23 +27,33 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "installers"))
+import release_payload as payload
 import update  # noqa: E402  (reuse the updater's own verify/safe-extract path)
 
 
-def check_zip(zip_path: Path, expect_tag: str | None, require_provenance: bool) -> list[str]:
+def check_zip(zip_path: Path, expect_tag: str | None, require_provenance: bool, *,
+              source_root: Path | None = None, expect_sha: str | None = None,
+              privacy_check: bool = False, report_path: Path | None = None,
+              reference: Path | None = None) -> list[str]:
     """Return a list of problems (empty == OK)."""
     problems: list[str] = []
     data = zip_path.read_bytes()
+    if reference is not None and data != reference.read_bytes():
+        return ['downloaded ZIP differs from the verified pre-upload bytes']
 
     # Single root + inventory + manifest version, read exactly as the updater does. Note: the
     # inventory is read FROM the ZIP, so this proves the ZIP is internally self-consistent (every
     # payload file matches the bundled distribution_files.json). That the inventory itself equals the
     # real source tree is a separate anchor — gen_distribution_manifest.py --check, run by validate.yml
-    # and re-run by release.yml before the build — not this script's job.
+    # and re-run by release.yml before the build — also checked here when --source-root is supplied.
     try:
         root, inventory = update.read_inventory_from_zip(data)
-    except update.UpdateError as exc:
-        return [f"inventory: {exc}"]
+    except update.UpdateError:
+        return ["inventory: invalid release inventory"]
+    if source_root is not None or privacy_check:
+        with zipfile.ZipFile(zip_path) as z:
+            if any(not n.startswith(root + '/') for n in z.namelist() if not n.endswith('/')):
+                return ['ZIP contains entries outside the verified payload root']
     man_version = update.read_manifest_version_from_zip(data, root)
     if man_version == "unknown":
         problems.append("distribution_manifest.json missing or unparseable in ZIP")
@@ -54,8 +65,8 @@ def check_zip(zip_path: Path, expect_tag: str | None, require_provenance: bool) 
         extract.mkdir()
         try:
             update.safe_extract(data, extract, inventory)
-        except update.UpdateError as exc:
-            problems.append(f"safe-extract: {exc}")
+        except update.UpdateError:
+            problems.append("safe-extract: unsafe or inconsistent ZIP payload")
             return problems  # nothing else is trustworthy if extraction fails
 
         if not (extract / "installers" / "install.py").is_file():
@@ -69,22 +80,38 @@ def check_zip(zip_path: Path, expect_tag: str | None, require_provenance: bool) 
                 # --expect-tag must not pass vacuously on a provenance-less ZIP.
                 problems.append(f"--expect-tag {expect_tag} given but provenance.json is absent (cannot verify tag)")
         else:
-            prov = json.loads(prov_path.read_text(encoding="utf-8"))
+            try:
+                prov = json.loads(prov_path.read_text(encoding="utf-8"))
+                if not isinstance(prov, dict):
+                    raise ValueError('not an object')
+            except ValueError:
+                return ['invalid provenance JSON']
+            if expect_sha and prov.get('git_sha') != expect_sha:
+                problems.append('provenance git_sha differs from the selected source commit')
             ptag, pver = prov.get("tag", ""), prov.get("version", "")
             # tag/version internal consistency: vX.Y.Z <-> X.Y.Z, version == manifest version.
             if ptag and pver and (ptag[1:] if ptag.startswith("v") else ptag) != pver:
-                problems.append(f"provenance tag {ptag!r} inconsistent with version {pver!r}")
+                problems.append("provenance tag inconsistent with version")
             if pver and man_version != "unknown" and pver != man_version:
-                problems.append(f"provenance version {pver!r} != manifest version {man_version!r}")
+                problems.append("provenance version differs from manifest version")
             # The updater's own provenance check (tag + version) against the expected tag.
             if expect_tag:
                 try:
                     update.validate_provenance(extract, expect_tag, man_version)
-                except update.UpdateError as exc:
-                    problems.append(f"validate_provenance vs {expect_tag}: {exc}")
+                except update.UpdateError:
+                    problems.append("validate_provenance: release tag/version mismatch")
                 if ptag and ptag != expect_tag:
-                    problems.append(f"provenance tag {ptag!r} != expected {expect_tag!r}")
+                    problems.append("provenance tag differs from expected tag")
 
+        files = {p.relative_to(extract).as_posix(): p.read_bytes()
+                 for p in extract.rglob('*') if p.is_file()}
+        if source_root is not None:
+            problems.extend(payload.compare_source(files, source_root, 'zip'))
+        counts = None
+        if privacy_check:
+            findings, counts = payload.privacy(files)
+            problems.extend(findings)
+        payload.write_report(report_path, zip_path, files, problems, channel='zip', counts=counts)
     return problems
 
 
@@ -93,12 +120,25 @@ def main(argv=None) -> int:
     ap.add_argument("--zip", required=True, type=Path, help="path to a built classroom ZIP")
     ap.add_argument("--expect-tag", default=None, help="assert provenance tag == this release tag")
     ap.add_argument("--require-provenance", action="store_true", help="fail if provenance.json is absent")
+    ap.add_argument('--source-root', type=Path, help='selected release checkout; compare every payload byte')
+    ap.add_argument('--expect-sha', help='selected source commit recorded by provenance')
+    ap.add_argument('--privacy', action='store_true', help='inspect actual text and binary metadata')
+    ap.add_argument('--report', type=Path, help='write hashes and inspection coverage; never raw findings')
+    ap.add_argument('--reference', type=Path, help='pre-upload ZIP whose exact bytes must match')
     args = ap.parse_args(argv)
 
+    if args.report:
+        args.report.unlink(missing_ok=True)
     if not args.zip.is_file():
         print(f"FAIL: no such ZIP: {args.zip}", file=sys.stderr)
         return 2
-    problems = check_zip(args.zip, args.expect_tag, args.require_provenance)
+    try:
+        problems = check_zip(args.zip, args.expect_tag, args.require_provenance,
+                             source_root=args.source_root, expect_sha=args.expect_sha,
+                             privacy_check=args.privacy, report_path=args.report, reference=args.reference)
+    except (OSError, ValueError, KeyError, TypeError, AttributeError, zipfile.BadZipFile, payload.PayloadError):
+        print('FAIL: release ZIP inspection could not complete', file=sys.stderr)
+        return 2
     if problems:
         print(f"FAIL: {args.zip.name} is not updater-consumable:", file=sys.stderr)
         for p in problems:

--- a/scripts/release_payload.py
+++ b/scripts/release_payload.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Shared release-payload plumbing for the existing ZIP and npm audits.
+
+Uses the updater's archive limits, the public identifier scanner, contribution
+credential patterns and the asset metadata scanner. Findings never quote values.
+No code from an unpacked payload is imported or executed.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'installers'))
+import update
+import check_precedent
+
+
+def _module(name, rel):
+    spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+asset = _module('release_asset_privacy', 'skills/sync-submission/scripts/check_asset_anonymization.py')
+safety = _module('release_contribution_safety', 'skills/contribute/scripts/check_contribution_safety.py')
+BINARY = {'.png', '.jpg', '.jpeg', '.tif', '.tiff', '.pdf', '.docx', '.pptx', '.xlsx'}
+OFFICE = {'.docx', '.pptx', '.xlsx'}
+# Exactly one reviewed synthetic token in the contribution scanner's regression.
+# A different token in the same file still fails; the credential is never stored here.
+SYNTHETIC_SECRETS = {
+    ('skills/contribute/tests/test_contribution_safety.sh',
+     '03aafb028d538b06c4341bf8cf2a692a3c6d1f36e34e0e0b376f407c6117a246'),
+}
+EXIF_TAGS = ('Author Creator LastModifiedBy LastSavedBy Copyright Artist Owner OwnerName '
+             'CompanyName Manager HostComputer UserComment Subject Title Description Keywords '
+             'Comment Producer CreatorTool Software').split()
+
+
+class PayloadError(Exception):
+    pass
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def label(path):
+    # Even a filename can contain a private identifier. Logs use opaque file IDs.
+    return 'file-' + digest(path.encode())[:12]
+
+
+def tar_files(path):
+    """Read a single package/ root; reject links, duplicates and unsafe paths."""
+    files, modes, seen = {}, {}, set()
+    total = 0
+    with tarfile.open(path, 'r:gz') as archive:
+        for i, member in enumerate(archive, 1):
+            if i > update.MAX_ENTRIES:
+                raise PayloadError('tar entry limit exceeded')
+            name = member.name.rstrip('/') if member.isdir() else member.name
+            parts = name.split('/')
+            if (parts[0] != 'package' or any(p in ('', '.', '..') for p in parts)
+                    or '\\' in name or ':' in name):
+                raise PayloadError(f'unsafe tar entry #{i}')
+            if member.isdir():
+                continue
+            if not member.isfile() or len(parts) < 2:
+                raise PayloadError(f'non-regular tar entry #{i}')
+            rel = '/'.join(parts[1:])
+            if rel.casefold() in seen:
+                raise PayloadError(f'duplicate tar entry #{i}')
+            seen.add(rel.casefold())
+            total += member.size
+            if member.size < 0 or total > update.MAX_TOTAL_UNCOMPRESSED:
+                raise PayloadError('tar uncompressed size limit exceeded')
+            data = archive.extractfile(member).read()
+            if len(data) != member.size:
+                raise PayloadError(f'truncated tar entry #{i}')
+            files[rel], modes[rel] = data, member.mode
+    if not files:
+        raise PayloadError('tarball has no payload files')
+    return files, modes
+
+
+def tracked_files(source):
+    try:
+        top = subprocess.check_output(['git', '-C', str(source), 'rev-parse', '--show-toplevel'], text=True).strip()
+        if Path(top).resolve() != source.resolve():
+            raise PayloadError('source-root must be the root of the selected Git checkout')
+        raw = subprocess.check_output(['git', '-C', str(source), 'ls-files', '-z'], text=True)
+    except subprocess.CalledProcessError as exc:
+        raise PayloadError('cannot enumerate the selected source checkout') from exc
+    return set(raw.rstrip('\0').split('\0'))
+
+
+def npm_expected(source):
+    config = json.loads((source / 'package.json').read_text())
+    include = config.get('files', [])
+    if not isinstance(include, list) or not include or any(
+            not isinstance(p, str) or not p or any(c in p for c in '*?[]') for p in include):
+        raise PayloadError('npm source requires an explicit files allowlist')
+    # npm always includes root README/licence files as well as package.json.
+    return {p for p in tracked_files(source) if p == 'package.json'
+            or ('/' not in p and p.lower().startswith(('readme', 'license', 'licence')))
+            or any(p == x.rstrip('/') or p.startswith(x.rstrip('/') + '/') for x in include)}
+
+
+def compare_source(files, source, channel):
+    if channel == 'npm':
+        expected = npm_expected(source)
+    else:
+        inv = json.loads((source / 'metadata/distribution_files.json').read_text())['files']
+        expected = {e['path'] for e in inv} | (update.METADATA_ALLOWLIST - {'provenance.json'})
+    actual = set(files) - ({'provenance.json'} if channel == 'zip' else set())
+    problems = []
+    for kind, paths in [('missing', expected - actual), ('unexpected', actual - expected)]:
+        problems.extend(f'{kind} source payload {label(p)}' for p in sorted(paths))
+    for p in sorted(actual & expected):
+        target = source / p
+        if ('_corpus' in Path(p).parts or not target.resolve().is_relative_to(source.resolve())
+                or target.is_symlink() or not target.is_file() or target.read_bytes() != files[p]):
+            problems.append(f'bytes differ from selected source: {label(p)}')
+    return problems
+
+
+def privacy(files):
+    """Scan the actual bytes; publication attribution stays allowed in root READMEs."""
+    problems = []
+    counts = {'text': 0, 'binary_metadata': 0, 'office_xml_parts': 0, 'pdf_text': 0}
+    hashes = check_precedent.load_hashes()
+    author_hashes = check_precedent.load_hashes(allow_author=True)
+
+    def scan(text, rel, *, hidden=False):
+        allowed = author_hashes if re.fullmatch(r'README(?:\.[A-Za-z-]+)?\.md', rel) else hashes
+        if check_precedent.scan_text(text, allowed):
+            problems.append(f'private identifier: {label(rel)}')
+        cleaned = text.replace('private-journal-profiles', 'journal-profiles')
+        if re.search(r'\.claude/(plans|projects|private)', cleaned):
+            problems.append(f'private configuration path: {label(rel)}')
+        if hidden and asset.DOCX_ABS_PATH_RE.search(text):
+            problems.append(f'home path in hidden metadata: {label(rel)}')
+        for match in safety.SECRET.finditer(text):
+            if (rel, digest(match.group().encode())) not in SYNTHETIC_SECRETS:
+                problems.append(f'credential pattern: {label(rel)}')
+
+    with tempfile.TemporaryDirectory(prefix='release-privacy-') as temp:
+        binaries = []
+        for i, (rel, data) in enumerate(sorted(files.items())):
+            scan(rel, rel)
+            suffix = Path(rel).suffix.lower()
+            if suffix in BINARY:
+                path = Path(temp) / f'asset-{i}{suffix}'
+                path.write_bytes(data)
+                binaries.append((rel, path))
+                if suffix == '.pdf':
+                    try:
+                        proc = subprocess.run(['pdftotext', '-q', str(path), '-'],
+                            capture_output=True, text=True, check=True, timeout=60)
+                        scan(proc.stdout, rel)
+                        counts['pdf_text'] += 1
+                    except (OSError, subprocess.SubprocessError):
+                        problems.append(f'PDF text could not be inspected: {label(rel)}')
+                if suffix in OFFICE:
+                    try:
+                        with zipfile.ZipFile(io.BytesIO(data)) as z:
+                            parts = z.infolist()
+                            if len(parts) > update.MAX_ENTRIES or sum(x.file_size for x in parts) > update.MAX_TOTAL_UNCOMPRESSED:
+                                raise PayloadError('office archive limits exceeded')
+                            for part in parts:
+                                if part.filename.endswith(('.xml', '.rels')):
+                                    counts['office_xml_parts'] += 1
+                                    scan(z.read(part).decode('utf-8'), rel, hidden=True)
+                        # Reuse the submission scanner's all-part embedded-path check.
+                        if asset._docx_embedded_abs_paths(path):
+                            problems.append(f'embedded document path: {label(rel)}')
+                    except (zipfile.BadZipFile, UnicodeError, RuntimeError, PayloadError):
+                        problems.append(f'unreadable office package: {label(rel)}')
+            else:
+                try:
+                    scan(data.decode('utf-8'), rel)
+                    counts['text'] += 1
+                except UnicodeError:
+                    problems.append(f'unsupported binary (not scanned): {label(rel)}')
+        if binaries:
+            try:
+                proc = subprocess.run(['exiftool', '-json', *['-' + t for t in EXIF_TAGS],
+                                       *[str(p) for _, p in binaries]], capture_output=True, text=True, timeout=60)
+                if proc.returncode != 0:
+                    raise PayloadError('metadata extraction failed')
+                records = json.loads(proc.stdout)
+                by_path = {r['SourceFile']: r for r in records}
+                for rel, path in binaries:
+                    record = by_path.get(str(path))
+                    if record is None or 'Error' in record or 'Warning' in record:
+                        raise PayloadError('metadata extraction incomplete')
+                    scan(json.dumps({k: v for k, v in record.items() if k != 'SourceFile'}, ensure_ascii=False), rel, hidden=True)
+                    counts['binary_metadata'] += 1
+            except (OSError, ValueError, KeyError, subprocess.TimeoutExpired, PayloadError):
+                problems.append('binary metadata could not be fully inspected (exiftool required)')
+    return sorted(set(problems)), counts
+
+
+def write_report(path, artifact, files, problems, *, channel, counts=None):
+    report = {'schema_version': 1, 'channel': channel, 'artifact_sha256': digest(artifact.read_bytes()),
+              'file_count': len(files), 'ok': not problems, 'problems': problems,
+              'privacy': {'performed': counts is not None, 'scanned': counts},
+              'files': [{'path': p, 'size': len(data), 'sha256': digest(data)}
+                        for p, data in sorted(files.items())] if not problems else []}
+    if path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, indent=2) + '\n')
+    return report

--- a/skills/self-review/tests/fixtures/binning_drift/sensitivity.R
+++ b/skills/self-review/tests/fixtures/binning_drift/sensitivity.R
@@ -1,4 +1,4 @@
-# CAC>10 sensitivity — DIFFERENT cut definition (bug)
+# Synthetic sensitivity example — DIFFERENT cut definition (bug)
 df <- df %>% mutate(
   age_band = cut(bl_age, breaks = c(-Inf, 44, 49, 59, Inf),
                  labels = c("<45", "45-49", "50-59", ">=60"), right = TRUE)

--- a/tests/test_release_payloads.py
+++ b/tests/test_release_payloads.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Synthetic normal and broken release artifacts; no publication or credentials."""
+import hashlib
+import base64
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts'))
+import release_payload as payload
+import check_release_zip as zcheck
+import check_npm_package_contents as ncheck
+
+
+class PayloadControls(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(); self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name) / 'source'; self.root.mkdir()
+        self.out = Path(self.temp.name) / 'artifacts'; self.out.mkdir()
+        self.files = {'README.md': b'Synthetic public documentation.\n',
+                      'README_FIRST.md': b'Synthetic setup.\n', 'LICENSE': b'Synthetic license.\n',
+                      'installers/install.py': b'print("Synthetic installer")\n',
+                      'bin/medsci-skills.js': b'#!/usr/bin/env node\n',
+                      'skills/demo/SKILL.md': b'Synthetic example skill.\n'}
+        config = {'name': 'medsci-skills', 'version': '9.9.9',
+                  'files': ['skills/', 'installers/install.py', 'bin/medsci-skills.js',
+                            'README.md', 'README_FIRST.md', 'LICENSE', 'metadata/']}
+        self.files['package.json'] = json.dumps(config).encode()
+        self.files['metadata/distribution_manifest.json'] = json.dumps({
+            'schema_version': 1, 'version': '9.9.9', 'owned_skills': ['demo']}).encode()
+        self.refresh_inventory()
+        for rel, data in self.files.items():
+            path = self.root / rel; path.parent.mkdir(parents=True, exist_ok=True); path.write_bytes(data)
+        subprocess.run(['git', 'init', '-q', str(self.root)], check=True)
+        self.track()
+
+    def track(self):
+        subprocess.run(['git', '-C', str(self.root), 'add', '--', *sorted(self.files)], check=True)
+
+    def refresh_inventory(self, files=None):
+        files = self.files if files is None else files
+        rows = [{'path': p, 'size': len(data), 'sha256': hashlib.sha256(data).hexdigest()}
+                for p, data in sorted(files.items()) if p.startswith(('skills/', 'installers/'))
+                or p in ('LICENSE', 'README_FIRST.md')]
+        files['metadata/distribution_files.json'] = json.dumps({'schema_version': 1, 'files': rows}).encode()
+
+    def zip(self, files=None, *, sha='a'*40, tag='v9.9.9', omit=(), extra=None):
+        files = self.files if files is None else files
+        inv = json.loads(files['metadata/distribution_files.json'])['files']
+        names = {x['path'] for x in inv} | {'metadata/distribution_files.json', 'metadata/distribution_manifest.json'}
+        path = self.out / 'test.zip'
+        with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as z:
+            for name in sorted(names - set(omit)):
+                z.writestr('release/' + name, files[name])
+            z.writestr('release/provenance.json', json.dumps({'schema_version':1, 'version':'9.9.9', 'tag':tag, 'git_sha':sha}))
+            if extra:
+                z.writestr(*extra)
+        return path
+
+    def tar(self, files=None, *, name='test.tgz', omit=(), extra=None, cli_mode=0o755, mtime=0):
+        files = self.files if files is None else files
+        path = self.out / name
+        with tarfile.open(path, 'w:gz') as t:
+            for rel, data in sorted(files.items()):
+                if rel in omit: continue
+                info = tarfile.TarInfo('package/' + rel); info.size = len(data); info.mtime = mtime
+                info.mode = cli_mode if rel == 'bin/medsci-skills.js' else 0o644
+                t.addfile(info, io.BytesIO(data))
+            if extra:
+                info, data = extra
+                info.size = len(data)
+                t.addfile(info, io.BytesIO(data))
+        return path
+
+    def check_zip(self, path, **kwargs):
+        return zcheck.check_zip(path, 'v9.9.9', True, source_root=self.root, expect_sha='a'*40, **kwargs)
+
+    def check_npm(self, path, **kwargs):
+        return ncheck.check_tarball(path, source_root=self.root, expect_version='9.9.9', **kwargs)
+
+    def test_clean_zip_has_a_real_inspection_report(self):
+        report = self.out / 'report.json'
+        self.assertEqual(self.check_zip(self.zip(), privacy_check=True, report_path=report), [])
+        result = json.loads(report.read_text())
+        self.assertTrue(result['ok']); self.assertTrue(result['privacy']['performed'])
+        self.assertGreater(result['privacy']['scanned']['text'], 0)
+
+    def test_self_consistent_zip_is_still_bound_to_selected_source(self):
+        forged = dict(self.files); forged['skills/demo/SKILL.md'] = b'Different synthetic content'
+        self.refresh_inventory(forged)
+        path = self.zip(forged)
+        self.assertEqual(zcheck.check_zip(path, 'v9.9.9', True), [])
+        self.assertTrue(any('source' in p for p in self.check_zip(path)))
+
+    def test_zip_missing_inventory_file_is_rejected(self):
+        self.assertTrue(self.check_zip(self.zip(omit=['skills/demo/SKILL.md'])))
+
+    def test_wrong_source_commit_is_rejected(self):
+        self.assertTrue(any('git_sha' in p for p in self.check_zip(self.zip(sha='b'*40))))
+
+    def test_wrong_zip_tag_is_rejected(self):
+        self.assertTrue(self.check_zip(self.zip(tag='v8.8.8')))
+
+    def test_ignored_archive_sidecar_is_not_a_release_payload(self):
+        self.assertTrue(self.check_zip(self.zip(extra=('__MACOSX/synthetic.txt', b'Synthetic'))))
+
+    def test_downloaded_zip_must_match_preupload_bytes(self):
+        path = self.zip(); reference = self.out / 'reference.zip'; reference.write_bytes(path.read_bytes())
+        self.assertEqual(self.check_zip(path, reference=reference), [])
+        path.write_bytes(path.read_bytes()+b'different archive comment')
+        self.assertTrue(any('pre-upload' in p for p in self.check_zip(path, reference=reference)))
+
+    def test_normal_npm_payload_passes(self):
+        self.assertEqual(self.check_npm(self.tar(), privacy_check=True), [])
+
+    def test_npm_missing_deep_skill_asset_is_rejected(self):
+        self.assertTrue(any('missing' in p for p in self.check_npm(self.tar(omit=['skills/demo/SKILL.md']))))
+
+    def test_npm_unlisted_scratch_file_is_rejected(self):
+        files = dict(self.files); files['skills/demo/private-draft.txt'] = b'Synthetic'
+        self.assertTrue(any('unexpected' in p for p in self.check_npm(self.tar(files))))
+
+    def test_npm_same_version_different_bytes_is_rejected(self):
+        files = dict(self.files); files['skills/demo/SKILL.md'] = b'Wrong payload'
+        self.assertTrue(any('bytes differ' in p for p in self.check_npm(self.tar(files))))
+
+    def test_npm_wrong_version_is_rejected(self):
+        files = dict(self.files); config = json.loads(files['package.json']); config['version'] = '8.8.8'
+        files['package.json'] = json.dumps(config).encode()
+        self.assertTrue(any('identity/version' in p for p in self.check_npm(self.tar(files))))
+
+    def test_npm_executable_bit_is_verified(self):
+        self.assertTrue(any('executable' in p for p in self.check_npm(self.tar(cli_mode=0o644))))
+
+    def test_npm_headers_may_change_but_payload_must_not(self):
+        before = self.tar(name='before.tgz', mtime=1)
+        after = self.tar(name='after.tgz', mtime=2)
+        self.assertNotEqual(before.read_bytes(), after.read_bytes())
+        self.assertEqual(self.check_npm(after, reference=before), [])
+        with tarfile.open(after, 'w:gz') as t:
+            entry = tarfile.TarInfo('package/README.md'); entry.size = 7
+            t.addfile(entry, io.BytesIO(b'changed'))
+        self.assertTrue(self.check_npm(after, reference=before))
+
+    def test_tar_traversal_links_and_duplicates_are_rejected(self):
+        for name, kind in [('package/../escape', tarfile.REGTYPE),
+                           ('package/link', tarfile.SYMTYPE), ('package/README.md', tarfile.REGTYPE)]:
+            with self.subTest(name=name):
+                info = tarfile.TarInfo(name); info.type = kind; info.linkname = 'README.md'
+                path = self.tar(extra=(info, b''))
+                with self.assertRaises(payload.PayloadError): payload.tar_files(path)
+
+    def test_new_credential_in_existing_synthetic_fixture_still_fails(self):
+        rel = 'skills/contribute/tests/test_contribution_safety.sh'
+        source = (ROOT / rel).read_text()
+        original = payload.safety.SECRET.search(source).group()
+        self.assertEqual(payload.privacy({rel: original.encode()})[0], [])
+        token = 'sk-' + 'Q'*32
+        problems, _ = payload.privacy({rel: (original+'\n'+token).encode()})
+        self.assertTrue(any('credential' in p for p in problems))
+        self.assertNotIn(token, str(problems))
+
+    def test_hidden_office_path_is_found_without_printing_it(self):
+        hidden = '/' + 'Users' + '/synthetic-owner/source.csl'
+        binary = io.BytesIO()
+        with zipfile.ZipFile(binary, 'w') as z:
+            z.writestr('docProps/custom.xml', '<Properties><path>'+hidden+'</path></Properties>')
+        for suffix in ('.docx', '.pptx', '.xlsx'):
+            problems, counts = payload.privacy({'skills/demo/template'+suffix: binary.getvalue()})
+            self.assertTrue(any('path' in p for p in problems))
+            self.assertEqual(counts['office_xml_parts'], 1)
+            self.assertNotIn(hidden, str(problems))
+
+    def test_unreadable_office_package_does_not_pass(self):
+        problems, _ = payload.privacy({'skills/demo/template.docx': b'not a document'})
+        self.assertTrue(any('unreadable office' in p for p in problems))
+
+    def test_missing_metadata_tool_is_not_a_clean_scan(self):
+        with patch.object(payload.subprocess, 'run', side_effect=FileNotFoundError):
+            problems, counts = payload.privacy({'skills/demo/example.png': b'synthetic'})
+        self.assertTrue(any('could not' in p for p in problems)); self.assertEqual(counts['binary_metadata'], 0)
+
+    def test_identifier_scan_includes_r_source(self):
+        text = 'Synthetic confidential label'
+        hashed = hashlib.sha256(text.lower().encode()).hexdigest()
+        with patch.object(payload.check_precedent, 'load_hashes', return_value={hashed}):
+            problems, _ = payload.privacy({'skills/demo/example.R': text.encode()})
+        self.assertTrue(any('private identifier' in p for p in problems))
+        self.assertNotIn(text, str(problems))
+
+    def step(self, name, **extra_env):
+        steps = yaml.safe_load((ROOT / '.github/workflows/release.yml').read_text())['jobs']['release']['steps']
+        run, = [s['run'] for s in steps if s.get('name', '').startswith(name)]
+        env = dict(os.environ, RELEASE_TAG='v9.9.9', SOURCE_SHA='a'*40, **extra_env)
+        return subprocess.run(['bash', '-e', '-c', run], cwd=self.root, env=env, capture_output=True, text=True)
+
+    def tools_checkout(self):
+        (self.root / '.release-tools').symlink_to(ROOT, target_is_directory=True)
+        (self.root / 'dist').mkdir(exist_ok=True)
+
+    def test_workflow_builds_selected_source_and_preserves_other_output(self):
+        self.tools_checkout()
+        sentinel = self.root / 'dist/keep.txt'; sentinel.write_text('keep')
+        result = self.step('Build classroom release ZIPs')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(sentinel.read_text(), 'keep')
+        for platform in ('macos', 'windows'):
+            path = self.root / f'dist/medsci-skills-classroom-{platform}.zip'
+            self.assertEqual(self.check_zip(path), [])
+        self.assertEqual(self.step('Verify ZIPs are consumable').returncode, 0)
+
+    def test_workflow_records_tag_commit_not_dispatch_sha(self):
+        subprocess.run(['git', '-C', str(self.root), '-c', 'user.name=Synthetic Test',
+                        '-c', 'user.email=test@example.org', 'commit', '-qm', 'Synthetic source'], check=True)
+        subprocess.run(['git', '-C', str(self.root), 'tag', 'v9.9.9'], check=True)
+        expected = subprocess.check_output(['git', '-C', str(self.root), 'rev-parse', 'HEAD'], text=True).strip()
+        env_file = self.out / 'env'
+        result = self.step('Resolve the selected release commit', GITHUB_ENV=str(env_file), GITHUB_SHA='b'*40)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(env_file.read_text(), f'SOURCE_SHA={expected}\n')
+
+    def test_workflow_publishes_the_inspected_tarball_and_skips_existing_version(self):
+        stub = self.out / 'npm'
+        stub.write_text('#!/bin/sh\nif [ "$1" = view ]; then exit "$EXISTS_EXIT"; fi\nprintf "%s\\n" "$@" > "$CALLS"\n')
+        stub.chmod(0o755); calls = self.out / 'calls'
+        for exists in ('1', '0'):
+            calls.unlink(missing_ok=True)
+            result = self.step('Publish to npm', PATH=str(self.out)+os.pathsep+os.environ['PATH'],
+                               EXISTS_EXIT=exists, CALLS=str(calls))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            if exists == '1':
+                self.assertEqual(calls.read_text().splitlines(), ['publish', './dist/medsci-skills-9.9.9.tgz',
+                                 '--ignore-scripts', '--provenance', '--access', 'public'])
+            else:
+                self.assertFalse(calls.exists())
+
+    def test_workflow_downloaded_zip_missing_or_mutated_is_rejected(self):
+        self.tools_checkout()
+        stub = self.out / 'gh'
+        stub.write_text('#!/bin/sh\nmkdir -p dist/downloaded\ncp dist/*.zip dist/downloaded/\n'
+                        'if [ "$DAMAGE" = mutate ]; then printf changed >> dist/downloaded/medsci-skills-classroom-macos.zip; fi\n'
+                        'if [ "$DAMAGE" = missing ]; then rm dist/downloaded/medsci-skills-classroom-windows.zip; fi\n')
+        stub.chmod(0o755)
+        for platform in ('macos', 'windows'):
+            (self.root / f'dist/medsci-skills-classroom-{platform}.zip').write_bytes(self.zip().read_bytes())
+        for damage in ('none', 'mutate', 'missing'):
+            result = self.step('Download and compare published ZIPs', DAMAGE=damage,
+                               PATH=str(self.out)+os.pathsep+os.environ['PATH'])
+            self.assertEqual(result.returncode == 0, damage == 'none', result.stderr)
+
+    def test_notes_are_checked_before_upload_without_echoing_credentials(self):
+        self.tools_checkout()
+        notes = self.root / 'CHANGELOG.md'
+        notes.write_text('## [9.9.9]\n\nSynthetic release notes.\n')
+        self.assertEqual(self.step('Extract release notes').returncode, 0)
+        token = 'sk-' + 'Q'*32
+        notes.write_text('## [9.9.9]\n\n'+token+'\n')
+        result = self.step('Extract release notes')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn(token, result.stdout+result.stderr)
+
+    def test_workflow_checks_before_and_after_publication_with_pinned_tools(self):
+        workflow = yaml.safe_load((ROOT / '.github/workflows/release.yml').read_text())
+        steps = workflow['jobs']['release']['steps']
+        names = [s['name'] for s in steps]
+        index = lambda prefix: next(i for i,n in enumerate(names) if n.startswith(prefix))
+        self.assertLess(index('Verify actual npm'), index('Create GitHub Release'))
+        self.assertLess(index('Extract release notes'), index('Create GitHub Release'))
+        self.assertLess(index('Create GitHub Release'), index('Download and compare published ZIPs'))
+        self.assertLess(index('Publish to npm'), index('Download and compare published npm'))
+        checkout = steps[index('Checkout verification tools')]['with']
+        self.assertEqual(checkout['ref'], '${{ github.workflow_sha }}')
+        self.assertFalse(checkout['persist-credentials'])
+        after = steps[index('Download and compare published npm')]
+        self.assertEqual(after['if'], "env.HAS_NPM_TOKEN == 'true'")
+        self.assertIn('--published-version', after['run']); self.assertIn('--reference', after['run'])
+
+    def registry_responses(self, data, *, version='9.9.9', integrity=None, url=None):
+        url = url or 'https://registry.npmjs.org/medsci-skills/-/medsci-skills-9.9.9.tgz'
+        integrity = integrity or 'sha512-'+base64.b64encode(hashlib.sha512(data).digest()).decode()
+        info = {'name':'medsci-skills', 'version':version, 'dist':{'tarball':url, 'integrity':integrity}}
+        body = io.BytesIO(data); body.geturl = lambda: url
+        return [io.BytesIO(json.dumps(info).encode()), body]
+
+    def test_registry_download_checks_integrity_and_actual_selected_source(self):
+        data = self.tar().read_bytes(); dest = self.out / 'download.tgz'
+        with patch.object(ncheck.urllib.request, 'urlopen', side_effect=self.registry_responses(data)):
+            ncheck.download_published('9.9.9', dest)
+        self.assertEqual(dest.read_bytes(), data); self.assertEqual(self.check_npm(dest), [])
+
+    def test_registry_wrong_version_integrity_or_host_fails(self):
+        data = self.tar().read_bytes(); dest = self.out / 'download.tgz'
+        for kwargs in ({'version':'8.8.8'}, {'integrity':'sha512-wrong'}, {'url':'https://example.org/package.tgz'}):
+            with patch.object(ncheck.urllib.request, 'urlopen', side_effect=self.registry_responses(data, **kwargs)):
+                with self.assertRaises(payload.PayloadError): ncheck.download_published('9.9.9', dest)
+            self.assertFalse(dest.exists())
+
+    def test_registry_unavailable_never_leaves_a_passable_download(self):
+        dest = self.out / 'download.tgz'
+        with patch.object(ncheck.urllib.request, 'urlopen', side_effect=ncheck.urllib.error.URLError('unavailable')), \
+                patch.object(ncheck.time, 'sleep') as sleep:
+            with self.assertRaises(payload.PayloadError): ncheck.download_published('9.9.9', dest)
+        self.assertEqual(sleep.call_count, 4); self.assertFalse(dest.exists())
+
+    def test_malformed_package_identity_is_rejected(self):
+        files = dict(self.files); files['package.json'] = b'[]'
+        self.assertTrue(self.check_npm(self.tar(files)))
+
+    def test_zip_rejection_does_not_quote_untrusted_entry_paths(self):
+        private = 'synthetic-private-value'
+        path = self.zip(extra=('release/'+private, b'synthetic'))
+        findings = self.check_zip(path)
+        self.assertTrue(findings); self.assertNotIn(private, str(findings))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Release verification previously trusted ZIP-internal inventories and npm file lists, then repacked the npm directory at publication. This change compares actual ZIP and tarball files against the selected release checkout, reuses existing privacy scanners on packaged bytes, publishes the inspected tarball, and compares downloads after publication. Recovery runs record the selected tag commit and verify existing npm versions as well.

Prepare v5.26.2 as a hotfix for the already merged PDF identity and slide-overflow false-clean results, with the font/render and consistency-linter fixes. Neutralize one contextual R fixture comment without changing its computation.

Validation: 31 synthetic payload/workflow/registry regressions, existing release and binning controls, and the full 251-step local CI mirror. New tests run within existing CI steps. Live v5.26.1 ZIPs match their selected source; the npm archive matches source but contains the now-neutralized fixture comment. The new payload passes the configured privacy scans. No new manuscript detector or promotion gate is introduced.

Privacy inspection covers existing configured identifiers and credential patterns, PDF text, and binary/Office metadata; it is not OCR or certification against every possible personal identifier. A post-publication failure requires recovery and does not roll back an already public release. npm steps require the configured token.
