### PR TITLE
Connect citation claims to source evidence and recorded assessments

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -375,7 +375,9 @@ jobs:
         run: bash skills/verify-refs/tests/test_audit_source_path.sh
 
       - name: "Run verify-refs claim-fidelity challenge (a real citation carrying a claim its source never makes)"
-        run: bash skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
+        run: |
+          bash skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
+          python3 skills/verify-refs/tests/test_claim_evidence.py
 
       - name: Run manage-refs bib-title publisher-markup gate test
         run: bash skills/manage-refs/tests/test_bib_title_markup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- Claim-fidelity reports include sentence/citation evidence rows and an optional
+  Markdown table linking source hashes, retrieval identity, metadata audit context,
+  and attributed source comparisons. Existing JSON remains the evidence store;
+  changed inputs and unmatched review records stay visible on rerun.
+
+### Fixed
+
+- Claim-fidelity output no longer equates an absence of automated findings with
+  source support. Citation prefixes and page locators are preserved in the evidence
+  inventory. New controls run within the existing validation job.
+
 ## [5.26.2] - 2026-09-06
 
 **Hotfix:** shipped PDF identity and presentation overflow checks could report a match or clean result without measuring the relevant evidence.

--- a/docs/artifact_contract.md
+++ b/docs/artifact_contract.md
@@ -44,6 +44,8 @@ Dual-path behavior: `SSOT.yaml` preferred, `project.yaml` warns, neither fails.
 | `artifact_manifest.json` | `/render`, `/sync-submission` (auto) | all | advisory | Derived inventory. |
 | `qc/status.json` | pipeline runner | all | advisory | Runtime pipeline state. |
 | `qc/reference_audit.json` | `/verify-refs` | `/render`, pre-save hooks | read-only (consumers) | Citation audit output. |
+| `qc/claim_fidelity.json` | `/verify-refs` | `/self-review`, `/sync-submission`, human reviewers | read-only (consumers) | Existing probe findings plus sentence-level evidence rows. Assessor annotations are preserved by explicit `--reviewed-report`; input changes invalidate their current status. |
+| `qc/claim_fidelity.md` | `/verify-refs` (derived view) | human reviewers | read-only | Optional table generated from the same JSON; edit assessments in JSON, not in this view. No automatic claim-support certification. |
 | `references/library.bib` | `/search-lit` (produces verified candidates) | `/lit-sync` (imports to Zotero), `/verify-refs` | advisory | Not the SSOT bibliography; that is `manuscript/_src/refs.bib`. |
 | `references/fulltext_retrieval.json` | `/lit-sync` (Phase 2.7) | `/meta-analysis`, human reviewers | advisory | Opt-in fulltext-retrieval report: retrieved (OA-disk / Zotero-native, user-reported) vs not-retrieved + institutional-fallback list + title-match flags. |
 | `pdfs/` + `pdfs/retrieval_report.json` | `/fulltext-retrieval` (engine) | `/lit-sync`, `/meta-analysis`, `/obsidian-paper-vault` | none | OA PDFs + per-DOI `status` (arxiv/oa/pmc/skip/fail), `source`, and `title_match` (match / mismatch / unavailable). Engine report; `/lit-sync` merges it into `references/fulltext_retrieval.json`. |

--- a/docs/skills/verify-refs.md
+++ b/docs/skills/verify-refs.md
@@ -23,6 +23,7 @@
 
 - Confirms DOI/PMID and author identity, not topical appropriateness of the citation.
 - CrossRef given-name errors are possible; PubMed efetch is treated as authoritative.
+- Evidence rows record assessor judgments bound to input hashes, not automatically verified source support. Source PDF pages, extraction provenance, and semantic comparisons require actual source inspection.
 - Claim fidelity checks only claims with a checkable anchor (a quotation, an attributed concept, a stated count) and only against full texts already on disk; a citation with no full text is reported unresolved, never guessed at. A small alteration inside a long quotation falls within the extraction tolerance of the quote matcher and is surfaced as a prompt rather than as a fabrication.
 - OpenAlex (tertiary index for conference proceedings / non-DOI works) gives an existence check plus a tolerant first-author membership check only; its display names carry no structured family field, so it never drives the strict positional or author-count cross-check. Use --no-openalex to restrict to PubMed + CrossRef.
 
@@ -33,6 +34,7 @@
 - `bash tests/test_openalex_tier.sh`
 - `bash tests/test_fabricated_author.sh`
 - `bash scripts/claim_fidelity_challenge/verify.sh`
+- `python3 tests/test_claim_evidence.py`
 
 **Evidence** — `bundled_script`
 
@@ -40,10 +42,12 @@
 
 **References** (`skills/verify-refs/references/`):
 
+- `claim_evidence_workflow.md`
 - `manual_checkpoint_guide.md`
 
 **Scripts** (`skills/verify-refs/scripts/`):
 
