### PR TITLE
Preserve submission bundles and expose verification coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -339,7 +339,9 @@ jobs:
         run: bash skills/write-paper/tests/test_placeholders.sh
 
       - name: Run sync-submission preflight gate test (A6)
-        run: bash skills/sync-submission/tests/test_preflight_gate.sh
+        run: |
+          bash skills/sync-submission/tests/test_preflight_gate.sh
+          python3 skills/sync-submission/tests/test_submission_bundle.py
 
       - name: "Run sync-submission marked-build failure test (a failed Compare leaves no file behind)"
         run: bash skills/sync-submission/tests/test_marked_build_failure.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Submission build accepts a declared bundle of final Word/PDF, supplement,
+  cover-letter and other files. Existing metadata/manifest outputs record byte
+  hashes, pinned render inputs, declared reuse rights and unassessed visual and
+  content fidelity. Preflight records executed/skipped checks and bundle binding.
 - Claim-fidelity reports include sentence/citation evidence rows and an optional
   Markdown table linking source hashes, retrieval identity, metadata audit context,
   and attributed source comparisons. Existing JSON remains the evidence store;
@@ -11,6 +15,10 @@
 
 ### Fixed
 
+- Submission sync refuses missing-package freeze, frozen/edited output overwrite,
+  unregistered-file loss and colliding paths. Malformed metadata fails explicitly;
+  staged copies preserve source bytes and cooperating mutations share a lock.
+  A required preflight check that exits without running cannot report a safe pass.
 - Claim-fidelity output no longer equates an absence of automated findings with
   source support. Citation prefixes and page locators are preserved in the evidence
   inventory. New controls run within the existing validation job.

--- a/docs/skills/sync-submission.md
+++ b/docs/skills/sync-submission.md
@@ -21,6 +21,8 @@
 
 **Known limitations**
 
+- Build copies declared final files byte for byte; rendering remains with existing renderers. Hashes do not establish visual or semantic fidelity or reuse permission.
+- Preflight bundle binding covers declared sources/dependencies and package bytes, not every external check input. Skipped checks and unassessed readiness remain explicit.
 - Detects drift it is configured to scan (counts, cover-letter fields, scope); portal free-text fields still need a human check.
 - A clean audit is necessary, not sufficient, for acceptance.
 - Building a marked (tracked-changes) manuscript drives Microsoft Word and therefore needs macOS + Word; the round-trip verification of a marked file is portable and runs anywhere.
@@ -41,6 +43,7 @@
 
 **References** (`skills/sync-submission/references/`):
 
