### PR TITLE
feat(analyze-stats): bind binary results to execution evidence

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python test dependencies
-        run: pip install pyyaml pandas numpy python-pptx python-docx fonttools
+        run: pip install pyyaml pandas numpy scipy scikit-learn matplotlib python-pptx python-docx fonttools
 
       - name: Install exiftool + poppler + pandoc (artifact and render tests; no TeX)
         run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl poppler-utils pandoc
@@ -305,8 +305,11 @@ jobs:
       - name: Run analyze-stats separation gate test (complete / quasi-complete separation)
         run: bash skills/analyze-stats/tests/test_separation.sh
 
-      - name: Run analyze-stats survival template test (A1)
-        run: bash skills/analyze-stats/tests/test_survival_template.sh
+      - name: Run analyze-stats survival template and bound analysis tests
+        run: |
+          bash skills/analyze-stats/tests/test_survival_template.sh
+          python3 skills/analyze-stats/tests/test_analysis_run.py
+          bash skills/analyze-stats/scripts/analysis_run_challenge/verify.sh
 
       - name: Run sync-submission asset-anonymization gate test (A2)
         run: bash skills/sync-submission/tests/test_asset_anonymization.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Prespecified binary diagnostic-accuracy runs produce full precision tables,
+  confusion-matrix PDF/PNG and an execution record in the existing analysis
+  manifest. Data/configuration/code/output hashes, exact denominators and read-only
+  audit/compare commands expose changed versions without implying study validity.
+  An original synthetic demo and independent arithmetic/interval controls run
+  within the existing analysis CI step.
 - Submission build accepts a declared bundle of final Word/PDF, supplement,
   cover-letter and other files. Existing metadata/manifest outputs record byte
   hashes, pinned render inputs, declared reuse rights and unassessed visual and
@@ -15,6 +21,9 @@
 
 ### Fixed
 