+- `_claim_evidence.py`
 - `_quote_match.py`
 - `check_claim_fidelity.py`
 - `claim_fidelity_challenge/` (8 files)

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5773,13 +5773,23 @@
     },
     {
       "path": "skills/verify-refs/SKILL.md",
-      "size": 13883,
-      "sha256": "783cf8b9fb181cb1d0ae05770f8ed6732f4e834decd58b8eb2431ed72acd9e05"
+      "size": 15318,
+      "sha256": "09d8f8899feb9f89aedd92225bfe2cca9be9a24e841f1edbead9aaffd3e28e8f"
+    },
+    {
+      "path": "skills/verify-refs/references/claim_evidence_workflow.md",
+      "size": 6466,
+      "sha256": "20765c9c23122fef6c44eea6327d29a79c73929cf710800addab5f9b1ff29468"
     },
     {
       "path": "skills/verify-refs/references/manual_checkpoint_guide.md",
       "size": 4031,
       "sha256": "4da6bd649d672bcae7505098d4712d6fb253fea8fa3be41c95870587cc6553a4"
+    },
+    {
+      "path": "skills/verify-refs/scripts/_claim_evidence.py",
+      "size": 13992,
+      "sha256": "4b471cb1f6c20c09746af5b7f51093b4f4cc5be7ff2ab972285158b797abd2ca"
     },
     {
       "path": "skills/verify-refs/scripts/_quote_match.py",
@@ -5788,8 +5798,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/check_claim_fidelity.py",
-      "size": 28138,
-      "sha256": "e90932f24c794c35ed525ac578e51658599bf7bef2b0efee32d4e75be82f7c3c"
+      "size": 33348,
+      "sha256": "a654a537e6cc00c62ecaa1edcf4ee8bc137d77eeb3d40ddc2ff616059ac85480"
     },
     {
       "path": "skills/verify-refs/scripts/claim_fidelity_challenge/fixture/fulltext/10.1000_synthetic.oversight.md",
@@ -5828,8 +5838,8 @@
     },
     {
       "path": "skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh",
-      "size": 9306,
-      "sha256": "19bec2649a74ff92d7f58913b70d04716d8e7838ba075d905dabb0b0697f92ff"
+      "size": 8835,
+      "sha256": "8553470dcbaa3890b5964762ac6c3c87656752e44c56a96438b2a234b3e1fe97"
     },
     {
       "path": "skills/verify-refs/scripts/verify_cli.sh",
@@ -5843,8 +5853,8 @@
     },
     {
       "path": "skills/verify-refs/skill.yml",
-      "size": 3092,
-      "sha256": "54b90d79ba5eec1d8d1776e08c7740c7b9d461c9fc5a6c32f1cf24ce71c3d9ac"
+      "size": 3422,
+      "sha256": "f96396276ad8cfb10b0c671d3813033105dc2e8894be3dbbf40c8e7451d93686"
     },
     {
       "path": "skills/version-dataset/SKILL.md",

--- a/scripts/check_domain_probe_sync.py
+++ b/scripts/check_domain_probe_sync.py
@@ -133,6 +133,8 @@ VENDOR_SETS: tuple[VendorSet, ...] = (
         # /revise owns other scripts; only the helpers it publishes are vendored.
         canonical_exhaustive=False,
         pattern="_*.py",
+        # Claim evidence is owned by verify-refs, not copied from revise.
+        vendored_local=("_claim_evidence.py",),
     ),
     VendorSet(
         name="quote-match-helper-sync",

--- a/skills/verify-refs/SKILL.md
+++ b/skills/verify-refs/SKILL.md
@@ -88,7 +88,7 @@ to restrict verification to PubMed + CrossRef.
 
 | Artifact | Path | Purpose |
 |---|---|---|
-| Audit JSON | `qc/reference_audit.json` | Sole output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, `cited_authors[]`/`actual_authors[]`, `duplicate_findings[]`, submission-safe flag, full records |
+| Audit JSON | `qc/reference_audit.json` | Metadata audit output — row-level status (OK/MISMATCH/UNVERIFIED/FABRICATED), counts, `cited_authors[]`/`actual_authors[]`, `duplicate_findings[]`, submission-safe flag, full records |
 
 **v1.2.0 (2026-05)** adds `duplicate_findings[]` to the audit JSON. Verbatim PMID or DOI duplicates within the reference list are flagged as MAJOR findings (resolves `/peer-review` Phase 2A P7). DOI normalization strips `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes plus trailing slashes before comparison so `https://doi.org/10.x/abc/` and `10.x/abc` collapse to one key. Both `submission_safe` and `fully_verified` now require `duplicate_findings` to be empty.
 
@@ -210,12 +210,38 @@ unresolved and never guessed at, and a source whose extracted text is an abstrac
 as too short to judge — absence proves nothing against an abstract. Silence from this
 detector means "nothing checkable was wrong", which is not the same as "everything is right".
 
+### Sentence-level source evidence table
+
+The same `qc/claim_fidelity.json` now includes `evidence_rows`: recognized prose
+sentence/citation pairs, manuscript coordinates, source-text and PDF hashes,
+advisory retrieval identity, and a separate assessor-entered comparison. Initial
+rows are `not_assessed`, even when bibliographic status is OK and no probe fires.
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/check_claim_fidelity.py" \
+  --manuscript manuscript/manuscript.md --bib manuscript/_src/refs.bib \
+  --fulltext-dir fulltext/ --retrieval-report pdfs/retrieval_report.json \
+  --reference-audit qc/reference_audit.json \
+  --out qc/claim_fidelity.json --evidence-table qc/claim_fidelity.md
+```
+
+Inspect the actual source before entering pages, excerpts, metric/unit/denominator,
+population, direction, and a named assessment. Neither equal numbers nor matching
+words establish support. Record whether the assessor used AI assistance; do not
+describe an AI-generated assessment as human approval. Rerun with
+`--reviewed-report qc/claim_fidelity.json` to retain annotations. Changed inputs
+leave old assessments unresolved; unmatched rows remain in the JSON for review.
+The Markdown table is a derived view, not a second editable evidence store.
+
+See `references/claim_evidence_workflow.md` for field meanings, re-review steps,
+source-identity limitations, and the difference between recorded and verified.
+
 ## What This Skill Does NOT Do
 
 - Does not fetch full texts (use `/fulltext-retrieval`); claim fidelity reads converted text
   off disk so it stays deterministic and CI-runnable.
-- Does not judge whether a citation is topically appropriate — only whether the specific
-  quoted, attributed, or counted claim is supported by the source's own words.
+- Does not automatically judge topical fit or semantic support. The probes check limited
+  wording patterns; the evidence table records attributed assessments, not verified facts.
 - Does not generate new references from memory.
 - Does not replace missing citations with plausible alternatives without
   `/search-lit` or user approval.

--- a/skills/verify-refs/references/claim_evidence_workflow.md
+++ b/skills/verify-refs/references/claim_evidence_workflow.md
@@ -1,0 +1,99 @@
+# Reviewing a sentence against its cited source
+
+Use the existing claim-fidelity report to connect a manuscript sentence to the
+source actually inspected. This workflow does not fetch papers, invent source
+excerpts, or turn word/number matches into semantic support. It adds no detector
+or submission-blocking verdict; `--strict` retains the existing probe behavior.
+
+## Create the review surface
+
+Run the command in the skill's “Sentence-level source evidence table” section.
+`--retrieval-report` consumes the existing `fetch_oa.py` report, including each
+DOI's PDF filename, hash and advisory identity assessment. PDFs are looked up next
+to that report unless `--pdf-dir` selects another directory. The converted texts
+can be in a different `--fulltext-dir`.
+
+`--reference-audit` reads existing `records[]` from the metadata audit. Its recorded
+OK status has no input hash binding in that artifact and is shown as context only.
+It cannot establish PDF identity, a current bibliography audit, or source support.
+Missing/ambiguous links remain visible. No network or bibliography writes occur.
+
+`qc/claim_fidelity.json` schema 2 retains the existing `findings`, probe counts,
+and source-resolution fields, and adds:
+
+| Field | Meaning |
+|---|---|
+| `evidence_rows[]` | One row per recognized prose sentence/citation pair, including citations outside the three probes. Duplicate occurrences have distinct IDs. |
+| `manuscript` | Exact text, character offsets and line coordinates in the `read_text` representation. DOCX coordinates refer to extracted paragraph/table text, not rendered pages. |
+| `source` | Selected converted text and hash, actual PDF hash, report hash, advisory identity and hash status. Filename/DOI resolution is not identity verification. |
+| `reference_audit` | Linked metadata status with its binding limitation. |
+| `automatic_finding_indices` | Same-sentence or quoted-span links to existing `findings`; these do not assign the manual assessment. |
+| `assessment` | Editable, attributed review record described below. Initially `not_assessed`. |
+| `binding` / `binding_sha256` | Current manuscript, bibliography, mapping, report and source hashes. |
+| `verdict` / `review_state` | Effective recorded outcome and whether the assessment is current, incomplete or stale. Never a machine-certified fact. |
+| `orphaned_evidence_reviews` | Preserved prior rows that no longer match a current sentence/citation pair. Excluded from current assessment counts. |
+
+The old `sources_resolved` and `claims_checked` fields still describe probe
+execution; use `evidence_counts` for the broader sentence/citation inventory.
+Neither count covers uncited statements, Markdown tables, blockquotes, code or
+the bibliography. Citation recognition is syntactic and can miss unsupported
+formats. A complete inventory is not a complete scientific review.
+
+## Enter an assessment after reading the source
+
+Edit only the row's `assessment` in the JSON. Supply:
+
+- `verdict`: `supported`, `contradicted`, `unresolved` or `not_assessed`.
+- `assessor`, `assessed_at`, `method`, `rationale`: who made the judgment, when,
+  how it was made (including AI assistance), and why. These are attributed
+  declarations, not authenticated human signatures or approval.
+- `source_scope`: `full_text`, `abstract_only`, `partial` or `unknown`;
+  `identity_checked`: whether the assessor actually checked the paper identity.
+- `source_pages`: a nonempty list of one-based PDF page indices, not printed
+  journal page numbers; `source_excerpt`: the relevant text actually inspected.
+- `claim` and `source`: compare `metric`, `unit`, `denominator`, `population`,
+  and `direction` separately. Use an explicit `not applicable` explanation for a
+  qualitative field; an empty field is not a completed comparison.
+
+For example, a synthetic software experiment can report the same latency
+percentage for a subgroup that the manuscript attributes to the whole sample.
+The equal number does not support the manuscript's population claim. A direction
+reversal also needs a source-level judgment despite matching terms and numbers.
+
+Do not fill pages or excerpts from memory. The tool does not check that an
+excerpt appears on the declared PDF page, authenticate an assessor, or adjudicate
+the meaning of a comparison. Complete fields allow a **recorded judgment**, not
+an independent source verification. Check the PDF itself, including tables,
+subgroups and qualification of the claim, before using a recorded conclusion.
+
+The extraction tool does not currently bind the converted text to the PDF with a
+conversion manifest. The report explicitly marks that derivation as unrecorded;
+matching filenames are insufficient. Source-text and PDF hashes identify the
+files reviewed, not proof that one was faithfully extracted from the other.
+
+## Carry reviews forward without losing their history
+
+Rerun the original command with `--reviewed-report qc/claim_fidelity.json` and the
+same `--out`. The old JSON is read first; findings and the Markdown view are
+regenerated. `--evidence-table` requires `--out`, and output aliases of selected
+source inputs are rejected. Input files are not edited.
+
+The assessment's `binding_sha256` stays pinned to its original inputs. Changes to
+the manuscript, bibliography, source text, PDF, input reports or reference map
+make the old conclusion `unresolved` with `stale_inputs`. Repeating the command
+does not make it current again. Inspect the changed source/context, update the
+assessment, and only then copy the row's current `binding_sha256` into
+`assessment.binding_sha256`. Changed sentence IDs retain the old row under
+`orphaned_evidence_reviews` for explicit reconciliation; they are not silently
+discarded or transferred to a different sentence.
+
+A supported/contradicted outcome additionally requires a source text, a PDF
+matching the retrieval hash, no reported identity conflict, full-text inspection,
+pages, an excerpt and a populated comparison. Missing PDFs, legacy reports
+without hashes, DOI-unresolved sources, abstract-only evidence, and incomplete
+reviews remain unresolved. A consistent retrieval identity is advisory, not
+enough by itself. Resolve conflicting source identity before recording support;
+this workflow does not override the retrieval assessment automatically.
+
+The Markdown file is a derived view. Its source excerpts and project context may
+be private; do not publish generated reports without reviewing their contents.

--- a/skills/verify-refs/scripts/_claim_evidence.py
+++ b/skills/verify-refs/scripts/_claim_evidence.py
@@ -1,0 +1,254 @@
+"""Report helpers for claim fidelity; no clinical verdicts or network calls.
+
+An assessment is an attributed review record, not a mechanically verified fact.
+The helpers bind that record to inputs and render a view of the existing JSON.
+"""
+from __future__ import annotations
+
+from collections import Counter
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+
+DIMENSIONS = ("metric", "unit", "denominator", "population", "direction")
+VERDICTS = ("supported", "contradicted", "unresolved", "not_assessed")
+
+
+def sha256(path: Path | None) -> str | None:
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path and path.is_file() else None
+
+
+def normalized_doi(value: str) -> str:
+    return re.sub(r"^(?:https?://(?:dx\.)?doi\.org/|doi:\s*)", "", value.strip(),
+                  flags=re.I).lower().rstrip(".,;")
+
+
+def prose_spans(raw: str, abbrev: re.Pattern):
+    """Prose sentence offsets in the read_text representation, not PDF coordinates.
+
+    Mask excluded regions without shifting positions. As with the existing probes,
+    prose inventory excludes code, blockquotes, markdown tables and references.
+    """
+    def mask(match):
+        return re.sub(r"[^\n]", " ", match.group())
+
+    body = re.sub(r"\A---[^\n]*\n.*?\n(?:---|\.\.\.)[^\n]*(?:\n|$)", mask, raw, flags=re.S)
+    body = re.sub(r"(?m)^[ \t]*(```|~~~)[^\n]*\n.*?^[ \t]*\1[^\n]*(?:\n|$)",
+                  mask, body, flags=re.S)
+    cut = re.search(r"(?im)^#{1,3}\s*\**\s*(references|bibliography|works cited)\b", body)
+    if cut:
+        body = body[:cut.start()]
+    body = re.sub(r"(?m)^[ \t]*(?:>|\||#{1,6}\s)[^\n]*", mask, body)
+    bracket_spans = [(m.start(), m.end()) for m in re.finditer(r"\[[^\]]*\]", body)]
+    start = 0
+    for boundary in re.finditer(r"(?<=[.!?])\s+|\n[ \t]*\n|\Z", body):
+        end = boundary.start()
+        if any(a < end < b for a, b in bracket_spans):
+            continue  # e.g. a page locator inside [see @key, p. 3]
+        if abbrev.search(body[start:end].strip()) and "\n\n" not in boundary.group():
+            continue
+        part = body[start:end]
+        left = len(part) - len(part.lstrip())
+        right = len(part.rstrip())
+        if right > left:
+            yield start + left, start + right
+        start = boundary.end()
+
+
+def blank_assessment() -> dict:
+    return {"verdict": "not_assessed", "assessor": "", "assessed_at": "", "method": "",
+            "source_scope": "unknown", "identity_checked": False,
+            "source_pages": [], "source_excerpt": "", "rationale": "",
+            "claim": {key: "" for key in DIMENSIONS},
+            "source": {key: "" for key in DIMENSIONS}}
+
+
+def binding_hash(binding: dict) -> str:
+    return hashlib.sha256(json.dumps(binding, sort_keys=True).encode()).hexdigest()
+
+
+def reference_record(audit: dict | None, token: str, doi: str) -> dict:
+    """Metadata audit is contextual, never proof of source identity or claim support."""
+    records = (audit or {}).get("records", [])
+    matches = [r for r in records if r.get("ref_id") == token]
+    if not matches and doi:
+        matches = [r for r in records if normalized_doi(r.get("doi", "")) == doi]
+    if len(matches) != 1:
+        return {"link": "ambiguous" if matches else "not_available", "recorded_status": None}
+    row = matches[0]
+    same_doi = not doi or normalized_doi(row.get("doi", "")) == doi
+    return {"link": "matched_identifier" if same_doi else "identifier_conflict",
+            "recorded_status": row.get("status"), "doi": row.get("doi", ""),
+            "input_binding": "not_recorded_by_reference_audit"}
+
+
+def pdf_record(retrieval: dict | None, pdf_dir: Path | None, doi: str) -> dict:
+    rows = [r for r in (retrieval or {}).get("items", [])
+            if doi and normalized_doi(r.get("doi", "")) == doi]
+    result = {"file": None, "sha256": None, "report_sha256": None,
+              "hash_status": "not_available", "identity": {"status": "unavailable"},
+              "text_derivation": "not_recorded; equal filenames do not establish PDF-to-text provenance"}
+    if len(rows) != 1:
+        result["hash_status"] = "ambiguous_report" if rows else "not_available"
+        return result
+    row = rows[0]
+    identity = row.get("source_identity")
+    if not isinstance(identity, dict) or identity.get("status") not in {"consistent", "conflict", "unresolved", "unavailable"}:
+        identity = {"status": "unavailable", "reason": "missing_or_invalid_identity_record"}
+    result["identity"] = copy.deepcopy(identity)
+    result["report_sha256"] = row.get("file_sha256") or None
+    name = row.get("file", "")
+    # Retrieval reports contain basenames, not arbitrary local read instructions.
+    if not name or Path(name).name != name or "/" in name or "\\" in name or not pdf_dir:
+        result["hash_status"] = "invalid_or_missing_filename"
+        return result
+    path = pdf_dir / name
+    if not path.resolve().is_relative_to(pdf_dir.resolve()):
+        result["hash_status"] = "path_outside_pdf_directory"
+        return result
+    result["file"] = name
+    result["sha256"] = sha256(path)
+    if result["sha256"] is None:
+        result["hash_status"] = "file_missing"
+    elif result["report_sha256"] is None:
+        result["hash_status"] = "report_hash_missing"
+    elif result["sha256"] != result["report_sha256"]:
+        result["hash_status"] = "changed_since_retrieval"
+    else:
+        result["hash_status"] = "matched"
+    return result
+
+
+def nonempty(value) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def assessment_state(assessment: dict, row: dict, binding_matches: bool) -> tuple[str, str]:
+    """Validate record completeness and freshness, not scientific interpretation."""
+    verdict = assessment.get("verdict")
+    if verdict == "not_assessed":
+        return "not_assessed", "not_assessed"
+    if not binding_matches:
+        return "unresolved", "stale_inputs"
+    if verdict not in VERDICTS:
+        return "unresolved", "invalid_verdict"
+    if not all(nonempty(assessment.get(key)) for key in ("assessor", "assessed_at", "method", "rationale")):
+        return "unresolved", "incomplete_assessment"
+    if verdict == "unresolved":
+        return verdict, "recorded"
+    if row["source"]["text_sha256"] is None:
+        return "unresolved", "source_not_available"
+    if row["source"]["pdf"]["hash_status"] != "matched":
+        return "unresolved", "pdf_not_bound"
+    if row["source"]["pdf"]["identity"].get("status") == "conflict":
+        return "unresolved", "source_identity_conflict"
+    if assessment.get("source_scope") != "full_text" or assessment.get("identity_checked") is not True:
+        return "unresolved", "source_review_incomplete"
+    pages = assessment.get("source_pages")
+    if not isinstance(pages, list) or not pages or any(type(p) is not int or p < 1 for p in pages):
+        return "unresolved", "missing_pdf_pages"
+    if not nonempty(assessment.get("source_excerpt")):
+        return "unresolved", "missing_source_excerpt"
+    for side in ("claim", "source"):
+        values = assessment.get(side)
+        if not isinstance(values, dict) or not all(nonempty(values.get(key)) for key in DIMENSIONS):
+            return "unresolved", "incomplete_comparison"
+    return verdict, "recorded"
+
+
+def build_evidence(raw: str, manuscript: Path, fulltext_dir: Path, resolver,
+                   abbrev: re.Pattern, *, binding: dict, retrieval: dict | None = None,
+                   pdf_dir: Path | None = None, reference_audit: dict | None = None,
+                   reviewed_report: dict | None = None) -> dict:
+    previous_rows = (reviewed_report or {}).get("evidence_rows", [])
+    previous = {r["id"]: r for r in previous_rows}
+    if len(previous) != len(previous_rows):
+        raise ValueError("duplicate evidence row IDs in reviewed report")
+    rows = []
+    occurrences = Counter()
+    pdf_cache = {}
+    for start, end in prose_spans(raw, abbrev):
+        sentence = raw[start:end]
+        for token in dict.fromkeys(resolver.citations_in(sentence)):
+            sentence_hash = hashlib.sha256(sentence.encode()).hexdigest()
+            base = hashlib.sha256((sentence + "\0" + token).encode()).hexdigest()[:20]
+            occurrences[base] += 1
+            ident = f"claim-{base}-{occurrences[base]}"
+            doi = normalized_doi(resolver.key_doi.get(token) or resolver.num_doi.get(token) or "")
+            mapped = resolver.refmap.get(token, "")
+            if not doi and normalized_doi(mapped).startswith("10."):
+                doi = normalized_doi(mapped)
+            source = resolver.resolve(token)
+            if doi not in pdf_cache:
+                pdf_cache[doi] = pdf_record(retrieval, pdf_dir, doi)
+            pdf = copy.deepcopy(pdf_cache[doi])
+            source_hash = resolver._source_hashes[source[0]] if source else None
+            current_binding = {**binding, "sentence_sha256": sentence_hash, "citation": token,
+                               "doi": doi, "text_sha256": source_hash, "pdf_sha256": pdf["sha256"]}
+            row = {"id": ident, "citation": token, "doi": doi or None,
+                   "manuscript": {"file": manuscript.name, "text": sentence,
+                                  "line_start": raw.count("\n", 0, start) + 1,
+                                  "line_end": raw.count("\n", 0, end) + 1,
+                                  "char_start": start, "char_end": end,
+                                  "coordinate_system": "read_text character offsets; lines are not rendered pages"},
+                   "source": {"text_file": source[0].relative_to(fulltext_dir).as_posix() if source else None,
+                              "text_sha256": source_hash, "pdf": pdf},
+                   "reference_audit": reference_record(reference_audit, token, doi),
+                   "binding": current_binding, "assessment": blank_assessment(),
+                   "verdict": "not_assessed", "review_state": "not_assessed"}
+            row["binding_sha256"] = binding_hash(current_binding)
+            row["assessment"]["binding_sha256"] = row["binding_sha256"]
+            prior = previous.get(ident)
+            if prior:
+                assessment = prior.get("assessment")
+                if not isinstance(assessment, dict):
+                    raise ValueError("assessment must be an object")
+                row["assessment"] = copy.deepcopy(assessment)
+                # Preserve the assessment's original binding through repeated reruns.
+                # Comparing only the prior report's current inputs would make a stale
+                # assessment look current on the second rerun.
+                matches = assessment.get("binding_sha256") == binding_hash(current_binding)
+                row["verdict"], row["review_state"] = assessment_state(assessment, row, matches)
+                if not matches:
+                    row["previous_binding"] = prior.get("binding")
+            rows.append(row)
+    present = {r["id"] for r in rows}
+    # Do not silently drop a review when its sentence/citation disappears on rerun.
+    orphaned = [copy.deepcopy(r) for r in previous_rows if r["id"] not in present]
+    orphaned += copy.deepcopy((reviewed_report or {}).get("orphaned_evidence_reviews", []))
+    return {"evidence_rows": rows, "orphaned_evidence_reviews": orphaned,
+            "evidence_counts": {"sentence_citation_pairs": len(rows),
+                                "verdicts": dict(Counter(r["verdict"] for r in rows)),
+                                "orphaned_reviews": len(orphaned)},
+            "evidence_scope": "Recognized prose citations only; tables, blockquotes, code, bibliography and uncited claims are not inventoried. Recorded assessments are attributed judgments, not automatically verified facts. PDF pages and excerpts require assessor inspection; PDF-to-text derivation is not inferred."}
+
+
+def render_table(report: dict) -> str:
+    def cell(value):
+        # Literal user/source text must not become HTML, links or multiline table syntax.
+        import html
+        value = html.escape(str(value), quote=False)
+        value = re.sub(r"([\\`*\[\]_])", r"\\\1", value)
+        return value.replace("|", "&#124;").replace("\n", " ").replace("\r", " ")
+
+    lines = ["# Claim-source evidence table", "",
+             "Derived from claim_fidelity.json. Recorded judgments are not automatic source verification.",
+             "Automated findings and manual assessments are separate. Unknown or stale evidence remains visible.",
+             "", "| ID / citation | Manuscript location and claim | Source / PDF SHA256 / identity | Pages and excerpt | Claim vs source | Assessment |",
+             "|---|---|---|---|---|---|"]
+    for row in report["evidence_rows"]:
+        assessment = row["assessment"]; source = row["source"]; pdf = source["pdf"]
+        comparison = "; ".join(f"{k}: {assessment.get('claim', {}).get(k, '')} / {assessment.get('source', {}).get(k, '')}" for k in DIMENSIONS)
+        columns = [f"{row['id']} / {row['citation']}",
+                   f"{row['manuscript']['file']} L{row['manuscript']['line_start']}: {row['manuscript']['text']}",
+                   f"Text: {source['text_file'] or 'missing'}; PDF: {pdf['file'] or 'missing'} / {pdf['sha256'] or 'unbound'} / {pdf['identity'].get('status', 'unavailable')} ({pdf['hash_status']})",
+                   f"{assessment.get('source_pages', [])}: {assessment.get('source_excerpt', '')}",
+                   comparison,
+                   f"{row['verdict']} ({row['review_state']}); {assessment.get('assessor', '')}; {assessment.get('assessed_at', '')}; {assessment.get('method', '')}; {assessment.get('rationale', '')}"]
+        lines.append("| " + " | ".join(cell(c) for c in columns) + " |")
+    lines += ["", report["evidence_scope"], "",
+              f"Orphaned review records retained in JSON: {len(report['orphaned_evidence_reviews'])}.",
+              f"Automated findings retained in JSON: {len(report['findings'])}.", ""]
+    return "\n".join(lines)