+- `bundle_workflow.md`
 - `journal_availability_policy.json`
 
 **Scripts** (`skills/sync-submission/scripts/`):

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -5478,8 +5478,18 @@
     },
     {
       "path": "skills/sync-submission/SKILL.md",
-      "size": 40790,
-      "sha256": "45b228823952b028f0ec8160cd3e457f95b37a0a8fe692a09349a49d1e91054a"
+      "size": 41988,
+      "sha256": "f7b831bc599966f0b9e2fbcb78b7802d19ea05d3c066ace673a67604ea91e24c"
+    },
+    {
+      "path": "skills/sync-submission/examples/build_synthetic_bundle.py",
+      "size": 3690,
+      "sha256": "35ec00892fcc1f188784c1113ec107dde40f6b859693d975f4e88b6219b604a9"
+    },
+    {
+      "path": "skills/sync-submission/references/bundle_workflow.md",
+      "size": 7344,
+      "sha256": "d4295e169cea53b79a93458a937f8c4ffaa544951907de02758426aee9ab8c78"
     },
     {
       "path": "skills/sync-submission/references/journal_availability_policy.json",
@@ -5703,8 +5713,8 @@
     },
     {
       "path": "skills/sync-submission/scripts/preflight_gate.py",
-      "size": 27400,
-      "sha256": "958e18e4ca4f48390a68c6c7407d341f396bc6673f9c8d918a7a51b72d000a7e"
+      "size": 29080,
+      "sha256": "af5688aa499b6890270d1367260d1460f180a9f57decbdc3542c74c24e4fdf8e"
     },
     {
       "path": "skills/sync-submission/scripts/scope_drift_check.py",
@@ -5713,13 +5723,13 @@
     },
     {
       "path": "skills/sync-submission/scripts/sync_submission.py",
-      "size": 6439,
-      "sha256": "dc6f6a81e846bc218a37e2d655659a02fa38bd738a42036cc8854d7e1ea32308"
+      "size": 21796,
+      "sha256": "c6c0adaf9f58357f3f8241c71ac7b47e72a4d56a06156f5e310bc1bc6f964c23"
     },
     {
       "path": "skills/sync-submission/skill.yml",
-      "size": 2309,
-      "sha256": "f291953988db61d64ee9f4649971236d5474e3b71e4b92fad8987cdf81a82daf"
+      "size": 2736,
+      "sha256": "ed880953ab130995994e371baa5347cffe8c79bef21a0fa1f4fd48f115b03acf"
     },
     {
       "path": "skills/uncertainty-imaging/SKILL.md",

--- a/skills/sync-submission/SKILL.md
+++ b/skills/sync-submission/SKILL.md
@@ -25,8 +25,8 @@ and records whether it is current, stale, or frozen.
 2. Journal short name, e.g. `chest`, `ryai`, `academic_radiology`.
 3. Optional mode:
    - `audit`: compare existing submission against canonical source.
-   - `build`: copy canonical source into `submission/{journal}/manuscript/` and write metadata.
-   - `freeze`: mark a package as submitted/frozen.
+   - `build`: copy canonical source and optional declared final artifacts, preserving file bytes, and write metadata.
+   - `freeze`: freeze the chosen byte snapshot with its available check context (not submission approval).
 
 ## Deterministic Script
 
@@ -57,6 +57,14 @@ The registry is a project-local YAML mapping author identifiers (full names, nat
 | Pre-flight gate | `qc/preflight_gate_report.json` | Aggregated halt-on-failure manifest (see "Pre-flight gate" below) |
 | Supplement structure | `qc/supplement_structure.json` | Gate 14: index↔file 1:1, sub-section gaps, callout coverage |
 
+For a complete bundle, use `build --bundle-spec bundle.json` after running the
+existing renderers. The declaration adds final Word/PDF, supplement, cover-letter,
+table/figure and notice files with pinned render-input hashes and reuse-rights
+records. Copies preserve file bytes; content and visual fidelity remain
+`not_assessed` until separately reviewed. Build refuses edited or frozen outputs
+and destructive path collisions. See [bundle workflow](references/bundle_workflow.md)
+for the schema, a runnable synthetic example and the limits of each recorded check.
+
 ## Pre-flight gate (single command — last step before freeze)
 
 Run this once, right before `freeze`/submission. It orchestrates the existing
@@ -65,6 +73,14 @@ writes a single aggregated manifest (`qc/preflight_gate_report.json`), and exits
 **non-zero** so a build wrapper or CI step can stop the freeze. It shells out to
 the per-check scripts and reimplements none of them — the halt decision is driven
 by each sub-check's normalized exit code.
+
+The report distinguishes executed, skipped and errored checks. Its legacy
+`submission_safe` field means no configured blocker/error, not submission
+approval; `readiness` remains `not_assessed`. The optional bundle hash binding
+identifies the package present during the run, not per-file visual inspection or
+all external check inputs. Run `audit` again after preflight to expose current,
+stale or unbound evidence. Freeze records a byte snapshot and its available check
+context; it does not run preflight or approve source fidelity or reuse permissions.
 
 ```bash
 python "${CLAUDE_SKILL_DIR}/scripts/preflight_gate.py" --project-root . --journal chest

--- a/skills/sync-submission/examples/build_synthetic_bundle.py
+++ b/skills/sync-submission/examples/build_synthetic_bundle.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Original synthetic bundle demo; creates files only in a new/empty directory.
+
+Usage: python build_synthetic_bundle.py --project-root /tmp/submission-demo [--pdf]
+Requires pandoc; --pdf also requires render-pdf-doc and its XeLaTeX dependencies.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+SKILL = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL / "scripts"))
+from sync_submission import sha256_file
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", required=True)
+    parser.add_argument("--pdf", action="store_true")
+    args = parser.parse_args()
+    root = Path(args.project_root).resolve()
+    if root.exists() and any(root.iterdir()):
+        parser.error("Demo requires a new or empty directory")
+    root.mkdir(parents=True, exist_ok=True)
+    for directory in ("manuscript", "build"):
+        (root / directory).mkdir()
+    sources = {
+        "manuscript/manuscript.md": "# Synthetic study\n\nThis is original demonstration text, not research evidence.\n\n"
+        "| Group | Count |\n|---|---:|\n| A | 12 |\n| B | 18 |\n\nTotal: 30 synthetic observations.\n",
+        "manuscript/supplement.md": "# Synthetic supplement\n\nGroup A: 12. Group B: 18. Total: 30.\n",
+        "manuscript/cover_letter.md": "Dear Editor,\n\nThis is a synthetic packaging demonstration.\n",
+    }
+    for name, content in sources.items():
+        (root / name).write_text(content, encoding="utf-8")
+    before = {name: sha256_file(root / name) for name in sources}
+    version = subprocess.run(["pandoc", "--version"], check=True, capture_output=True, text=True).stdout.splitlines()[0]
+    entries = []
+    for name, stem, role in (("manuscript/manuscript.md", "final", "manuscript"),
+                             ("manuscript/supplement.md", "supplement", "supplement"),
+                             ("manuscript/cover_letter.md", "cover_letter", "cover_letter")):
+        formats = ["docx"] + (["pdf"] if args.pdf else [])
+        for extension in formats:
+            output = f"build/{stem}.{extension}"
+            target = f"{role}/{stem}.{extension}"
+            command = ["pandoc", name, "-o", output]
+            recorded = list(command)
+            if extension == "pdf":
+                renderer = SKILL.parent / "render-pdf-doc/scripts/render_pdf.sh"
+                command = ["bash", str(renderer), "-i", name, "-o", output]
+                recorded = ["render-pdf-doc/scripts/render_pdf.sh", "-i", name, "-o", output]
+            subprocess.run(command, cwd=root, check=True)
+            entries.append({"id": f"{stem}-{extension}", "role": f"{role}_{extension}",
+                            "source": output, "target": target,
+                            "derived_from": [{"path": name, "sha256": before[name]}],
+                            "transformation": {"kind": "rendered", "command": recorded, "pandoc_version": version},
+                            "rights": {"status": "original", "changes": "Rendered original synthetic example"}})
+    if before != {name: sha256_file(root / name) for name in sources}:
+        raise RuntimeError("Sources changed during rendering")
+    (root / "bundle.json").write_text(json.dumps({"schema_version": 1, "artifacts": entries}, indent=2) + "\n")
+    subprocess.run([sys.executable, str(SKILL / "scripts/sync_submission.py"), "build",
+                    "--project-root", str(root), "--journal", "example", "--bundle-spec", "bundle.json"], check=True)
+    print("Synthetic bundle built. Visual, semantic, metadata and preflight checks remain separate.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sync-submission/references/bundle_workflow.md
+++ b/skills/sync-submission/references/bundle_workflow.md
@@ -1,0 +1,130 @@
+# Preserve sources while assembling a submission bundle
+
+`sync_submission.py build` copies files byte for byte. It does not rewrite prose,
+reformat third-party templates, render documents, or certify a submission. Use
+the existing manuscript/figure/supplement renderers first, inspect their output,
+then declare exactly which files belong in this journal package.
+
+## From changed sources to final files
+
+1. Preserve the previous submitted/frozen package. Work from canonical sources in
+   a new revision directory. Do not run side-effecting checks against the only
+   copy of a submitted package; use an isolated project copy for that audit.
+2. Before rendering, record SHA-256 hashes of the manuscript, supplement sources,
+   bibliography, tables, figures, configuration and any reference template actually
+   used. Run the existing renderer and confirm those inputs did not change during
+   the run. Record its command/version and the output in the bundle declaration.
+3. Inspect the actual final DOCX/PDF, including tables, figures, equations, Unicode,
+   captions, pagination, tracked changes and hidden metadata. A source-text check
+   does not establish that those survived conversion. Keep review notes local.
+4. Build using the declaration, run the existing preflight with explicit final
+   file paths where discovery would select only one file, then audit again to
+   connect its report to the bundle. Only freeze the chosen byte snapshot after
+   the existing skill's submission review steps. Freeze is not approval.
+
+```bash
+python scripts/sync_submission.py build --project-root . --journal example \
+  --bundle-spec bundle.json
+python scripts/preflight_gate.py --project-root . --journal example \
+  --docx submission/example/manuscript/final.docx
+python scripts/sync_submission.py audit --project-root . --journal example
+python scripts/sync_submission.py freeze --project-root . --journal example
+```
+
+Paths above are relative to this skill directory for the scripts and to the
+chosen project root for the declaration's inputs. Use absolute script paths when
+running from a research project. `--bundle-spec` itself is project-relative.
+
+The declaration is an input to the existing build, not a second output ledger.
+The canonical manuscript is always included as `manuscript/manuscript.md`.
+Additional entries in `bundle.json` use schema version 1:
+
+```json
+{
+  "schema_version": 1,
+  "artifacts": [{
+    "id": "final-word",
+    "role": "manuscript_docx",
+    "source": "build/final.docx",
+    "target": "manuscript/final.docx",
+    "derived_from": [{
+      "path": "manuscript/manuscript.md",
+      "sha256": "sha256:REPLACE_WITH_THE_HASH_OBSERVED_BEFORE_RENDERING"
+    }],
+    "transformation": {
+      "kind": "rendered",
+      "command": ["pandoc", "manuscript/manuscript.md", "-o", "build/final.docx"],
+      "version": "RECORD_THE_RENDERER_VERSION"
+    },
+    "rights": {"status": "original"}
+  }]
+}
+```
+
+Repeat entries for the final PDF, supplement, cover letter, title page, tables,
+figures and required notices. List every render dependency, not just the main
+manuscript. Commands are recorded declarations; build never executes them. Do
+not attach today's source hashes to an old output without actually rebuilding.
+If a declared dependency changed, build stops and asks for the existing renderer
+to be rerun. A declared link is not authenticated proof of how an output was made.
+
+For a runnable example using only original synthetic text and a synthetic table:
+
+```bash
+python examples/build_synthetic_bundle.py --project-root /tmp/synthetic-submission
+# Optional real PDF, using the installed render-pdf-doc skill and XeLaTeX:
+python examples/build_synthetic_bundle.py --project-root /tmp/synthetic-submission-pdf --pdf
+```
+
+## Output contract and limits
+
+- `.journal_meta.json` schema 2 records each file's source/output hashes, pinned
+  render inputs, declared transformation and rights, plus explicit unassessed
+  content/visual review. `artifact_manifest.json` retains its existing schema and
+  other fields; its selected `submissions` entry carries the same artifacts.
+- `qc/submission_sync_{journal}.json` schema 2 reports changed/missing source,
+  output or dependency files and unregistered package files. A clean legacy
+  manuscript-only audit does not claim full-package coverage. Exit 0 means no
+  tracked drift, 1 means drift, and 2 means missing/invalid input.
+- `preflight_gate_report.json` schema 2 lists executed/skipped/error checks and
+  their invocation targets. Its byte binding covers the declared sources,
+  dependencies and package present before and after the run, **not every input
+  of every check**. `package_bytes_current` in sync audit means only that this
+  binding still matches. Changes to an undeclared bibliography or external
+  profile require rerunning the relevant checks even if that binding matches.
+- Preflight's compatibility field `submission_safe` means no configured blocker
+  or error. Read `coverage`, warnings and `readiness: not_assessed` as well. An
+  exit-zero check may have its own partial-coverage limitations. No aggregated
+  pass is propagated to an individual PDF's visual review or semantic fidelity.
+- Missing reports remain `not_run`, legacy/unbound reports remain `unbound`, and
+  changed bundles make recorded checks `stale` on every audit, including reruns.
+- Build refuses frozen/submitted packages, edited outputs, undeclared files that
+  would be lost, removed registered files, symlinks, hidden input/target paths,
+  traversal, hard-link source aliases and overlapping/case-colliding targets.
+  Use a new revision journal slug for a deliberately different package.
+- Builds stage copies and roll back ordinary replacement failures. A cooperative
+  project lock serializes build/freeze manifest mutations. This is not a filesystem
+  transaction or protection against external concurrent editors or power loss.
+  After an interrupted process, inspect its lock/staging directory before recovery.
+
+## Reuse rights and fidelity
+
+The default `rights.status` is `unknown`; nothing infers permission from download
+success, a DOI, a journal logo, or an unchanged hash. `original` and `documented`
+are user declarations, not legal determinations. For `documented`, provide
+`source`, `license_or_permission`, `attribution`, and `changes`; retain permission
+evidence locally and include required notices in the actual distributed files.
+Do not put private permission correspondence or identifiers in a public example.
+
+Keep an official source unmodified where required. If an adaptation is permitted,
+retain the source/version and describe changes; do not label your adapted summary
+as the official checklist. This repository's MIT license does not relicense
+third-party templates or papers. Its index is `THIRD-PARTY-NOTICES.md`.
+
+CC BY 4.0 requires attribution, a license link and an indication of changes.
+CC BY-NC-ND 4.0 also restricts commercial use and distribution of adaptations;
+its deed distinguishes a mere format change from an adaptation. Consult the
+specific material's actual terms and intended use rather than treating every
+file conversion as an adaptation or every open-access item as redistributable.
+Sources: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) and
+[CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/).

--- a/skills/sync-submission/scripts/preflight_gate.py
+++ b/skills/sync-submission/scripts/preflight_gate.py
@@ -45,7 +45,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
-from sync_submission import resolve_canonical, submission_md_path  # noqa: E402
+from sync_submission import resolve_canonical, submission_md_path, bundle_binding  # noqa: E402
 
 PY = sys.executable
 
@@ -448,6 +448,8 @@ def run_check(spec, ctx, args):
         status = "blocker" if effective_p0 else "warn"
     elif base == "warn_post":
         status = "warn"
+    elif base == "skipped" and in_require:
+        status = "error"
     else:
         status = base  # ok / skipped / error
 
@@ -461,6 +463,7 @@ def run_check(spec, ctx, args):
             "script": _rel(S[_script_key(cid)]), "ran": True, "exit_code": rc,
             "status": status, "blocker": status == "blocker",
             "artifact": _rel(artifact_path) if (artifact_path and artifact_path.exists()) else None,
+            "invocation": [_rel(Path(a)) if Path(a).is_absolute() else a for a in argv],
             "message": msg}
 
 
@@ -536,7 +539,16 @@ def main() -> int:
         sys.stderr.write(f"ERROR: project root not found: {ctx.root}\n")
         return 2
 
+    # This identifies the declared bundle present during the run. It is not
+    # per-file inspection coverage (some checks inspect only a selected DOCX).
+    def snapshot():
+        try:
+            return bundle_binding(ctx.root, ctx.journal)
+        except (OSError, ValueError, KeyError, TypeError):
+            return None
+    binding_before = snapshot()
     checks = [run_check(spec, ctx, args) for spec in CHECKS]
+    binding_after = snapshot()
 
     summary = {k: 0 for k in ("ok", "warn", "blocker", "skipped", "error")}
     for c in checks:
@@ -545,14 +557,30 @@ def main() -> int:
     gate_error = any(c["status"] == "error" for c in checks)
 
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_by": "preflight_gate.py",
         "project_root": str(ctx.root),
         "journal": ctx.journal,
         "strict": args.strict,
         "online": args.online,
         "double_blind": args.double_blind,
-        "submission_safe": not halt,
+        # Compatibility field: no configured blocker/error, NOT submission approval.
+        "submission_safe": not halt and not gate_error,
+        "submission_safe_scope": "configured_checks_only",
+        "readiness": "not_assessed",
+        "coverage": {
+            "status": "incomplete" if summary["skipped"] or summary["error"] else "executed",
+            "invoked": [c["id"] for c in checks if c["ran"]],
+            "executed": [c["id"] for c in checks if c["status"] in {"ok", "warn", "blocker"}],
+            "skipped": [c["id"] for c in checks if c["status"] == "skipped"],
+            "errors": [c["id"] for c in checks if c["status"] == "error"],
+            "visual_review": "not_assessed",
+            "source_claim_fidelity": "not_assessed",
+            "reuse_permissions": "not_assessed",
+        },
+        "bundle_binding": binding_before,
+        "bundle_unchanged_during_checks": bool(binding_before and binding_before == binding_after),
+        "bundle_binding_scope": "declared sources, render dependencies and package bytes; other check inputs are not bound",
         "halt": halt,
         "summary": summary,
         "checks": checks,
@@ -579,8 +607,9 @@ def main() -> int:
             blockers = [c["id"] for c in checks if c["blocker"]]
             print(f"\nHALT: {len(blockers)} blocker(s) — {', '.join(blockers)}. Submission is NOT safe.")
         else:
-            print("\nOK: no blockers. Submission pre-flight passed"
-                  + (" (P1 warnings may remain — see table)." if summary["warn"] else "."))
+            print("\nNo configured blockers. "
+                  f"{summary['skipped']} checks skipped; {summary['warn']} warnings. "
+                  "Submission readiness, visual fidelity and permissions are not assessed.")
 
     if gate_error:
         return 2

--- a/skills/sync-submission/scripts/sync_submission.py
+++ b/skills/sync-submission/scripts/sync_submission.py
@@ -1,15 +1,26 @@
 #!/usr/bin/env python3
-"""Audit and build submission packages from canonical manuscript sources."""
+"""Copy and audit declared submission artifacts without rewriting source files.
 
+Usage: sync_submission.py build --project-root . --journal example
+       sync_submission.py build --project-root . --journal example --bundle-spec bundle.json
+       sync_submission.py audit --project-root . --journal example
+
+Rendering stays with the existing renderers. A bundle spec records the input
+hashes observed for that render; build never refreshes those hashes for you.
+"""
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
+from datetime import date
 import hashlib
 import json
+import os
+from pathlib import Path, PurePosixPath
+import re
 import shutil
 import sys
-from datetime import date
-from pathlib import Path
+import tempfile
 
 
 def sha256_file(path: Path) -> str:
@@ -20,149 +31,408 @@ def sha256_file(path: Path) -> str:
     return "sha256:" + h.hexdigest()
 
 
-def read_project_yaml(path: Path) -> dict[str, str]:
-    data: dict[str, str] = {}
+def digest(payload) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(
+        payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    ).encode()).hexdigest()
+
+
+def read_project_yaml(path: Path) -> dict:
     if not path.exists():
-        return data
-    for raw in path.read_text(encoding="utf-8").splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#") or ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        data[key.strip()] = value.strip().strip('"').strip("'")
-    return data
+        return {}
+    # Use the repository's declared YAML dependency, not indentation-blind parsing.
+    import yaml
+    try:
+        value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError("project.yaml is invalid YAML") from exc
+    if not isinstance(value, dict):
+        raise ValueError("project.yaml must be a mapping")
+    return value
 
 
 def resolve_canonical(project_root: Path, explicit: str | None) -> Path:
-    if explicit:
-        path = Path(explicit)
-        return path if path.is_absolute() else project_root / path
-    project = read_project_yaml(project_root / "project.yaml")
-    rel = project.get("canonical_manuscript", "manuscript/manuscript.md")
-    return project_root / rel
+    rel = explicit or read_project_yaml(project_root / "project.yaml").get(
+        "canonical_manuscript", "manuscript/manuscript.md")
+    path = Path(rel)
+    return path if path.is_absolute() else project_root / path
+
+
+def safe_path(root: Path, relative: str) -> Path:
+    """Confine named files and reject symlinks, hidden components and traversal."""
+    if not isinstance(relative, str) or not relative or "\\" in relative or ":" in relative:
+        raise ValueError("Expected a relative POSIX path")
+    parts = PurePosixPath(relative).parts
+    if relative.startswith("/") or any(p.startswith(".") for p in parts):
+        raise ValueError("Hidden, absolute or traversing paths are not supported")
+    path = root
+    for part in parts:
+        path = path / part
+        if path.is_symlink():
+            raise ValueError("Symlink paths are not supported")
+    path.resolve().relative_to(root.resolve())
+    return path
+
+
+def journal_root(root: Path, journal: str) -> Path:
+    if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_-]*", journal):
+        raise ValueError("Journal must be a single letter/digit/underscore/hyphen slug")
+    return safe_path(root, f"submission/{journal}")
 
 
 def submission_md_path(project_root: Path, journal: str) -> Path:
-    return project_root / "submission" / journal / "manuscript" / "manuscript.md"
+    return journal_root(project_root, journal) / "manuscript/manuscript.md"
+
+
+def load_json(path: Path) -> dict:
+    if path.is_symlink():
+        raise ValueError("JSON metadata must not be a symlink")
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("JSON metadata must be an object")
+    return payload
 
 
 def write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
-
-
-def load_json(path: Path) -> dict:
-    if not path.exists():
-        return {}
+    if path.is_symlink():
+        raise ValueError("Refusing to overwrite a symlink")
+    fd, temp = tempfile.mkstemp(prefix=".sync-", dir=path.parent)
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(temp, path)
+    finally:
+        Path(temp).unlink(missing_ok=True)
 
 
-def update_manifest(project_root: Path, journal: str, meta_rel: str, status: str, source_hash: str) -> None:
-    manifest_path = project_root / "artifact_manifest.json"
-    manifest = load_json(manifest_path) or {"schema_version": 1, "submissions": {}}
-    manifest.setdefault("schema_version", 1)
-    manifest.setdefault("submissions", {})
-    manifest["submissions"][journal] = {
+@contextmanager
+def mutation_lock(root: Path):
+    """Serialize cooperating builds/freezes, including the shared manifest update."""
+    lock = root / ".submission-sync.lock"
+    try:
+        fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        raise ValueError("Another sync mutation is active; inspect .submission-sync.lock") from None
+    try:
+        os.close(fd)
+        yield
+    finally:
+        lock.unlink()
+
+
+def manifest_payload(root: Path, journal: str, meta: dict) -> dict:
+    manifest = load_json(safe_path(root, "artifact_manifest.json")) or {"schema_version": 1}
+    submissions = manifest.setdefault("submissions", {})
+    if not isinstance(submissions, dict) or not isinstance(submissions.get(journal, {}), dict):
+        raise ValueError("Manifest submissions must contain objects")
+    entry = submissions.setdefault(journal, {})
+    entry.update({
         "path": f"submission/{journal}",
-        "metadata": meta_rel,
-        "status": status,
-        "source_hash": source_hash,
-    }
-    write_json(manifest_path, manifest)
+        "metadata": f"submission/{journal}/.journal_meta.json",
+        "status": meta["status"], "source_hash": meta["source_hash"],
+        "artifacts": meta.get("artifacts", []),
+        "readiness": "not_assessed",  # Neither copying nor freezing is a submission approval.
+    })
+    return manifest
+
+
+def inventory(directory: Path) -> list[str]:
+    """Only the selected submission directory; never discover project-wide inputs."""
+    if not directory.exists():
+        return []
+    result = []
+    for base, dirs, files in os.walk(directory, followlinks=False):
+        for name in dirs + files:
+            if (Path(base) / name).is_symlink():
+                raise ValueError("Submission package contains a symlink")
+        result.extend((Path(base) / name).relative_to(directory).as_posix() for name in files)
+    return sorted(result)
+
+
+def bundle_binding(root: Path, journal: str | None) -> dict | None:
+    """Byte snapshot, not a statement that every file was inspected by every check."""
+    if not journal:
+        return None
+    directory = journal_root(root, journal)
+    meta = load_json(directory / ".journal_meta.json")
+    if not meta.get("artifacts"):
+        return None
+    package_paths = {f"submission/{journal}/{name}" for name in inventory(directory)
+             if name != ".journal_meta.json"}
+    paths = set(package_paths)
+    for row in meta["artifacts"]:
+        paths.add(row["source"])
+        paths.update(d["path"] for d in row.get("derived_from", []))
+    files = {}
+    for relative in sorted(paths):
+        path = root / relative if relative in package_paths else safe_path(root, relative)
+        files[relative] = sha256_file(path) if path.is_file() else None
+    # Exclude status/freeze dates so freezing doesn't invalidate its own evidence.
+    data = {"files": files, "declaration_hash": digest(meta["artifacts"])}
+    return {**data, "sha256": digest(data)}
+
+
+def verification_context(root: Path, journal: str) -> dict:
+    report_path = safe_path(root, "qc/preflight_gate_report.json")
+    report = load_json(report_path)
+    if not report or report.get("journal") != journal:
+        return {"status": "not_run", "checks": [], "readiness": "not_assessed"}
+    now = bundle_binding(root, journal)
+    recorded = report.get("bundle_binding")
+    state = "unbound" if not now or not recorded else (
+        "package_bytes_current" if recorded == now and report.get("bundle_unchanged_during_checks") is True else "stale")
+    return {"status": state, "report": "qc/preflight_gate_report.json",
+            "report_hash": sha256_file(report_path), "checks": report.get("checks", []),
+            "coverage": report.get("coverage", {}), "readiness": "not_assessed",
+            "scope": "Bundle byte binding only; other check inputs are not bound. No visual, semantic or rights approval."}
+
+
+def prepare_artifacts(root: Path, journal: str, canonical: Path, spec: dict) -> list[dict]:
+    if spec and spec.get("schema_version") != 1:
+        raise ValueError("Bundle spec schema_version must be 1")
+    extra = spec.get("artifacts", [])
+    if not isinstance(extra, list):
+        raise ValueError("Bundle artifacts must be a list")
+    rows = [{"id": "canonical", "role": "manuscript_source",
+             "source": canonical.relative_to(root).as_posix(),
+             "target": "manuscript/manuscript.md"}] + extra
+    directory = journal_root(root, journal)
+    prepared, ids, targets, inputs = [], set(), [], set()
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("id"), str) or not row["id"]:
+            raise ValueError("Each artifact requires an id")
+        if row["id"] in ids:
+            raise ValueError("Duplicate artifact id")
+        ids.add(row["id"])
+        source = safe_path(root, row["source"])
+        target = safe_path(directory, row["target"])
+        if not source.is_file() or source.is_relative_to(directory):
+            raise ValueError("Artifact source must exist outside the destination package")
+        key = target.relative_to(directory).as_posix().casefold()
+        if any(key == old or key.startswith(old + "/") or old.startswith(key + "/") for old in targets):
+            raise ValueError("Overlapping or case-colliding artifact targets")
+        targets.append(key)
+        deps = row.get("derived_from", [])
+        if not isinstance(deps, list):
+            raise ValueError("derived_from must be a list")
+        for dep in deps:
+            path = safe_path(root, dep["path"])
+            if path.is_relative_to(directory) or not path.is_file() or sha256_file(path) != dep["sha256"]:
+                raise ValueError("Render dependency missing or changed; rebuild with the existing renderer")
+            inputs.add(path)
+        transformation = row.get("transformation", {"kind": "not_recorded"})
+        if not isinstance(transformation, dict):
+            raise ValueError("transformation must be an object")
+        if transformation.get("kind") == "rendered" and not deps:
+            raise ValueError("Rendered artifacts require pinned derived_from inputs")
+        rights = row.get("rights", {"status": "unknown"})
+        if not isinstance(rights, dict) or rights.get("status") not in {"unknown", "original", "documented"}:
+            raise ValueError("rights.status must be unknown, original or documented")
+        if rights["status"] == "documented" and not all(rights.get(k) for k in (
+                "source", "license_or_permission", "attribution", "changes")):
+            raise ValueError("Documented rights require source, license_or_permission, attribution and changes")
+        inputs.add(source)
+        prepared.append({"id": row["id"], "role": row.get("role", "unspecified"),
+                         "source": row["source"], "target": row["target"],
+                         "source_hash": sha256_file(source), "derived_from": deps,
+                         "transformation": transformation, "rights": rights,
+                         "copy_fidelity": "byte_identical",
+                         "content_fidelity": "not_assessed", "visual_review": "not_assessed"})
+    controls = [root / "artifact_manifest.json", root / "project.yaml"]
+    for source in inputs:
+        if source in controls or source.is_relative_to(root / "qc"):
+            raise ValueError("Source aliases a mutable control/report path")
+        for row in prepared:
+            target = directory / row["target"]
+            if target.exists() and source.samefile(target):
+                raise ValueError("Source and output alias the same file")
+    return prepared
 
 
 def audit(project_root: Path, journal: str, canonical: Path) -> int:
-    qc_path = project_root / "qc" / f"submission_sync_{journal}.json"
+    directory = journal_root(project_root, journal)
+    qc_path = safe_path(project_root, f"qc/submission_sync_{journal}.json")
     sub_path = submission_md_path(project_root, journal)
-    if not canonical.exists():
-        write_json(qc_path, {"schema_version": 1, "journal": journal, "status": "ERROR", "message": "canonical manuscript missing"})
+    meta = load_json(directory / ".journal_meta.json")
+    if not canonical.is_file():
+        write_json(qc_path, {"schema_version": 2, "journal": journal, "status": "ERROR",
+                             "message": "canonical manuscript missing"})
         return 2
     source_hash = sha256_file(canonical)
-    meta_path = project_root / "submission" / journal / ".journal_meta.json"
-    meta = load_json(meta_path)
-    current_hash = sha256_file(sub_path) if sub_path.exists() else None
-    recorded_hash = meta.get("source_hash")
-    drift = bool(sub_path.exists() and current_hash != source_hash)
-    status = "DRIFT" if drift else "CURRENT" if sub_path.exists() else "MISSING_SUBMISSION"
-    payload = {
-        "schema_version": 1,
-        "journal": journal,
-        "status": status,
-        "canonical": str(canonical.relative_to(project_root)),
-        "submission_manuscript": str(sub_path.relative_to(project_root)),
-        "source_hash": source_hash,
-        "submission_hash": current_hash,
-        "recorded_source_hash": recorded_hash,
-        "message": "Submission differs from canonical manuscript" if drift else "",
-    }
+    current_hash = sha256_file(sub_path) if sub_path.is_file() else None
+    problems, artifacts = [], []
+    if current_hash is not None and current_hash != source_hash:
+        problems.append("canonical_copy_differs")
+    if meta.get("canonical") and meta["canonical"] != canonical.relative_to(project_root).as_posix():
+        problems.append("canonical_source_changed")
+    if meta.get("source_hash") and meta["source_hash"] != source_hash:
+        problems.append("recorded_canonical_changed")
+    for row in meta.get("artifacts", []):
+        source = safe_path(project_root, row["source"])
+        output = safe_path(directory, row["target"])
+        actual_source = sha256_file(source) if source.is_file() else None
+        actual_output = sha256_file(output) if output.is_file() else None
+        state = []
+        if actual_source != row["source_hash"]:
+            state.append("source_changed_or_missing")
+        if actual_output != row["output_hash"]:
+            state.append("output_changed_or_missing")
+        for dep in row.get("derived_from", []):
+            path = safe_path(project_root, dep["path"])
+            if not path.is_file() or sha256_file(path) != dep["sha256"]:
+                state.append("render_input_changed_or_missing")
+        if state:
+            problems.append(row["id"])
+        artifacts.append({**row, "current_source_hash": actual_source,
+                          "current_output_hash": actual_output, "drift": state})
+    expected = {r["target"] for r in meta.get("artifacts", [])} | {".journal_meta.json"}
+    unregistered = sorted(set(inventory(directory)) - expected) if artifacts else []
+    if unregistered:
+        problems.append("unregistered_files")
+    status = "MISSING_SUBMISSION" if current_hash is None else "DRIFT" if problems else "CURRENT"
+    payload = {"schema_version": 2, "journal": journal, "status": status,
+               "canonical": canonical.relative_to(project_root).as_posix(),
+               "submission_manuscript": sub_path.relative_to(project_root).as_posix(),
+               "source_hash": source_hash, "submission_hash": current_hash,
+               "recorded_source_hash": meta.get("source_hash"), "artifacts": artifacts,
+               "unregistered_files": unregistered, "issues": problems,
+               "verification": verification_context(project_root, journal),
+               "readiness": "not_assessed", "message": "; ".join(problems)}
     write_json(qc_path, payload)
     print(json.dumps(payload, indent=2))
-    return 1 if drift else 0
+    # Missing input is distinct from detected drift (preflight already understands exit 2).
+    return 2 if current_hash is None else 1 if problems else 0
 
 
-def build(project_root: Path, journal: str, canonical: Path) -> int:
-    if not canonical.exists():
-        print(f"Canonical manuscript missing: {canonical}", file=sys.stderr)
-        return 2
-    sub_path = submission_md_path(project_root, journal)
-    sub_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(canonical, sub_path)
-    source_hash = sha256_file(canonical)
-    meta_path = project_root / "submission" / journal / ".journal_meta.json"
-    meta = {
-        "schema_version": 1,
-        "journal": journal,
-        "status": "built",
-        "canonical": str(canonical.relative_to(project_root)),
-        "submission_manuscript": str(sub_path.relative_to(project_root)),
-        "source_hash": source_hash,
-        "built_date": date.today().isoformat(),
-        "frozen": False,
-    }
-    write_json(meta_path, meta)
-    update_manifest(project_root, journal, str(meta_path.relative_to(project_root)), "built", source_hash)
+def build(project_root: Path, journal: str, canonical: Path, spec: dict | None = None) -> int:
+    directory = journal_root(project_root, journal)
+    old_meta = load_json(directory / ".journal_meta.json")
+    # Validate a pre-existing report before modifying the package; malformed
+    # evidence must not turn a completed build into a late parse failure.
+    load_json(safe_path(project_root, "qc/preflight_gate_report.json"))
+    if old_meta.get("frozen") or old_meta.get("status") in {"submitted", "accepted", "published"}:
+        raise ValueError("Frozen/submitted package is immutable; use a new revision journal slug")
+    rows = prepare_artifacts(project_root, journal, canonical, spec or {})
+    old_rows = old_meta.get("artifacts", [])
+    allowed = {r["target"] for r in old_rows} | {".journal_meta.json"}
+    if old_meta and not old_rows:
+        allowed.add("manuscript/manuscript.md")
+        if submission_md_path(project_root, journal).is_file() and sha256_file(
+                submission_md_path(project_root, journal)) != old_meta.get("source_hash"):
+            raise ValueError("Legacy submission was edited; preserve it and reconcile before building")
+    if set(inventory(directory)) - allowed:
+        raise ValueError("Unregistered package files would be lost; use a new revision slug")
+    if {r["target"] for r in old_rows} - {r["target"] for r in rows}:
+        raise ValueError("Build would remove a registered artifact; use a new revision slug")
+    for row in old_rows:
+        target = safe_path(directory, row["target"])
+        if target.is_file() and sha256_file(target) != row["output_hash"]:
+            raise ValueError("Submission output was edited; preserve it and reconcile before building")
+    meta = {**old_meta, "schema_version": 2, "journal": journal, "status": "built",
+            "canonical": canonical.relative_to(project_root).as_posix(),
+            "submission_manuscript": f"submission/{journal}/manuscript/manuscript.md",
+            "source_hash": rows[0]["source_hash"], "built_date": date.today().isoformat(),
+            "frozen": False, "artifacts": rows, "readiness": "not_assessed"}
+    for row in rows:
+        row["output_hash"] = row["source_hash"]
+    manifest = manifest_payload(project_root, journal, meta)  # Validate before any replacement.
+    safe_path(project_root, "qc/submission_sync_" + journal + ".json")
+    directory.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".sync-build-", dir=directory.parent) as temp:
+        stage, backup = Path(temp) / "stage", Path(temp) / "backup"
+        stage.mkdir()
+        for row in rows:
+            output = stage / row["target"]
+            output.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(project_root / row["source"], output)
+            if sha256_file(output) != row["source_hash"]:
+                raise ValueError("Source changed during copy; package not replaced")
+        # Recheck pinned sources, including dependencies, before installing the staged package.
+        if prepare_artifacts(project_root, journal, canonical, spec or {}) != [
+                {k: v for k, v in r.items() if k != "output_hash"} for r in rows]:
+            raise ValueError("Source changed during build; package not replaced")
+        write_json(stage / ".journal_meta.json", meta)
+        existed = directory.exists()
+        if existed:
+            directory.rename(backup)
+        try:
+            stage.rename(directory)
+            write_json(project_root / "artifact_manifest.json", manifest)
+        except BaseException:
+            if directory.exists():
+                shutil.rmtree(directory)
+            if existed:
+                backup.rename(directory)
+            raise
     return audit(project_root, journal, canonical)
 
 
 def freeze(project_root: Path, journal: str, canonical: Path, status: str) -> int:
-    audit_code = audit(project_root, journal, canonical)
-    if audit_code != 0:
-        print("Cannot freeze a drifted or invalid submission package.", file=sys.stderr)
-        return audit_code
-    meta_path = project_root / "submission" / journal / ".journal_meta.json"
+    code = audit(project_root, journal, canonical)
+    if code:
+        print("Cannot freeze a missing, drifted or invalid submission package.", file=sys.stderr)
+        return code
+    meta_path = journal_root(project_root, journal) / ".journal_meta.json"
     meta = load_json(meta_path)
-    meta.update({"status": status, "frozen": True, "frozen_date": date.today().isoformat()})
-    write_json(meta_path, meta)
-    update_manifest(project_root, journal, str(meta_path.relative_to(project_root)), status, meta.get("source_hash", ""))
-    print(json.dumps(meta, indent=2))
+    if not meta or not meta.get("source_hash"):
+        raise ValueError("Build metadata is required before freeze")
+    if meta.get("frozen"):
+        if meta.get("status") != status:
+            raise ValueError("Frozen status cannot be overwritten")
+        return 0
+    meta.update({"status": status, "frozen": True, "frozen_date": date.today().isoformat(),
+                 "verification_at_freeze": verification_context(project_root, journal),
+                 "readiness": "not_assessed"})
+    manifest = manifest_payload(project_root, journal, meta)
+    previous = meta_path.read_bytes()
+    try:
+        write_json(meta_path, meta)
+        write_json(project_root / "artifact_manifest.json", manifest)
+    except BaseException:
+        write_json(meta_path, json.loads(previous))
+        raise
+    print("Frozen byte snapshot; visual, semantic, permissions and submission approval remain separate.")
     return 0
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Audit or build journal submission package.")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("mode", choices=["audit", "build", "freeze"])
     parser.add_argument("--project-root", default=".")
     parser.add_argument("--journal", required=True)
     parser.add_argument("--canonical")
+    parser.add_argument("--bundle-spec", help="JSON declaration of additional files and pinned render inputs (build only)")
     parser.add_argument("--status", default="submitted")
     args = parser.parse_args()
-
-    project_root = Path(args.project_root).resolve()
-    canonical = resolve_canonical(project_root, args.canonical).resolve()
     try:
-        canonical.relative_to(project_root)
-    except ValueError:
-        print("Canonical manuscript must be inside project root.", file=sys.stderr)
+        root = Path(args.project_root).resolve()
+        if not root.is_dir():
+            raise ValueError("Project root must exist")
+        journal_root(root, args.journal)
+        canonical = resolve_canonical(root, args.canonical)
+        canonical = safe_path(root, canonical.relative_to(root).as_posix())
+        if canonical.is_relative_to(journal_root(root, args.journal)):
+            raise ValueError("Canonical manuscript must be outside its submission package")
+        if canonical.is_relative_to(root / "qc") or canonical in {root / "artifact_manifest.json", root / "project.yaml"}:
+            raise ValueError("Canonical manuscript aliases a mutable control/report path")
+        if args.bundle_spec and args.mode != "build":
+            raise ValueError("--bundle-spec is only supported by build")
+        if args.mode == "audit":
+            return audit(root, args.journal, canonical)
+        with mutation_lock(root):
+            if args.mode == "build":
+                spec = load_json(safe_path(root, args.bundle_spec)) if args.bundle_spec else {}
+                if args.bundle_spec and not spec:
+                    raise ValueError("Bundle spec is missing or empty")
+                return build(root, args.journal, canonical, spec)
+            return freeze(root, args.journal, canonical, args.status)
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"Submission sync error: {exc}", file=sys.stderr)
         return 2
-
-    if args.mode == "audit":
-        return audit(project_root, args.journal, canonical)
-    if args.mode == "build":
-        return build(project_root, args.journal, canonical)
-    return freeze(project_root, args.journal, canonical, args.status)
 
 
 if __name__ == "__main__":

--- a/skills/sync-submission/skill.yml
+++ b/skills/sync-submission/skill.yml
@@ -15,6 +15,7 @@ when_NOT_to_use:
 inputs:
   - project.yaml
   - manuscript/manuscript.md
+  - "optional bundle.json declaring final files and pinned render dependencies"
 outputs:
   - submission/{journal}/.journal_meta.json
   - qc/submission_sync_{journal}.json
@@ -38,6 +39,8 @@ safety_boundaries:
   - "Never silently edits the canonical manuscript; a drifted submission is not frozen until reconciled."
   - "Submission packages are derived from canonical sources, not hand-assembled."
 known_limitations:
+  - "Build copies declared final files byte for byte; rendering remains with existing renderers. Hashes do not establish visual or semantic fidelity or reuse permission."
+  - "Preflight bundle binding covers declared sources/dependencies and package bytes, not every external check input. Skipped checks and unassessed readiness remain explicit."
   - "Detects drift it is configured to scan (counts, cover-letter fields, scope); portal free-text fields still need a human check."
   - "A clean audit is necessary, not sufficient, for acceptance."
   - "Building a marked (tracked-changes) manuscript drives Microsoft Word and therefore needs macOS + Word; the round-trip verification of a marked file is portable and runs anywhere."

--- a/skills/sync-submission/tests/test_preflight_gate.sh
+++ b/skills/sync-submission/tests/test_preflight_gate.sh
@@ -74,6 +74,16 @@ RPT="$DIRTY/qc/preflight_gate_report.json"
 python3 "$SCRIPT" --project-root "$CLEAN" --quiet
 [ $? -eq 0 ] && ok "clean package passes (exit 0)" || bad "clean package should pass"
 [ "$(J "$CLEAN/qc/preflight_gate_report.json" submission_safe)" = "True" ] && ok "clean report submission_safe=true" || bad "clean should be submission_safe"
+python3 - "$CLEAN/qc/preflight_gate_report.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r['readiness'] == 'not_assessed'
+assert r['submission_safe_scope'] == 'configured_checks_only'
+assert r['coverage']['status'] == 'incomplete'
+assert r['coverage']['skipped']
+assert r['coverage']['visual_review'] == 'not_assessed'
+PY
+[ $? -eq 0 ] && ok "no blockers does not hide skipped/visual checks" || bad "coverage must remain explicit"
 
 # 5. inverted cover-letter exit code normalized to warn (default), blocker under --require
 cat > "$CLEAN/submission/chest/cover_letter.md" <<'EOF'
@@ -102,6 +112,12 @@ python3 "$SCRIPT" --project-root "$CLEAN" --journal chest --strict --skip cover_
 # 8. --require on a check that cannot run -> gate error (exit 2)
 python3 "$SCRIPT" --project-root "$DIRTY" --require sync_drift --quiet
 [ $? -eq 2 ] && ok "--require sync_drift (no journal) -> gate error exit 2" || bad "required-but-unrunnable should exit 2"
+[ "$(J "$DIRTY/qc/preflight_gate_report.json" submission_safe)" = "False" ] && ok "required check error cannot be safe" || bad "gate error marked safe"
+
+# Canonical exists, but the submission is missing: child exit 2 is still an
+# error under --require, rather than silently becoming a skipped clean pass.
+python3 "$SCRIPT" --project-root "$CLEAN" --journal chest --require sync_drift --quiet
+[ $? -eq 2 ] && ok "required child exit 2 cannot pass" || bad "required child skip should be an error"
 
 # 9. unknown check id -> exit 2
 python3 "$SCRIPT" --project-root "$CLEAN" --require nonsense --quiet 2>/dev/null

--- a/skills/sync-submission/tests/test_submission_bundle.py
+++ b/skills/sync-submission/tests/test_submission_bundle.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Synthetic submission-bundle controls; no private or third-party fixture files."""
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import sync_submission as sync
+
+
+class BundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.canonical = self.put("manuscript/manuscript.md", "# Synthetic study\n\nSample size: 30.\n")
+        self.put("build/supplement.md", "# Synthetic supplement\n\nSample size: 30.\n")
+        self.put("build/final.pdf", b"%PDF-1.4\nsynthetic byte-copy fixture; not a render\n")
+        self.put("artifact_manifest.json", json.dumps({"schema_version": 1, "artifacts": ["keep"],
+                                                      "submissions": {"other": {"status": "submitted"}}}))
+        self.spec = {"schema_version": 1, "artifacts": [
+            {"id": "supplement", "role": "supplement", "source": "build/supplement.md",
+             "target": "supplement/supplement.md", "derived_from": [self.dep(self.canonical)]},
+            {"id": "pdf", "role": "manuscript_pdf", "source": "build/final.pdf",
+             "target": "manuscript/final.pdf", "transformation": {"kind": "rendered", "command": ["record-only"]},
+             "derived_from": [self.dep(self.canonical)], "rights": {"status": "original"}}]}
+        self.directory = self.root / "submission/example"
+
+    def put(self, relative, data):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data if isinstance(data, bytes) else data.encode())
+        return path
+
+    def dep(self, path):
+        return {"path": path.relative_to(self.root).as_posix(), "sha256": sync.sha256_file(path)}
+
+    def build(self, spec=None):
+        with contextlib.redirect_stdout(io.StringIO()):
+            return sync.build(self.root, "example", self.canonical, self.spec if spec is None else spec)
+
+    def audit(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            code = sync.audit(self.root, "example", self.canonical)
+        return code, sync.load_json(self.root / "qc/submission_sync_example.json")
+
+    def snapshot(self):
+        return {p.relative_to(self.root).as_posix(): (p.read_bytes(), p.stat().st_mtime_ns)
+                for p in self.root.rglob("*") if p.is_file()}
+
+    def test_copy_preserves_bytes_mtime_sources_and_manifest_fields(self):
+        before = self.snapshot()
+        self.assertEqual(self.build(), 0)
+        for path in ("manuscript/manuscript.md", "build/supplement.md", "build/final.pdf"):
+            self.assertEqual(self.snapshot()[path], before[path])
+        meta = sync.load_json(self.directory / ".journal_meta.json")
+        for row in meta["artifacts"]:
+            self.assertEqual((self.root / row["source"]).read_bytes(), (self.directory / row["target"]).read_bytes())
+        manifest = sync.load_json(self.root / "artifact_manifest.json")
+        self.assertEqual(manifest["artifacts"], ["keep"])
+        self.assertEqual(manifest["submissions"]["other"], {"status": "submitted"})
+        self.assertEqual(manifest["submissions"]["example"]["artifacts"], meta["artifacts"])
+
+    def test_rerun_is_current_but_not_reviewed(self):
+        self.build()
+        binding = sync.bundle_binding(self.root, "example")
+        self.build()
+        self.assertEqual(binding, sync.bundle_binding(self.root, "example"))
+        code, report = self.audit()
+        self.assertEqual(code, 0)
+        self.assertEqual(report["readiness"], "not_assessed")
+        self.assertEqual(report["verification"]["status"], "not_run")
+        self.assertEqual(report["artifacts"][2]["visual_review"], "not_assessed")
+
+    def test_stale_supplement_not_reblessed_after_main_changes(self):
+        self.build()
+        self.canonical.write_text("# Synthetic study\n\nSample size: 40.\n")
+        before = self.snapshot()
+        with self.assertRaisesRegex(ValueError, "dependency"):
+            self.build()
+        self.assertEqual(before, self.snapshot())
+        code, report = self.audit()
+        self.assertEqual(code, 1)
+        self.assertIn("render_input_changed_or_missing", report["artifacts"][1]["drift"])
+        self.assertEqual(self.audit()[0], 1)
+
+    def test_edited_output_is_not_overwritten_or_frozen(self):
+        self.build()
+        edited = self.put("submission/example/manuscript/final.pdf", b"manually edited")
+        before = edited.read_bytes()
+        with self.assertRaisesRegex(ValueError, "edited"):
+            self.build()
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(sync.freeze(self.root, "example", self.canonical, "submitted"), 1)
+        self.assertEqual(edited.read_bytes(), before)
+
+    def test_missing_output_and_source_are_drift(self):
+        self.build()
+        (self.directory / "supplement/supplement.md").unlink()
+        (self.root / "build/final.pdf").unlink()
+        code, report = self.audit()
+        self.assertEqual(code, 1)
+        self.assertIn("output_changed_or_missing", report["artifacts"][1]["drift"])
+        self.assertIn("source_changed_or_missing", report["artifacts"][2]["drift"])
+
+    def test_missing_submission_cannot_freeze(self):
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(sync.freeze(self.root, "example", self.canonical, "submitted"), 2)
+        self.assertFalse(self.directory.exists())
+
+    def test_frozen_bundle_immutable_and_freeze_idempotent(self):
+        self.build()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(sync.freeze(self.root, "example", self.canonical, "submitted"), 0)
+            original = (self.directory / ".journal_meta.json").read_bytes()
+            self.assertEqual(sync.freeze(self.root, "example", self.canonical, "submitted"), 0)
+        self.assertEqual((self.directory / ".journal_meta.json").read_bytes(), original)
+        with self.assertRaisesRegex(ValueError, "immutable"):
+            self.build()
+
+    def test_unknown_rights_preserved_no_legal_approval(self):
+        self.build()
+        row = self.audit()[1]["artifacts"][1]
+        self.assertEqual(row["rights"]["status"], "unknown")
+        self.assertEqual(row["content_fidelity"], "not_assessed")
+
+    def test_incomplete_documented_rights_rejected(self):
+        self.spec["artifacts"][0]["rights"] = {"status": "documented", "license_or_permission": "CC BY 4.0"}
+        with self.assertRaisesRegex(ValueError, "Documented rights"):
+            self.build()
+        self.assertFalse(self.directory.exists())
+
+    def test_rights_attribution_and_modification_notice_roundtrip(self):
+        rights = {"status": "documented", "source": "synthetic rights example",
+                  "license_or_permission": "synthetic permission record", "attribution": "Synthetic creator",
+                  "changes": "Example wording adapted"}
+        self.spec["artifacts"][0]["rights"] = rights
+        self.build()
+        self.assertEqual(self.audit()[1]["artifacts"][1]["rights"], rights)
+
+    def test_hidden_and_unregistered_files_remain_visible(self):
+        self.build()
+        self.put("submission/example/.hidden.txt", "synthetic")
+        code, report = self.audit()
+        self.assertEqual(code, 1)
+        self.assertEqual(report["unregistered_files"], [".hidden.txt"])
+        with self.assertRaisesRegex(ValueError, "Unregistered"):
+            self.build()
+
+    def test_paths_reject_traversal_symlinks_and_hidden_inputs(self):
+        for value in ("../outside", "/tmp/absolute", ".hidden", "nested/../outside", "C:/absolute", "x\\y"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                sync.safe_path(self.root, value)
+        (self.root / "alias").symlink_to(self.root / "build", target_is_directory=True)
+        with self.assertRaises(ValueError):
+            sync.safe_path(self.root, "alias/final.pdf")
+
+    def test_bad_journal_is_rejected_before_writes(self):
+        for journal in ("../bad", "nested/path", ".hidden", ""):
+            with self.subTest(journal=journal), self.assertRaises(ValueError):
+                sync.journal_root(self.root, journal)
+
+    def test_case_duplicate_ancestor_and_reserved_target_rejected(self):
+        for target in ("manuscript/MANUSCRIPT.md", "MANUSCRIPT", ".journal_meta.json"):
+            self.spec["artifacts"][0]["target"] = target
+            with self.subTest(target=target), self.assertRaises(ValueError):
+                self.build()
+
+    def test_hardlink_source_output_alias_rejected(self):
+        self.directory.mkdir(parents=True)
+        dest = self.directory / "manuscript/manuscript.md"
+        dest.parent.mkdir()
+        os.link(self.canonical, dest)
+        before = self.canonical.read_bytes()
+        with self.assertRaisesRegex(ValueError, "alias"):
+            self.build()
+        self.assertEqual(self.canonical.read_bytes(), before)
+
+    def test_missing_declared_input_leaves_prior_package_unchanged(self):
+        self.build()
+        self.spec["artifacts"][0]["source"] = "build/missing.md"
+        before = self.snapshot()
+        with self.assertRaises(ValueError):
+            self.build()
+        self.assertEqual(before, self.snapshot())
+
+    def test_removed_registered_artifact_rejected(self):
+        self.build()
+        self.spec["artifacts"].pop()
+        with self.assertRaisesRegex(ValueError, "remove"):
+            self.build()
+
+    def test_malformed_manifest_not_silently_replaced(self):
+        self.put("artifact_manifest.json", "{broken")
+        before = self.snapshot()
+        with self.assertRaises(ValueError):
+            self.build()
+        self.assertEqual(before, self.snapshot())
+
+    def test_manifest_failure_rolls_back_package(self):
+        self.build()
+        before = {p: b for p, (b, _) in self.snapshot().items()}
+        original = sync.write_json
+        def failing(path, payload):
+            if path == self.root / "artifact_manifest.json":
+                raise OSError("synthetic disk failure")
+            return original(path, payload)
+        with patch.object(sync, "write_json", side_effect=failing), self.assertRaises(OSError):
+            self.build()
+        self.assertEqual(before, {p: b for p, (b, _) in self.snapshot().items()})
+
+    def test_lock_does_not_remove_another_writers_lock(self):
+        with sync.mutation_lock(self.root):
+            with self.assertRaises(ValueError):
+                with sync.mutation_lock(self.root):
+                    pass
+            self.assertTrue((self.root / ".submission-sync.lock").exists())
+        self.assertFalse((self.root / ".submission-sync.lock").exists())
+
+    def test_rendered_inputs_must_be_pinned(self):
+        self.spec["artifacts"][1]["derived_from"] = []
+        with self.assertRaisesRegex(ValueError, "pinned"):
+            self.build()
+
+    def test_source_change_during_copy_keeps_prior_bundle(self):
+        self.build()
+        before = (self.directory / "manuscript/manuscript.md").read_bytes()
+        original = sync.shutil.copy2
+        def changing(src, dst):
+            result = original(src, dst)
+            if src == self.canonical:
+                self.canonical.write_text("Changed during copy")
+            return result
+        with patch.object(sync.shutil, "copy2", side_effect=changing), self.assertRaises(ValueError):
+            self.build()
+        self.assertEqual((self.directory / "manuscript/manuscript.md").read_bytes(), before)
+
+    def test_copied_hidden_docx_metadata_reaches_existing_check(self):
+        from docx import Document
+        source = self.root / "build/final.docx"
+        document = Document()
+        document.add_paragraph("Synthetic metadata control")
+        document.save(source)
+        with zipfile.ZipFile(source, "a") as archive:
+            archive.writestr("docProps/custom.xml", '<Properties><property name="source">'
+                             '<value>/Users/testuser/styles/journal.csl</value></property></Properties>')
+        self.spec["artifacts"][1].update({"source": "build/final.docx", "target": "manuscript/final.docx"})
+        self.build()
+        self.assertEqual(source.read_bytes(), (self.directory / "manuscript/final.docx").read_bytes())
+        report = self.root / "metadata-check.json"
+        proc = subprocess.run([sys.executable, str(SCRIPTS / "check_asset_anonymization.py"),
+                               "--dir", str(self.directory), "--out", str(report), "--quiet"], capture_output=True)
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        findings = json.loads(report.read_text())["findings"]
+        self.assertTrue(any(f["type"] == "docx_embedded_abs_path" for f in findings))
+
+    def test_preflight_binding_stays_stale_on_repeated_audit(self):
+        self.build()
+        self.put("qc/preflight_gate_report.json", json.dumps({"journal": "example",
+            "bundle_binding": sync.bundle_binding(self.root, "example"),
+            "bundle_unchanged_during_checks": True, "checks": [{"id": "synthetic", "status": "skipped"}]}))
+        self.assertEqual(self.audit()[1]["verification"]["status"], "package_bytes_current")
+        self.put("submission/example/manuscript/final.pdf", b"changed")
+        for _ in range(2):
+            self.assertEqual(self.audit()[1]["verification"]["status"], "stale")
+
+    def test_legacy_preflight_is_unbound_not_verified(self):
+        self.build()
+        self.put("qc/preflight_gate_report.json", json.dumps({"journal": "example", "submission_safe": True}))
+        self.assertEqual(self.audit()[1]["verification"]["status"], "unbound")
+
+    def test_yaml_comments_and_nested_paths_do_not_retarget_canonical(self):
+        self.put("project.yaml", 'canonical_manuscript: "manuscript/manuscript.md" # source\nother:\n  canonical_manuscript: ignored.md\n')
+        self.assertEqual(sync.resolve_canonical(self.root, None), self.canonical)
+
+    def test_explicit_canonical_must_match_recorded_path(self):
+        self.build()
+        alternate = self.put("alternate.md", self.canonical.read_bytes())
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(sync.audit(self.root, "example", alternate), 1)
+
+    @unittest.skipUnless(shutil.which("pandoc"), "pandoc required for real DOCX control")
+    def test_actual_docx_copy_and_manual_word_edit(self):
+        from docx import Document
+        docx = self.root / "build/final.docx"
+        subprocess.run(["pandoc", str(self.canonical), "-o", str(docx)], check=True)
+        self.spec["artifacts"][1].update({"source": "build/final.docx", "target": "manuscript/final.docx"})
+        self.build()
+        output = self.directory / "manuscript/final.docx"
+        self.assertEqual(docx.read_bytes(), output.read_bytes())
+        document = Document(output)
+        document.add_paragraph("Synthetic manual edit")
+        document.save(output)
+        self.assertEqual(self.audit()[0], 1)
+
+    def test_cli_build_audit_freeze_contract(self):
+        self.put("bundle.json", json.dumps(self.spec))
+        command = [sys.executable, str(SCRIPTS / "sync_submission.py"), "build", "--project-root", str(self.root),
+                   "--journal", "example", "--bundle-spec", "bundle.json"]
+        proc = subprocess.run(command, capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        command[2] = "audit"
+        proc = subprocess.run(command[:-2], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_missing_spec_fails_without_writing_package(self):
+        command = [sys.executable, str(SCRIPTS / "sync_submission.py"), "build", "--project-root", str(self.root),
+                   "--journal", "example", "--bundle-spec", "missing.json"]
+        self.assertEqual(subprocess.run(command, capture_output=True).returncode, 2)
+        self.assertFalse(self.directory.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Submission build previously tracked only the canonical Markdown copy: final Word/PDF and supplementary files had no source/output binding, a missing package could be frozen, and rebuilding could overwrite edited or frozen outputs.

Extend the existing build/audit and artifact manifest with an optional bundle declaration. Copy final artifacts byte for byte, retain pinned render inputs and declared reuse rights, report missing/changed/unregistered files, and preserve edited/frozen packages. Existing renderers remain responsible for conversion. Staged copies and a cooperative mutation lock protect ordinary build failures and concurrent sync writes.

Preflight keeps its current checks and exit policy, records invoked/executed/skipped coverage and the declared bundle bytes present during the run, and distinguishes an absence of configured blockers from submission readiness. Required checks that cannot run now report an error. A bundle binding does not attest visual/semantic fidelity, legal permission, or external inputs not listed in the declaration.

Validation: 30 synthetic bundle controls, 19 preflight controls, and a real-render example containing three DOCX files, three PDFs and the canonical source (7/7 byte-identical copies). A copied DOCX with synthetic hidden path metadata still reaches the existing anonymization check. No third-party source documents or private research fixtures are added; the synthetic example and documentation link to the applicable Creative Commons guidance. Full local CI mirror and privacy results are recorded before push.