+- The diagnostic-accuracy template uses a valid SciPy version lookup, preserves
+  a 2-by-2 confusion matrix when a class is absent, and reports zero-denominator
+  metrics as undefined rather than zero performance. Importing the template is quiet.
 - Submission sync refuses missing-package freeze, frozen/edited output overwrite,
   unregistered-file loss and colliding paths. Malformed metadata fails explicitly;
   staged copies preserve source bytes and cooperating mutations share a lock.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ suite uses synthetic fixtures and needs no private data or network access.
 To run the same gates CI runs, install the test dependencies and run the mirror:
 
 ```bash
-pip install pyyaml pandas numpy python-pptx python-docx fonttools
+pip install pyyaml pandas numpy scipy scikit-learn matplotlib python-pptx python-docx fonttools
 # Also install pandoc, exiftool and poppler with your OS package manager.
 # Render regression tests generate LaTeX with pandoc; CI does not install TeX.
 

--- a/docs/skills/analyze-stats.md
+++ b/docs/skills/analyze-stats.md
@@ -17,15 +17,18 @@
 **Safety boundaries**
 
 - All numbers come from executed code on the supplied data; never hand-typed (seed-fixed transforms).
-- Primary estimates report effect size with 95% CI and exact p-values.
+- Primary estimates report 95% CIs; planned hypothesis tests also report effect sizes and exact p-values.
 
 **Known limitations**
 
 - Correctness depends on a correct analysis plan and clean data (use design-study / clean-data first).
 - Does not adjudicate clinical validity of the chosen test.
+- The bound binary workflow requires declared independent units and fixed 0/1 predictions; hashes do not establish design validity or data rights.
 
 **Validation**
 
+- `python3 tests/test_analysis_run.py`
+- `python3 scripts/demo_analysis_run.py --out demo-project`
 - `re-run the emitted script and diff results`
 - `/self-review`
 
@@ -36,15 +39,19 @@
 **References** (`skills/analyze-stats/references/`):
 
 - `analysis_guides/` (18 files)
+- `analysis_run_workflow.md`
 - `style/` (2 files)
 - `table-standards/` (17 files)
 - `templates/` (14 files)
 
 **Scripts** (`skills/analyze-stats/scripts/`):
 
+- `analysis_run_challenge/` (2 files)
 - `check_generated_code.py`
 - `check_separation.py`
+- `demo_analysis_run.py`
 - `rating_monotonicity.py`
+- `run_analysis.py`
 
 ## Source
 

--- a/metadata/distribution_files.json
+++ b/metadata/distribution_files.json
@@ -183,8 +183,8 @@
     },
     {
       "path": "skills/analyze-stats/SKILL.md",
-      "size": 59999,
-      "sha256": "62fec491713bd24d0c44d87280a39bc52a6dc439fa0fb2004d80d4c6f8dea3ef"
+      "size": 60456,
+      "sha256": "c541c8811b918bb5b5cb380297a52659b4bda88537841574dc1272a8f7918aa8"
     },
     {
       "path": "skills/analyze-stats/references/analysis_guides/agreement_reliability.md",
@@ -275,6 +275,11 @@
       "path": "skills/analyze-stats/references/analysis_guides/test_selection.md",
       "size": 3439,
       "sha256": "105476a719db4d728dece0c03e620c322597e1ce56afa8a685782075d2f5bad1"
+    },
+    {
+      "path": "skills/analyze-stats/references/analysis_run_workflow.md",
+      "size": 7675,
+      "sha256": "9b6c18cad4a5171ae17c70b87b1cca35c21500734889b04254e1141ab3f87c59"
     },
     {
       "path": "skills/analyze-stats/references/style/figure_style.mplstyle",
@@ -383,8 +388,8 @@
     },
     {
       "path": "skills/analyze-stats/references/templates/diagnostic_accuracy.py",
-      "size": 14943,
-      "sha256": "25caa62a5a4d1635cee9b2248d729d817697c32290674726c65421aa8d159abc"
+      "size": 14976,
+      "sha256": "5931adbc672332a7b1f1d1f10fa79ccde9d4c38ac67b8c253b01733543ac3f32"
     },
     {
       "path": "skills/analyze-stats/references/templates/dta_meta_analysis.R",
@@ -442,6 +447,16 @@
       "sha256": "752ca6383ce0b11974436a8fc7a41209fe6a2caab4c630e5ae096271bf324329"
     },
     {
+      "path": "skills/analyze-stats/scripts/analysis_run_challenge/README.md",
+      "size": 761,
+      "sha256": "13ce9ddeacf6c4ec38469976f62ee79c2c4e9bf30fac5440296ca147927c73fa"
+    },
+    {
+      "path": "skills/analyze-stats/scripts/analysis_run_challenge/verify.sh",
+      "size": 1555,
+      "sha256": "ee75660797507253fd8b6f75c109cad95c1637ad81c3a644356592883ab071ff"
+    },
+    {
       "path": "skills/analyze-stats/scripts/check_generated_code.py",
       "size": 15064,
       "sha256": "acf06d2ed995242a3332b496fdce116cc364dfb1758a03ad6fee3a8c7f1d0180"
@@ -452,14 +467,24 @@
       "sha256": "92dbe9eca972bf1800954ac9b95c52e93f94b2c5d33b57dd1cad378a6b69f356"
     },
     {
+      "path": "skills/analyze-stats/scripts/demo_analysis_run.py",
+      "size": 2086,
+      "sha256": "93eee505392f44919ad472b31ecfffd06179f7eac2b1daed4f98b0fc84ae2bf2"
+    },
+    {
       "path": "skills/analyze-stats/scripts/rating_monotonicity.py",
       "size": 5494,
       "sha256": "b7f8f36c7af060e2dec60f51185ef4cc5a0f2ef20c1d509fb845b36521f420b3"
     },
     {
+      "path": "skills/analyze-stats/scripts/run_analysis.py",
+      "size": 17834,
+      "sha256": "9eaaabe34689ab6ec6a65ced1afff5c6162d2c9ed21108dd2336ee19503547da"
+    },
+    {
       "path": "skills/analyze-stats/skill.yml",
-      "size": 1421,
-      "sha256": "912c52e9289a7ccb014aa8a18105b6dfe04c2cc040e970c73b4bbc6b2d8a8a39"
+      "size": 1798,
+      "sha256": "eb88eddff554dcfd5ee3ba59a82f523c128b02bbc38affaf149c673b51fbc582"
     },
     {
       "path": "skills/architecture-zoo/SKILL.md",

--- a/skills/analyze-stats/SKILL.md
+++ b/skills/analyze-stats/SKILL.md
@@ -169,25 +169,22 @@ Before running parametric tests, always check and report:
 
 #### Output Manifest
 
-After all analyses complete, save a manifest file `_analysis_outputs.md` in the output directory:
-
-```markdown
-# Analysis Outputs
-Generated: {YYYY-MM-DD}
-Study type: {detected or user-specified type}
-
-## Tables
-- `table1_demographics.csv` -- Baseline characteristics
-- `diagnostic_accuracy_table.csv` -- Performance metrics with 95% CIs
-
-## Figures  
-- `roc_curve.pdf` / `roc_curve.png` -- ROC curves (vector / 300 DPI)
-
-## Data
-- `predictions.csv` -- Per-subject model predictions with ground truth
-```
+After all analyses complete, save `_analysis_outputs.md` in the output directory.
+Use the [output format and bound binary workflow](references/analysis_run_workflow.md)
+when producing the analysis outputs.
 
 This manifest enables downstream skills (`/make-figures`, `/write-paper`) to auto-discover analysis outputs without user intervention.
+
+For **prespecified binary predictions on independent units**, use the bundled
+`scripts/run_analysis.py run` workflow described in
+[`references/analysis_run_workflow.md`](references/analysis_run_workflow.md).
+It executes the existing diagnostic template and embeds data/configuration/code/
+output hashes, exact counts, metric-specific denominators and the reproduction
+command in this same manifest. `audit` checks recorded versions without rewriting
+them; `compare` separates declared context and recorded numeric equality from byte
+drift. It does not select thresholds or establish study validity, privacy clearance
+or reuse rights. The original synthetic example runs with
+`python3 ${CLAUDE_SKILL_DIR}/scripts/demo_analysis_run.py --out demo-project`.
 
 ### Phase 3.5: Generated-Code Quality Gate
 

--- a/skills/analyze-stats/references/analysis_run_workflow.md
+++ b/skills/analyze-stats/references/analysis_run_workflow.md
@@ -1,0 +1,150 @@
+# Binary diagnostic accuracy with an execution record
+
+Use this bounded workflow when reference labels and **prespecified predictions**
+are already literal `0`/`1`, with one row per independent analysis unit. It uses
+the existing diagnostic-accuracy template to produce counts, five proportions
+with Wilson 95% confidence intervals, and a confusion-matrix figure. It does not
+train a model, select a threshold, calculate AUC or compare models. Those tasks
+require a separate analysis plan and the corresponding template.
+
+## Try the original synthetic example
+
+From this skill's directory, with Python 3.10+ and `numpy`, `pandas`, `scipy`,
+`scikit-learn` and `matplotlib` installed:
+
+```bash
+python3 scripts/demo_analysis_run.py --out demo-project
+```
+
+The new project contains generated row-level data, configuration and two runs.
+Open `demo-project/runs/first/_analysis_outputs.md`, the full precision CSV and
+both confusion-matrix files. The example checks independently specified TP/FP/
+TN/FN counts and reruns the calculation. Tests additionally compare the intervals
+against SciPy's implementation. It is an authored software control, not a clinical
+validation dataset or an independent evaluation of the whole skill.
+
+## Run on a defined project
+
+Keep the complete installed skill directory: the runner imports its bundled
+template and style; it does not require another MedSci skill at runtime. Set
+`SKILL_DIR` to that directory and run these commands from the project directory:
+
+```bash
+python3 "$SKILL_DIR/scripts/run_analysis.py" run --project-root . \
+  --data data.csv --config analysis.json --out runs/first
+python3 "$SKILL_DIR/scripts/run_analysis.py" audit --project-root . --out runs/first
+python3 "$SKILL_DIR/scripts/run_analysis.py" run --project-root . \
+  --data data.csv --config analysis.json --out runs/repeat
+python3 "$SKILL_DIR/scripts/run_analysis.py" compare --project-root . \
+  --previous runs/first --out runs/repeat
+```
+
+The configuration must contain exactly these fields; unknown options are errors:
+
+```json
+{
+  "schema_version": 1,
+  "analysis_unit": "case",
+  "unit_id_col": "unit_id",
+  "truth_col": "truth",
+  "prediction_col": "prediction",
+  "missing_policy": "error",
+  "independent_units": true,
+  "data_status": "synthetic"
+}
+```
+
+- Allowed declared units: `patient`, `participant`, `exam`, `lesion`, `image`,
+  `case`, `study`, `sample`. Unique nonempty IDs are required, including excluded
+  rows. Uniqueness alone does not establish independence: multiple lesions or
+  images from one patient may require clustering and are outside this workflow.
+- Positive class is `1`; negative class is `0`. Scores, other labels and rounded
+  aggregate percentages are refused. Do not reconstruct purported raw observations
+  from a paper's rounded results. Map labels and fix predictions in separately
+  preserved preprocessing code before running.
+- Empty labels fail by default. Use `complete_case` only with a justified plan;
+  it records input/included rows, excluded rows and missing counts for each label.
+  This records exclusion, without establishing that complete-case inference is valid.
+- For real inputs, `data_status` must be `deidentified_authorized`. This is the
+  operator's declaration, not automatic de-identification or privacy approval.
+  Reports omit row values and IDs but contain project-relative paths, column names,
+  aggregate counts and hashes. Keep paths/column names non-identifying and review
+  small-cell disclosure and reuse rights before sharing the outputs.
+- Inputs and output paths are relative to the project root. Hidden paths, symlinks,
+  traversal and an existing output directory are refused. Raw inputs are read only;
+  failed rendering or changed inputs/code during execution do not publish a completed
+  run. Preserve data, configuration and code versions separately: hashes are not backups.
+
+## One output manifest, with bounded checks
+
+`_analysis_outputs.md` retains the existing Tables/Figures/Data discovery sections
+and embeds one JSON execution record. It records the data/configuration hashes,
+runner/template/style hashes, dependency versions, resolved font hash, exact
+confusion counts, every metric's numerator/denominator, missing-data counts and
+output hashes. The command uses `<analyze-stats>` as a portable skill-path
+placeholder. The deterministic count workflow records seed 42 but uses no random
+sampling. Archive the recorded dependency/code versions for later reproduction;
+figure bytes may differ across rendering environments.
+
+The CSV stores proportions on the 0–1 scale at full float precision. Markdown
+rounding is display only. Sensitivity uses TP+FN, specificity TN+FP, PPV TP+FP,
+NPV TN+FN and accuracy all included rows. A zero denominator produces an undefined
+estimate and CI (JSON `null`, empty CSV cells), never zero performance. Figure cell
+percentages use **all included rows**, not the metric-specific denominators.
+
+`audit` reads without rewriting the record. `current` means that recorded input,
+code and output bytes still match and the readable manifest is unchanged; it does
+not rerun the analysis or audit the current environment. Legacy output lists
+without an execution record are not silently promoted. A mismatch returns `drift`
+and exit code 1; invalid/missing records or inputs return an error and exit code 2.
+
+`compare` compares recorded full precision values, including denominators and CIs,
+and includes both read-only byte audits. A different declared unit or label column
+sets `context_status: not_comparable`; changed input/code/environment records stay
+visible even if estimates match. Any byte-audit mismatch makes the top-level status
+`drift` and exits 1. `recorded_*_equal` describes the stored records, not an assertion
+that current files are equal or that the analyses are statistically equivalent.
+Preserve versioned input files if both old and new runs must remain current.
+
+These unsigned records are not tamper-proof. Study validity, reference-label
+correctness, independence, privacy clearance, reuse rights and visual inspection
+remain `not_assessed`; read the actual figure and analysis plan before reporting.
+
+## Method and source scope
+
+The repository's existing Wilson implementation is retained and checked against
+the documented [SciPy Wilson interval](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.BinomTestResult.proportion_ci.html)
+without continuity correction. Binary figure ordering is explicitly `[0, 1]`,
+consistent with the [scikit-learn confusion-matrix interface](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.confusion_matrix.html).
+The example and documentation are original contributions under the repository
+license. No third-party paper, dataset, image, font or documentation text is bundled.
+
+Run the synthetic regression controls from the skill directory:
+
+```bash
+python3 tests/test_analysis_run.py
+bash scripts/analysis_run_challenge/verify.sh
+```
+
+## Other analysis outputs
+
+For analyses outside the bounded binary workflow, retain the existing output-list
+format below. This list supports discovery but does not claim to bind an execution.
+
+After all analyses complete, save a manifest file `_analysis_outputs.md` in the output directory:
+
+```markdown
+# Analysis Outputs
+Generated: {YYYY-MM-DD}
+Study type: {detected or user-specified type}
+
+## Tables
+- `table1_demographics.csv` -- Baseline characteristics
+- `diagnostic_accuracy_table.csv` -- Performance metrics with 95% CIs
+
+## Figures
+- `roc_curve.pdf` / `roc_curve.png` -- ROC curves (vector / 300 DPI)
+
+## Data
+- `predictions.csv` -- Per-subject model predictions with ground truth
+```

--- a/skills/analyze-stats/references/templates/diagnostic_accuracy.py
+++ b/skills/analyze-stats/references/templates/diagnostic_accuracy.py
@@ -17,19 +17,10 @@ import os
 import datetime
 import numpy as np
 import pandas as pd
+import scipy
 from scipy import stats
 
-np.random.seed(42)
-print(f"Date: {datetime.date.today()}")
-print(f"Python: {sys.version}")
-print(f"numpy: {np.__version__}, pandas: {pd.__version__}, scipy: {stats.scipy.__version__}")
-
-try:
-    import sklearn
-    print(f"sklearn: {sklearn.__version__}")
-except ImportError:
-    print("Warning: scikit-learn not installed. Install with: pip install scikit-learn")
-    sys.exit(1)
+import sklearn
 
 import matplotlib
 matplotlib.use("Agg")
@@ -38,8 +29,6 @@ import matplotlib.pyplot as plt
 STYLE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "style", "figure_style.mplstyle")
 if os.path.exists(STYLE_PATH):
     plt.style.use(STYLE_PATH)
-
-print()
 
 # === CONFIGURATION (modify for your study) ===
 INPUT_FILE = "data.csv"           # Path to input data
@@ -57,7 +46,7 @@ POSITIVE_LABEL = 1                # Value representing positive class
 def wilson_ci(p: float, n: int, alpha: float = 0.05) -> tuple:
     """Wilson score confidence interval for a proportion."""
     if n == 0:
-        return (0.0, 0.0)
+        return (np.nan, np.nan)  # No denominator: undefined, not zero performance.
     z = stats.norm.ppf(1 - alpha / 2)
     denominator = 1 + z**2 / n
     center = (p + z**2 / (2 * n)) / denominator
@@ -144,11 +133,11 @@ def compute_metrics(y_true: np.ndarray, y_pred: np.ndarray,
     fn = np.sum((y_pred == 0) & (y_true == 1))
     n = len(y_true)
 
-    sens = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-    spec = tn / (tn + fp) if (tn + fp) > 0 else 0.0
-    ppv = tp / (tp + fp) if (tp + fp) > 0 else 0.0
-    npv = tn / (tn + fn) if (tn + fn) > 0 else 0.0
-    acc = (tp + tn) / n if n > 0 else 0.0
+    sens = tp / (tp + fn) if (tp + fn) > 0 else np.nan
+    spec = tn / (tn + fp) if (tn + fp) > 0 else np.nan
+    ppv = tp / (tp + fp) if (tp + fp) > 0 else np.nan
+    npv = tn / (tn + fn) if (tn + fn) > 0 else np.nan
+    acc = (tp + tn) / n if n > 0 else np.nan
 
     metrics = {
         "Sensitivity": (sens, *wilson_ci(sens, tp + fn)),
@@ -207,7 +196,7 @@ def plot_confusion_matrix(y_true: np.ndarray, pred_dict: dict,
 
     for ax, (name, y_pred) in zip(axes, pred_dict.items()):
         from sklearn.metrics import confusion_matrix as cm_func
-        cm = cm_func(y_true, y_pred)
+        cm = cm_func(y_true, y_pred, labels=[0, 1])
         cm_pct = cm.astype(float) / cm.sum() * 100
 
         im = ax.imshow(cm, interpolation="nearest", cmap=plt.cm.Blues)
@@ -230,7 +219,8 @@ def plot_confusion_matrix(y_true: np.ndarray, pred_dict: dict,
     fig.tight_layout()
     pdf_path = os.path.join(output_dir, "confusion_matrix.pdf")
     png_path = os.path.join(output_dir, "confusion_matrix.png")
-    fig.savefig(pdf_path, format="pdf", bbox_inches="tight")
+    fig.savefig(pdf_path, format="pdf", bbox_inches="tight",
+                metadata={"CreationDate": None, "ModDate": None})
     fig.savefig(png_path, format="png", dpi=300, bbox_inches="tight")
     plt.close(fig)
     print(f"Saved: {pdf_path}")
@@ -320,6 +310,11 @@ def print_results_text(results: dict) -> None:
 
 # === MAIN ===
 if __name__ == "__main__":
+    np.random.seed(42)
+    print(f"Date: {datetime.date.today()}")
+    print(f"Python: {sys.version}")
+    print(f"numpy: {np.__version__}, pandas: {pd.__version__}, scipy: {scipy.__version__}")
+    print(f"sklearn: {sklearn.__version__}")
     print("=" * 60)
     print("Diagnostic Accuracy Analysis")
     print("=" * 60)

--- a/skills/analyze-stats/scripts/analysis_run_challenge/README.md
+++ b/skills/analyze-stats/scripts/analysis_run_challenge/README.md
@@ -1,0 +1,12 @@
+# Analysis execution record challenge
+
+Run `bash verify.sh` from this directory. Requires Python 3.10+, numpy, pandas,
+SciPy, scikit-learn and matplotlib; no network or private data is used.
+
+The bundled demo creates original synthetic observations in a temporary project.
+The normal control checks exact confusion counts, two matching calculations and
+a current byte audit. The defect control adds one synthetic input row: two audits
+must report drift without rewriting the old record. The temporary project is removed.
+The complete regression suite under `../../tests/test_analysis_run.py` additionally
+covers units, denominators, undefined metrics, rounded-input refusal and output/code
+changes. These controls test software behavior, not clinical validity.

--- a/skills/analyze-stats/scripts/analysis_run_challenge/verify.sh
+++ b/skills/analyze-stats/scripts/analysis_run_challenge/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Standalone original synthetic normal and stale-result controls.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 - "$HERE/.." <<'PY'
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+scripts = Path(sys.argv[1]).resolve()
+with tempfile.TemporaryDirectory() as temp:
+    project = Path(temp) / "project"
+    demo = subprocess.run([sys.executable, str(scripts / "demo_analysis_run.py"),
+                           "--out", str(project)], capture_output=True, text=True, check=True)
+    result = json.loads(demo.stdout)
+    assert result["synthetic_counts"] == {"TP": 8, "FP": 3, "TN": 7, "FN": 2}
+    assert result["comparison"]["status"] == "compared"
+    assert result["comparison"]["recorded_numeric_results_equal"]
+    runner = [sys.executable, str(scripts / "run_analysis.py")]
+    audit = runner + ["audit", "--project-root", str(project), "--out", "runs/first"]
+    assert subprocess.run(audit, capture_output=True).returncode == 0
+    manifest = project / "runs/first/_analysis_outputs.md"
+    original = manifest.read_bytes()
+    with (project / "data.csv").open("a") as stream:
+        stream.write("synthetic_changed,0,1\n")
+    for _ in range(2):
+        check = subprocess.run(audit, capture_output=True, text=True)
+        assert check.returncode == 1
+        assert "input:data" in json.loads(check.stdout)["changes"]
+        assert manifest.read_bytes() == original
+print("PASS: synthetic calculation, repeat, stale-input detection and read-only audit")
+PY

--- a/skills/analyze-stats/scripts/demo_analysis_run.py
+++ b/skills/analyze-stats/scripts/demo_analysis_run.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Create an original synthetic project, calculate twice and compare the records.
+
+Usage: demo_analysis_run.py --out NEW_PROJECT_DIRECTORY
+No study data, downloaded sources or network access are used.
+"""
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import run_analysis
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="New directory; existing directories are refused")
+    args = parser.parse_args()
+    root = Path(args.out).resolve()
+    root.mkdir(parents=True, exist_ok=False)
+    with (root / "data.csv").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["unit_id", "truth", "prediction"])
+        for i in range(20):
+            writer.writerow([f"synthetic_{i:02}", int(i < 10), int(i < 8 or 10 <= i < 13)])
+    config = {"schema_version": 1, "analysis_unit": "case", "unit_id_col": "unit_id",
+              "truth_col": "truth", "prediction_col": "prediction", "missing_policy": "error",
+              "independent_units": True, "data_status": "synthetic"}
+    (root / "analysis.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    first = run_analysis.run(root, "data.csv", "analysis.json", "runs/first")
+    # Independent fixture arithmetic: the first ten rows are positive; predictions
+    # include eight of those and three of the remaining ten rows.
+    if first["counts"] != {"TP": 8, "FN": 2, "FP": 3, "TN": 7}:
+        raise RuntimeError("Synthetic confusion counts disagree with the authored fixture")
+    run_analysis.run(root, "data.csv", "analysis.json", "runs/repeat")
+    comparison = run_analysis.compare(root, "runs/first", "runs/repeat")
+    if comparison["status"] != "compared" or not comparison["recorded_numeric_results_equal"]:
+        raise RuntimeError("Synthetic rerun failed its execution-record comparison")
+    print(json.dumps({"synthetic_counts": first["counts"], "comparison": comparison}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/analyze-stats/scripts/run_analysis.py
+++ b/skills/analyze-stats/scripts/run_analysis.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Run a bounded binary diagnostic-accuracy workflow with its existing template.
+
+Usage: run_analysis.py run --project-root . --data data.csv --config analysis.json --out runs/run1
+       run_analysis.py audit --project-root . --out runs/run1
+       run_analysis.py compare --project-root . --previous runs/run1 --out runs/run2
+
+The existing _analysis_outputs.md is both the readable output index and the
+execution record. No raw rows/identifiers are copied into reports. Audit checks
+recorded file versions, not whether a study design or declaration is true.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import io
+import json
+import math
+from pathlib import Path, PurePosixPath
+import platform
+import sys
+import tempfile
+
+SKILL = Path(__file__).resolve().parents[1]
+CODE = {"runner": Path(__file__).resolve(),
+        "template": SKILL / "references/templates/diagnostic_accuracy.py",
+        "style": SKILL / "references/style/figure_style.mplstyle"}
+MANIFEST = "_analysis_outputs.md"
+BEGIN = "<!-- MEDSCI_ANALYSIS_RUN_BEGIN -->\n```json\n"
+END = "\n```\n<!-- MEDSCI_ANALYSIS_RUN_END -->\n"
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def local_path(root: Path, relative: str) -> Path:
+    if not isinstance(relative, str) or not relative or "\\" in relative or ":" in relative:
+        raise ValueError("Use a project-relative POSIX path")
+    parts = PurePosixPath(relative).parts
+    if not parts or relative.startswith("/") or any(p.startswith(".") for p in parts):
+        raise ValueError("Absolute, hidden or traversing paths are not supported")
+    path = root
+    for part in parts:
+        path = path / part
+        if path.is_symlink():
+            raise ValueError("Symlink paths are not supported")
+    path.resolve().relative_to(root)
+    return path
+
+
+def configuration(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    fields = {"schema_version", "analysis_unit", "unit_id_col", "truth_col",
+              "prediction_col", "missing_policy", "independent_units", "data_status"}
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValueError("Configuration must contain exactly the documented fields")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise ValueError("Configuration schema_version must be 1")
+    if value["analysis_unit"] not in {"patient", "participant", "exam", "lesion", "image", "case", "study", "sample"}:
+        raise ValueError("Unsupported analysis unit")
+    if value["independent_units"] is not True:
+        raise ValueError("This workflow requires declared independent units; clustered analysis is separate")
+    if value["missing_policy"] not in {"error", "complete_case"}:
+        raise ValueError("Choose error or complete_case for missing labels")
+    if value["data_status"] not in {"synthetic", "deidentified_authorized"}:
+        raise ValueError("Declare synthetic or deidentified_authorized data before running")
+    columns = [value[k] for k in ("unit_id_col", "truth_col", "prediction_col")]
+    if any(not isinstance(x, str) or not x.strip() for x in columns) or len(set(columns)) != 3:
+        raise ValueError("Three distinct nonempty input columns are required")
+    return value
+
+
+def read_rows(path: Path, config: dict):
+    import numpy as np
+    ids, truth, predictions = set(), [], []
+    counts = {"input_rows": 0, "included_rows": 0, "excluded_missing_labels": 0,
+              "missing_truth": 0, "missing_prediction": 0}
+    with path.open(encoding="utf-8-sig", newline="") as stream:
+        reader = csv.DictReader(stream)
+        headers = reader.fieldnames or []
+        if len(set(headers)) != len(headers):
+            raise ValueError("Duplicate CSV headers")
+        if not {config[k] for k in ("unit_id_col", "truth_col", "prediction_col")} <= set(headers):
+            raise ValueError("Required row-level columns are missing; aggregate percentages are unsupported")
+        for row in reader:
+            if None in row or any(v is None for v in row.values()):
+                raise ValueError("Malformed CSV row")
+            counts["input_rows"] += 1
+            unit = row[config["unit_id_col"]].strip()
+            if not unit or unit in ids:
+                raise ValueError("Missing or repeated unit ID; no raw identifiers are printed")
+            ids.add(unit)
+            a, b = (row[config[k]].strip() for k in ("truth_col", "prediction_col"))
+            if a not in {"", "0", "1"} or b not in {"", "0", "1"}:
+                raise ValueError("Labels must be literal 0/1 or empty; scores and rounded summaries are unsupported")
+            counts["missing_truth"] += int(a == "")
+            counts["missing_prediction"] += int(b == "")
+            if not a or not b:
+                counts["excluded_missing_labels"] += 1
+                if config["missing_policy"] == "error":
+                    raise ValueError("Missing labels; choose a justified missing-data policy explicitly")
+                continue
+            truth.append(int(a))
+            predictions.append(int(b))
+    counts["included_rows"] = len(truth)
+    if not truth:
+        raise ValueError("No complete observations")
+    return np.array(truth), np.array(predictions), counts
+
+
+def load_template():
+    spec = importlib.util.spec_from_file_location("medsci_diagnostic_template", CODE["template"])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def file_record(path: Path, relative: str) -> dict:
+    return {"path": relative, "sha256": sha256(path), "bytes": path.stat().st_size}
+
+
+def code_records() -> dict:
+    return {role: file_record(path, path.relative_to(SKILL).as_posix()) for role, path in CODE.items()}
+
+
+def render_manifest(record: dict) -> str:
+    rows = record["metrics"]
+    lines = ["# Analysis Outputs", f"Generated: {record['generated_at']}",
+             "Study type: binary diagnostic accuracy from prespecified labels", "",
+             "## Tables", "- `diagnostic_accuracy_table.csv` -- Full precision estimates, counts and Wilson 95% CIs", "",
+             "## Figures", "- `confusion_matrix.pdf` / `confusion_matrix.png` -- Counts; percentages use included N", "",
+             "## Data", "Input data are referenced by hash below; no raw rows or IDs are copied.", "",
+             "## Results", f"Declared analysis unit: {record['config']['analysis_unit']}.",
+             f"Included: {record['cohort']['included_rows']}/{record['cohort']['input_rows']} rows; "
+             f"excluded for missing labels: {record['cohort']['excluded_missing_labels']}.", "",
+             "| Metric | Numerator / denominator | Estimate | 95% CI | Status |",
+             "|---|---:|---:|---|---|"]
+    for row in rows:
+        estimate = "undefined" if row["estimate"] is None else f"{row['estimate']:.3f}"
+        interval = "undefined" if row["ci_lower"] is None else f"{row['ci_lower']:.3f} to {row['ci_upper']:.3f}"
+        lines.append(f"| {row['metric']} | {row['numerator']} / {row['denominator']} | {estimate} | {interval} | {row['status']} |")
+    lines += ["", "## Scope", "Wilson intervals are conditional on independent units and the declared sample.",
+              "Unique IDs do not establish independence, valid reference labels or representative sampling.",
+              "No p-value comparison, AUC, calibration, threshold optimization or clinical-utility analysis is performed.",
+              "Study validity, privacy clearance, reuse rights and visual review remain not_assessed.",
+              "Hashes identify versions, not a backup or authenticated proof of correct source declarations.", "",
+              "## Execution record", BEGIN.rstrip("\n"),
+              json.dumps(record, indent=2, ensure_ascii=False, allow_nan=False), END.lstrip("\n").rstrip("\n"), ""]
+    return "\n".join(lines)
+
+
+def read_manifest(directory: Path) -> tuple[dict, bool]:
+    path = local_path(directory, MANIFEST)
+    text = path.read_text(encoding="utf-8")
+    if text.count(BEGIN) != 1 or text.count(END) != 1:
+        raise ValueError("Missing or ambiguous execution record; legacy manifests are not bound")
+    payload = text.split(BEGIN, 1)[1].split(END, 1)[0]
+    record = json.loads(payload)
+    if not isinstance(record, dict) or record.get("schema_version") != 1 or record.get("workflow") != "binary_diagnostic_accuracy":
+        raise ValueError("Unsupported execution record")
+    return record, text == render_manifest(record)
+
+
+def run(root: Path, data_rel: str, config_rel: str, out_rel: str) -> dict:
+    data, config_path, out = (local_path(root, x) for x in (data_rel, config_rel, out_rel))
+    if out.exists():
+        raise ValueError("Output directory already exists; use a new run directory")
+    if data == config_path or data.samefile(config_path):
+        raise ValueError("Data and configuration must be distinct files")
+    before = {"data": file_record(data, data_rel), "config": file_record(config_path, config_rel)}
+    code = code_records()
+    config = configuration(config_path)
+    truth, predictions, cohort = read_rows(data, config)
+    template = load_template()
+    template.np.random.seed(42)
+    metrics = template.compute_metrics(truth, predictions)
+    tp, fp, tn, fn = (metrics["_counts"][k] for k in ("TP", "FP", "TN", "FN"))
+    denominators = {"Sensitivity": (tp, tp + fn), "Specificity": (tn, tn + fp),
+                    "PPV": (tp, tp + fp), "NPV": (tn, tn + fn), "Accuracy": (tp + tn, len(truth))}
+    rows = []
+    for name, (numerator, denominator) in denominators.items():
+        estimate, lower, upper = metrics[name]
+        rows.append({"metric": name, "numerator": int(numerator), "denominator": int(denominator),
+                     "estimate": float(estimate) if math.isfinite(estimate) else None,
+                     "ci_lower": float(lower) if math.isfinite(lower) else None,
+                     "ci_upper": float(upper) if math.isfinite(upper) else None,
+                     "status": "defined" if denominator else "undefined_zero_denominator",
+                     "analysis_unit": config["analysis_unit"], "ci_method": "wilson_95_no_continuity_correction"})
+    from matplotlib import font_manager
+    font = Path(font_manager.findfont(font_manager.FontProperties()))
+    environment = {"python": platform.python_version(), "numpy": template.np.__version__,
+                   "pandas": template.pd.__version__, "scipy": template.scipy.__version__,
+                   "sklearn": template.sklearn.__version__, "matplotlib": template.matplotlib.__version__,
+                   "font_file": font.name, "font_sha256": sha256(font)}
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".analysis-run-", dir=out.parent) as temporary:
+        stage = Path(temporary) / "result"
+        stage.mkdir()
+        with (stage / "diagnostic_accuracy_table.csv").open("w", encoding="utf-8", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+            writer.writeheader()
+            writer.writerows(rows)
+        with contextlib.redirect_stdout(io.StringIO()):
+            template.plot_confusion_matrix(truth, {"Prespecified predictions": predictions},
+                                           ["Prespecified predictions"], str(stage))
+        outputs = [file_record(stage / name, name) for name in (
+            "diagnostic_accuracy_table.csv", "confusion_matrix.pdf", "confusion_matrix.png")]
+        after = {"data": file_record(data, data_rel), "config": file_record(config_path, config_rel)}
+        if before != after or code != code_records():
+            raise ValueError("An input, code or style file changed during execution; run not published")
+        record = {"schema_version": 1, "workflow": "binary_diagnostic_accuracy",
+                  "generated_at": datetime.now(timezone.utc).isoformat(), "inputs": before,
+                  "code": code, "config": config, "environment": environment,
+                  "random_seed": 42, "randomness_used": False,
+                  "cohort": cohort, "counts": metrics["_counts"], "metrics": rows, "outputs": outputs,
+                  "command": ["python3", "<analyze-stats>/scripts/run_analysis.py", "run", "--project-root", ".",
+                              "--data", data_rel, "--config", config_rel, "--out", out_rel],
+                  "checks": {"binary_labels": "passed", "unique_declared_unit_ids": "passed",
+                             "input_code_unchanged_during_run": "passed", "study_validity": "not_assessed",
+                             "privacy_clearance": "not_assessed", "reuse_rights": "not_assessed", "visual_review": "not_assessed"}}
+        (stage / MANIFEST).write_text(render_manifest(record), encoding="utf-8")
+        if out.exists():
+            raise ValueError("Output appeared during execution; nothing overwritten")
+        stage.rename(out)
+    return record
+
+
+def audit(root: Path, out_rel: str) -> dict:
+    directory = local_path(root, out_rel)
+    record, text_matches = read_manifest(directory)
+    changes = [] if text_matches else ["manifest_text_changed"]
+    for role, entry in record["inputs"].items():
+        path = local_path(root, entry["path"])
+        if not path.is_file() or sha256(path) != entry["sha256"]:
+            changes.append(f"input:{role}")
+    if set(record["code"]) != set(CODE):
+        changes.append("code:inventory")
+    for role, path in CODE.items():
+        if record["code"].get(role, {}).get("sha256") != sha256(path):
+            changes.append(f"code:{role}")
+    expected = {MANIFEST}
+    for entry in record["outputs"]:
+        expected.add(entry["path"])
+        path = local_path(directory, entry["path"])
+        if not path.is_file() or sha256(path) != entry["sha256"]:
+            changes.append(f"output:{entry['path']}")
+    actual = {p.name for p in directory.iterdir()}
+    if actual != expected:
+        changes.append("output:inventory")
+    return {"status": "drift" if changes else "current", "changes": changes,
+            "scope": "Recorded input/code/output bytes only; no re-analysis or design approval",
+            "study_validity": "not_assessed"}
+
+
+def compare(root: Path, previous: str, current: str) -> dict:
+    old, _ = read_manifest(local_path(root, previous))
+    new, _ = read_manifest(local_path(root, current))
+    # Declared units and columns are part of the estimand context, even if the
+    # displayed estimate happens to be identical. Do not compare rounded prose.
+    keys = ("analysis_unit", "unit_id_col", "truth_col", "prediction_col", "missing_policy", "independent_units")
+    comparable = all(old["config"][k] == new["config"][k] for k in keys)
+    context_changed = [k for k in ("inputs", "code", "environment") if old[k] != new[k]]
+    previous_audit, current_audit = audit(root, previous), audit(root, current)
+    drift = any(result["status"] == "drift" for result in (previous_audit, current_audit))
+    return {"status": "drift" if drift else "compared",
+            "context_status": "not_comparable" if not comparable else "context_changed" if context_changed else "same_context",
+            "context_changed": context_changed, "declared_context_matches": comparable,
+            "recorded_numeric_results_equal": old["metrics"] == new["metrics"] if comparable else None,
+            "cohort_equal": old["cohort"] == new["cohort"],
+            "recorded_outputs_equal": old["outputs"] == new["outputs"],
+            "previous_audit": previous_audit, "current_audit": current_audit,
+            "scope": "Comparison of recorded values, not equivalence or a rerun; consult both byte audits",
+            "study_validity": "not_assessed"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("run", "audit", "compare"))
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--data")
+    parser.add_argument("--config")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--previous")
+    args = parser.parse_args()
+    try:
+        root = Path(args.project_root).resolve()
+        if not root.is_dir():
+            raise ValueError("Project root must exist")
+        if args.mode == "run":
+            if not args.data or not args.config or args.previous:
+                raise ValueError("run requires --data and --config, without --previous")
+            record = run(root, args.data, args.config, args.out)
+            result = {"status": "completed", "manifest": f"{args.out}/{MANIFEST}",
+                      "included_rows": record["cohort"]["included_rows"], "study_validity": "not_assessed"}
+        elif args.data or args.config:
+            raise ValueError("audit/compare read recorded inputs; do not supply --data or --config")
+        elif args.mode == "audit":
+            if args.previous:
+                raise ValueError("--previous is only used by compare")
+            result = audit(root, args.out)
+        else:
+            if not args.previous:
+                raise ValueError("compare requires --previous")
+            result = compare(root, args.previous, args.out)
+        print(json.dumps(result, indent=2, allow_nan=False))
+        return 1 if result["status"] == "drift" else 0
+    except (OSError, ValueError, KeyError, TypeError, ImportError) as exc:
+        print(f"Analysis workflow error ({type(exc).__name__}): {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/analyze-stats/skill.yml
+++ b/skills/analyze-stats/skill.yml
@@ -14,6 +14,7 @@ outputs:
   - "analysis code (Python/R)"
   - "result tables"
   - "analysis figures"
+  - "_analysis_outputs.md (bound execution record for prespecified binary predictions)"
 side_effects:
   - writes_project_artifacts
   - executes_analysis_code
@@ -29,11 +30,14 @@ forbidden_actions:
 purpose: "Produce reproducible statistical code and publication-ready output for a specified design (DTA, agreement, survival, regression, survey, etc.)."
 safety_boundaries:
   - "All numbers come from executed code on the supplied data; never hand-typed (seed-fixed transforms)."
-  - "Primary estimates report effect size with 95% CI and exact p-values."
+  - "Primary estimates report 95% CIs; planned hypothesis tests also report effect sizes and exact p-values."
 known_limitations:
   - "Correctness depends on a correct analysis plan and clean data (use design-study / clean-data first)."
   - "Does not adjudicate clinical validity of the chosen test."
+  - "The bound binary workflow requires declared independent units and fixed 0/1 predictions; hashes do not establish design validity or data rights."
 validation_commands:
+  - "python3 tests/test_analysis_run.py"
+  - "python3 scripts/demo_analysis_run.py --out demo-project"
   - "re-run the emitted script and diff results"
   - "/self-review"
 evidence_surface: demo

--- a/skills/analyze-stats/tests/test_analysis_run.py
+++ b/skills/analyze-stats/tests/test_analysis_run.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Original synthetic controls for execution records and exact binary counts."""
+import contextlib
+import csv
+from fractions import Fraction
+import io
+import json
+import math
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import run_analysis as run
+
+CONFIG = {"schema_version": 1, "analysis_unit": "case", "unit_id_col": "unit_id",
+          "truth_col": "truth", "prediction_col": "prediction", "missing_policy": "error",
+          "independent_units": True, "data_status": "synthetic"}
+
+
+def write_data(root):
+    with (root / "data.csv").open("w", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["unit_id", "truth", "prediction"])
+        # The fixture is assembled from four groups, not inferred from rounded metrics.
+        index = 0
+        for truth, prediction, count in ((1, 1, 8), (1, 0, 2), (0, 1, 3), (0, 0, 7)):
+            for _ in range(count):
+                writer.writerow([f"unit_{index}", truth, prediction])
+                index += 1
+    (root / "analysis.json").write_text(json.dumps(CONFIG))
+
+
+class AnalysisTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base = tempfile.TemporaryDirectory()
+        cls.base_path = Path(cls.base.name).resolve()
+        write_data(cls.base_path)
+        cls.record = run.run(cls.base_path, "data.csv", "analysis.json", "runs/first")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.base.cleanup()
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        shutil.copytree(self.base_path, self.root, dirs_exist_ok=True)
+        self.output = self.root / "runs/first"
+
+    def config(self, **changes):
+        value = {**CONFIG, **changes}
+        (self.root / "analysis.json").write_text(json.dumps(value))
+
+    def execute(self, out="runs/second"):
+        return run.run(self.root, "data.csv", "analysis.json", out)
+
+    def test_exact_independent_counts_and_denominators(self):
+        # Independent integer arithmetic, without calling the implementation's metric helper.
+        cells = self.record["counts"]
+        self.assertEqual(cells, {"TP": 8, "FP": 3, "TN": 7, "FN": 2})
+        expected = {"Sensitivity": Fraction(8, 10), "Specificity": Fraction(7, 10),
+                    "PPV": Fraction(8, 11), "NPV": Fraction(7, 9), "Accuracy": Fraction(15, 20)}
+        for row in self.record["metrics"]:
+            self.assertEqual(Fraction(row["numerator"], row["denominator"]), expected[row["metric"]])
+            self.assertAlmostEqual(row["estimate"], float(expected[row["metric"]]), places=14)
+
+    def test_intervals_match_independent_scipy_implementation(self):
+        from scipy.stats import binomtest
+        for row in self.record["metrics"]:
+            reference = binomtest(row["numerator"], row["denominator"]).proportion_ci(method="wilson")
+            self.assertAlmostEqual(row["ci_lower"], reference.low, places=12)
+            self.assertAlmostEqual(row["ci_upper"], reference.high, places=12)
+
+    def test_unrounded_csv_and_readable_manifest_are_same_record(self):
+        with (self.output / "diagnostic_accuracy_table.csv").open() as stream:
+            rows = list(csv.DictReader(stream))
+        self.assertAlmostEqual(float(rows[2]["estimate"]), 8 / 11, places=14)
+        self.assertNotEqual(float(rows[2]["estimate"]), 0.727)
+        record, matches = run.read_manifest(self.output)
+        self.assertTrue(matches)
+        self.assertEqual(record["metrics"], self.record["metrics"])
+        self.assertEqual(record["checks"]["study_validity"], "not_assessed")
+
+    def test_same_context_rerun_preserves_sources_and_outputs(self):
+        before = {p.name: (p.read_bytes(), p.stat().st_mtime_ns) for p in (
+            self.root / "data.csv", self.root / "analysis.json")}
+        self.execute()
+        self.assertEqual(before, {p.name: (p.read_bytes(), p.stat().st_mtime_ns) for p in (
+            self.root / "data.csv", self.root / "analysis.json")})
+        result = run.compare(self.root, "runs/first", "runs/second")
+        self.assertEqual(result["status"], "compared")
+        self.assertEqual(result["context_status"], "same_context")
+        self.assertTrue(result["recorded_numeric_results_equal"])
+        self.assertTrue(result["recorded_outputs_equal"])
+
+    def test_changed_input_stays_drift_on_repeated_audits(self):
+        with (self.root / "data.csv").open("a") as stream:
+            stream.write("additional_unit,0,0\n")
+        old = (self.output / run.MANIFEST).read_bytes()
+        for _ in range(2):
+            self.assertIn("input:data", run.audit(self.root, "runs/first")["changes"])
+        self.assertEqual(old, (self.output / run.MANIFEST).read_bytes())
+
+    def test_changed_configuration_does_not_rebind_old_run(self):
+        self.config(missing_policy="complete_case")
+        self.assertIn("input:config", run.audit(self.root, "runs/first")["changes"])
+
+    def test_same_estimates_different_unit_not_comparable(self):
+        self.config(analysis_unit="lesion")
+        second = self.execute()
+        self.assertEqual(self.record["metrics"][0]["estimate"], second["metrics"][0]["estimate"])
+        result = run.compare(self.root, "runs/first", "runs/second")
+        self.assertEqual(result["context_status"], "not_comparable")
+        self.assertIsNone(result["recorded_numeric_results_equal"])
+
+    def test_same_percentage_different_denominator_is_not_equal_result(self):
+        with (self.root / "data.csv").open() as stream:
+            rows = list(csv.DictReader(stream))
+        with (self.root / "data.csv").open("a", newline="") as stream:
+            writer = csv.writer(stream)
+            for row in rows:
+                writer.writerow([row["unit_id"] + "_copy", row["truth"], row["prediction"]])
+        second = self.execute()
+        self.assertEqual(self.record["metrics"][0]["estimate"], second["metrics"][0]["estimate"])
+        self.assertEqual(second["metrics"][0]["denominator"], 20)
+        comparison = run.compare(self.root, "runs/first", "runs/second")
+        self.assertFalse(comparison["recorded_numeric_results_equal"])
+        self.assertFalse(comparison["cohort_equal"])
+
+    def test_repeated_unit_ids_are_not_silently_treated_as_independent(self):
+        with (self.root / "data.csv").open("a") as stream:
+            stream.write("unit_0,0,0\n")
+        with self.assertRaisesRegex(ValueError, "repeated unit"):
+            self.execute()
+        self.assertFalse((self.root / "runs/second").exists())
+
+    def test_clustered_unit_declaration_is_not_supported(self):
+        self.config(independent_units=False)
+        with self.assertRaisesRegex(ValueError, "independent"):
+            self.execute()
+
+    def test_missing_labels_require_explicit_policy(self):
+        with (self.root / "data.csv").open("a") as stream:
+            stream.write("missing_1,,1\nmissing_2,0,\nmissing_both,,\n")
+        with self.assertRaisesRegex(ValueError, "Missing labels"):
+            self.execute()
+        self.config(missing_policy="complete_case")
+        result = self.execute()
+        self.assertEqual(result["cohort"], {"input_rows": 23, "included_rows": 20,
+            "excluded_missing_labels": 3, "missing_truth": 2, "missing_prediction": 2})
+
+    def test_one_class_keeps_undefined_metrics_and_two_by_two_figure(self):
+        (self.root / "data.csv").write_text("unit_id,truth,prediction\na,0,0\nb,0,0\n")
+        result = self.execute()
+        sensitivity = result["metrics"][0]
+        self.assertEqual(sensitivity["status"], "undefined_zero_denominator")
+        self.assertIsNone(sensitivity["estimate"])
+        self.assertIsNone(sensitivity["ci_lower"])
+        self.assertEqual(result["metrics"][-1]["estimate"], 1.0)
+        self.assertTrue((self.root / "runs/second/confusion_matrix.pdf").is_file())
+
+    def test_rounded_scores_and_nonbinary_labels_rejected_without_echo(self):
+        for value in ("0.727", "2", "NaN", "private_marker"):
+            (self.root / "data.csv").write_text(f"unit_id,truth,prediction\na,1,{value}\n")
+            with self.subTest(value=value), self.assertRaises(ValueError) as error:
+                self.execute()
+            self.assertNotIn(value, str(error.exception))
+
+    def test_aggregate_metrics_cannot_be_reverse_engineered_into_rows(self):
+        (self.root / "data.csv").write_text("sensitivity,specificity,N\n0.800,0.700,20\n")
+        with self.assertRaisesRegex(ValueError, "aggregate"):
+            self.execute()
+
+    def test_duplicate_headers_and_malformed_rows_rejected(self):
+        for text in ("unit_id,truth,truth,prediction\na,1,1,1\n", "unit_id,truth,prediction\na,1\n"):
+            (self.root / "data.csv").write_text(text)
+            with self.assertRaises(ValueError):
+                self.execute()
+
+    def test_unknown_configuration_and_privacy_status_not_silently_ignored(self):
+        for changes in ({"threshold": 0.5}, {"data_status": "unknown"}, {"truth_col": "unit_id"}):
+            self.config(**changes)
+            with self.subTest(changes=changes), self.assertRaises(ValueError):
+                self.execute()
+
+    def test_existing_output_and_input_alias_not_overwritten(self):
+        original = (self.output / run.MANIFEST).read_bytes()
+        for target in ("runs/first", "data.csv"):
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                self.execute(target)
+        self.assertEqual(original, (self.output / run.MANIFEST).read_bytes())
+
+    def test_symlinks_traversal_hidden_and_absolute_paths_rejected(self):
+        for path in ("../outside", "/tmp/output", ".hidden", "a/../b", "C:/outside", "a\\b"):
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                run.local_path(self.root, path)
+        (self.root / "alias").symlink_to(self.root / "data.csv")
+        with self.assertRaises(ValueError):
+            run.local_path(self.root, "alias")
+
+    def test_modified_or_missing_output_is_drift(self):
+        (self.output / "diagnostic_accuracy_table.csv").write_text("manually edited\n")
+        (self.output / "confusion_matrix.png").unlink()
+        result = run.audit(self.root, "runs/first")
+        self.assertIn("output:diagnostic_accuracy_table.csv", result["changes"])
+        self.assertIn("output:confusion_matrix.png", result["changes"])
+
+    def test_extra_file_and_edited_readable_summary_are_visible(self):
+        (self.output / "unexpected.txt").write_text("synthetic")
+        path = self.output / run.MANIFEST
+        path.write_text(path.read_text().replace("Included: 20/20", "Included: 19/20", 1))
+        result = run.audit(self.root, "runs/first")
+        self.assertIn("manifest_text_changed", result["changes"])
+        self.assertIn("output:inventory", result["changes"])
+
+    def test_changed_code_is_visible_with_identical_numeric_results(self):
+        self.execute()
+        path = self.output / run.MANIFEST
+        old, _ = run.read_manifest(self.output)
+        old["code"]["runner"]["sha256"] = "0" * 64
+        path.write_text(run.render_manifest(old))
+        result = run.compare(self.root, "runs/first", "runs/second")
+        self.assertTrue(result["recorded_numeric_results_equal"])
+        self.assertEqual(result["status"], "drift")
+        self.assertEqual(result["context_status"], "context_changed")
+        self.assertIn("code", result["context_changed"])
+        self.assertIn("code:runner", result["previous_audit"]["changes"])
+
+    def test_actual_code_change_invalidates_prior_run(self):
+        copied = self.root / "skill_copy"
+        for path in run.CODE.values():
+            destination = copied / path.relative_to(run.SKILL)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, destination)
+        replacements = {role: copied / path.relative_to(run.SKILL) for role, path in run.CODE.items()}
+        with patch.object(run, "SKILL", copied), patch.object(run, "CODE", replacements):
+            self.execute()
+            with replacements["template"].open("a") as stream:
+                stream.write("\n# Synthetic code-version change.\n")
+            result = run.audit(self.root, "runs/second")
+            self.assertIn("code:template", result["changes"])
+
+    def test_equal_records_do_not_hide_modified_output_or_exit_successfully(self):
+        self.execute()
+        (self.output / "diagnostic_accuracy_table.csv").write_text("edited output\n")
+        result = run.compare(self.root, "runs/first", "runs/second")
+        self.assertTrue(result["recorded_numeric_results_equal"])
+        self.assertTrue(result["recorded_outputs_equal"])
+        self.assertEqual(result["status"], "drift")
+        proc = subprocess.run([sys.executable, str(run.CODE["runner"]), "compare",
+            "--project-root", str(self.root), "--previous", "runs/first", "--out", "runs/second"],
+            capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout)["status"], "drift")
+
+    def test_input_changes_during_plot_do_not_publish_a_run(self):
+        template = run.load_template()
+        original = template.plot_confusion_matrix
+        def changing(*args):
+            original(*args)
+            with (self.root / "data.csv").open("a") as stream:
+                stream.write("added_during_run,0,0\n")
+        with patch.object(template, "plot_confusion_matrix", side_effect=changing), patch.object(run, "load_template", return_value=template):
+            with self.assertRaisesRegex(ValueError, "changed during execution"):
+                self.execute()
+        self.assertFalse((self.root / "runs/second").exists())
+        self.assertTrue((self.output / run.MANIFEST).is_file())
+
+    def test_failed_plot_leaves_no_completed_manifest(self):
+        template = run.load_template()
+        with patch.object(template, "plot_confusion_matrix", side_effect=OSError("synthetic renderer failure")), patch.object(run, "load_template", return_value=template):
+            with self.assertRaises(OSError):
+                self.execute()
+        self.assertFalse((self.root / "runs/second").exists())
+
+    def test_legacy_or_corrupt_manifest_is_not_a_current_run(self):
+        for text in ("# Analysis Outputs\n- table.csv\n", run.BEGIN + "[]" + run.END):
+            (self.output / run.MANIFEST).write_text(text)
+            with self.assertRaises(ValueError):
+                run.audit(self.root, "runs/first")
+
+    def test_real_pdf_png_and_no_raw_identifiers_in_record(self):
+        self.assertTrue((self.output / "confusion_matrix.pdf").read_bytes().startswith(b"%PDF"))
+        self.assertTrue((self.output / "confusion_matrix.png").read_bytes().startswith(b"\x89PNG"))
+        self.assertNotIn("unit_0", (self.output / run.MANIFEST).read_text())
+
+    def test_cli_run_and_read_only_audit(self):
+        base = [sys.executable, str(run.CODE["runner"])]
+        proc = subprocess.run(base + ["run", "--project-root", str(self.root), "--data", "data.csv",
+                                     "--config", "analysis.json", "--out", "runs/cli"], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        path = self.root / "runs/cli" / run.MANIFEST
+        before = path.read_bytes(), path.stat().st_mtime_ns
+        proc = subprocess.run(base + ["audit", "--project-root", str(self.root), "--out", "runs/cli"], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(before, (path.read_bytes(), path.stat().st_mtime_ns))
+
+    def test_template_import_and_zero_denominator_contract(self):
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            template = run.load_template()
+        self.assertEqual(output.getvalue(), "")
+        self.assertTrue(all(math.isnan(x) for x in template.wilson_ci(0, 0)))
+
+    def test_shipped_demo_runs_and_refuses_existing_project(self):
+        command = [sys.executable, str(run.SKILL / "scripts/demo_analysis_run.py"),
+                   "--out", str(self.root / "demo")]
+        proc = subprocess.run(command, capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout)["comparison"]["status"], "compared")
+        source = self.root / "demo/data.csv"
+        before = source.read_bytes(), source.stat().st_mtime_ns
+        proc = subprocess.run(command, capture_output=True, text=True)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(before, (source.read_bytes(), source.stat().st_mtime_ns))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Prespecified binary diagnostic-accuracy results now retain their data, configuration, code and output versions in the existing `_analysis_outputs.md`. The runner executes the existing template, producing a full precision metric table and confusion-matrix PDF/PNG. Repeated runs compare recorded values and declared units; changed inputs, code or outputs remain visible as drift instead of silently rebinding an old result.

The workflow is limited to row-level 0/1 predictions on declared independent units. It records each metric's numerator, denominator and Wilson interval, explicit missing-data exclusions and undefined zero-denominator metrics. Study validity, privacy clearance, reuse rights and visual inspection remain unassessed. The template's invalid SciPy version lookup and one-class confusion-matrix failure are also corrected.

Validation: 30 synthetic regression tests, independent integer arithmetic and SciPy interval checks, a standalone normal/stale-input challenge, an executed synthetic demo with CSV/PDF/PNG inspection, and the complete 251-step local CI mirror. The existing analysis CI step runs the new controls; no new workflow or job is added. Public changes and synthetic artifact metadata are scanned for private identifiers and credential patterns. No third-party source material is bundled, and no release-version bump is included.