--- a/skills/verify-refs/scripts/check_claim_fidelity.py
+++ b/skills/verify-refs/scripts/check_claim_fidelity.py
@@ -9,10 +9,8 @@ citing it* is true of it. A citation can be perfectly real and still be attached
 the source never makes. That failure survives every existing gate: the DOI resolves, the
 authors match, the reference list renders, and the sentence is wrong.
 
-The incident this was built from: a manuscript sentence read "the field has begun to offer
-the chair [41]". The cited work uses the word "chair" zero times; it uses "advocate" four
-times, twice in the sense the manuscript was reaching for. A co-author caught it by reading
-the source. Nothing in the toolkit could have.
+A source can discuss one concept while the manuscript attributes a different concept to it.
+Bibliographic identity checks do not inspect that attribution; source reading is still needed.
 
 THREE PROBES, ORDERED BY HOW CHECKABLE THE CLAIM IS
 
@@ -62,8 +60,8 @@ searched. Two guards make that argument honest:
     source is downgraded to unresolved, never to a defect.
   * Quote matching goes through `_quote_match.py`, so a correct quote read through a dirty
     extraction (a bled reference column, PDF line numbers, a hyphen split across a line) is
-    reported as UNRESOLVED rather than as a fabrication. That module exists because a
-    contiguous-substring test produced thirteen false absences in one day.
+    reported as UNRESOLVED rather than as a fabrication. That module exists because
+    contiguous-substring tests can mistake extraction damage for an absent quotation.
 
 INPUT CONTRACT
 
@@ -95,6 +93,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _quote_match import match_quality, normalize, tokens  # noqa: E402  (vendored, same-dir)
+from _claim_evidence import build_evidence, render_table, sha256  # noqa: E402
 
 DETECTOR = "check_claim_fidelity"
 
@@ -296,6 +295,7 @@ class Resolver:
         self.refmap = refmap
         self.unresolved: set[str] = set()
         self._cache: dict[str, tuple[Path, str] | None] = {}
+        self._source_hashes: dict[Path, str | None] = {}
 
     def _file_for(self, token: str) -> Path | None:
         mapped = self.refmap.get(token)
@@ -316,7 +316,12 @@ class Resolver:
         if token in self._cache:
             return self._cache[token]
         path = self._file_for(token)
+        before = sha256(path)
         got = (path, read_text(path)) if path else None
+        if path:
+            if before != sha256(path):
+                raise ValueError("source changed while reading")
+            self._source_hashes[path] = before
         if got is None:
             self.unresolved.add(token)
         self._cache[token] = got
@@ -326,8 +331,7 @@ class Resolver:
     def citations_in(text: str) -> list[str]:
         out: list[str] = []
         for m in CITE_KEY.finditer(text):
-            out += [k.strip().lstrip("@").strip()
-                    for k in re.split(r"[;,]", m.group(1)) if "@" in k]
+            out += re.findall(r"@([A-Za-z0-9_][A-Za-z0-9_:.#$%&+?<>~/\-]*)", m.group(1))
         for m in CITE_NUM.finditer(text):
             out += expand_numeric(m.group(1))
         return [t for t in out if t]
@@ -561,7 +565,23 @@ def probe_cardinal(md: str, res: Resolver, findings: list[dict]) -> int:
 # ------------------------------------------------------------------------------------ main
 
 def build_report(manuscript: Path, fulltext_dir: Path, bib: Path | None,
-                 refmap: dict[str, str]) -> dict:
+                 refmap: dict[str, str], *, retrieval_report: Path | None = None,
+                 pdf_dir: Path | None = None, reference_audit: Path | None = None,
+                 reviewed_report: Path | None = None) -> dict:
+    def optional_json(path):
+        if path is None:
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError(f"expected a JSON object: {path.name}")
+        return value
+
+    inputs = [p for p in (manuscript, bib, retrieval_report, reference_audit, reviewed_report) if p]
+    initial_hashes = {p: sha256(p) for p in inputs}
+    # Read review input before writing --out, which may intentionally be the same report.
+    retrieval = optional_json(retrieval_report)
+    audit = optional_json(reference_audit)
+    reviewed = optional_json(reviewed_report)
     raw = read_text(manuscript)
     body = strip_noise(raw)
     res = Resolver(
@@ -579,7 +599,8 @@ def build_report(manuscript: Path, fulltext_dir: Path, bib: Path | None,
     resolved = {t: v for t, v in res._cache.items() if v}
     short = sorted({v[0].name for t, v in resolved.items()
                     if len(tokens(v[1])) < MIN_SOURCE_TOKENS})
-    return {
+    report = {
+        "schema_version": 2,
         "detector": DETECTOR,
         "manuscript": str(manuscript),
         "fulltext_dir": str(fulltext_dir),
@@ -589,6 +610,27 @@ def build_report(manuscript: Path, fulltext_dir: Path, bib: Path | None,
         "claims_checked": {"quotes": n_quote, "attributions": n_attr, "cardinals": n_card},
         "findings": findings,
     }
+    report.update(build_evidence(
+        raw, manuscript, fulltext_dir, res, ABBREV,
+        binding={"manuscript_sha256": initial_hashes[manuscript], "bib_sha256": initial_hashes.get(bib),
+                 "retrieval_report_sha256": initial_hashes.get(retrieval_report),
+                 "reference_audit_sha256": initial_hashes.get(reference_audit),
+                 "refmap": refmap},
+        retrieval=retrieval, pdf_dir=pdf_dir or (retrieval_report.parent if retrieval_report else None),
+        reference_audit=audit, reviewed_report=reviewed,
+    ))
+    for row in report["evidence_rows"]:
+        sentence = " ".join(row["manuscript"]["text"].split())
+        row["automatic_finding_indices"] = [
+            i for i, finding in enumerate(findings)
+            if finding["citation"] == row["citation"] and (
+                (finding.get("sentence") and " ".join(finding["sentence"].split()) == sentence[:300])
+                or (finding.get("quote") and " ".join(finding["quote"].split()) in sentence))]
+    if any(sha256(p) != digest for p, digest in initial_hashes.items()):
+        raise ValueError("input changed while building report")
+    if any(sha256(p) != digest for p, digest in res._source_hashes.items()):
+        raise ValueError("source changed while building report")
+    return report
 
 
 def main() -> int:
@@ -600,8 +642,20 @@ def main() -> int:
     ap.add_argument("--refmap", type=Path,
                     help='JSON {"41": "10.1000/xyz"} for citations neither bib nor list resolves')
     ap.add_argument("--out", type=Path, help="write the JSON report here")
+    ap.add_argument("--retrieval-report", type=Path,
+                    help="existing fetch_oa report; advisory identity and PDF hashes, not claim support")
+    ap.add_argument("--pdf-dir", type=Path,
+                    help="PDF directory, when different from the retrieval report's directory")
+    ap.add_argument("--reference-audit", type=Path, help="existing reference_audit.json (read-only)")
+    ap.add_argument("--reviewed-report", type=Path,
+                    help="prior claim_fidelity.json containing assessor-entered evidence_rows")
+    ap.add_argument("--evidence-table", type=Path, help="optional Markdown view derived from this report")
     ap.add_argument("--strict", action="store_true", help="exit 1 if any major verdict fires")
     args = ap.parse_args()
+
+    if args.evidence_table and not args.out:
+        print("ERROR: --evidence-table requires --out to preserve the source JSON", file=sys.stderr)
+        return 2
 
     if not args.manuscript.is_file():
         print(f"ERROR: manuscript not found: {args.manuscript}", file=sys.stderr)
@@ -609,16 +663,41 @@ def main() -> int:
     if not args.fulltext_dir.is_dir():
         print(f"ERROR: --fulltext-dir not a directory: {args.fulltext_dir}", file=sys.stderr)
         return 2
-    refmap: dict[str, str] = {}
-    if args.refmap:
-        refmap = {str(k): str(v)
-                  for k, v in json.loads(args.refmap.read_text(encoding="utf-8")).items()}
-
-    report = build_report(args.manuscript, args.fulltext_dir, args.bib, refmap)
+    protected = [args.manuscript, args.bib, args.refmap, args.retrieval_report, args.reference_audit]
+    protected += list(index_fulltext(args.fulltext_dir).values())
+    protected = {p.resolve() for p in protected if p}
+    outputs = [p.resolve() for p in (args.out, args.evidence_table) if p]
+    if any(p in protected for p in outputs) or len(outputs) != len(set(outputs)):
+        print("ERROR: output paths must be distinct and must not overwrite source inputs", file=sys.stderr)
+        return 2
+    if args.reviewed_report and args.evidence_table and args.reviewed_report.resolve() == args.evidence_table.resolve():
+        print("ERROR: the table must not overwrite the reviewed JSON", file=sys.stderr)
+        return 2
+    try:
+        refmap: dict[str, str] = {}
+        if args.refmap:
+            refmap = {str(k): str(v)
+                      for k, v in json.loads(args.refmap.read_text(encoding="utf-8")).items()}
+        report = build_report(args.manuscript, args.fulltext_dir, args.bib, refmap,
+                              retrieval_report=args.retrieval_report, pdf_dir=args.pdf_dir,
+                              reference_audit=args.reference_audit, reviewed_report=args.reviewed_report)
+        selected_pdf_dir = args.pdf_dir or (args.retrieval_report.parent if args.retrieval_report else None)
+        if selected_pdf_dir:
+            protected.update((selected_pdf_dir / row["source"]["pdf"]["file"]).resolve()
+                             for row in report["evidence_rows"] if row["source"]["pdf"]["file"])
+        if any(p in protected for p in outputs):
+            raise ValueError("output would overwrite a source PDF")
+        table_text = render_table(report) if args.evidence_table else None
+    except (OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
+        print(f"ERROR: cannot build claim evidence report: {exc}", file=sys.stderr)
+        return 2
 
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    if args.evidence_table:
+        args.evidence_table.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence_table.write_text(table_text, encoding="utf-8")
 
     c = report["claims_checked"]
     print(f"{DETECTOR}: {report['sources_resolved']} source(s) resolved; "
@@ -632,8 +711,11 @@ def main() -> int:
               f"{', '.join(report['sources_too_short'][:8])}")
 
     majors = [f for f in report["findings"] if f["severity"] == "major"]
+    e = report["evidence_counts"]
+    print(f"  evidence table: {e['sentence_citation_pairs']} sentence/citation pair(s); "
+          f"recorded review outcomes: {json.dumps(e['verdicts'], sort_keys=True)}")
     if not report["findings"]:
-        print("OK: every checkable claim is supported by its cited source.")
+        print("No automated findings. Claim support has not been established by this check.")
         return 0
     for f in report["findings"]:
         print(f"  [{f['severity']}] {f['verdict']}: {f['message']}")

--- a/skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
+++ b/skills/verify-refs/scripts/claim_fidelity_challenge/verify.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 # Deterministic verifier for the claim-fidelity challenge card.
 #
-# The failure this gate exists to catch was found by a human co-author, not by the toolkit. A
-# manuscript sentence read "the field has begun to offer the chair [41]". The cited work uses
-# "chair" zero times and "advocate" four times, twice in the sense the sentence was reaching
-# for. Every existing gate passed: the DOI resolved, the authors matched, the reference list
-# rendered. Nothing checked whether the source says what the sentence says it says.
+# A real citation can carry an unsupported attribution even when its DOI and authors match.
+# These synthetic controls separate source-word checks from bibliographic identity checks.
 #
 # So the positive fixtures reproduce that shape across all three probes:
 #   an attributed concept the source never uses          -> ATTRIBUTION_UNSUPPORTED
@@ -16,10 +13,8 @@
 # the cases where firing would be WRONG:
 #   a real paraphrase, worded nothing like the source, that keeps one of its terms
 #   a correct quote read through a DIRTY EXTRACTION (line numbers and a bled reference wedged
-#     mid-sentence). A contiguous substring test calls that absent; that assumption produced
-#     thirteen false absences in one day and came one step from having two accurate quotes
-#     deleted. This gate inherits _quote_match.py precisely so it cannot repeat that, and the
-#     test below is what proves the inheritance is live rather than nominal.
+#     mid-sentence). A contiguous substring test can call that absent. The test exercises the
+#     inherited _quote_match.py behavior with extraction damage.
 #   a source whose extracted text is an abstract — absence proves nothing against it
 #   a citation with no full text at all — counted as unchecked, never guessed at
 set -uo pipefail

--- a/skills/verify-refs/skill.yml
+++ b/skills/verify-refs/skill.yml
@@ -21,6 +21,7 @@ inputs:
 outputs:
   - qc/reference_audit.json
   - qc/claim_fidelity.json
+  - qc/claim_fidelity.md (optional derived view of the JSON evidence rows)
 deterministic_scripts:
   - scripts/verify_refs.py
   - scripts/verify_cli.sh
@@ -43,6 +44,7 @@ safety_boundaries:
 known_limitations:
   - "Confirms DOI/PMID and author identity, not topical appropriateness of the citation."
   - "CrossRef given-name errors are possible; PubMed efetch is treated as authoritative."
+  - "Evidence rows record assessor judgments bound to input hashes, not automatically verified source support. Source PDF pages, extraction provenance, and semantic comparisons require actual source inspection."
   - "Claim fidelity checks only claims with a checkable anchor (a quotation, an attributed concept, a stated count) and only against full texts already on disk; a citation with no full text is reported unresolved, never guessed at. A small alteration inside a long quotation falls within the extraction tolerance of the quote matcher and is surfaced as a prompt rather than as a fabrication."
   - "OpenAlex (tertiary index for conference proceedings / non-DOI works) gives an existence check plus a tolerant first-author membership check only; its display names carry no structured family field, so it never drives the strict positional or author-count cross-check. Use --no-openalex to restrict to PubMed + CrossRef."
 validation_commands:
@@ -51,4 +53,5 @@ validation_commands:
   - "bash tests/test_openalex_tier.sh"
   - "bash tests/test_fabricated_author.sh"
   - "bash scripts/claim_fidelity_challenge/verify.sh"
+  - "python3 tests/test_claim_evidence.py"
 evidence_surface: bundled_script

--- a/skills/verify-refs/tests/test_claim_evidence.py
+++ b/skills/verify-refs/tests/test_claim_evidence.py
@@ -1,0 +1,276 @@
+"""Synthetic source-evidence workflow controls; no private papers or network."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import check_claim_fidelity as fidelity
+from _claim_evidence import binding_hash, render_table
+
+
+def write_pdf(path: Path, text: str):
+    """A real one-page PDF, using only stdlib and synthetic ASCII text."""
+    escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = f"BT /F1 10 Tf 40 740 Td ({escaped}) Tj ET".encode()
+    objects = [b"<< /Type /Catalog /Pages 2 0 R >>",
+               b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+               b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+               b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+               b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream"]
+    data = b"%PDF-1.4\n"; offsets = [0]
+    for i, obj in enumerate(objects, 1):
+        offsets.append(len(data)); data += f"{i} 0 obj\n".encode() + obj + b"\nendobj\n"
+    start = len(data)
+    data += f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n".encode()
+    data += b"".join(f"{n:010d} 00000 n \n".encode() for n in offsets[1:])
+    data += f"trailer\n<< /Size {len(objects)+1} /Root 1 0 R >>\nstartxref\n{start}\n%%EOF\n".encode()
+    path.write_bytes(data)
+
+
+class ClaimEvidenceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.ft = self.root / "fulltext"; self.ft.mkdir()
+        self.manuscript = self.root / "manuscript.md"
+        self.manuscript.write_text("# Synthetic methods\n\nThe tool reduced latency by 18% in the complete sample [@demo].\n", encoding="utf-8")
+        self.bib = self.root / "refs.bib"
+        self.bib.write_text("@article{demo,\n title={Synthetic latency comparison},\n doi={10.1000/synthetic.latency}\n}\n", encoding="utf-8")
+        self.text = self.ft / "10.1000_synthetic.latency.md"
+        self.excerpt = "The tool reduced latency by 18% in the complete sample."
+        self.text.write_text(self.excerpt + "\n" + "Synthetic background for a software experiment. " * 85, encoding="utf-8")
+        self.pdf = self.ft / "10.1000_synthetic.latency.pdf"
+        write_pdf(self.pdf, self.excerpt)
+        self.retrieval = self.ft / "retrieval_report.json"
+        self.retrieval.write_text(json.dumps({"schema_version":2,"items":[{
+            "doi":"10.1000/synthetic.latency", "file":self.pdf.name,
+            "file_sha256":hashlib.sha256(self.pdf.read_bytes()).hexdigest(),
+            "source_identity":{"status":"consistent","reason":"synthetic first-page evidence"}}]}))
+        self.audit = self.root / "reference_audit.json"
+        self.audit.write_text(json.dumps({"schema_version":4,"records":[{
+            "ref_id":"demo","doi":"10.1000/synthetic.latency","status":"OK"}]}))
+
+    def report(self, reviewed=None, **kwargs):
+        args = dict(retrieval_report=self.retrieval, reference_audit=self.audit, reviewed_report=reviewed)
+        args.update(kwargs)
+        return fidelity.build_report(self.manuscript, self.ft, self.bib, {}, **args)
+
+    def review(self, report=None, verdict="supported"):
+        report = copy.deepcopy(report or self.report())
+        assessment = report["evidence_rows"][0]["assessment"]
+        assessment.update(verdict=verdict, assessor="Synthetic test assessor", assessed_at="2026-01-01",
+                          method="synthetic_fixture_annotation", source_scope="full_text", identity_checked=True,
+                          source_pages=[1], source_excerpt=self.excerpt,
+                          rationale="Synthetic source states the same latency change and population.")
+        for side in ("claim", "source"):
+            assessment[side] = dict(metric="latency change", unit="percent", denominator="all experimental runs",
+                                    population="complete sample", direction="decrease")
+        return report
+
+    def save(self, value, name="reviewed.json"):
+        path = self.root / name; path.write_text(json.dumps(value), encoding="utf-8"); return path
+
+    def replace_source(self, old, new):
+        self.text.write_text(self.text.read_text().replace(old, new))
+        self.excerpt = self.excerpt.replace(old, new)
+        write_pdf(self.pdf, self.excerpt)
+        report = json.loads(self.retrieval.read_text())
+        report["items"][0]["file_sha256"] = hashlib.sha256(self.pdf.read_bytes()).hexdigest()
+        self.retrieval.write_text(json.dumps(report))
+
+    def cli(self, *args):
+        return subprocess.run([sys.executable, str(SCRIPTS / "check_claim_fidelity.py"),
+                               "--manuscript", str(self.manuscript), "--fulltext-dir", str(self.ft),
+                               "--bib", str(self.bib), *map(str, args)], capture_output=True, text=True)
+
+    def test_no_warning_and_real_reference_do_not_establish_support(self):
+        report = self.report(); row = report["evidence_rows"][0]
+        self.assertEqual(report["findings"], [])
+        self.assertEqual(row["reference_audit"]["recorded_status"], "OK")
+        self.assertEqual(row["source"]["pdf"]["identity"]["status"], "consistent")
+        self.assertEqual(row["verdict"], "not_assessed")
+
+    def test_same_number_in_different_subgroup_stays_unassessed(self):
+        self.replace_source("complete sample", "fastest subgroup")
+        row = self.report()["evidence_rows"][0]
+        self.assertEqual(row["verdict"], "not_assessed")
+        reviewed = self.review(verdict="contradicted")
+        a = reviewed["evidence_rows"][0]["assessment"]
+        a["source"]["population"] = "fastest subgroup"
+        a["source_excerpt"] = "The tool reduced latency by 18% in the fastest subgroup."
+        a["rationale"] = "Same number describes a different population."
+        row = self.report(self.save(reviewed))["evidence_rows"][0]
+        self.assertEqual(row["verdict"], "contradicted")
+        self.assertNotEqual(row["assessment"]["claim"]["population"], row["assessment"]["source"]["population"])
+
+    def test_opposite_direction_is_not_inferred_from_matching_words(self):
+        self.replace_source("reduced", "increased")
+        self.assertEqual(self.report()["evidence_rows"][0]["verdict"], "not_assessed")
+
+    def test_wrong_pdf_identity_cannot_carry_support(self):
+        payload = json.loads(self.retrieval.read_text())
+        payload["items"][0]["source_identity"]["status"] = "conflict"
+        self.retrieval.write_text(json.dumps(payload))
+        row = self.report(self.save(self.review()))["evidence_rows"][0]
+        self.assertEqual(row["reference_audit"]["recorded_status"], "OK")
+        self.assertEqual((row["verdict"], row["review_state"]), ("unresolved", "source_identity_conflict"))
+
+    def test_abstract_only_review_remains_unresolved(self):
+        self.text.write_text("Synthetic abstract with the same reported latency change.")
+        reviewed = self.review(); reviewed["evidence_rows"][0]["assessment"]["source_scope"] = "abstract_only"
+        row = self.report(self.save(reviewed))["evidence_rows"][0]
+        self.assertEqual(row["verdict"], "unresolved")
+
+    def test_unresolved_citation_is_inventoried_without_attribution_verb(self):
+        self.manuscript.write_text("A latency difference of 18% [@missing].")
+        row = self.report()["evidence_rows"][0]
+        self.assertEqual(row["citation"], "missing"); self.assertIsNone(row["source"]["text_file"])
+        self.assertEqual(row["verdict"], "not_assessed")
+
+    def test_recorded_assessment_requires_pages_excerpt_and_comparison(self):
+        for key, value in [("assessor", ""), ("source_pages", []), ("source_pages", [True]),
+                           ("source_excerpt", ""), ("claim", {}), ("source", {})]:
+            with self.subTest(key=key, value=value):
+                reviewed = self.review(); reviewed["evidence_rows"][0]["assessment"][key] = value
+                self.assertEqual(self.report(self.save(reviewed))["evidence_rows"][0]["verdict"], "unresolved")
+
+    def test_complete_attributed_review_is_retained_without_changing_findings(self):
+        initial = self.report(); reviewed = self.review(initial)
+        report = self.report(self.save(reviewed)); row = report["evidence_rows"][0]
+        self.assertEqual((row["verdict"], row["review_state"]), ("supported", "recorded"))
+        self.assertEqual(report["findings"], initial["findings"])
+        self.assertIn("not automatically verified facts", report["evidence_scope"])
+
+    def test_changed_pdf_stays_stale_across_repeated_reruns(self):
+        reviewed = self.save(self.review())
+        write_pdf(self.pdf, "Different synthetic source version.")
+        for _ in range(2):
+            report = self.report(reviewed); row = report["evidence_rows"][0]
+            self.assertEqual(row["verdict"], "unresolved"); self.assertEqual(row["review_state"], "stale_inputs")
+            self.assertEqual(row["source"]["pdf"]["hash_status"], "changed_since_retrieval")
+            reviewed = self.save(report)
+
+    def test_changed_text_bibliography_and_manuscript_context_invalidate_review(self):
+        for path in (self.text, self.bib, self.manuscript):
+            with self.subTest(path=path.name):
+                old = path.read_bytes(); reviewed = self.save(self.review())
+                path.write_bytes(old + b"\nContext updated.\n")
+                row = self.report(reviewed)["evidence_rows"][0]
+                self.assertEqual(row["review_state"], "stale_inputs")
+                path.write_bytes(old)
+
+    def test_changed_sentence_preserves_orphaned_review(self):
+        reviewed = self.save(self.review()); self.manuscript.write_text("A changed claim [@demo].")
+        report = self.report(reviewed)
+        self.assertEqual(report["evidence_rows"][0]["verdict"], "not_assessed")
+        self.assertEqual(len(report["orphaned_evidence_reviews"]), 1)
+
+    def test_explicit_reinspection_can_refresh_a_stale_assessment(self):
+        reviewed = self.save(self.review())
+        self.text.write_text(self.text.read_text() + "\nAdditional synthetic context.\n")
+        stale = self.report(reviewed); row = stale["evidence_rows"][0]
+        self.assertEqual(row["review_state"], "stale_inputs")
+        row["assessment"]["binding_sha256"] = row["binding_sha256"]
+        row["assessment"]["rationale"] = "Synthetic assessor rechecked the changed context."
+        fresh = self.report(self.save(stale))["evidence_rows"][0]
+        self.assertEqual((fresh["verdict"], fresh["review_state"]), ("supported", "recorded"))
+
+    def test_numbered_citation_has_source_and_original_offsets(self):
+        raw = "A synthetic latency result [1].\n\n## References\n1. Synthetic source. doi:10.1000/synthetic.latency\n"
+        self.manuscript.write_text(raw)
+        row = self.report()["evidence_rows"][0]
+        self.assertEqual(row["citation"], "1")
+        self.assertEqual(row["doi"], "10.1000/synthetic.latency")
+        self.assertEqual(row["manuscript"]["char_start"], 0)
+
+    def test_docx_coordinates_are_extracted_text_not_rendered_pages(self):
+        from docx import Document
+        doc = Document(); doc.add_paragraph("Synthetic latency evidence [@demo].")
+        path = self.root / "manuscript.docx"; doc.save(path)
+        report = fidelity.build_report(path, self.ft, self.bib, {})
+        row = report["evidence_rows"][0]
+        self.assertEqual(row["manuscript"]["line_start"], 1)
+        self.assertIn("not rendered pages", row["manuscript"]["coordinate_system"])
+
+    def test_duplicate_review_ids_rejected(self):
+        reviewed = self.review(); reviewed["evidence_rows"].append(reviewed["evidence_rows"][0])
+        with self.assertRaisesRegex(ValueError, "duplicate"): self.report(self.save(reviewed))
+
+    def test_missing_or_duplicate_pdf_report_never_uses_first_match(self):
+        payload = json.loads(self.retrieval.read_text()); payload["items"] *= 2
+        self.retrieval.write_text(json.dumps(payload))
+        self.assertEqual(self.report()["evidence_rows"][0]["source"]["pdf"]["hash_status"], "ambiguous_report")
+
+    def test_report_paths_cannot_escape_the_pdf_directory(self):
+        payload = json.loads(self.retrieval.read_text()); payload["items"][0]["file"] = "../outside.pdf"
+        self.retrieval.write_text(json.dumps(payload))
+        row = self.report()["evidence_rows"][0]
+        self.assertIsNone(row["source"]["pdf"]["sha256"])
+
+    def test_prose_positions_survive_exclusions_and_duplicate_sentences(self):
+        line = "A synthetic claim [see @demo, p. 1; @missing]."
+        raw = "---\ntitle: ignored [@meta]\n---\n# Heading\n\n```\nignored [@code]\n```\n\n| ignored [@table] |\n\n> ignored [@quote]\n\n" + line + "\n\n" + line + "\n\n## References\nignored [@bib]\n"
+        self.manuscript.write_text(raw)
+        rows = self.report()["evidence_rows"]
+        self.assertEqual([r["citation"] for r in rows], ["demo", "missing", "demo", "missing"])
+        self.assertEqual(len({r["id"] for r in rows}), 4)
+        for row in rows:
+            location = row["manuscript"]
+            self.assertEqual(raw[location["char_start"]:location["char_end"]], line)
+            self.assertEqual(raw.splitlines()[location["line_start"] - 1], line)
+
+    def test_no_report_supplied_preserves_legacy_call_signature(self):
+        report = fidelity.build_report(self.manuscript, self.ft, self.bib, {})
+        self.assertEqual(report["evidence_rows"][0]["source"]["pdf"]["hash_status"], "not_available")
+        self.assertEqual(report["evidence_rows"][0]["verdict"], "not_assessed")
+
+    def test_table_escapes_source_markup(self):
+        report = self.report(); report["evidence_rows"][0]["assessment"]["source_excerpt"] = "<img src=x>|[link](https://example.com)\nnext"
+        table = render_table(report)
+        self.assertNotIn("<img", table); self.assertNotIn("[link](", table); self.assertIn("&#124;", table)
+
+    def test_cli_writes_derived_table_and_preserves_all_sources(self):
+        paths = (self.manuscript, self.bib, self.text, self.pdf, self.retrieval, self.audit)
+        before = {p:p.read_bytes() for p in paths}
+        output = self.root / "claim_fidelity.json"; table = self.root / "claim_fidelity.md"
+        result = self.cli("--retrieval-report", self.retrieval, "--reference-audit", self.audit,
+                          "--out", output, "--evidence-table", table)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("every checkable claim is supported", result.stdout)
+        self.assertIn("not been established", result.stdout)
+        self.assertIn(r"not\_assessed", table.read_text())
+        self.assertEqual(json.loads(output.read_text())["schema_version"], 2)
+        self.assertEqual(before, {p:p.read_bytes() for p in paths})
+
+    def test_cli_rejects_outputs_over_source_files(self):
+        for path in (self.manuscript, self.text, self.pdf, self.retrieval):
+            with self.subTest(path=path.name):
+                before = path.read_bytes()
+                result = self.cli("--retrieval-report", self.retrieval, "--out", path)
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertEqual(path.read_bytes(), before)
+
+    def test_invalid_json_does_not_overwrite_existing_output(self):
+        output = self.root / "claim_fidelity.json"; output.write_text("preserve existing output")
+        self.retrieval.write_text("broken json")
+        result = self.cli("--retrieval-report", self.retrieval, "--out", output)
+        self.assertEqual(result.returncode, 2); self.assertEqual(output.read_text(), "preserve existing output")
+
+    def test_table_requires_json_and_cannot_replace_it(self):
+        output = self.root / "claim_fidelity.json"
+        self.assertEqual(self.cli("--evidence-table", output).returncode, 2)
+        self.assertEqual(self.cli("--out", output, "--evidence-table", output).returncode, 2)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When claim-fidelity finds no warning, it can still leave citations and source meaning unassessed. This change replaces the blanket support message and extends the existing JSON with sentence/citation rows, source hashes, retrieval identity, metadata-audit context, and attributed comparisons. An optional Markdown table is derived from that JSON.

Previous assessments stay bound to their original inputs across reruns; changed or missing sources remain unresolved and unmatched reviews are retained. The tool records an assessor's judgment, not independently verified semantic support. Existing probes and strict-exit behavior remain in place.

Validation: 24 synthetic evidence-workflow tests, the existing 26-control claim-fidelity challenge, and the full local CI mirror. Tests cover different subgroups sharing a number, reversed effects, conflicting PDF identity, abstract-only sources, missing citations, stale reviews across repeated reruns, and preservation of source inputs. A synthetic CLI demonstration also round-trips real PDF text. The new tests use the existing CI job; no new detector or release is added.
